### PR TITLE
fix: handle SVG elements in element selector

### DIFF
--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -567,7 +567,11 @@ function getElementSelector(element: Element): string {
     }
 
     if (current.className) {
-      const classes = current.className.split(' ').filter(c => c).slice(0, 2);
+      // Handle SVG elements where className is SVGAnimatedString, not a string
+      const classNameStr = typeof current.className === 'string'
+        ? current.className
+        : (current.className as SVGAnimatedString).baseVal || '';
+      const classes = classNameStr.split(' ').filter(c => c).slice(0, 2);
       if (classes.length) {
         selector += `.${classes.join('.')}`;
       }


### PR DESCRIPTION
## Problem
Clicking on SVG elements during element selection causes the widget to crash with:
```
TypeError: e.className.split is not a function
```

This happens because SVG elements have `className` as an `SVGAnimatedString` object, not a string.

## Solution
Check if `className` is a string or SVGAnimatedString and extract the string value appropriately before calling `.split()`.

## Test
1. Open demo site
2. Click bug button → Select Element
3. Click on an SVG element (like the dog illustration)
4. Widget should continue to annotation/form step instead of crashing