### PR TITLE
fix: set root text color and center success Done button

### DIFF
--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -110,6 +110,7 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
 
     .bd-root {
       font-family: var(--bd-font);
+      color: var(--bd-text-primary);
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
     }
@@ -1037,7 +1038,7 @@ export function showSuccessModal(
           </div>
           ${issueInfo}
         </div>
-        <div class="bd-actions">
+        <div class="bd-actions" style="justify-content: center;">
           <button class="bd-btn bd-btn-primary" data-action="done">Done</button>
         </div>
         <div class="bd-powered-by">


### PR DESCRIPTION
## Summary

- **Category label text invisible on light-themed hosts**: `.bd-root` defined `--bd-text-primary` but never set `color` on itself, so text inherited from the host page via shadow DOM. On light-themed apps like Seatify, this made the Bug/Feature/Question labels nearly invisible.
- **Done button right-aligned on success screen**: The `.bd-actions` container uses `justify-content: flex-end` (correct for Cancel/Continue), but on the success modal the Done button appears alone and should be centered.

## Changes

`src/widget/ui.ts`:
- Add `color: var(--bd-text-primary)` to `.bd-root` (line 113)
- Add inline `justify-content: center` override on success modal's `.bd-actions` div (line 1041)

## Test plan

- [ ] Open widget on a light-themed host app — Bug/Feature/Question labels should be dark readable text
- [ ] Open widget on a dark-themed host app — labels should be light readable text
- [ ] Submit feedback — Done button should be centered on the success screen
- [ ] Cancel/Continue buttons on the main form should still be right-aligned