### PR TITLE
fix: pass release tag as VERSION to deploy builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
     if: github.event_name == 'merge_group'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -121,7 +123,7 @@ jobs:
         run: make install
 
       - name: Build all
-        run: make build-all
+        run: VERSION=$(git describe --tags --abbrev=0) make build-all
 
       - name: Deploy to preview
         uses: cloudflare/wrangler-action@v3
@@ -245,6 +247,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -255,7 +259,7 @@ jobs:
         run: make install
 
       - name: Build all
-        run: make build-all
+        run: VERSION=$(git describe --tags --abbrev=0) make build-all
 
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## Summary

- Deploy jobs were building widget.js with stale `package.json` version (`1.14.0`) because semantic-release doesn't bump `package.json` (no `@semantic-release/npm` plugin — branch protection blocks direct pushes).
- Every deploy since the widget was created has served `v1.14.0` in the modal footer, regardless of the actual release version.
- Fix: `fetch-depth: 0` + `VERSION=$(git describe --tags --abbrev=0)` passes the latest git tag to the build script, which already checks `process.env.VERSION` before `package.json`.
- Applied to both `deploy-preview` and `deploy` jobs.

## Test plan

- [ ] CI passes (only `.github/workflows/ci.yml` changed)
- [ ] After merge, verify `https://bugdrop.neonwatty.workers.dev/widget.v1.js` contains the new version number
- [ ] Open BugDrop widget on deckchecker — modal footer should show current version, not v1.14.0