### PR TITLE
Surface live BugDrop demo

### DIFF
--- a/docs/website/demo.mdx
+++ b/docs/website/demo.mdx
@@ -1,0 +1,11 @@
+# Live Demo
+
+Try the existing [BugDrop live widget demo](https://bugdrop-widget-test.vercel.app/) to see the hosted widget in action.
+
+Open the demo site and click the bug button in the bottom-right corner. The demo shows the same feedback flow documented here, including the form, optional screenshot capture, and GitHub Issue submission path.
+
+## Next Steps
+
+- [Install BugDrop](/docs/installation) on your own site
+- [Configure the widget](/docs/configuration) with data attributes
+- [Style the widget](/docs/styling) to match your brand

--- a/docs/website/faq.mdx
+++ b/docs/website/faq.mdx
@@ -24,6 +24,10 @@ Yes. BugDrop is completely free and open source under the [MIT License](https://
 
 Yes. The MIT License permits commercial use, modification, distribution, and private use. You can use BugDrop on commercial websites, SaaS products, and internal tools without paying any fees or attributing the project (though attribution is appreciated).
 
+### Can I try BugDrop before installing it?
+
+Yes. Use the existing [live widget demo](https://bugdrop-widget-test.vercel.app/) and click the bug button in the bottom-right corner. The demo uses the hosted BugDrop widget so you can see the feedback form, screenshot option, and submission flow before adding the script tag to your own site.
+
 ### Does BugDrop work with React, Next.js, Vue, and other frameworks?
 
 Yes. BugDrop is a plain JavaScript widget loaded via a `<script>` tag, so it is completely framework-agnostic. It works with:

--- a/docs/website/getting-started.mdx
+++ b/docs/website/getting-started.mdx
@@ -2,6 +2,10 @@
 
 BugDrop is a lightweight, open-source bug reporting widget that lets your users submit bugs, feature requests, and questions directly from your website — straight into GitHub Issues. No backend to manage, no dashboard to maintain, and no third-party accounts for your users to create. Just a single script tag and you're up and running.
 
+## Try the Live Demo
+
+Want to see the widget before installing it? Open the existing [live BugDrop demo](https://bugdrop-widget-test.vercel.app/) and click the bug button in the bottom-right corner. It is the same hosted widget flow documented here, running on a demo site.
+
 ## How It Works
 
 BugDrop operates in three simple steps, creating a seamless bridge between your users and your GitHub repository:
@@ -49,6 +53,7 @@ That is it. No servers to run, no databases to manage, no user accounts required
 
 Ready to get started? Here is where to go next:
 
+- **[Live demo](https://bugdrop-widget-test.vercel.app/)** -- Try the existing BugDrop widget demo before installing
 - **[Installation](/docs/installation)** -- Step-by-step setup guide to add BugDrop to your site
 - **[Configuration](/docs/configuration)** -- All widget attributes for customizing behavior
 - **[Styling](/docs/styling)** -- Theme your widget with colors, fonts, borders, and shadows

--- a/docs/website/installation.mdx
+++ b/docs/website/installation.mdx
@@ -2,6 +2,8 @@
 
 Getting BugDrop running on your site takes about 30 seconds. There are only two steps: install the GitHub App and add a script tag. No npm packages, no build configuration, no backend setup required.
 
+Before installing, you can try the existing [live widget demo](https://bugdrop-widget-test.vercel.app/) and click the bug button in the bottom-right corner.
+
 ## Step 1: Install the GitHub App
 
 BugDrop needs access to your GitHub repository to create issues and store screenshots. Install the official GitHub App to grant these permissions.
@@ -157,6 +159,7 @@ You can also test by clicking the bug button and submitting a test report. Check
 
 ## Next Steps
 
+- [Try the live demo](https://bugdrop-widget-test.vercel.app/) to see the widget flow end to end
 - [Configure the widget](/docs/configuration) with custom attributes
 - [Style the widget](/docs/styling) to match your site's design
 - [Use the JavaScript API](/docs/javascript-api) for advanced integrations

--- a/public/demo.html
+++ b/public/demo.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0;url=https://bugdrop-widget-test.vercel.app/">
+  <title>BugDrop Live Demo</title>
+</head>
+<body>
+  <p>Redirecting to the <a href="https://bugdrop-widget-test.vercel.app/">BugDrop live demo</a>...</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- add a dedicated docs demo page that points to the existing live demo
- link the live demo from getting started, installation, and FAQ docs
- add a static `/demo.html` redirect page for direct discovery

Closes #124.

## Testing

- `npx prettier --check docs/website/getting-started.mdx docs/website/installation.mdx docs/website/faq.mdx docs/website/demo.mdx public/demo.html`
- `git diff --check -- docs/website/getting-started.mdx docs/website/installation.mdx docs/website/faq.mdx`
- `curl -I -L --max-time 15 https://bugdrop-widget-test.vercel.app/`
- pre-push `npm run typecheck`