### PR TITLE
Fix annotation undo

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2137,7 +2137,9 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     }`;
   }
 
-  function reporterLikePng(variant: 'preview-size' | 'small-wide-area' | 'annotation-style') {
+  function reporterLikePng(
+    variant: 'preview-size' | 'small-wide-area' | 'annotation-style' | 'undo'
+  ) {
     return `function(el, opts) {
       window.__captureOpts = opts;
       var canvas = document.createElement('canvas');
@@ -2170,6 +2172,21 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
         ctx.fillStyle = '#525252';
         ctx.font = '28px Arial';
         ctx.fillText('Settlement Stage', 14, 36);
+      } else if ('${variant}' === 'undo') {
+        canvas.width = 600;
+        canvas.height = 300;
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#111827';
+        ctx.font = '600 18px Arial';
+        ctx.fillText('Undo regression canvas', 24, 38);
+        ctx.fillStyle = '#e5e7eb';
+        ctx.fillRect(36, 82, 210, 128);
+        ctx.fillRect(354, 82, 210, 128);
+        ctx.fillStyle = '#6b7280';
+        ctx.font = '14px Arial';
+        ctx.fillText('First annotation area', 58, 150);
+        ctx.fillText('Latest annotation area', 374, 150);
       } else {
         canvas.width = 1024;
         canvas.height = 252;
@@ -2346,6 +2363,93 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
 
       return { red, orange };
     });
+  }
+
+  async function countRedPixelsInRegion(
+    canvas: ReturnType<Page['locator']>,
+    region: { left: number; top: number; right: number; bottom: number }
+  ) {
+    return canvas.evaluate((el, targetRegion) => {
+      const source = el as HTMLCanvasElement;
+      const ctx = source.getContext('2d');
+      if (!ctx) {
+        throw new Error('Missing canvas context');
+      }
+
+      const xStart = Math.floor(source.width * targetRegion.left);
+      const xEnd = Math.ceil(source.width * targetRegion.right);
+      const yStart = Math.floor(source.height * targetRegion.top);
+      const yEnd = Math.ceil(source.height * targetRegion.bottom);
+      const { data, width } = ctx.getImageData(xStart, yStart, xEnd - xStart, yEnd - yStart);
+      let red = 0;
+
+      for (let y = 0; y < yEnd - yStart; y++) {
+        for (let x = 0; x < width; x++) {
+          const i = (y * width + x) * 4;
+          const r = data[i];
+          const g = data[i + 1];
+          const b = data[i + 2];
+          const a = data[i + 3];
+
+          if (a > 200 && r > 220 && g < 80 && b < 80) {
+            red++;
+          }
+        }
+      }
+
+      return red;
+    }, region);
+  }
+
+  async function countRedPixelsInDataUrl(
+    page: Page,
+    dataUrl: string,
+    region: { left: number; top: number; right: number; bottom: number }
+  ) {
+    return page.evaluate(
+      async target => {
+        const img = new Image();
+        await new Promise<void>((resolve, reject) => {
+          img.onload = () => resolve();
+          img.onerror = () => reject(new Error('Failed to load screenshot payload'));
+          img.src = target.dataUrl;
+        });
+
+        const source = document.createElement('canvas');
+        source.width = img.width;
+        source.height = img.height;
+        const ctx = source.getContext('2d');
+        if (!ctx) {
+          throw new Error('Missing canvas context');
+        }
+
+        ctx.drawImage(img, 0, 0);
+
+        const xStart = Math.floor(source.width * target.region.left);
+        const xEnd = Math.ceil(source.width * target.region.right);
+        const yStart = Math.floor(source.height * target.region.top);
+        const yEnd = Math.ceil(source.height * target.region.bottom);
+        const { data, width } = ctx.getImageData(xStart, yStart, xEnd - xStart, yEnd - yStart);
+        let red = 0;
+
+        for (let y = 0; y < yEnd - yStart; y++) {
+          for (let x = 0; x < width; x++) {
+            const i = (y * width + x) * 4;
+            const r = data[i];
+            const g = data[i + 1];
+            const b = data[i + 2];
+            const a = data[i + 3];
+
+            if (a > 200 && r > 220 && g < 80 && b < 80) {
+              red++;
+            }
+          }
+        }
+
+        return red;
+      },
+      { dataUrl, region }
+    );
   }
 
   async function dragOnCanvas(
@@ -2919,6 +3023,154 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
       path: test.info().outputPath('issue-115-annotation-style.png'),
       fullPage: false,
     });
