### PR TITLE
fix: improve screenshot option hierarchy

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -453,6 +453,54 @@ test.describe('Widget Interaction', () => {
     await expect(overlay).not.toBeVisible({ timeout: 3000 });
   });
 
+  test('screenshot options prioritize capture actions before skip', async ({ page }) => {
+    await page.route('**/api/check/**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/test/');
+
+    const host = page.locator('#bugdrop-host');
+    const button = host.locator('css=.bd-trigger');
+    await expect(button).toBeVisible({ timeout: 5000 });
+    await button.click();
+
+    const getStartedBtn = host.locator('css=[data-action="continue"]');
+    await expect(getStartedBtn).toBeVisible({ timeout: 5000 });
+    await getStartedBtn.click();
+
+    const titleInput = host.locator('css=#title');
+    await expect(titleInput).toBeVisible({ timeout: 5000 });
+    await titleInput.fill('Test screenshot hierarchy');
+
+    const screenshotCheckbox = host.locator('css=#include-screenshot');
+    await screenshotCheckbox.check();
+
+    const submitBtn = host.locator('css=#submit-btn');
+    await submitBtn.click();
+
+    const actions = host.locator('css=.bd-screenshot-actions [data-action]');
+    await expect(actions).toHaveCount(4);
+
+    const actionOrder = await actions.evaluateAll(buttons =>
+      buttons.map(button => (button as HTMLElement).dataset.action)
+    );
+    expect(actionOrder).toEqual(['capture', 'area', 'element', 'skip']);
+
+    await expect(host.locator('css=[data-action="capture"]')).toHaveClass(/bd-btn-primary/);
+    await expect(host.locator('css=[data-action="skip"]')).toHaveClass(/bd-btn-quiet/);
+
+    const verticalPositions = await actions.evaluateAll(buttons =>
+      buttons.map(button => Math.round((button as HTMLElement).getBoundingClientRect().top))
+    );
+    expect(verticalPositions).toEqual([...verticalPositions].sort((a, b) => a - b));
+  });
+
   test('retake button on annotation step returns to screenshot options', async ({ page }) => {
     await page.route('**/api/check/**', async route => {
       await route.fulfill({

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -1138,11 +1138,11 @@ function showScreenshotOptions(
       `
         <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">Choose what to capture:</p>
         ${complexNote}
-        <div class="bd-actions" style="flex-wrap: wrap; gap: 8px;">
-          ${allowSkip ? '<button class="bd-btn bd-btn-secondary" data-action="skip">Skip Screenshot</button>' : ''}
-          <button class="bd-btn bd-btn-secondary" data-action="element">Select Element</button>
-          ${fullPageDisabled ? '' : '<button class="bd-btn bd-btn-secondary" data-action="area">Select Area</button>'}
+        <div class="bd-actions bd-screenshot-actions">
           ${fullPageDisabled ? '' : '<button class="bd-btn bd-btn-primary" data-action="capture">Full Page</button>'}
+          ${fullPageDisabled ? '' : '<button class="bd-btn bd-btn-secondary" data-action="area">Select Area</button>'}
+          <button class="bd-btn bd-btn-secondary" data-action="element">Select Element</button>
+          ${allowSkip ? '<button class="bd-btn bd-btn-quiet" data-action="skip">Skip Screenshot</button>' : ''}
         </div>
       `
     );

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -462,6 +462,19 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       background: var(--bd-bg-secondary);
     }
 
+    .bd-btn-quiet {
+      background: transparent;
+      border: none;
+      color: var(--bd-text-secondary);
+      padding-left: 12px;
+      padding-right: 12px;
+    }
+
+    .bd-btn-quiet:hover {
+      background: var(--bd-bg-secondary);
+      color: var(--bd-text-primary);
+    }
+
     .bd-btn:disabled {
       opacity: 0.6;
       cursor: not-allowed;
@@ -668,6 +681,11 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       gap: 12px;
       justify-content: flex-end;
       margin-top: 20px;
+    }
+
+    .bd-screenshot-actions {
+      flex-wrap: wrap;
+      gap: 8px;
     }
 
     /* Tools Toolbar */
@@ -880,6 +898,10 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
 
       .bd-actions .bd-btn {
         width: 100%;
+      }
+
+      .bd-screenshot-actions {
+        flex-direction: column;
       }
 
       .bd-tools {


### PR DESCRIPTION
## Summary
- move screenshot capture actions before the skip action
- make Skip Screenshot visually quieter
- preserve mobile visual order for screenshot options

## Tests
- npm run build:widget
- PLAYWRIGHT_BASE_URL=http://localhost:8790 npx playwright test e2e/widget.spec.ts --grep "screenshot options prioritize capture actions before skip"
- npm run validate

Closes #129