### PR TITLE
Remember complex-page screenshot skips

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2298,6 +2298,19 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     return () => count;
   }
 
+  async function trackFeedbackPayloads(page: Page) {
+    const payloads: Array<Record<string, unknown>> = [];
+    await page.route('**/feedback', async route => {
+      payloads.push(route.request().postDataJSON());
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, issueNumber: 1, issueUrl: '#', isPublic: false }),
+      });
+    });
+    return payloads;
+  }
+
   async function expectReturnedToForm(host: ReturnType<Page['locator']>, title: string) {
     const titleInput = host.locator('css=#title');
     await expect(titleInput).toBeVisible({ timeout: 5000 });
@@ -2542,6 +2555,178 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     // Complexity notice should be shown
     const notice = host.locator('css=p >> text=too complex');
     await expect(notice).toBeVisible();
+  });
+
+  test('remembers complex-page screenshot skip for issue #116 repeated reports', async ({
+    page,
+  }) => {
+    const payloads = await trackFeedbackPayloads(page);
+    await page.goto('/test/complex-dom.html?nodes=12000');
+
+    const nodeCount = await page.evaluate(() => document.body.querySelectorAll('*').length);
+    expect(nodeCount).toBeGreaterThanOrEqual(10000);
+
+    const host = await navigateToScreenshotOptions(page);
+    await expect(host.locator('css=p >> text=too complex')).toBeVisible();
+
+    await host.locator('css=[data-action="skip"]').click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 5000 });
+    expect(payloads).toHaveLength(1);
+
+    await host.locator('css=.bd-close').click();
+    await host.locator('css=.bd-trigger').click();
+
+    const secondTitle = host.locator('css=#title');
+    await expect(secondTitle).toBeVisible({ timeout: 5000 });
+    await secondTitle.fill('Issue 116 second report');
+
+    const screenshotCheckbox = host.locator('css=#include-screenshot');
+    await expect(screenshotCheckbox).not.toBeChecked();
+
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=[data-action="element"]')).not.toBeVisible();
+    await expect(host.locator('css=p >> text=too complex')).not.toBeVisible();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 5000 });
+    expect(payloads).toHaveLength(2);
+
+    for (const payload of payloads) {
+      const metadata = payload.metadata as { domNodeCount?: number; fullPageDisabled?: boolean };
+      expect(payload.screenshot).toBeNull();
+      expect(metadata.domNodeCount).toBeGreaterThanOrEqual(10000);
+      expect(metadata.fullPageDisabled).toBe(true);
+    }
+  });
+
+  test('persists complex-page screenshot skip after reload for issue #116', async ({ page }) => {
+    const payloads = await trackFeedbackPayloads(page);
+    await page.goto('/test/complex-dom.html?nodes=12000');
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="skip"]').click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 5000 });
+
+    await page.reload();
+    await host.locator('css=.bd-trigger').click();
+
+    const titleInput = host.locator('css=#title');
+    await expect(titleInput).toBeVisible({ timeout: 5000 });
+    await titleInput.fill('Issue 116 after reload');
+
+    await expect(host.locator('css=#include-screenshot')).not.toBeChecked();
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=[data-action="element"]')).not.toBeVisible();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 5000 });
+    expect(payloads).toHaveLength(2);
+    expect(payloads[1].screenshot).toBeNull();
+  });
+
+  test('complex-page screenshot skip is scoped to redacted page and current complexity', async ({
+    page,
+  }) => {
+    await trackFeedbackSubmissions(page);
+    await page.goto('/test/complex-dom.html?nodes=12000');
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="skip"]').click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 5000 });
+
+    await page.goto('/test/complex-dom.html?nodes=4000');
+    await host.locator('css=.bd-trigger').click();
+    await expect(host.locator('css=#title')).toBeVisible({ timeout: 5000 });
+    await expect(host.locator('css=#include-screenshot')).toBeChecked();
+    await host.locator('css=.bd-close').click();
+
+    await page.goto('/test/complex-dom.html?nodes=12001');
+    await host.locator('css=.bd-trigger').click();
+    await expect(host.locator('css=#title')).toBeVisible({ timeout: 5000 });
+    await expect(host.locator('css=#include-screenshot')).not.toBeChecked();
+  });
+
+  test('complex-page screenshot skip is scoped by repo', async ({ page }) => {
+    await trackFeedbackSubmissions(page);
+    await page.goto('/test/complex-dom.html?nodes=12000&repo=owner/repo-a');
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="skip"]').click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 5000 });
+
+    await page.goto('/test/complex-dom.html?nodes=12000&repo=owner/repo-b');
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+    await expect(host.locator('css=#title')).toBeVisible({ timeout: 5000 });
+    await expect(host.locator('css=#include-screenshot')).toBeChecked();
+  });
+
+  test('complex-page screenshot skip does not apply after same-url DOM becomes simple', async ({
+    page,
+  }) => {
+    await trackFeedbackSubmissions(page);
+    await page.goto('/test/complex-dom.html?nodes=12000');
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="skip"]').click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 5000 });
+    await host.locator('css=.bd-close').click();
+
+    await page.evaluate(() => {
+      document.querySelector('#complex-root')?.replaceChildren();
+    });
+
+    await host.locator('css=.bd-trigger').click();
+    await expect(host.locator('css=#title')).toBeVisible({ timeout: 5000 });
+    await expect(host.locator('css=#include-screenshot')).toBeChecked();
+  });
+
+  test('allows users to opt back into screenshots after complex-page skip', async ({ page }) => {
+    await trackFeedbackSubmissions(page);
+    await page.goto('/test/complex-dom.html?nodes=12000');
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="skip"]').click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 5000 });
+
+    await host.locator('css=.bd-close').click();
+    await host.locator('css=.bd-trigger').click();
+
+    const titleInput = host.locator('css=#title');
+    await expect(titleInput).toBeVisible({ timeout: 5000 });
+    await titleInput.fill('Issue 116 opt back in');
+    const screenshotCheckbox = host.locator('css=#include-screenshot');
+    await expect(screenshotCheckbox).not.toBeChecked();
+    await screenshotCheckbox.check();
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=p >> text=too complex')).toBeVisible();
+    await expect(host.locator('css=[data-action="element"]')).toBeVisible();
+  });
+
+  test('remembers complex-page skip after element capture failure skip', async ({ page }) => {
+    await trackFeedbackSubmissions(page);
+    await mockHtmlToImage(page, "function() { return Promise.reject(new Error('mock failure')); }");
+    await page.goto('/test/complex-dom.html?nodes=12000');
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="element"]').click();
+    await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
+
+    const heading = page.locator('h1');
+    const headingBox = await heading.boundingBox();
+    expect(headingBox).toBeTruthy();
+    await page.mouse.click(
+      headingBox!.x + headingBox!.width / 2,
+      headingBox!.y + headingBox!.height / 2
+    );
+
+    await expect(host.locator('css=.bd-error-message__text')).toBeVisible({ timeout: 5000 });
+    await host.locator('css=[data-action="skip"]').click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 5000 });
+
+    await host.locator('css=.bd-close').click();
+    await host.locator('css=.bd-trigger').click();
+    await expect(host.locator('css=#title')).toBeVisible({ timeout: 5000 });
+    await expect(host.locator('css=#include-screenshot')).not.toBeChecked();
   });
 
   test('shows all buttons on pages below 10k nodes', async ({ page }) => {
@@ -2881,6 +3066,26 @@ test.describe('Screenshot Mode Configuration', () => {
         () => (window as Window & { __autoCaptureCount?: number }).__autoCaptureCount
       )
     ).toBe(1);
+  });
+
+  test('auto mode skips full-page capture on very complex pages', async ({ page }) => {
+    await setupInstalledApp(page);
+    await mockSuccessfulCapture(page);
+    const getPayload = await setupSuccessfulSubmit(page);
+
+    await page.goto('/test/complex-dom.html?nodes=12000&screenshot=auto');
+    const host = await openForm(page);
+
+    await expect(host.locator('css=#include-screenshot')).not.toBeAttached();
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+    expect(getPayload()?.screenshot).toBeNull();
+    expect(
+      await page.evaluate(
+        () => (window as Window & { __autoCaptureCount?: number }).__autoCaptureCount
+      )
+    ).toBeUndefined();
   });
 
   test('required mode removes the opt-out path and requires a capture before submit', async ({

--- a/public/test/complex-dom.html
+++ b/public/test/complex-dom.html
@@ -42,6 +42,15 @@
       document.body.querySelectorAll('*').length;
   </script>
 
-  <script src="/widget.js" data-repo="mean-weasel/bugdrop-widget-test" data-theme="dark"></script>
+  <script>
+    const widgetScript = document.createElement('script');
+    widgetScript.src = '/widget.js';
+    widgetScript.dataset.repo = params.get('repo') || 'mean-weasel/bugdrop-widget-test';
+    widgetScript.dataset.theme = 'dark';
+    if (params.get('screenshot')) {
+      widgetScript.dataset.screenshot = params.get('screenshot');
+    }
+    document.body.appendChild(widgetScript);
+  </script>
 </body>
 </html>

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -88,6 +88,8 @@ interface FeedbackData {
 // localStorage key for dismissed state
 const BUGDROP_DISMISSED_KEY = 'bugdrop_dismissed';
 const BUGDROP_WELCOMED_PREFIX = 'bugdrop_welcomed_';
+const BUGDROP_COMPLEX_SCREENSHOT_SKIPPED_PREFIX = 'bugdrop_complex_screenshot_skipped_';
+const COMPLEX_SCREENSHOT_SKIP_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 // Parse user agent to extract browser info
 function parseBrowser(ua: string): { name: string; version: string } {
@@ -220,6 +222,50 @@ function markWelcomeSeen(repo: string): void {
   } catch {
     // localStorage may be blocked
   }
+}
+
+function getComplexScreenshotSkipKey(repo: string): string {
+  return `${BUGDROP_COMPLEX_SCREENSHOT_SKIPPED_PREFIX}${repo}:${redactUrl(window.location.href)}`;
+}
+
+function hasSkippedComplexScreenshots(repo: string): boolean {
+  try {
+    const key = getComplexScreenshotSkipKey(repo);
+    const skippedAt = localStorage.getItem(key);
+    if (!skippedAt) return false;
+
+    const timestamp = parseInt(skippedAt, 10);
+    if (isNaN(timestamp) || Date.now() - timestamp > COMPLEX_SCREENSHOT_SKIP_TTL_MS) {
+      localStorage.removeItem(key);
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function markComplexScreenshotsSkipped(repo: string): void {
+  try {
+    localStorage.setItem(getComplexScreenshotSkipKey(repo), Date.now().toString());
+  } catch {
+    // localStorage may be blocked
+  }
+}
+
+function clearComplexScreenshotsSkipped(repo: string): void {
+  try {
+    localStorage.removeItem(getComplexScreenshotSkipKey(repo));
+  } catch {
+    // localStorage may be blocked
+  }
+}
+
+function rememberComplexScreenshotSkip(config: WidgetConfig, formResult: FeedbackFormResult): void {
+  if (!isFullPageDisabled()) return;
+  markComplexScreenshotsSkipped(config.repo);
+  formResult.includeScreenshot = false;
 }
 
 // Read config from script tag (fallback to src-based lookup for async/defer)
@@ -658,11 +704,13 @@ async function openFeedbackFlow(
 
     // Step 3: Screenshot flow (if configured/user opted in)
     if (config.screenshotMode === 'auto') {
-      const result = await captureWithLoading(root, undefined, config.screenshotScale);
-      if (result === 'cancel') {
-        returnToForm = true;
-      } else {
-        screenshot = result;
+      if (!isFullPageDisabled()) {
+        const result = await captureWithLoading(root, undefined, config.screenshotScale);
+        if (result === 'cancel') {
+          returnToForm = true;
+        } else {
+          screenshot = result;
+        }
       }
     } else if (formResult.includeScreenshot) {
       const screenshotRequired = config.screenshotMode === 'required';
@@ -678,6 +726,7 @@ async function openFeedbackFlow(
           break;
         }
         if (screenshotChoice === 'skip') {
+          rememberComplexScreenshotSkip(config, formResult);
           break;
         }
 
@@ -700,6 +749,7 @@ async function openFeedbackFlow(
             returnToForm = true;
             break;
           }
+          if (!result) rememberComplexScreenshotSkip(config, formResult);
           screenshot = result;
         } else if (screenshotChoice === 'element') {
           const element = await createElementPicker(pickerStyle);
@@ -711,6 +761,7 @@ async function openFeedbackFlow(
               returnToForm = true;
               break;
             }
+            if (!result) rememberComplexScreenshotSkip(config, formResult);
             screenshot = result;
             elementSelector = getElementSelector(element);
           }
@@ -1054,6 +1105,11 @@ function showFeedbackFormWithScreenshotOption(
         'input[name="category"]:checked'
       ) as HTMLInputElement;
       const category = (categoryInput?.value || 'bug') as FeedbackCategory;
+      const includeScreenshot =
+        config.screenshotMode === 'optional' ? (screenshotCheckbox?.checked ?? false) : true;
+      if (config.screenshotMode === 'optional' && includeScreenshot) {
+        clearComplexScreenshotsSkipped(config.repo);
+      }
 
       modal.remove();
       resolve({
@@ -1062,8 +1118,7 @@ function showFeedbackFormWithScreenshotOption(
         category,
         name: nameInput?.value.trim() || undefined,
         email: emailInput?.value.trim() || undefined,
-        includeScreenshot:
-          config.screenshotMode === 'optional' ? (screenshotCheckbox?.checked ?? false) : true,
+        includeScreenshot,
       });
     });
 
@@ -1094,9 +1149,13 @@ function getScreenshotFormControl(
     `;
   }
 
+  const includeScreenshot =
+    initialValues?.includeScreenshot ??
+    (!isFullPageDisabled() || !hasSkippedComplexScreenshots(config.repo));
+
   return `
     <div class="bd-form-group" style="display: flex; align-items: center; gap: 10px; margin-top: 8px;">
-      <input type="checkbox" id="include-screenshot" ${initialValues?.includeScreenshot === false ? '' : 'checked'} style="width: 18px; height: 18px; accent-color: var(--bd-primary); cursor: pointer;" />
+      <input type="checkbox" id="include-screenshot" ${includeScreenshot ? 'checked' : ''} style="width: 18px; height: 18px; accent-color: var(--bd-primary); cursor: pointer;" />
       <label for="include-screenshot" style="font-size: 0.95rem; color: var(--bd-text-secondary); cursor: pointer; user-select: none;">
         📸 Include a screenshot
       </label>


### PR DESCRIPTION
Fixes #116.

## Summary
- remember when a user skips screenshots from the complex-page fallback modal
- default future reports on that same complex page to no screenshot for 7 days
- keep simple pages, repo isolation, explicit opt-back-in, required mode, and auto mode covered

## Testing
- npm run build:widget
- npm run typecheck
- npm run test
- npm run lint
- LIVE_TARGET=1 PLAYWRIGHT_BASE_URL=http://localhost:8792 npx playwright test e2e/widget.spec.ts -g "issue #116|redacted page|scoped by repo|same-url|opt back|element capture failure|very complex|below 10k|auto mode" --project=chromium