### PR TITLE
Improve annotation mark styling

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2137,7 +2137,7 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     }`;
   }
 
-  function reporterLikePng(variant: 'preview-size' | 'small-wide-area') {
+  function reporterLikePng(variant: 'preview-size' | 'small-wide-area' | 'annotation-style') {
     return `function(el, opts) {
       window.__captureOpts = opts;
       var canvas = document.createElement('canvas');
@@ -2162,7 +2162,7 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
         ctx.fillRect(36, 160, 520, 34);
         ctx.fillStyle = '#374151';
         ctx.fillText('Object: example.company/feature/preview', 48, 181);
-      } else {
+      } else if ('${variant}' === 'small-wide-area') {
         canvas.width = 252;
         canvas.height = 54;
         ctx.fillStyle = '#ffffff';
@@ -2170,6 +2170,36 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
         ctx.fillStyle = '#525252';
         ctx.font = '28px Arial';
         ctx.fillText('Settlement Stage', 14, 36);
+      } else {
+        canvas.width = 1024;
+        canvas.height = 252;
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#2f2f2f';
+        ctx.font = '500 16px Arial';
+        ctx.fillText('Shipmen Overview', 24, 28);
+        var labels = ['Schedule Stage', 'Weight Stage', 'Settlement Stage', 'Amount Stage'];
+        var values = ['30-04-2026\\nForecasted', '25.000t\\nForecasted', "1'817.24\\nEUR/t\\nFinal", "45'431.03\\nEUR\\nForecasted"];
+        var xs = [24, 260, 520, 770];
+        labels.forEach(function(label, index) {
+          ctx.fillStyle = '#4a4a4a';
+          ctx.font = '14px Arial';
+          ctx.fillText(label, xs[index], 72);
+          ctx.fillStyle = '#f5f5f5';
+          ctx.fillRect(xs[index], 86, 128, 66);
+          ctx.fillStyle = index === 2 ? '#35a36d' : '#ef4444';
+          ctx.beginPath();
+          ctx.arc(xs[index] + 14, 106, 5, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.fillStyle = '#777777';
+          ctx.font = '600 14px Arial';
+          values[index].split('\\n').forEach(function(line, lineIndex) {
+            ctx.fillText(line, xs[index] + 28, 104 + lineIndex * 18);
+          });
+          ctx.fillStyle = '#8a8a8a';
+          ctx.font = '13px Arial';
+          ctx.fillText('Auto-derived status text for comparison', xs[index], 176);
+        });
       }
       return Promise.resolve(canvas.toDataURL('image/png'));
     }`;
@@ -2272,6 +2302,54 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     const titleInput = host.locator('css=#title');
     await expect(titleInput).toBeVisible({ timeout: 5000 });
     await expect(titleInput).toHaveValue(title);
+  }
+
+  async function countAnnotationPixels(canvas: ReturnType<Page['locator']>) {
+    return canvas.evaluate(el => {
+      const source = el as HTMLCanvasElement;
+      const ctx = source.getContext('2d');
+      if (!ctx) {
+        throw new Error('Missing canvas context');
+      }
+
+      const { data } = ctx.getImageData(0, 0, source.width, source.height);
+      let red = 0;
+      let orange = 0;
+
+      for (let i = 0; i < data.length; i += 4) {
+        const r = data[i];
+        const g = data[i + 1];
+        const b = data[i + 2];
+        const a = data[i + 3];
+
+        if (a > 200 && r > 220 && g < 80 && b < 80) {
+          red++;
+        }
+
+        if (a > 200 && r > 245 && g > 140 && g < 180 && b > 80 && b < 120) {
+          orange++;
+        }
+      }
+
+      return { red, orange };
+    });
+  }
+
+  async function dragOnCanvas(
+    page: Page,
+    canvas: ReturnType<Page['locator']>,
+    from: { x: number; y: number },
+    to: { x: number; y: number }
+  ) {
+    const box = await canvas.boundingBox();
+    expect(box).toBeTruthy();
+
+    await page.mouse.move(box!.x + from.x * box!.width, box!.y + from.y * box!.height);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + to.x * box!.width, box!.y + to.y * box!.height, {
+      steps: 12,
+    });
+    await page.mouse.up();
   }
 
   test('reduces pixelRatio on complex DOM pages (>3000 nodes)', async ({ page }) => {
@@ -2619,6 +2697,43 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     expect(frame.overflow).toBe('auto');
     expect(stageBox && canvasBox ? canvasBox.x > stageBox.x : false).toBe(true);
     expect(stageBox && canvasBox ? canvasBox.y > stageBox.y : false).toBe(true);
+  });
+
+  test('annotation tools use high-contrast red styling for issue #115', async ({ page }) => {
+    await mockHtmlToImage(page, reporterLikePng('annotation-style'));
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/test/annotation-style.html');
+    await navigateToFullPageCapture(page);
+
+    const host = page.locator('#bugdrop-host');
+    const stage = host.locator('css=#annotation-canvas');
+    const canvas = stage.locator('css=canvas');
+    await expect(host.locator('css=.bd-modal--annotator')).toBeVisible({ timeout: 10000 });
+    await expect(stage).toBeVisible();
+    await expect(canvas).toBeVisible();
+
+    const before = await countAnnotationPixels(canvas);
+
+    await host.locator('css=[data-tool="arrow"]').click();
+    await dragOnCanvas(page, canvas, { x: 0.72, y: 0.17 }, { x: 0.28, y: 0.34 });
+
+    await host.locator('css=[data-tool="rect"]').click();
+    await dragOnCanvas(page, canvas, { x: 0.58, y: 0.36 }, { x: 0.82, y: 0.72 });
+
+    const after = await countAnnotationPixels(canvas);
+
+    expect(after.red - before.red).toBeGreaterThan(2500);
+    expect(after.orange - before.orange).toBeLessThan(100);
+
+    const stageBox = await stage.boundingBox();
+    const canvasBox = await canvas.boundingBox();
+    expect(stageBox?.width).toBeGreaterThanOrEqual(980);
+    expect(canvasBox?.width).toBeGreaterThan(600);
+
+    await page.screenshot({
+      path: test.info().outputPath('issue-115-annotation-style.png'),
+      fullPage: false,
+    });
   });
 
   // --- Metadata: domNodeCount and fullPageDisabled in submission payload ---

--- a/public/test/annotation-style.html
+++ b/public/test/annotation-style.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Annotation Style Test</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: #f7f7f7;
+        color: #2f2f2f;
+        font-family:
+          Inter,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+      }
+
+      .page {
+        padding: 48px;
+      }
+
+      #annotation-style-target {
+        width: 1024px;
+        padding: 16px 18px;
+        background: #ffffff;
+        border: 1px solid #e6e6e6;
+      }
+
+      h1 {
+        margin: 0 0 18px;
+        font-size: 16px;
+        font-weight: 500;
+      }
+
+      .shipment-grid {
+        display: grid;
+        grid-template-columns: 210px 210px 210px 210px;
+        gap: 28px;
+        align-items: start;
+      }
+
+      .stage-title {
+        margin-bottom: 8px;
+        color: #4a4a4a;
+        font-size: 14px;
+      }
+
+      .metric {
+        display: inline-grid;
+        grid-template-columns: auto 1fr;
+        gap: 8px;
+        min-width: 124px;
+        padding: 8px 10px;
+        border-radius: 7px;
+        background: #f5f5f5;
+        color: #777777;
+        font-size: 14px;
+        line-height: 1.5;
+      }
+
+      .dot {
+        width: 10px;
+        height: 10px;
+        margin-top: 5px;
+        border-radius: 999px;
+        background: #ef4444;
+      }
+
+      .dot.green {
+        background: #35a36d;
+      }
+
+      .copy {
+        margin-top: 8px;
+        max-width: 150px;
+        color: #8a8a8a;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section id="annotation-style-target">
+        <h1>Shipmen Overview</h1>
+        <div class="shipment-grid">
+          <div>
+            <div class="stage-title">Schedule Stage</div>
+            <div class="metric">
+              <span class="dot"></span>
+              <span><strong>30-04-2026</strong><br />Forecasted</span>
+            </div>
+            <div class="copy">Click the dot to update stage and date via the pop-up (#453, #477, #479, #480)</div>
+          </div>
+          <div>
+            <div class="stage-title">Weight Stage</div>
+            <div class="metric">
+              <span class="dot"></span>
+              <span><strong>25.000t</strong><br />Forecasted</span>
+            </div>
+            <div class="copy">Auto-derived from weight stage (Unloaded &gt; Loaded &gt; Forecasted)</div>
+          </div>
+          <div>
+            <div class="stage-title">Settlement Stage</div>
+            <div class="metric">
+              <span class="dot green"></span>
+              <span><strong>1'817.24 EUR/t</strong><br />Final</span>
+            </div>
+            <div class="copy">Auto-derived from contract status and settlement amount</div>
+          </div>
+          <div>
+            <div class="stage-title">Amount Stage</div>
+            <div class="metric">
+              <span class="dot"></span>
+              <span><strong>45'431.03 EUR</strong><br />Forecasted</span>
+            </div>
+            <div class="copy">Auto-derived: min(weight, settlement) by dot level</div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script
+      id="bugdrop-script"
+      defer
+      src="/widget.js"
+      data-repo="mean-weasel/bugdrop-widget-test"
+      data-theme="dark"
+      data-color="#ff9e64"
+    ></script>
+  </body>
+</html>

--- a/src/widget/annotator.ts
+++ b/src/widget/annotator.ts
@@ -5,10 +5,13 @@ interface Point {
   y: number;
 }
 
+const ANNOTATION_COLOR = '#ff0000';
+const VISIBLE_ANNOTATION_LINE_WIDTH = 5.5;
+const ARROW_HEAD_ANGLE = Math.PI / 7;
+
 export function createAnnotator(
   container: HTMLElement,
-  imageData: string,
-  accentColor?: string
+  imageData: string
 ): {
   setTool: (tool: Tool) => void;
   undo: () => void;
@@ -42,10 +45,6 @@ export function createAnnotator(
 
   container.appendChild(canvas);
 
-  // Drawing settings
-  const color = accentColor || '#ff0000';
-  const lineWidth = 3;
-
   function saveState() {
     history.push(ctx.getImageData(0, 0, canvas.width, canvas.height));
   }
@@ -60,13 +59,22 @@ export function createAnnotator(
     };
   }
 
+  function getLineWidth() {
+    const rect = canvas.getBoundingClientRect();
+    const scale = Math.max(canvas.width / rect.width, canvas.height / rect.height, 1);
+    return Math.round(VISIBLE_ANNOTATION_LINE_WIDTH * scale);
+  }
+
   function drawLine(from: Point, to: Point) {
+    const lineWidth = getLineWidth();
+
     ctx.beginPath();
     ctx.moveTo(from.x, from.y);
     ctx.lineTo(to.x, to.y);
-    ctx.strokeStyle = color;
+    ctx.strokeStyle = ANNOTATION_COLOR;
     ctx.lineWidth = lineWidth;
     ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
     ctx.stroke();
   }
 
@@ -76,26 +84,28 @@ export function createAnnotator(
 
     // Arrowhead
     const angle = Math.atan2(to.y - from.y, to.x - from.x);
-    const headLength = 15;
+    const headLength = getLineWidth() * 5;
 
     ctx.beginPath();
     ctx.moveTo(to.x, to.y);
     ctx.lineTo(
-      to.x - headLength * Math.cos(angle - Math.PI / 6),
-      to.y - headLength * Math.sin(angle - Math.PI / 6)
+      to.x - headLength * Math.cos(angle - ARROW_HEAD_ANGLE),
+      to.y - headLength * Math.sin(angle - ARROW_HEAD_ANGLE)
     );
     ctx.lineTo(
-      to.x - headLength * Math.cos(angle + Math.PI / 6),
-      to.y - headLength * Math.sin(angle + Math.PI / 6)
+      to.x - headLength * Math.cos(angle + ARROW_HEAD_ANGLE),
+      to.y - headLength * Math.sin(angle + ARROW_HEAD_ANGLE)
     );
     ctx.closePath();
-    ctx.fillStyle = color;
+    ctx.fillStyle = ANNOTATION_COLOR;
     ctx.fill();
   }
 
   function drawRect(from: Point, to: Point) {
-    ctx.strokeStyle = color;
-    ctx.lineWidth = lineWidth;
+    ctx.strokeStyle = ANNOTATION_COLOR;
+    ctx.lineWidth = getLineWidth();
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
     ctx.strokeRect(from.x, from.y, to.x - from.x, to.y - from.y);
   }
 

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -733,7 +733,7 @@ async function openFeedbackFlow(
 
         // Step 4: Annotate (if screenshot exists)
         if (screenshot) {
-          const result = await showAnnotationStep(root, screenshot, config);
+          const result = await showAnnotationStep(root, screenshot);
           if (result === 'retake') continue;
           if (result === 'cancel') {
             returnToForm = true;
@@ -1182,8 +1182,7 @@ function showScreenshotOptions(
 
 function showAnnotationStep(
   root: HTMLElement,
-  screenshot: string,
-  config?: WidgetConfig
+  screenshot: string
 ): Promise<string | 'retake' | 'cancel'> {
   return new Promise(resolve => {
     const modal = createModal(
@@ -1208,7 +1207,7 @@ function showAnnotationStep(
     );
 
     const canvasContainer = modal.querySelector('#annotation-canvas') as HTMLElement;
-    const annotator = createAnnotator(canvasContainer, screenshot, config?.accentColor);
+    const annotator = createAnnotator(canvasContainer, screenshot);
 
     // Tool buttons
     const toolButtons = modal.querySelectorAll('[data-tool]');


### PR DESCRIPTION
## Summary
- use a dedicated high-contrast red for annotation marks instead of the widget accent color
- scale stroke width and arrowhead size from the displayed canvas scale so marks stay readable on high-DPI screenshots
- add a shipment-style Playwright fixture and pixel-level regression coverage for #115

## Tests
- npm run build:widget
- LIVE_TARGET=1 PLAYWRIGHT_BASE_URL=http://localhost:8791 npx playwright test e2e/widget.spec.ts -g "issue #115" --project=chromium
- LIVE_TARGET=1 PLAYWRIGHT_BASE_URL=http://localhost:8791 npx playwright test e2e/widget.spec.ts -g "issue #115|issue #117|issue #119" --project=chromium
- npm run typecheck
- npm run test
- npx prettier --check src/widget/annotator.ts src/widget/index.ts e2e/widget.spec.ts public/test/annotation-style.html

Fixes #115.