+  });
+
+  for (const tool of ['draw', 'arrow', 'rect'] as const) {
+    test(`undo button removes the latest ${tool} annotation for issue #128`, async ({ page }) => {
+      await mockHtmlToImage(page, reporterLikePng('undo'));
+      await page.setViewportSize({ width: 1280, height: 720 });
+      await page.goto('/test/');
+      await navigateToFullPageCapture(page);
+
+      const host = page.locator('#bugdrop-host');
+      const stage = host.locator('css=#annotation-canvas');
+      const canvas = stage.locator('css=canvas');
+      await expect(host.locator('css=.bd-modal--annotator')).toBeVisible({ timeout: 10000 });
+      await expect(stage).toBeVisible();
+      await expect(canvas).toBeVisible();
+      await expect.poll(() => canvas.evaluate(el => (el as HTMLCanvasElement).width)).toBe(600);
+
+      await host.locator(`css=[data-tool="${tool}"]`).click();
+      await dragOnCanvas(page, canvas, { x: 0.18, y: 0.28 }, { x: 0.42, y: 0.68 });
+      await dragOnCanvas(page, canvas, { x: 0.58, y: 0.28 }, { x: 0.82, y: 0.68 });
+
+      const firstRegion = { left: 0.1, top: 0.18, right: 0.48, bottom: 0.78 };
+      const latestRegion = { left: 0.52, top: 0.18, right: 0.9, bottom: 0.78 };
+      const firstBeforeUndo = await countRedPixelsInRegion(canvas, firstRegion);
+      const latestBeforeUndo = await countRedPixelsInRegion(canvas, latestRegion);
+
+      expect(firstBeforeUndo).toBeGreaterThan(20);
+      expect(latestBeforeUndo).toBeGreaterThan(20);
+
+      await host.locator('css=[data-action="undo"]').click();
+
+      const firstAfterOneUndo = await countRedPixelsInRegion(canvas, firstRegion);
+      const latestAfterOneUndo = await countRedPixelsInRegion(canvas, latestRegion);
+
+      expect(firstAfterOneUndo).toBeGreaterThan(20);
+      expect(latestAfterOneUndo).toBeLessThan(5);
+
+      await host.locator('css=[data-action="undo"]').click();
+
+      const firstAfterTwoUndos = await countRedPixelsInRegion(canvas, firstRegion);
+      const latestAfterTwoUndos = await countRedPixelsInRegion(canvas, latestRegion);
+
+      expect(firstAfterTwoUndos).toBeLessThan(5);
+      expect(latestAfterTwoUndos).toBeLessThan(5);
+
+      await host.locator('css=[data-action="undo"]').click();
+
+      expect(await countRedPixelsInRegion(canvas, firstRegion)).toBeLessThan(5);
+      expect(await countRedPixelsInRegion(canvas, latestRegion)).toBeLessThan(5);
+    });
+  }
+
+  test('undo preserves mixed annotation history in the submitted screenshot for issue #128', async ({
+    page,
+  }) => {
+    const payloads = await trackFeedbackPayloads(page);
+    await mockHtmlToImage(page, reporterLikePng('undo'));
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/test/');
+    await navigateToFullPageCapture(page);
+
+    const host = page.locator('#bugdrop-host');
+    const stage = host.locator('css=#annotation-canvas');
+    const canvas = stage.locator('css=canvas');
+    await expect(host.locator('css=.bd-modal--annotator')).toBeVisible({ timeout: 10000 });
+    await expect(stage).toBeVisible();
+    await expect(canvas).toBeVisible();
+
+    const drawRegion = { left: 0.08, top: 0.18, right: 0.32, bottom: 0.78 };
+    const arrowRegion = { left: 0.36, top: 0.18, right: 0.6, bottom: 0.78 };
+    const undoneRectRegion = { left: 0.62, top: 0.18, right: 0.9, bottom: 0.5 };
+    const finalRectRegion = { left: 0.62, top: 0.52, right: 0.9, bottom: 0.9 };
+
+    await host.locator('css=[data-tool="draw"]').click();
+    await dragOnCanvas(page, canvas, { x: 0.14, y: 0.28 }, { x: 0.3, y: 0.68 });
+
+    await host.locator('css=[data-tool="arrow"]').click();
+    await dragOnCanvas(page, canvas, { x: 0.4, y: 0.28 }, { x: 0.58, y: 0.68 });
+
+    await host.locator('css=[data-tool="rect"]').click();
+    await dragOnCanvas(page, canvas, { x: 0.66, y: 0.22 }, { x: 0.86, y: 0.45 });
+
+    expect(await countRedPixelsInRegion(canvas, drawRegion)).toBeGreaterThan(20);
+    expect(await countRedPixelsInRegion(canvas, arrowRegion)).toBeGreaterThan(20);
+    expect(await countRedPixelsInRegion(canvas, undoneRectRegion)).toBeGreaterThan(20);
+
+    await host.locator('css=[data-action="undo"]').click();
+
+    expect(await countRedPixelsInRegion(canvas, drawRegion)).toBeGreaterThan(20);
+    expect(await countRedPixelsInRegion(canvas, arrowRegion)).toBeGreaterThan(20);
+    expect(await countRedPixelsInRegion(canvas, undoneRectRegion)).toBeLessThan(5);
+
+    await dragOnCanvas(page, canvas, { x: 0.66, y: 0.58 }, { x: 0.86, y: 0.84 });
+    expect(await countRedPixelsInRegion(canvas, finalRectRegion)).toBeGreaterThan(20);
+
+    await host.locator('css=[data-action="done"]').click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+
+    expect(payloads).toHaveLength(1);
+    const submittedScreenshot = payloads[0].screenshot;
+    expect(typeof submittedScreenshot).toBe('string');
+
+    expect(
+      await countRedPixelsInDataUrl(page, submittedScreenshot as string, drawRegion)
+    ).toBeGreaterThan(20);
+    expect(
+      await countRedPixelsInDataUrl(page, submittedScreenshot as string, arrowRegion)
+    ).toBeGreaterThan(20);
+    expect(
+      await countRedPixelsInDataUrl(page, submittedScreenshot as string, undoneRectRegion)
+    ).toBeLessThan(5);
+    expect(
+      await countRedPixelsInDataUrl(page, submittedScreenshot as string, finalRectRegion)
+    ).toBeGreaterThan(20);
+  });
+
+  test('undo cancels an unfinished annotation draft for issue #128', async ({ page }) => {
+    await mockHtmlToImage(page, reporterLikePng('undo'));
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/test/');
+    await navigateToFullPageCapture(page);
+
+    const host = page.locator('#bugdrop-host');
+    const canvas = host.locator('css=#annotation-canvas canvas');
+    await expect(host.locator('css=.bd-modal--annotator')).toBeVisible({ timeout: 10000 });
+    await expect(canvas).toBeVisible();
+
+    const committedRegion = { left: 0.08, top: 0.18, right: 0.32, bottom: 0.78 };
+    const draftRegion = { left: 0.52, top: 0.18, right: 0.9, bottom: 0.78 };
+
+    await dragOnCanvas(page, canvas, { x: 0.14, y: 0.28 }, { x: 0.3, y: 0.68 });
+    expect(await countRedPixelsInRegion(canvas, committedRegion)).toBeGreaterThan(20);
+
+    await host.locator('css=[data-tool="arrow"]').click();
+    const box = await canvas.boundingBox();
+    expect(box).toBeTruthy();
+    await page.mouse.move(box!.x + box!.width * 0.58, box!.y + box!.height * 0.28);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width * 0.82, box!.y + box!.height * 0.68, {
+      steps: 12,
+    });
+    expect(await countRedPixelsInRegion(canvas, draftRegion)).toBeGreaterThan(20);
+
+    await host.locator('css=[data-action="undo"]').dispatchEvent('click');
+    await page.mouse.up();
+
+    expect(await countRedPixelsInRegion(canvas, committedRegion)).toBeGreaterThan(20);
+    expect(await countRedPixelsInRegion(canvas, draftRegion)).toBeLessThan(5);
   });
 
   // --- Metadata: domNodeCount and fullPageDisabled in submission payload ---

