### PR TITLE
Add configurable screenshot modes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,7 @@ node_modules/
 playwright-report/
 test-results/
 coverage/
+.playwright-cli/
 
 # Lock files
 package-lock.json

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -136,6 +136,37 @@ Every feedback submission automatically captures the following system informatio
 
 This information is included in every GitHub Issue body under a "System Info" section, giving your team the context they need to reproduce and fix bugs.
 
+## Screenshot Behavior
+
+Control how screenshots are collected during the feedback flow.
+
+| Attribute | Default | Description |
+|-----------|---------|-------------|
+| `data-screenshot` | `"optional"` | Screenshot mode: `"optional"`, `"auto"`, or `"required"` |
+| `data-screenshot-scale` | `"2"` | Minimum pixel ratio for screenshot captures |
+
+### Screenshot Modes
+
+- **`optional`** -- Shows the screenshot checkbox checked by default. Users can choose full page, element, area, annotate, or skip.
+- **`auto`** -- Automatically captures a full-page screenshot after the form is submitted, without showing the manual screenshot picker.
+- **`required`** -- Requires a screenshot before submission. Users can choose full page, element, or area, but cannot skip the screenshot step.
+
+```html
+<!-- Automatically attach a full-page screenshot -->
+<script
+  src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="owner/repo"
+  data-screenshot="auto"
+></script>
+
+<!-- Require a screenshot before submitting feedback -->
+<script
+  src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="owner/repo"
+  data-screenshot="required"
+></script>
+```
+
 ## Custom Icon and Label
 
 ### Custom Icon

--- a/docs/website/getting-started.mdx
+++ b/docs/website/getting-started.mdx
@@ -35,7 +35,7 @@ That is it. No servers to run, no databases to manage, no user accounts required
 ## Key Features
 
 - **One-line installation** -- Add a single script tag and BugDrop is live on your site
-- **Automatic screenshots** -- Users can attach screenshots captured client-side with html2canvas
+- **Configurable screenshots** -- Screenshots can be optional, automatic, or required
 - **System info capture** -- Browser, OS, viewport, language, and URL are automatically included
 - **GitHub-native** -- Issues land directly in your repository with proper labels and formatting
 - **Shadow DOM isolation** -- The widget never conflicts with your site's CSS

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2376,3 +2376,102 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     await expect(annotationCanvas).toBeVisible({ timeout: 30000 });
   });
 });
+
+test.describe('Screenshot Mode Configuration', () => {
+  const STUB_PNG =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+  async function setupInstalledApp(page: Page) {
+    await page.route('**/api/check/**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+  }
+
+  async function setupSuccessfulSubmit(page: Page) {
+    let payload: Record<string, unknown> | null = null;
+    await page.route('**/feedback', async route => {
+      payload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, issueNumber: 1, issueUrl: '#', isPublic: false }),
+      });
+    });
+    return () => payload;
+  }
+
+  async function mockSuccessfulCapture(page: Page) {
+    await page.addInitScript(`window.__bugdropMockToPng = function() {
+      window.__autoCaptureCount = (window.__autoCaptureCount || 0) + 1;
+      return Promise.resolve('${STUB_PNG}');
+    };`);
+  }
+
+  async function openForm(page: Page) {
+    const host = page.locator('#bugdrop-host');
+    await expect(host.locator('css=.bd-trigger')).toBeVisible({ timeout: 5000 });
+    await host.locator('css=.bd-trigger').click();
+
+    const getStartedBtn = host.locator('css=[data-action="continue"]');
+    await expect(getStartedBtn).toBeVisible({ timeout: 5000 });
+    await getStartedBtn.click();
+
+    const titleInput = host.locator('css=#title');
+    await expect(titleInput).toBeVisible({ timeout: 5000 });
+    await titleInput.fill('Screenshot mode test');
+    return host;
+  }
+
+  test('auto mode captures and submits a screenshot without the manual screenshot step', async ({
+    page,
+  }) => {
+    await setupInstalledApp(page);
+    await mockSuccessfulCapture(page);
+    const getPayload = await setupSuccessfulSubmit(page);
+
+    await page.goto('/test/?screenshot=auto');
+    const host = await openForm(page);
+
+    await expect(host.locator('css=#include-screenshot')).not.toBeAttached();
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+    await expect(host.locator('css=[data-action="capture"]')).not.toBeAttached();
+    await expect(host.locator('css=#annotation-canvas')).not.toBeAttached();
+
+    const payload = getPayload();
+    expect(payload?.screenshot).toBe(STUB_PNG);
+    expect(
+      await page.evaluate(
+        () => (window as Window & { __autoCaptureCount?: number }).__autoCaptureCount
+      )
+    ).toBe(1);
+  });
+
+  test('required mode removes the opt-out path and requires a capture before submit', async ({
+    page,
+  }) => {
+    await setupInstalledApp(page);
+    await mockSuccessfulCapture(page);
+    const getPayload = await setupSuccessfulSubmit(page);
+
+    await page.goto('/test/?screenshot=required');
+    const host = await openForm(page);
+
+    await expect(host.locator('css=#include-screenshot')).not.toBeAttached();
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=[data-action="skip"]')).not.toBeAttached();
+    await host.locator('css=[data-action="capture"]').click();
+
+    await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+    await host.locator('css=[data-action="done"]').click();
+
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+    expect(getPayload()?.screenshot).toEqual(expect.stringMatching(/^data:image\/png;base64,/));
+  });
+});

