### PR TITLE
fix: bundle html-to-image, hide full-page capture on complex DOMs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches: [main, develop]
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'benchmarks/**'
   merge_group:
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,5 +152,5 @@ installs dependencies, builds the widget, and runs all tests to verify the setup
 - Widget computes `apiUrl` from `script.src` using regex: `/\/widget(?:\.v[\d.]+)?\.js$/`
 - GitHub App slug: `neonwatty-bugdrop` (name `bugdrop` was reserved by a defunct app)
 - Repo is in the `mean-weasel` org (transferred from `neonwatty` for merge queue support)
-- `html-to-image` library loaded dynamically from CDN — not bundled
-- Complex DOM pages (>3000 nodes) get reduced pixelRatio to prevent OOM crashes
+- `html-to-image` library bundled into widget.js via esbuild (static import, not CDN-loaded)
+- Complex DOM pages (>3000 nodes) get reduced pixelRatio; pages with >10k nodes have Full Page and Select Area buttons hidden entirely

--- a/benchmarks/screenshot-threshold.spec.ts
+++ b/benchmarks/screenshot-threshold.spec.ts
@@ -12,7 +12,7 @@ interface BenchmarkResult {
   nodes: number;
   actualNodes: number;
   durationMs: number;
-  outcome: 'success' | 'error' | 'timeout';
+  outcome: 'success' | 'error' | 'timeout' | 'full_page_disabled';
 }
 
 const results: BenchmarkResult[] = [];
@@ -29,8 +29,9 @@ test.beforeEach(async ({ page }) => {
 });
 
 // Navigate widget to the "Full Page" capture button and click it.
