### PR TITLE
ci: split deploy jobs into deploy.yml, drop duplicate push-to-main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main, develop]
   pull_request:
     types: [opened, synchronize, reopened]
   merge_group:
@@ -107,7 +105,7 @@ jobs:
   deploy-preview:
     name: Deploy Preview
     runs-on: ubuntu-latest
-    needs: [check]
+    needs: check
     if: github.event_name == 'merge_group'
     steps:
       - uses: actions/checkout@v4
@@ -210,59 +208,3 @@ jobs:
           name: playwright-live-report
           path: playwright-report/
           retention-days: 7
-
-  # Automated release via semantic-release (only on push to main)
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: [test, e2e]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: make install
-
-      - name: Run semantic-release
-        run: npx semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Deploy to Cloudflare Workers (runs after release on push to main)
-  deploy:
-    name: Deploy to Cloudflare
-    runs-on: ubuntu-latest
-    needs: [release]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: make install
-
-      - name: Build all
-        run: VERSION=$(git describe --tags --abbrev=0) make build-all
-
-      - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy
+
+# Fires only on actual pushes to main. Merge-queue rulesets gate which commits
+# reach main, so the SHA here has already passed ci.yml in the merge_group
+# context — no need to re-run tests.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  # Automated release via semantic-release
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Run semantic-release
+        run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Deploy to Cloudflare Workers (runs after release so the new tag is visible)
+  deploy:
+    name: Deploy to Cloudflare
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # needed for `git describe` to see the release tag
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Build all
+        run: VERSION=$(git describe --tags --abbrev=0) make build-all
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Closes #109

## Summary

- **Removed** the `push: [main, develop]` trigger and the `release` + `deploy` jobs from `.github/workflows/ci.yml`. `ci.yml` now runs only on `pull_request` and `merge_group`.
- **Added** `.github/workflows/deploy.yml` — triggered on `push: branches: [main]`, containing the `release` (semantic-release) and `deploy` (Cloudflare Workers) jobs, connected by `needs: [release]`.
- **Nit**: normalized `needs: [check]` → `needs: check` on `deploy-preview` for consistency with the rest of the file.

## Why

Every merged PR was running the full test suite **three times**: once on the feature branch (`pull_request`), once in the merge queue (`merge_group`), and once on the post-merge main (`push: main`) — re-validating the exact SHA the queue had just validated. The merge queue's entire guarantee is *the SHA we tested is the SHA that lands on main*, so the third run proved nothing.

Expected savings: **~25 runner-minutes per merged PR** (per the measurements in mean-weasel/bleep-that-shit#594, the reference fix cited in the issue).

## Correctness notes

- **Tag visibility for `git describe`**: `deploy` chains after `release` via `needs: [release]` in the *same* workflow, so semantic-release's newly-pushed tag is visible to `git describe --tags --abbrev=0` in the deploy build step. This preserves the VERSION-injection fix from #107.
- **No `GITHUB_TOKEN` event-chain trap**: `release` and `deploy` stay in the same workflow — we don't rely on a `release: published` event to kick off deploy, which would never fire (project memory documents that `GITHUB_TOKEN`-generated events don't trigger new workflow runs).
- **No orphaned required status checks**: the merge-queue ruleset (id 11303548) requires Lint/Typecheck/Knip/Audit, Unit Tests & Build, E2E Shard 1/2, E2E Shard 2/2, Deploy Preview, Live Preview Tests. None of those are the moved `Release` or `Deploy to Cloudflare` jobs, so merge-queue gating is unaffected.
- **`develop` branch**: doesn't exist in this repo, so dropping `[main, develop]` is equivalent to dropping `main` alone.

## Test plan

- [ ] CI runs on this PR (pull_request event): lint / unit / E2E x2 complete; `deploy-preview` and `live-preview-tests` are skipped (they're `merge_group`-only).
- [ ] Add to merge queue: `deploy-preview` and `live-preview-tests` run; `Release` and `Deploy to Cloudflare` do **not** appear on this run (moved out of ci.yml).
- [ ] After merge: `Deploy` workflow fires on `push: main`, `release` job publishes a new tag (conventional-commit type is `ci:` → no release), `deploy` job builds with whatever `git describe --tags --abbrev=0` returns and deploys to Cloudflare Workers.
- [ ] Compare wall-clock for the post-merge phase against current baseline to validate the savings estimate.

## Out of scope (intentionally)

Silent-failure review flagged that the new `release` job has no pre-release test gate (no `needs: [test, e2e]`). This is deliberate — re-adding it would re-introduce the exact duplication this PR is eliminating. The merge-queue ruleset is the gate. If defense-in-depth against queue bypass is desired, the right layer is ruleset config (prevent admin bypass), not the workflow.

Silent-failure review also flagged that `deploy` runs even when semantic-release produces no new tag (e.g. pure `chore:`/`ci:` pushes), causing a redundant redeploy with the previous tag. This is pre-existing behavior from before this PR and can be addressed separately by gating `deploy` on `needs.release.outputs.new_release_published`.