### PR TITLE
fix: update html-to-image CDN version and add production CORS guidance

### DIFF
--- a/src/widget/screenshot.ts
+++ b/src/widget/screenshot.ts
@@ -1,5 +1,5 @@
 // Load html-to-image dynamically to reduce initial bundle size
-const HTML_TO_IMAGE_CDN = 'https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js';
+const HTML_TO_IMAGE_CDN = 'https://cdn.jsdelivr.net/npm/html-to-image@1.11.13/dist/html-to-image.js';
 
 let htmlToImage: typeof import('html-to-image') | null = null;
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,6 +14,11 @@ ALLOWED_ORIGINS = "*"  # "*" for dev, comma-separated URLs for production
 GITHUB_APP_NAME = "neonwatty-bugdrop"  # Your GitHub App's URL slug
 MAX_SCREENSHOT_SIZE_MB = "5"  # Maximum screenshot size in MB
 
+# Production configuration example (uncomment and customize for deployment)
+# [env.production.vars]
+# ENVIRONMENT = "production"
+# ALLOWED_ORIGINS = "https://yourdomain.com,https://app.yourdomain.com"
+
 # Secrets (set with: wrangler secret put GITHUB_APP_ID)
 # GITHUB_APP_ID
 # GITHUB_PRIVATE_KEY


### PR DESCRIPTION
## Summary
- Update html-to-image CDN URL from `@1.11.11` to `@1.11.13` to match package.json
- Add commented production environment example in wrangler.toml for CORS configuration

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build:widget` succeeds (28.4kb bundle)
- [ ] After merge, run `npm run deploy` to update Cloudflare Workers