### PR TITLE
Improve annotation preview sizing and framing

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2089,6 +2089,44 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     }`;
   }
 
+  function reporterLikePng(variant: 'preview-size' | 'small-wide-area') {
+    return `function(el, opts) {
+      window.__captureOpts = opts;
+      var canvas = document.createElement('canvas');
+      var ctx = canvas.getContext('2d');
+      if ('${variant}' === 'preview-size') {
+        canvas.width = 1040;
+        canvas.height = 260;
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#111827';
+        ctx.font = '600 16px Arial';
+        ctx.fillText('Widget', 36, 34);
+        ctx.fillStyle = '#4b5563';
+        ctx.font = '13px Arial';
+        ctx.fillText('Password Widget v2', 36, 68);
+        ctx.fillText('Preview settings are represented here with small but readable text.', 36, 98);
+        ctx.fillStyle = '#f3f4f6';
+        ctx.fillRect(36, 120, 420, 24);
+        ctx.fillStyle = '#6b7280';
+        ctx.fillText('Location Widget #3', 48, 137);
+        ctx.fillStyle = '#f9fafb';
+        ctx.fillRect(36, 160, 520, 34);
+        ctx.fillStyle = '#374151';
+        ctx.fillText('Object: example.company/feature/preview', 48, 181);
+      } else {
+        canvas.width = 252;
+        canvas.height = 54;
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#525252';
+        ctx.font = '28px Arial';
+        ctx.fillText('Settlement Stage', 14, 36);
+      }
+      return Promise.resolve(canvas.toDataURL('image/png'));
+    }`;
+  }
+
   test.beforeEach(async ({ page }) => {
     await page.route('**/api/check/**', async route => {
       await route.fulfill({
@@ -2138,6 +2176,35 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     const captureBtn = host.locator('css=[data-action="capture"]');
     await expect(captureBtn).toBeVisible({ timeout: 5000 });
     await captureBtn.click();
+  }
+
+  async function captureElementForAnnotation(page: Page, path: string, selector: string) {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto(path);
+
+    const host = await navigateToScreenshotOptions(page);
+    const elementBtn = host.locator('css=[data-action="element"]');
+    await expect(elementBtn).toBeVisible({ timeout: 5000 });
+    await elementBtn.click();
+    await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
+
+    const target = page.locator(selector);
+    await expect(target).toBeVisible({ timeout: 5000 });
+    const targetBox = await target.boundingBox();
+    expect(targetBox).toBeTruthy();
+    const targetX = targetBox!.x + targetBox!.width / 2;
+    const targetY = targetBox!.y + targetBox!.height / 2;
+    await page.mouse.move(targetX, targetY);
+    await page.mouse.click(targetX, targetY);
+
+    const modal = host.locator('css=.bd-modal--annotator');
+    const stage = host.locator('css=#annotation-canvas');
+    const canvas = stage.locator('css=canvas');
+    await expect(modal).toBeVisible({ timeout: 30000 });
+    await expect(stage).toBeVisible();
+    await expect(canvas).toBeVisible();
+
+    return { host, modal, stage, canvas };
   }
 
   async function trackFeedbackSubmissions(page: Page) {
@@ -2366,6 +2433,144 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
 
     // Complexity notice should NOT be shown
     await expect(host.locator('css=p >> text=too complex')).not.toBeAttached();
+  });
+
+  test('annotation modal gives issue #117 style previews enough readable width', async ({
+    page,
+  }) => {
+    await mockHtmlToImage(page, reporterLikePng('preview-size'));
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/test/');
+    await navigateToFullPageCapture(page);
+
+    const host = page.locator('#bugdrop-host');
+    const modal = host.locator('css=.bd-modal--annotator');
+    const stage = host.locator('css=#annotation-canvas');
+    const canvas = stage.locator('css=canvas');
+
+    await expect(modal).toBeVisible({ timeout: 10000 });
+    await expect(stage).toBeVisible();
+    await expect(canvas).toBeVisible();
+
+    const modalBox = await modal.boundingBox();
+    const stageBox = await stage.boundingBox();
+    const canvasBox = await canvas.boundingBox();
+
+    expect(modalBox?.width).toBeGreaterThanOrEqual(1040);
+    expect(stageBox?.width).toBeGreaterThanOrEqual(980);
+    expect(canvasBox?.width).toBeGreaterThanOrEqual(980);
+
+    const toolbarBox = await host.locator('css=.bd-tools').boundingBox();
+    const actionsBox = await host.locator('css=.bd-actions').boundingBox();
+    expect(toolbarBox && stageBox ? toolbarBox.y + toolbarBox.height <= stageBox.y : false).toBe(
+      true
+    );
+    expect(stageBox && actionsBox ? stageBox.y + stageBox.height <= actionsBox.y : false).toBe(
+      true
+    );
+  });
+
+  test('annotation stage frames issue #119 style short wide captures clearly', async ({ page }) => {
+    await mockHtmlToImage(page, reporterLikePng('small-wide-area'));
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/test/');
+    await navigateToFullPageCapture(page);
+
+    const host = page.locator('#bugdrop-host');
+    const stage = host.locator('css=#annotation-canvas');
+    const canvas = stage.locator('css=canvas');
+
+    await expect(host.locator('css=.bd-modal--annotator')).toBeVisible({ timeout: 10000 });
+    await expect(stage).toBeVisible();
+    await expect(canvas).toBeVisible();
+
+    const stageBox = await stage.boundingBox();
+    const canvasBox = await canvas.boundingBox();
+    expect(stageBox?.width).toBeGreaterThanOrEqual(980);
+    expect(stageBox?.height).toBeGreaterThanOrEqual(230);
+    expect(canvasBox?.width).toBeLessThan(320);
+    expect(canvasBox?.height).toBeLessThan(90);
+
+    const stageStyles = await stage.evaluate(el => {
+      const styles = getComputedStyle(el);
+      return {
+        borderStyle: styles.borderTopStyle,
+        borderWidth: styles.borderTopWidth,
+        overflow: styles.overflow,
+        padding: styles.paddingTop,
+      };
+    });
+
+    expect(stageStyles.borderStyle).not.toBe('none');
+    expect(parseFloat(stageStyles.borderWidth)).toBeGreaterThan(0);
+    expect(stageStyles.overflow).toBe('auto');
+    expect(parseFloat(stageStyles.padding)).toBeGreaterThan(0);
+
+    expect(stageBox && canvasBox ? canvasBox.x > stageBox.x : false).toBe(true);
+    expect(stageBox && canvasBox ? canvasBox.y > stageBox.y : false).toBe(true);
+  });
+
+  test('real element capture keeps issue #117 style content readable in annotation preview', async ({
+    page,
+  }) => {
+    const { modal, stage, canvas } = await captureElementForAnnotation(
+      page,
+      '/test/annotation-preview-size.html',
+      '#preview-size-target'
+    );
+
+    const modalBox = await modal.boundingBox();
+    const stageBox = await stage.boundingBox();
+    const canvasBox = await canvas.boundingBox();
+    const intrinsicSize = await canvas.evaluate(el => ({
+      width: (el as HTMLCanvasElement).width,
+      height: (el as HTMLCanvasElement).height,
+    }));
+
+    expect(intrinsicSize.width).toBeGreaterThanOrEqual(1000);
+    expect(intrinsicSize.height).toBeGreaterThanOrEqual(250);
+    expect(modalBox?.width).toBeGreaterThanOrEqual(1040);
+    expect(stageBox?.width).toBeGreaterThanOrEqual(980);
+    expect(canvasBox?.width).toBeGreaterThanOrEqual(980);
+  });
+
+  test('real element capture clearly frames issue #119 style small annotation targets', async ({
+    page,
+  }) => {
+    const { stage, canvas } = await captureElementForAnnotation(
+      page,
+      '/test/annotation-small-wide-area.html',
+      '#small-wide-target'
+    );
+
+    const stageBox = await stage.boundingBox();
+    const canvasBox = await canvas.boundingBox();
+    const intrinsicSize = await canvas.evaluate(el => ({
+      width: (el as HTMLCanvasElement).width,
+      height: (el as HTMLCanvasElement).height,
+    }));
+
+    expect(intrinsicSize.width).toBeLessThanOrEqual(600);
+    expect(intrinsicSize.height).toBeLessThanOrEqual(140);
+    expect(stageBox?.width).toBeGreaterThanOrEqual(980);
+    expect(stageBox?.height).toBeGreaterThanOrEqual(230);
+    expect(canvasBox?.width).toBeLessThan(600);
+    expect(canvasBox?.height).toBeLessThan(140);
+
+    const frame = await stage.evaluate(el => {
+      const styles = getComputedStyle(el);
+      return {
+        borderWidth: parseFloat(styles.borderTopWidth),
+        padding: parseFloat(styles.paddingTop),
+        overflow: styles.overflow,
+      };
+    });
+
+    expect(frame.borderWidth).toBeGreaterThan(0);
+    expect(frame.padding).toBeGreaterThan(0);
+    expect(frame.overflow).toBe('auto');
+    expect(stageBox && canvasBox ? canvasBox.x > stageBox.x : false).toBe(true);
+    expect(stageBox && canvasBox ? canvasBox.y > stageBox.y : false).toBe(true);
   });
 
   // --- Metadata: domNodeCount and fullPageDisabled in submission payload ---

--- a/public/test/annotation-preview-size.html
+++ b/public/test/annotation-preview-size.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BugDrop Annotation Preview Size Fixture</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      padding: 80px;
+      background: #f3f4f6;
+      color: #111827;
+      font-family: Arial, sans-serif;
+    }
+
+    .fixture-panel {
+      width: 1040px;
+      height: 260px;
+      padding: 28px 36px;
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+    }
+
+    .fixture-panel > * {
+      pointer-events: none;
+    }
+
+    .fixture-panel h1 {
+      margin: 0 0 18px;
+      font-size: 18px;
+    }
+
+    .fixture-panel p {
+      margin: 0 0 14px;
+      color: #4b5563;
+      font-size: 13px;
+      font-weight: 600;
+    }
+
+    .row {
+      width: 520px;
+      margin-bottom: 14px;
+      padding: 9px 12px;
+      background: #f9fafb;
+      color: #374151;
+      font-size: 13px;
+    }
+  </style>
+</head>
+<body>
+  <main id="preview-size-target" class="fixture-panel">
+    <h1>Widget</h1>
+    <p>Password Widget v2</p>
+    <p>Preview settings are represented here with small but readable text.</p>
+    <div class="row">Location Widget #3</div>
+    <div class="row">Object: example.company/feature/preview</div>
+  </main>
+
+  <script id="bugdrop-script" defer src="/widget.js" data-repo="mean-weasel/bugdrop-widget-test" data-theme="dark" data-color="#ff9e64"></script>
+</body>
+</html>

--- a/public/test/annotation-small-wide-area.html
+++ b/public/test/annotation-small-wide-area.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BugDrop Annotation Small Wide Fixture</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      padding: 140px 80px;
+      background: #f5f5f5;
+      color: #525252;
+      font-family: Arial, sans-serif;
+    }
+
+    .field-label {
+      display: inline-block;
+      width: 252px;
+      height: 54px;
+      padding: 9px 14px;
+      background: #ffffff;
+      border: 1px solid #d4d4d4;
+      font-size: 28px;
+      line-height: 34px;
+    }
+  </style>
+</head>
+<body>
+  <div id="small-wide-target" class="field-label">Settlement Stage</div>
+
+  <script id="bugdrop-script" defer src="/widget.js" data-repo="mean-weasel/bugdrop-widget-test" data-theme="dark" data-color="#ff9e64"></script>
+</body>
+</html>

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -1196,13 +1196,15 @@ function showAnnotationStep(
           <button class="bd-tool" data-tool="rect">▢ Rectangle</button>
           <button class="bd-tool" data-action="undo">↶ Undo</button>
         </div>
-        <div id="annotation-canvas"></div>
+        <div id="annotation-canvas" class="bd-annotation-stage"></div>
         <div class="bd-actions">
           <button class="bd-btn bd-btn-secondary" data-action="retake">Retake</button>
           <button class="bd-btn bd-btn-secondary" data-action="skip">Skip Annotations</button>
           <button class="bd-btn bd-btn-primary" data-action="done">Done</button>
         </div>
-      `
+      `,
+      false,
+      'bd-modal--annotator'
     );
 
     const canvasContainer = modal.querySelector('#annotation-canvas') as HTMLElement;

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -323,6 +323,11 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       animation: bd-slideUp var(--bd-transition-slow);
     }
 
+    .bd-modal--annotator {
+      width: min(96vw, 1100px);
+      max-width: 1100px;
+    }
+
     /* Modal Header */
     .bd-header {
       padding: 16px 20px;
@@ -704,6 +709,37 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       box-shadow: var(--bd-shadow-sm);
     }
 
+    .bd-annotation-stage {
+      min-height: 240px;
+      max-height: min(58vh, 620px);
+      padding: 18px;
+      border: 1px solid var(--bd-border, #e7e5e4);
+      border-radius: var(--bd-radius-md);
+      background:
+        linear-gradient(45deg, var(--bd-bg-secondary) 25%, transparent 25%),
+        linear-gradient(-45deg, var(--bd-bg-secondary) 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, var(--bd-bg-secondary) 75%),
+        linear-gradient(-45deg, transparent 75%, var(--bd-bg-secondary) 75%),
+        var(--bd-bg-primary);
+      background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+      background-size: 16px 16px;
+      box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--bd-border) 60%, transparent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: auto;
+    }
+
+    .bd-annotation-stage canvas {
+      display: block;
+      max-width: 100%;
+      max-height: calc(min(58vh, 620px) - 36px);
+      width: auto;
+      height: auto;
+      background: #ffffff;
+      box-shadow: var(--bd-shadow-md);
+    }
+
     /* Preview */
     .bd-preview {
       border: var(--bd-border-style);
@@ -839,6 +875,11 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
         animation: bd-slideUpMobile var(--bd-transition-slow);
       }
 
+      .bd-modal--annotator {
+        width: calc(100% - 16px);
+        max-width: calc(100% - 16px);
+      }
+
       .bd-header {
         padding: 16px;
         position: sticky;
@@ -884,6 +925,16 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
 
       .bd-tools {
         flex-wrap: wrap;
+      }
+
+      .bd-annotation-stage {
+        min-height: 180px;
+        max-height: 46vh;
+        padding: 12px;
+      }
+
+      .bd-annotation-stage canvas {
+        max-height: calc(46vh - 24px);
       }
 
       .bd-tool {
@@ -979,17 +1030,19 @@ export function createModal(
   container: HTMLElement,
   title: string,
   content: string,
-  showVersion: boolean = false
+  showVersion: boolean = false,
+  modalClass: string = ''
 ): HTMLElement {
   const overlay = document.createElement('div');
   overlay.className = 'bd-overlay';
+  const modalClasses = ['bd-modal', modalClass].filter(Boolean).join(' ');
 
   const versionBadge = showVersion
     ? `<div class="bd-version">BugDrop v${typeof __BUGDROP_VERSION__ !== 'undefined' ? __BUGDROP_VERSION__ : 'dev'}</div>`
     : '';
 
   overlay.innerHTML = `
-    <div class="bd-modal">
+    <div class="${modalClasses}">
       <div class="bd-header">
         <h2 class="bd-title">${title}</h2>
         <button class="bd-close">&times;</button>


### PR DESCRIPTION
## Summary
- widen the annotation modal so detailed screenshots remain readable
- add a framed, scrollable annotation stage so small/wide captures have clear editable bounds
- add deterministic and real element-capture Playwright coverage for the #117 and #119 examples

## Tests
- npm run build:widget
- LIVE_TARGET=1 PLAYWRIGHT_BASE_URL=http://localhost:8790 npx playwright test e2e/widget.spec.ts -g "issue #117|issue #119|real element capture"
- npm run typecheck
- npm run test
- npx prettier --check src/widget/ui.ts src/widget/index.ts e2e/widget.spec.ts public/test/annotation-preview-size.html public/test/annotation-small-wide-area.html

Addresses #117 and #119.