--- a/src/widget/annotator.ts
+++ b/src/widget/annotator.ts
@@ -1,4 +1,4 @@
-type Tool = 'draw' | 'arrow' | 'rect' | 'text';
+export type Tool = 'draw' | 'arrow' | 'rect' | 'text';
 
 interface Point {
   x: number;
@@ -8,6 +8,7 @@ interface Point {
 const ANNOTATION_COLOR = '#ff0000';
 const VISIBLE_ANNOTATION_LINE_WIDTH = 5.5;
 const ARROW_HEAD_ANGLE = Math.PI / 7;
+const MIN_ANNOTATION_DISTANCE = 2;
 
 export function createAnnotator(
   container: HTMLElement,
@@ -24,6 +25,8 @@ export function createAnnotator(
   let currentTool: Tool = 'draw';
   let isDrawing = false;
   let points: Point[] = [];
+  let draftBase: ImageData | null = null;
+  let hasDrawnStroke = false;
   const history: ImageData[] = [];
 
   // Load image
@@ -38,15 +41,40 @@ export function createAnnotator(
 
     ctx.drawImage(img, 0, 0);
 
-    // Save initial state
-    saveState();
+    // Commit the unannotated screenshot as the undo floor.
+    commitState();
   };
   img.src = imageData;
 
   container.appendChild(canvas);
 
-  function saveState() {
+  function commitState() {
     history.push(ctx.getImageData(0, 0, canvas.width, canvas.height));
+  }
+
+  function restoreState(state: ImageData) {
+    ctx.putImageData(state, 0, 0);
+  }
+
+  function getLatestState() {
+    return history[history.length - 1] ?? null;
+  }
+
+  function getDistance(from: Point, to: Point) {
+    return Math.hypot(to.x - from.x, to.y - from.y);
+  }
+
+  function resetDraft() {
+    window.removeEventListener('mouseup', handleMouseUp);
+    isDrawing = false;
+    points = [];
+    draftBase = null;
+    hasDrawnStroke = false;
+  }
+
+  function cancelDraft() {
+    if (draftBase) restoreState(draftBase);
+    resetDraft();
   }
 
   function getCanvasPoint(e: MouseEvent): Point {
@@ -109,24 +137,29 @@ export function createAnnotator(
     ctx.strokeRect(from.x, from.y, to.x - from.x, to.y - from.y);
   }
 
-  // Event handlers
-  canvas.addEventListener('mousedown', e => {
+  function handleMouseDown(e: MouseEvent) {
+    const base = getLatestState();
+    if (!base) return;
+
     isDrawing = true;
     points = [getCanvasPoint(e)];
-    saveState();
-  });
+    draftBase = base;
+    hasDrawnStroke = false;
+    window.addEventListener('mouseup', handleMouseUp);
+  }
 
-  canvas.addEventListener('mousemove', e => {
-    if (!isDrawing) return;
+  function handleMouseMove(e: MouseEvent) {
+    if (!isDrawing || !draftBase) return;
 
     const point = getCanvasPoint(e);
 
     if (currentTool === 'draw') {
       drawLine(points[points.length - 1], point);
       points.push(point);
+      hasDrawnStroke = hasDrawnStroke || getDistance(points[0], point) >= MIN_ANNOTATION_DISTANCE;
     } else {
       // Preview for arrow/rect
-      ctx.putImageData(history[history.length - 1], 0, 0);
+      restoreState(draftBase);
 
       if (currentTool === 'arrow') {
         drawArrow(points[0], point);
@@ -134,33 +167,62 @@ export function createAnnotator(
         drawRect(points[0], point);
       }
     }
-  });
+  }
 
-  canvas.addEventListener('mouseup', e => {
-    if (!isDrawing) return;
-    isDrawing = false;
-
-    const point = getCanvasPoint(e);
-
-    if (currentTool === 'arrow') {
-      drawArrow(points[0], point);
-    } else if (currentTool === 'rect') {
-      drawRect(points[0], point);
+  function handleMouseUp(e: MouseEvent) {
+    if (!isDrawing || !draftBase) {
+      resetDraft();
+      return;
     }
 
-    points = [];
-  });
+    const point = getCanvasPoint(e);
+    const start = points[0];
+    const isMeaningfulAnnotation =
+      hasDrawnStroke || getDistance(start, point) >= MIN_ANNOTATION_DISTANCE;
+
+    if (!isMeaningfulAnnotation) {
+      restoreState(draftBase);
+      resetDraft();
+      return;
+    }
+
+    if (currentTool === 'arrow') {
+      restoreState(draftBase);
+      drawArrow(start, point);
+    } else if (currentTool === 'rect') {
+      restoreState(draftBase);
+      drawRect(start, point);
+    } else if (currentTool === 'draw' && !hasDrawnStroke) {
+      drawLine(start, point);
+    }
+
+    commitState();
+    resetDraft();
+  }
+
+  // Event handlers
+  canvas.addEventListener('mousedown', handleMouseDown);
+  canvas.addEventListener('mousemove', handleMouseMove);
+  canvas.addEventListener('mouseup', handleMouseUp);
 
   return {
     setTool(tool: Tool) {
+      cancelDraft();
       currentTool = tool;
     },
 
     undo() {
-      if (history.length > 1) {
-        history.pop();
-        ctx.putImageData(history[history.length - 1], 0, 0);
+      if (draftBase) {
+        cancelDraft();
+        return;
       }
+
+      if (history.length <= 1) return;
+
+      resetDraft();
+      history.pop();
+      const previousState = getLatestState();
+      if (previousState) restoreState(previousState);
     },
 
     getImageData(): string {
@@ -168,6 +230,10 @@ export function createAnnotator(
     },
 
     destroy() {
+      resetDraft();
+      canvas.removeEventListener('mousedown', handleMouseDown);
+      canvas.removeEventListener('mousemove', handleMouseMove);
+      canvas.removeEventListener('mouseup', handleMouseUp);
       canvas.remove();
     },
   };

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -8,7 +8,7 @@ import {
 } from './screenshot';
 import { createElementPicker } from './picker';
 import { createAreaPicker } from './area-picker';
-import { createAnnotator } from './annotator';
+import { createAnnotator, type Tool } from './annotator';
 import { injectStyles, createModal, showSuccessModal } from './ui';
 import {
   resolveTheme,
@@ -1272,18 +1272,19 @@ function showAnnotationStep(
     const toolButtons = modal.querySelectorAll('[data-tool]');
     toolButtons.forEach(btn => {
       btn.addEventListener('click', e => {
-        const target = e.target as HTMLElement;
+        const target = e.currentTarget as HTMLElement;
         const tool = target.dataset.tool;
 
-        if (tool === 'undo') {
-          annotator.undo();
-        } else if (tool) {
+        if (tool) {
           toolButtons.forEach(b => b.classList.remove('active'));
           target.classList.add('active');
-          annotator.setTool(tool as any);
+          annotator.setTool(tool as Tool);
         }
       });
     });
+
+    const undoBtn = modal.querySelector('[data-action="undo"]') as HTMLElement | null;
+    undoBtn?.addEventListener('click', () => annotator.undo());
 
     // Action buttons
     const closeBtn = modal.querySelector('.bd-close') as HTMLElement;


### PR DESCRIPTION
## Summary
- Wire the annotation toolbar Undo button to the annotator
- Store committed annotation states so undo removes the latest completed action only
- Cancel unfinished drafts safely on undo/tool changes and preserve the submitted screenshot state

Fixes #128.

## Testing
- npm run typecheck
- npm run build:widget
- npm test
- npm run lint (existing warnings only)
- PLAYWRIGHT_BASE_URL=http://localhost:8793 npx playwright test e2e/widget.spec.ts -g "issue #128" --project=chromium
- PLAYWRIGHT_BASE_URL=http://localhost:8793 npx playwright test e2e/widget.spec.ts -g "issue #11(5|7|9)|issue #128" --project=chromium