-// Returns the timestamp immediately after clicking.
-async function navigateToFullPageCapture(page: Page): Promise<number> {
+// Returns the timestamp immediately after clicking, or null if the button
+// is hidden (DOM too complex — widget disables full-page capture at 10k+ nodes).
+async function navigateToFullPageCapture(page: Page): Promise<number | null> {
   const host = page.locator('#bugdrop-host');
 
   // Open widget
@@ -56,9 +57,14 @@ async function navigateToFullPageCapture(page: Page): Promise<number> {
   const submitBtn = host.locator('css=#submit-btn');
   await submitBtn.click();
 
-  // Click "Full Page"
+  // Wait for screenshot options to appear
+  const elementBtn = host.locator('css=[data-action="element"]');
+  await expect(elementBtn).toBeVisible({ timeout: 5_000 });
+
+  // Check if "Full Page" button exists (hidden when DOM ≥ 10k nodes)
   const captureBtn = host.locator('css=[data-action="capture"]');
-  await expect(captureBtn).toBeVisible({ timeout: 5_000 });
+  const isVisible = await captureBtn.isVisible();
+  if (!isVisible) return null;
 
   const startTime = Date.now();
   await captureBtn.click();
@@ -80,6 +86,17 @@ for (const nodeCount of NODE_COUNTS) {
     // Drive the widget to Full Page capture
     const startTime = await navigateToFullPageCapture(page);
 
+    // Widget hides "Full Page" button when DOM is too complex (≥10k nodes)
+    if (startTime === null) {
+      results.push({
+        nodes: nodeCount,
+        actualNodes,
+        durationMs: 0,
+        outcome: 'full_page_disabled',
+      });
+      return;
+    }
+
     const host = page.locator('#bugdrop-host');
     const annotationCanvas = host.locator('css=#annotation-canvas');
     const errorMessage = host.locator('css=.bd-error-message__text');
@@ -99,9 +116,11 @@ for (const nodeCount of NODE_COUNTS) {
         durationMs,
         outcome: succeeded ? 'success' : 'error',
       });
-    } catch {
+    } catch (error) {
       // Neither appeared within 60s — hard freeze / timeout
       const durationMs = Date.now() - startTime;
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[${nodeCount} nodes] Benchmark failed after ${durationMs}ms: ${message}`);
       results.push({
         nodes: nodeCount,
         actualNodes,
@@ -130,8 +149,14 @@ test.afterAll(() => {
   );
   console.log('| Nodes (target) | Nodes (actual) | Duration (ms) | Outcome |');
   console.log('|---------------:|---------------:|--------------:|---------|');
+  const outcomeFlags: Record<string, string> = {
+    timeout: ' ⚠️',
+    error: ' ❌',
+    full_page_disabled: ' ⏭️',
+  };
+
   for (const r of results) {
-    const flag = r.outcome === 'timeout' ? ' ⚠️' : r.outcome === 'error' ? ' ❌' : '';
+    const flag = outcomeFlags[r.outcome] ?? '';
     console.log(`| ${r.nodes} | ${r.actualNodes} | ${r.durationMs} | ${r.outcome}${flag} |`);
   }
   console.log(

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2075,14 +2075,10 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
   const STUB_PNG =
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 
-  // Mock the html-to-image CDN with a custom toPng implementation
+  // Mock toPng via the widget's __bugdropMockToPng test seam (addInitScript
+  // runs before the bundled IIFE, so the mock is in place when captureScreenshot fires)
   function mockHtmlToImage(page: Page, toPngBody: string) {
-    return page.route('**/html-to-image**', async route => {
-      await route.fulfill({
-        contentType: 'application/javascript',
-        body: `window.htmlToImage = { toPng: ${toPngBody} };`,
-      });
-    });
+    return page.addInitScript(`window.__bugdropMockToPng = ${toPngBody};`);
   }
 
   // Spy mock: records opts and returns a valid PNG
@@ -2103,33 +2099,42 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     });
   });
 
-  // Helper: navigate widget to screenshot options and click "Full Page"
-  async function navigateToFullPageCapture(page: Page) {
+  // Helper: open widget, click through welcome, fill title — returns the host locator
+  async function navigateToForm(page: Page, title = 'Screenshot test') {
     const host = page.locator('#bugdrop-host');
 
-    // Open widget
     const button = host.locator('css=.bd-trigger');
     await expect(button).toBeVisible({ timeout: 5000 });
     await button.click();
 
-    // Click through welcome screen
     const getStartedBtn = host.locator('css=[data-action="continue"]');
     await expect(getStartedBtn).toBeVisible({ timeout: 5000 });
     await getStartedBtn.click();
 
-    // Fill minimal form and check "Include screenshot"
     const titleInput = host.locator('css=#title');
     await expect(titleInput).toBeVisible({ timeout: 5000 });
-    await titleInput.fill('Screenshot test');
+    await titleInput.fill(title);
+
+    return host;
+  }
+
+  // Helper: navigate widget to screenshot options and return the host locator
+  async function navigateToScreenshotOptions(page: Page) {
+    const host = await navigateToForm(page);
 
     const screenshotCheckbox = host.locator('css=#include-screenshot');
     await screenshotCheckbox.check();
 
-    // Continue to screenshot options
     const continueBtn = host.locator('css=#submit-btn');
     await continueBtn.click();
 
-    // Click "Full Page"
+    await expect(host.locator('css=[data-action="element"]')).toBeVisible({ timeout: 5000 });
+    return host;
+  }
+
+  // Helper: navigate to screenshot options and click "Full Page"
+  async function navigateToFullPageCapture(page: Page) {
+    const host = await navigateToScreenshotOptions(page);
     const captureBtn = host.locator('css=[data-action="capture"]');
     await expect(captureBtn).toBeVisible({ timeout: 5000 });
     await captureBtn.click();
@@ -2256,5 +2261,118 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     // Second attempt succeeds — annotation canvas should appear
     const annotationCanvas = host.locator('css=#annotation-canvas');
     await expect(annotationCanvas).toBeVisible({ timeout: 10000 });
+  });
+
+  // --- Full-page disable threshold (10k+ nodes) ---
+
+  test('hides Full Page and Select Area buttons on very complex pages (>10k nodes)', async ({
+    page,
+  }) => {
+    await mockHtmlToImage(page, spyToPng());
+    await page.goto('/test/complex-dom.html?nodes=12000');
+
+    const nodeCount = await page.evaluate(() => document.body.querySelectorAll('*').length);
+    expect(nodeCount).toBeGreaterThanOrEqual(10000);
+
+    const host = await navigateToScreenshotOptions(page);
+
+    // Select Element should still be visible
+    await expect(host.locator('css=[data-action="element"]')).toBeVisible();
+
+    // Full Page and Select Area should be hidden
+    await expect(host.locator('css=[data-action="capture"]')).not.toBeAttached();
+    await expect(host.locator('css=[data-action="area"]')).not.toBeAttached();
+
+    // Complexity notice should be shown
+    const notice = host.locator('css=p >> text=too complex');
+    await expect(notice).toBeVisible();
+  });
+
+  test('shows all buttons on pages below 10k nodes', async ({ page }) => {
+    await mockHtmlToImage(page, spyToPng());
+    await page.goto('/test/complex-dom.html?nodes=4000');
+
+    const nodeCount = await page.evaluate(() => document.body.querySelectorAll('*').length);
+    expect(nodeCount).toBeLessThan(10000);
+
+    const host = await navigateToScreenshotOptions(page);
+
+    await expect(host.locator('css=[data-action="element"]')).toBeVisible();
+    await expect(host.locator('css=[data-action="capture"]')).toBeVisible();
+    await expect(host.locator('css=[data-action="area"]')).toBeVisible();
+
+    // Complexity notice should NOT be shown
+    await expect(host.locator('css=p >> text=too complex')).not.toBeAttached();
+  });
+
+  // --- Metadata: domNodeCount and fullPageDisabled in submission payload ---
+
+  // Helper: submit feedback without screenshot, capturing the POST body
+  async function submitAndCaptureMetadata(page: Page) {
+    let capturedMetadata: Record<string, unknown> | null = null;
+
+    await page.route('**/feedback', async route => {
+      const body = route.request().postDataJSON();
+      capturedMetadata = body.metadata;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, issueNumber: 1, issueUrl: '#', isPublic: false }),
+      });
+    });
+
+    const host = await navigateToForm(page, 'Metadata test');
+
+    // Uncheck screenshot and submit
+    const screenshotCheckbox = host.locator('css=#include-screenshot');
+    await screenshotCheckbox.uncheck();
+
+    const submitBtn = host.locator('css=#submit-btn');
+    await submitBtn.click();
+
+    // Wait for success modal (confirms submission completed)
+    const successModal = host.locator('css=.bd-success-icon');
+    await expect(successModal).toBeVisible({ timeout: 10000 });
+
+    return capturedMetadata!;
+  }
+
+  test('includes domNodeCount and fullPageDisabled=false in metadata on simple pages', async ({
+    page,
+  }) => {
+    await page.goto('/test/');
+
+    const metadata = await submitAndCaptureMetadata(page);
+
+    expect(metadata).toBeTruthy();
+    expect(typeof metadata.domNodeCount).toBe('number');
+    expect(metadata.domNodeCount).toBeGreaterThan(0);
+    expect(metadata.domNodeCount).toBeLessThan(10000);
+    expect(metadata.fullPageDisabled).toBe(false);
+  });
+
+  test('includes domNodeCount and fullPageDisabled=true in metadata on complex pages', async ({
+    page,
+  }) => {
+    await page.goto('/test/complex-dom.html?nodes=12000');
+
+    const metadata = await submitAndCaptureMetadata(page);
+
+    expect(metadata).toBeTruthy();
+    expect(typeof metadata.domNodeCount).toBe('number');
+    expect(metadata.domNodeCount).toBeGreaterThanOrEqual(10000);
+    expect(metadata.fullPageDisabled).toBe(true);
+  });
+
+  // --- Real capture (no mock) — verifies bundled html-to-image works ---
+
+  test('real bundled html-to-image captures a screenshot without mocks', async ({ page }) => {
+    await page.goto('/test/');
+
+    // No __bugdropMockToPng — real html-to-image runs here
+    await navigateToFullPageCapture(page);
+
+    const annotationCanvas = page.locator('#bugdrop-host').locator('css=#annotation-canvas');
+    await expect(annotationCanvas).toBeVisible({ timeout: 30000 });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "bugdrop",
       "version": "1.14.0",
       "dependencies": {
-        "hono": "^4.6.14"
+        "hono": "^4.6.14",
+        "html-to-image": "^1.11.13"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241127.0",
@@ -21,7 +22,6 @@
         "esbuild": "^0.24.0",
         "eslint": "^9.39.2",
         "globals": "^16.5.0",
-        "html-to-image": "^1.11.13",
         "husky": "^9.1.7",
         "jsdom": "^29.0.1",
         "knip": "^5.76.1",
@@ -6048,7 +6048,6 @@
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
       "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/http-proxy-agent": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "esbuild": "^0.24.0",
     "eslint": "^9.39.2",
     "globals": "^16.5.0",
-    "html-to-image": "^1.11.13",
     "husky": "^9.1.7",
     "jsdom": "^29.0.1",
     "knip": "^5.76.1",
@@ -67,6 +66,7 @@
     "wrangler": "^3.96.0"
   },
   "dependencies": {
-    "hono": "^4.6.14"
+    "hono": "^4.6.14",
+    "html-to-image": "^1.11.13"
   }
 }

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -1,4 +1,11 @@
-import { captureScreenshot, cropScreenshot, getPixelRatio } from './screenshot';
+import {
+  captureScreenshot,
+  cropScreenshot,
+  FULL_PAGE_DISABLE_THRESHOLD,
+  getDomNodeCount,
+  getPixelRatio,
+  isFullPageDisabled,
+} from './screenshot';
 import { createElementPicker } from './picker';
 import { createAreaPicker } from './area-picker';
 import { createAnnotator } from './annotator';
@@ -966,17 +973,24 @@ function showFeedbackFormWithScreenshotOption(
 function showScreenshotOptions(
   root: HTMLElement
 ): Promise<'skip' | 'capture' | 'element' | 'area'> {
+  const fullPageDisabled = isFullPageDisabled();
+
   return new Promise(resolve => {
+    const complexNote = fullPageDisabled
+      ? `<p style="margin: 0 0 12px; padding: 8px 12px; background: var(--bd-bg-secondary, #f5f5f5); border-radius: 6px; font-size: 13px; color: var(--bd-text-secondary);">This page is too complex for full-page or area capture. Select a specific element instead.</p>`
+      : '';
+
     const modal = createModal(
       root,
       'Capture Screenshot',
       `
         <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">Choose what to capture:</p>
+        ${complexNote}
         <div class="bd-actions" style="flex-wrap: wrap; gap: 8px;">
           <button class="bd-btn bd-btn-secondary" data-action="skip">Skip Screenshot</button>
           <button class="bd-btn bd-btn-secondary" data-action="element">Select Element</button>
-          <button class="bd-btn bd-btn-secondary" data-action="area">Select Area</button>
-          <button class="bd-btn bd-btn-primary" data-action="capture">Full Page</button>
+          ${fullPageDisabled ? '' : '<button class="bd-btn bd-btn-secondary" data-action="area">Select Area</button>'}
+          ${fullPageDisabled ? '' : '<button class="bd-btn bd-btn-primary" data-action="capture">Full Page</button>'}
         </div>
       `
     );
@@ -1111,6 +1125,7 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
 
     // Collect system info
     const systemInfo = getSystemInfo();
+    const domNodeCount = getDomNodeCount();
 
     const response = await fetch(`${config.apiUrl}/feedback`, {
       method: 'POST',
@@ -1131,6 +1146,8 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
           },
           timestamp: new Date().toISOString(),
           elementSelector: data.elementSelector,
+          domNodeCount,
+          fullPageDisabled: domNodeCount >= FULL_PAGE_DISABLE_THRESHOLD,
           // Parsed system info
           browser: systemInfo.browser,
           os: systemInfo.os,

--- a/src/widget/screenshot.ts
+++ b/src/widget/screenshot.ts
@@ -1,29 +1,19 @@
-// Load html-to-image dynamically to reduce initial bundle size
-const HTML_TO_IMAGE_CDN =
-  'https://cdn.jsdelivr.net/npm/html-to-image@1.11.13/dist/html-to-image.js';
-
-let htmlToImage: typeof import('html-to-image') | null = null;
-
-async function loadHtmlToImage() {
-  if (htmlToImage) return htmlToImage;
-
-  return new Promise<typeof import('html-to-image')>((resolve, reject) => {
-    const script = document.createElement('script');
-    script.src = HTML_TO_IMAGE_CDN;
-    script.onload = () => {
-      htmlToImage = (window as any).htmlToImage;
-      resolve(htmlToImage!);
-    };
-    script.onerror = () => reject(new Error('Failed to load html-to-image'));
-    document.head.appendChild(script);
-  });
-}
+import * as htmlToImage from 'html-to-image';
 
 const CAPTURE_TIMEOUT_MS = 15_000;
 const DOM_COMPLEXITY_THRESHOLD = 3_000;
+export const FULL_PAGE_DISABLE_THRESHOLD = 10_000;
+
+export function getDomNodeCount(): number {
+  return document.body.querySelectorAll('*').length;
+}
+
+export function isFullPageDisabled(): boolean {
+  return getDomNodeCount() >= FULL_PAGE_DISABLE_THRESHOLD;
+}
 
 export function getPixelRatio(isFullPage: boolean, screenshotScale?: number): number {
-  if (isFullPage && document.body.querySelectorAll('*').length > DOM_COMPLEXITY_THRESHOLD) {
+  if (isFullPage && getDomNodeCount() > DOM_COMPLEXITY_THRESHOLD) {
     return 1;
   }
   const minScale = screenshotScale ?? 2;
@@ -34,21 +24,22 @@ export async function captureScreenshot(
   element?: Element,
   screenshotScale?: number
 ): Promise<string> {
-  const lib = await loadHtmlToImage();
-
   const target = element || document.body;
   const isFullPage = !element;
 
   const pixelRatio = getPixelRatio(isFullPage, screenshotScale);
 
-  const capturePromise = lib.toPng(target as HTMLElement, {
+  const toPng =
+    (window as unknown as { __bugdropMockToPng?: typeof htmlToImage.toPng }).__bugdropMockToPng ??
+    htmlToImage.toPng;
+
+  const opts = {
     cacheBust: true,
     pixelRatio,
-    filter: (node: HTMLElement) => {
-      // Exclude our widget from screenshot
-      return node.id !== 'bugdrop-host';
-    },
-  });
+    filter: (node: HTMLElement) => node.id !== 'bugdrop-host',
+  };
+
+  const capturePromise = toPng(target as HTMLElement, opts);
 
   let timer: ReturnType<typeof setTimeout>;
   const timeoutPromise = new Promise<never>((_, reject) => {

--- a/test/cropScreenshot.test.ts
+++ b/test/cropScreenshot.test.ts
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getPixelRatio, cropScreenshot } from '../src/widget/screenshot';
+import {
+  getPixelRatio,
+  getDomNodeCount,
+  isFullPageDisabled,
+  FULL_PAGE_DISABLE_THRESHOLD,
+  cropScreenshot,
+} from '../src/widget/screenshot';
 
 describe('getPixelRatio', () => {
   let originalDPR: number;
@@ -67,6 +73,38 @@ describe('getPixelRatio', () => {
     );
 
     expect(getPixelRatio(false)).toBe(2); // max(0||1, 2) = 2
+  });
+});
+
+describe('getDomNodeCount', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns the number of child elements in document.body', () => {
+    const elements = new Array(500).fill(document.createElement('div'));
+    vi.spyOn(document.body, 'querySelectorAll').mockReturnValue(
+      elements as unknown as NodeListOf<Element>
+    );
+    expect(getDomNodeCount()).toBe(500);
+  });
+});
+
+describe('isFullPageDisabled', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns true when node count >= FULL_PAGE_DISABLE_THRESHOLD', () => {
+    const elements = new Array(FULL_PAGE_DISABLE_THRESHOLD).fill(document.createElement('div'));
+    vi.spyOn(document.body, 'querySelectorAll').mockReturnValue(
+      elements as unknown as NodeListOf<Element>
+    );
+    expect(isFullPageDisabled()).toBe(true);
+  });
+
+  it('returns false when node count < FULL_PAGE_DISABLE_THRESHOLD', () => {
+    const elements = new Array(FULL_PAGE_DISABLE_THRESHOLD - 1).fill(document.createElement('div'));
+    vi.spyOn(document.body, 'querySelectorAll').mockReturnValue(
+      elements as unknown as NodeListOf<Element>
+    );
+    expect(isFullPageDisabled()).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #101 — screenshot capture fails on complex DOM pages (11k+ nodes) due to main-thread blocking and CDN being blocked by Tracking Prevention.

- **Bundle html-to-image** via esbuild instead of CDN loading — eliminates Tracking Prevention blocking. Widget size ~50KB → ~67KB.
- **Hide Full Page and Select Area buttons** when DOM exceeds 10k nodes — area capture does a full-page render under the hood, so it hits the same freeze. Only "Select Element" remains. Adds `domNodeCount` and `fullPageDisabled` to issue metadata.
- **Rework E2E mocking** from CDN route interception (`page.route`) to `page.addInitScript` with a `window.__bugdropMockToPng` test seam.
- **Fix benchmark spec** to handle hidden Full Page button gracefully (`full_page_disabled` outcome).
- **Remove CI `paths-ignore`** that would block merge queue on benchmark-only PRs.

## Test plan

- [ ] 66 unit tests pass (including 3 new: `getDomNodeCount`, `isFullPageDisabled` boundary x2)
- [ ] 11 screenshot E2E tests pass (6 existing + 2 threshold + 2 metadata + 1 unmocked smoke)
- [ ] Unmocked smoke test verifies real bundled html-to-image captures a screenshot
- [ ] Full E2E suite (99 local tests) passes
- [ ] Widget builds at 66.5KB with html-to-image bundled
- [ ] TypeScript and ESLint clean (0 errors)