### PR TITLE
feat: add configurable name/email fields to feedback form

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
 | `data-repo` | `owner/repo` | required |
 | `data-theme` | `light`, `dark`, `auto` | `auto` |
 | `data-position` | `bottom-right`, `bottom-left` | `bottom-right` |
+| `data-show-name` | `true`, `false` | `false` |
+| `data-require-name` | `true`, `false` | `false` |
+| `data-show-email` | `true`, `false` | `false` |
+| `data-require-email` | `true`, `false` | `false` |
 
 ```html
 <script src="https://bugdrop.neonwatty.workers.dev/widget.js"
@@ -37,6 +41,21 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
         data-theme="dark"
         data-position="bottom-left"></script>
 ```
+
+### Collecting Submitter Info
+
+By default, BugDrop only asks for a title and description. You can optionally collect user name and email:
+
+```html
+<!-- Require name, optional email -->
+<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
+        data-repo="owner/repo"
+        data-show-name="true"
+        data-require-name="true"
+        data-show-email="true"></script>
+```
+
+When provided, submitter info appears at the top of the GitHub issue.
 
 ## Live Demo
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "feedback-widget",
+  "name": "bugdrop",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "feedback-widget",
+      "name": "bugdrop",
       "version": "1.0.0",
       "dependencies": {
         "hono": "^4.6.14"

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -161,6 +161,20 @@ function formatIssueBody(
 ): string {
   const sections: string[] = [];
 
+  // Submitter info (if provided)
+  if (payload.submitter?.name || payload.submitter?.email) {
+    sections.push('## Submitted by');
+    const parts: string[] = [];
+    if (payload.submitter.name) {
+      parts.push(`**${payload.submitter.name}**`);
+    }
+    if (payload.submitter.email) {
+      parts.push(`(${payload.submitter.email})`);
+    }
+    sections.push(parts.join(' '));
+    sections.push('');
+  }
+
   // Description
   sections.push('## Description');
   sections.push(payload.description);

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,10 @@ export interface FeedbackPayload {
   description: string;
   screenshot?: string;    // base64 data URL
   annotations?: string;   // base64 annotated image
+  submitter?: {           // Optional submitter info (configured per widget)
+    name?: string;
+    email?: string;
+  };
   metadata: {
     url: string;
     userAgent: string;


### PR DESCRIPTION
## Summary
- Add optional name and email input fields that can be configured via widget data attributes
- Developers can choose whether to collect submitter information based on their users' needs
- Submitter info displays at top of GitHub issue when provided

## Changes
- Added `data-show-name`, `data-require-name`, `data-show-email`, `data-require-email` widget attributes
- Updated FeedbackPayload type to include optional submitter info
- Updated API to format submitter section in GitHub issue body
- Added 3 new tests for submitter functionality
- Updated README with new configuration options

## Example Usage
```html
<!-- Require name, optional email -->
<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
        data-repo="owner/repo"
        data-show-name="true"
        data-require-name="true"
        data-show-email="true"></script>
```

## Test plan
- [ ] Verify widget works without name/email attributes (backwards compatible)
- [ ] Verify name field shows when `data-show-name="true"`
- [ ] Verify name is required when `data-require-name="true"`
- [ ] Verify email field shows when `data-show-email="true"`
- [ ] Verify submitter info appears in GitHub issue body