### PR TITLE
Support PKCS#1 (RSA) private keys from GitHub

### DIFF
--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -72,7 +72,7 @@ async function importPrivateKey(pem: string): Promise<CryptoKey> {
   // Import key
   return crypto.subtle.importKey(
     'pkcs8',
-    pkcs8Bytes.buffer,
+    pkcs8Bytes.buffer as ArrayBuffer,
     { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
     false,
     ['sign']


### PR DESCRIPTION
## Summary
GitHub generates private keys in PKCS#1 format (`-----BEGIN RSA PRIVATE KEY-----`), but WebCrypto requires PKCS#8 format. This adds automatic conversion so users can use keys directly from GitHub without manual conversion.

## Changes
- Detect PKCS#1 vs PKCS#8 format from PEM headers
- Convert PKCS#1 to PKCS#8 by wrapping with RSA algorithm identifier
- Support both formats transparently

## Test plan
- [x] Unit tests pass
- [ ] Deploy and verify with original GitHub key