### PR TITLE
docs: add GitHub Marketplace links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Version](https://img.shields.io/badge/version-1.11.0-14b8a6)](./CHANGELOG.md)
 [![Security Policy](https://img.shields.io/badge/Security-Policy-blue)](./SECURITY.md)
 [![Live Demo](https://img.shields.io/badge/Demo-Try_It_Live-ff9e64)](https://bugdrop-widget-test.vercel.app)
+[![GitHub Marketplace](https://img.shields.io/badge/GitHub%20Marketplace-Install-2ea44f?logo=github)](https://github.com/marketplace/bugdrop-in-app-feedback-to-github-issues)
 
 In-app feedback → GitHub Issues. Screenshots, annotations, the works.
 
@@ -15,7 +16,7 @@ In-app feedback → GitHub Issues. Screenshots, annotations, the works.
 
 **1. Install the GitHub App** on your repository:
 
-https://github.com/apps/neonwatty-bugdrop/installations/new
+https://github.com/marketplace/bugdrop-in-app-feedback-to-github-issues
 
 **2. Add the script** to your website:
 
@@ -47,6 +48,7 @@ See [full documentation](https://bugdrop.dev/docs/configuration) for all options
 ## Documentation
 
 - [Full Documentation](https://bugdrop.dev/docs)
+- [GitHub Marketplace](https://github.com/marketplace/bugdrop-in-app-feedback-to-github-issues)
 - [Configuration](https://bugdrop.dev/docs/configuration)
 - [Styling](https://bugdrop.dev/docs/styling)
 - [JavaScript API](https://bugdrop.dev/docs/javascript-api)

--- a/docs/website/installation.mdx
+++ b/docs/website/installation.mdx
@@ -6,7 +6,7 @@ Getting BugDrop running on your site takes about 30 seconds. There are only two 
 
 BugDrop needs access to your GitHub repository to create issues and store screenshots. Install the official GitHub App to grant these permissions.
 
-**[Install BugDrop GitHub App](https://github.com/apps/neonwatty-bugdrop/installations/new)**
+**[Install BugDrop from GitHub Marketplace](https://github.com/marketplace/bugdrop-in-app-feedback-to-github-issues)**
 
 During installation you will be asked which repositories to grant access to. You can choose specific repositories or grant access to all repositories in your account or organization.
 


### PR DESCRIPTION
## Summary
- add a GitHub Marketplace badge to the README
- point Quick Start and install docs at the Marketplace listing
- add Marketplace to the README documentation links

## Verification
- npm run format:check -- README.md docs/website/installation.mdx
- pre-push hook: npm run typecheck