### PR TITLE
Simplify annotation action labels

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -3362,4 +3362,44 @@ test.describe('Screenshot Mode Configuration', () => {
     await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
     expect(getPayload()?.screenshot).toEqual(expect.stringMatching(/^data:image\/png;base64,/));
   });
+
+  test('annotation actions use distinct labels and submit from one primary action', async ({
+    page,
+  }) => {
+    await setupInstalledApp(page);
+    await mockSuccessfulCapture(page);
+    const getPayload = await setupSuccessfulSubmit(page);
+
+    await page.goto('/test/');
+    const host = await openForm(page);
+
+    await host.locator('css=#include-screenshot').check();
+    await host.locator('css=#submit-btn').click();
+    await host.locator('css=[data-action="capture"]').click();
+
+    const annotationModal = host.locator('css=.bd-modal--annotator');
+    await expect(annotationModal).toBeVisible({ timeout: 10000 });
+    const annotationActions = annotationModal.locator('css=.bd-actions [data-action]');
+    await expect(annotationActions).toHaveCount(2);
+
+    expect(
+      await annotationActions.evaluateAll(buttons =>
+        buttons.map(button => ({
+          action: (button as HTMLElement).dataset.action,
+          label: (button as HTMLElement).textContent?.trim(),
+        }))
+      )
+    ).toEqual([
+      { action: 'retake', label: 'Retake' },
+      { action: 'done', label: 'Submit Feedback' },
+    ]);
+
+    await expect(annotationModal.locator('css=[data-action="skip"]')).toHaveCount(0);
+    await expect(annotationModal.getByRole('button', { name: 'Skip Annotations' })).toHaveCount(0);
+
+    await annotationModal.locator('css=[data-action="done"]').click();
+
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+    expect(getPayload()?.screenshot).toEqual(expect.stringMatching(/^data:image\/png;base64,/));
+  });
 });

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -1257,8 +1257,7 @@ function showAnnotationStep(
         <div id="annotation-canvas" class="bd-annotation-stage"></div>
         <div class="bd-actions">
           <button class="bd-btn bd-btn-secondary" data-action="retake">Retake</button>
-          <button class="bd-btn bd-btn-secondary" data-action="skip">Skip Annotations</button>
-          <button class="bd-btn bd-btn-primary" data-action="done">Done</button>
+          <button class="bd-btn bd-btn-primary" data-action="done">Submit Feedback</button>
         </div>
       `,
       false,
@@ -1289,7 +1288,6 @@ function showAnnotationStep(
     // Action buttons
     const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
     const retakeBtn = modal.querySelector('[data-action="retake"]') as HTMLElement;
-    const skipBtn = modal.querySelector('[data-action="skip"]') as HTMLElement;
     const doneBtn = modal.querySelector('[data-action="done"]') as HTMLElement;
 
     closeBtn?.addEventListener('click', () => {
@@ -1302,12 +1300,6 @@ function showAnnotationStep(
       annotator.destroy();
       modal.remove();
       resolve('retake');
-    });
-
-    skipBtn?.addEventListener('click', () => {
-      annotator.destroy();
-      modal.remove();
-      resolve(screenshot);
     });
 
     doneBtn?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- remove the redundant annotation "Skip Annotations" action
- rename the annotation submit action to "Submit Feedback"
- add Playwright coverage proving the annotation actions are exactly Retake and Submit Feedback

Closes #130

## Validation
- npm run typecheck
- npm run build:widget
- npm run lint (existing warnings only)
- npm test
- npx prettier --check e2e/widget.spec.ts src/widget/index.ts
- LIVE_TARGET=local PLAYWRIGHT_BASE_URL=http://localhost:8796 npx playwright test e2e/widget.spec.ts --project=chromium -g "annotation actions use distinct labels" --workers=1
- LIVE_TARGET=local PLAYWRIGHT_BASE_URL=http://localhost:8796 npx playwright test e2e/widget.spec.ts --project=chromium -g "Screenshot Mode Configuration|retake button on annotation step returns" --workers=1