--- a/public/test/index.html
+++ b/public/test/index.html
@@ -604,7 +604,7 @@
         var script = document.getElementById('bugdrop-script');
         if (!script) return;
         var params = new URLSearchParams(location.search);
-        var mapping = { theme: 'data-theme', bg: 'data-bg' };
+        var mapping = { theme: 'data-theme', bg: 'data-bg', screenshot: 'data-screenshot' };
         Object.keys(mapping).forEach(function (key) {
           var v = params.get(key);
           if (v != null) script.setAttribute(mapping[key], v);

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -53,6 +53,7 @@ interface WidgetConfig {
   // Welcome screen behavior
   welcome: 'once' | 'always' | 'never';
   // Screenshot configuration
+  screenshotMode: 'optional' | 'auto' | 'required';
   screenshotScale?: number; // Minimum pixel ratio for captures (default: 2)
 }
 
@@ -272,6 +273,16 @@ const config: WidgetConfig = {
     return 'once' as const;
   })(),
   // Screenshot configuration
+  screenshotMode: (() => {
+    const val = script?.dataset.screenshot;
+    if (val === 'auto' || val === 'required') return val;
+    if (val && val !== 'optional') {
+      console.warn(
+        `[BugDrop] Invalid data-screenshot "${val}". Expected "optional", "auto", or "required".`
+      );
+    }
+    return 'optional' as const;
+  })(),
   screenshotScale: script?.dataset.screenshotScale
     ? parseFloat(script.dataset.screenshotScale)
     : undefined,
@@ -642,13 +653,26 @@ async function openFeedbackFlow(
   let screenshot: string | null = null;
   let elementSelector: string | null = null;
 
-  // Step 3: Screenshot flow (if user opted in)
-  if (formResult.includeScreenshot) {
+  // Step 3: Screenshot flow (if configured/user opted in)
+  if (config.screenshotMode === 'auto') {
+    screenshot = await captureWithLoading(root, undefined, config.screenshotScale);
+  } else if (formResult.includeScreenshot) {
+    const screenshotRequired = config.screenshotMode === 'required';
     while (true) {
       screenshot = null;
       elementSelector = null;
 
-      const screenshotChoice = await showScreenshotOptions(root);
+      const screenshotChoice = await showScreenshotOptions(root, {
+        allowSkip: !screenshotRequired,
+      });
+      if (screenshotChoice === 'cancel') {
+        _isModalOpen = false;
+        return;
+      }
+      if (screenshotChoice === 'skip') {
+        break;
+      }
+
       const pickerStyle = {
         accentColor: config.accentColor,
         font: config.font,
@@ -661,18 +685,24 @@ async function openFeedbackFlow(
       };
 
       if (screenshotChoice === 'capture') {
-        screenshot = await captureWithLoading(root, undefined, config.screenshotScale);
+        screenshot = await captureWithLoading(root, undefined, config.screenshotScale, {
+          allowSkip: !screenshotRequired,
+        });
       } else if (screenshotChoice === 'element') {
         const element = await createElementPicker(pickerStyle);
         if (element) {
-          screenshot = await captureWithLoading(root, element, config.screenshotScale);
+          screenshot = await captureWithLoading(root, element, config.screenshotScale, {
+            allowSkip: !screenshotRequired,
+          });
           elementSelector = getElementSelector(element);
         }
       } else if (screenshotChoice === 'area') {
         const rect = await createAreaPicker(pickerStyle);
         if (rect) {
           const pixelRatio = getPixelRatio(true, config.screenshotScale);
-          const fullPage = await captureWithLoading(root, undefined, config.screenshotScale);
+          const fullPage = await captureWithLoading(root, undefined, config.screenshotScale, {
+            allowSkip: !screenshotRequired,
+          });
           if (fullPage) {
             screenshot = await cropScreenshot(fullPage, rect, pixelRatio);
           }
@@ -685,6 +715,7 @@ async function openFeedbackFlow(
         if (result === 'retake') continue;
         screenshot = result;
       }
+      if (screenshotRequired && !screenshot) continue;
       break;
     }
   }
@@ -707,7 +738,8 @@ async function openFeedbackFlow(
 async function captureWithLoading(
   root: HTMLElement,
   element?: Element,
-  screenshotScale?: number
+  screenshotScale?: number,
+  opts?: { allowSkip?: boolean }
 ): Promise<string | null> {
   // Show a temporary loading indicator
   const loadingModal = createModal(
@@ -727,6 +759,7 @@ async function captureWithLoading(
     return screenshot;
   } catch (_error) {
     loadingModal.remove();
+    const allowSkip = opts?.allowSkip !== false;
 
     // Show error with retry option
     return new Promise(resolve => {
@@ -741,7 +774,7 @@ async function captureWithLoading(
             <span class="bd-error-message__text">Failed to capture screenshot. The page may be too complex or browser restrictions may apply.</span>
           </div>
           <div class="bd-actions">
-            <button class="bd-btn bd-btn-secondary" data-action="skip">Skip Screenshot</button>
+            <button class="bd-btn bd-btn-secondary" data-action="skip">${allowSkip ? 'Skip Screenshot' : 'Choose Another Method'}</button>
             <button class="bd-btn bd-btn-primary" data-action="retry">Try Again</button>
           </div>
         `,
@@ -764,7 +797,7 @@ async function captureWithLoading(
 
       retryBtn?.addEventListener('click', async () => {
         errorModal.remove();
-        const result = await captureWithLoading(root, element, screenshotScale);
+        const result = await captureWithLoading(root, element, screenshotScale, opts);
         resolve(result);
       });
     });
@@ -933,15 +966,10 @@ function showFeedbackFormWithScreenshotOption(
             <label class="bd-label" for="description">Description</label>
             <textarea id="description" class="bd-textarea" placeholder="Provide additional details, steps to reproduce, or context..."></textarea>
           </div>
-          <div class="bd-form-group" style="display: flex; align-items: center; gap: 10px; margin-top: 8px;">
-            <input type="checkbox" id="include-screenshot" checked style="width: 18px; height: 18px; accent-color: var(--bd-primary); cursor: pointer;" />
-            <label for="include-screenshot" style="font-size: 0.95rem; color: var(--bd-text-secondary); cursor: pointer; user-select: none;">
-              📸 Include a screenshot
-            </label>
-          </div>
+          ${getScreenshotFormControl(config)}
           <div class="bd-actions">
             <button type="button" class="bd-btn bd-btn-secondary" data-action="cancel">Cancel</button>
-            <button type="submit" class="bd-btn bd-btn-primary" id="submit-btn">Continue</button>
+            <button type="submit" class="bd-btn bd-btn-primary" id="submit-btn">${config.screenshotMode === 'auto' ? 'Submit' : 'Continue'}</button>
           </div>
         </form>
       `
@@ -952,7 +980,9 @@ function showFeedbackFormWithScreenshotOption(
     const emailInput = modal.querySelector('#email') as HTMLInputElement | null;
     const titleInput = modal.querySelector('#title') as HTMLInputElement;
     const descInput = modal.querySelector('#description') as HTMLTextAreaElement;
-    const screenshotCheckbox = modal.querySelector('#include-screenshot') as HTMLInputElement;
+    const screenshotCheckbox = modal.querySelector(
+      '#include-screenshot'
+    ) as HTMLInputElement | null;
     const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
     const cancelBtn = modal.querySelector('[data-action="cancel"]') as HTMLElement;
 
@@ -1001,7 +1031,8 @@ function showFeedbackFormWithScreenshotOption(
         category,
         name: nameInput?.value.trim() || undefined,
         email: emailInput?.value.trim() || undefined,
-        includeScreenshot: screenshotCheckbox.checked,
+        includeScreenshot:
+          config.screenshotMode === 'optional' ? (screenshotCheckbox?.checked ?? false) : true,
       });
     });
 
@@ -1012,10 +1043,39 @@ function showFeedbackFormWithScreenshotOption(
   });
 }
 
+function getScreenshotFormControl(config: WidgetConfig): string {
+  if (config.screenshotMode === 'auto') {
+    return `
+      <p style="margin: 8px 0 0; color: var(--bd-text-secondary); font-size: 0.95rem;">
+        📸 A screenshot will be attached automatically.
+      </p>
+    `;
+  }
+
+  if (config.screenshotMode === 'required') {
+    return `
+      <p style="margin: 8px 0 0; color: var(--bd-text-secondary); font-size: 0.95rem;">
+        📸 A screenshot is required before submitting.
+      </p>
+    `;
+  }
+
+  return `
+    <div class="bd-form-group" style="display: flex; align-items: center; gap: 10px; margin-top: 8px;">
+      <input type="checkbox" id="include-screenshot" checked style="width: 18px; height: 18px; accent-color: var(--bd-primary); cursor: pointer;" />
+      <label for="include-screenshot" style="font-size: 0.95rem; color: var(--bd-text-secondary); cursor: pointer; user-select: none;">
+        📸 Include a screenshot
+      </label>
+    </div>
+  `;
+}
+
 function showScreenshotOptions(
-  root: HTMLElement
-): Promise<'skip' | 'capture' | 'element' | 'area'> {
+  root: HTMLElement,
+  opts?: { allowSkip?: boolean }
+): Promise<'skip' | 'capture' | 'element' | 'area' | 'cancel'> {
   const fullPageDisabled = isFullPageDisabled();
+  const allowSkip = opts?.allowSkip !== false;
 
   return new Promise(resolve => {
     const complexNote = fullPageDisabled
@@ -1029,7 +1089,7 @@ function showScreenshotOptions(
         <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">Choose what to capture:</p>
         ${complexNote}
         <div class="bd-actions" style="flex-wrap: wrap; gap: 8px;">
-          <button class="bd-btn bd-btn-secondary" data-action="skip">Skip Screenshot</button>
+          ${allowSkip ? '<button class="bd-btn bd-btn-secondary" data-action="skip">Skip Screenshot</button>' : ''}
           <button class="bd-btn bd-btn-secondary" data-action="element">Select Element</button>
           ${fullPageDisabled ? '' : '<button class="bd-btn bd-btn-secondary" data-action="area">Select Area</button>'}
           ${fullPageDisabled ? '' : '<button class="bd-btn bd-btn-primary" data-action="capture">Full Page</button>'}
@@ -1038,14 +1098,14 @@ function showScreenshotOptions(
     );
 
     const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
-    const skipBtn = modal.querySelector('[data-action="skip"]') as HTMLElement;
+    const skipBtn = modal.querySelector('[data-action="skip"]') as HTMLElement | null;
     const elementBtn = modal.querySelector('[data-action="element"]') as HTMLElement;
     const areaBtn = modal.querySelector('[data-action="area"]') as HTMLElement;
     const captureBtn = modal.querySelector('[data-action="capture"]') as HTMLElement;
 
     closeBtn?.addEventListener('click', () => {
       modal.remove();
-      resolve('skip');
+      resolve(allowSkip ? 'skip' : 'cancel');
     });
 
     skipBtn?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary

- add `data-screenshot="optional|auto|required"` support to the widget
- keep current optional screenshot flow as the default
- add auto full-page screenshot submission and required screenshot modes
- document screenshot modes and add E2E coverage

Closes #123.

## Testing

- `LIVE_TARGET=1 PLAYWRIGHT_BASE_URL=http://localhost:8790 npx playwright test e2e/widget.spec.ts --grep "Screenshot Crash Prevention|Screenshot Mode Configuration|screenshot checkbox is checked by default" --workers=1`
- `npm run validate`

Note: lint reports existing warnings, but no errors.