### PR TITLE
Clarify select-area copy

### DIFF
--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -144,7 +144,7 @@ test.describe('Widget Loading (Live)', () => {
       }
     });
 
-    await page.goto('/');
+    await page.goto(process.env.LIVE_TARGET === 'preview' ? '/' : '/test/');
     await page.waitForTimeout(2000);
 
     // Widget host element should exist
@@ -182,7 +182,7 @@ test.describe('Widget Loading (Live)', () => {
 
 test.describe('Feedback Button (Live)', () => {
   test('feedback button is visible and clickable', async ({ page }) => {
-    await page.goto('/');
+    await page.goto(process.env.LIVE_TARGET === 'preview' ? '/' : '/test/');
 
     const button = page.locator('#bugdrop-host').locator('css=.bd-trigger');
     await expect(button).toBeVisible({ timeout: 10_000 });
@@ -359,7 +359,7 @@ test.describe('Screenshot Capture (Live)', () => {
       });
     });
 
-    await page.goto('/');
+    await page.goto(process.env.LIVE_TARGET === 'preview' ? '/' : '/test/');
 
     const host = page.locator('#bugdrop-host');
     const button = host.locator('css=.bd-trigger');
@@ -382,6 +382,17 @@ test.describe('Screenshot Capture (Live)', () => {
 
     const areaBtn = host.locator('css=[data-action="area"]');
     await expect(areaBtn).toBeVisible({ timeout: 5_000 });
+    await expect(areaBtn).toHaveText('Select Area');
+
+    await areaBtn.click();
+
+    const tooltip = page.locator('#bugdrop-area-picker-tooltip');
+    await expect(tooltip).toBeVisible({ timeout: 5_000 });
+    await expect(tooltip).toHaveText('Draw a selection around the area to capture (ESC to cancel)');
+    await expect(tooltip).not.toContainText('Drag');
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#bugdrop-area-picker-overlay')).not.toBeVisible({ timeout: 3_000 });
   });
 
   test('annotation undo works on the deployed preview widget', async ({ page }) => {

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -444,7 +444,8 @@ test.describe('Widget Interaction', () => {
     // Tooltip should be visible
     const tooltip = page.locator('#bugdrop-area-picker-tooltip');
     await expect(tooltip).toBeVisible();
-    await expect(tooltip).toContainText('Drag to select an area');
+    await expect(tooltip).toHaveText('Draw a selection around the area to capture (ESC to cancel)');
+    await expect(tooltip).not.toContainText('Drag');
 
     // Press ESC to cancel
     await page.keyboard.press('Escape');

--- a/src/widget/area-picker.ts
+++ b/src/widget/area-picker.ts
@@ -2,6 +2,7 @@ import type { PickerStyle } from './picker';
 import { resolvePickerStyle } from './picker';
 
 const MIN_SELECTION_SIZE = 10;
+const AREA_PICKER_INSTRUCTION = 'Draw a selection around the area to capture (ESC to cancel)';
 
 export function createAreaPicker(style?: PickerStyle): Promise<DOMRect | null> {
   return new Promise(resolve => {
@@ -64,7 +65,7 @@ function startAreaPicker(resolve: (rect: DOMRect | null) => void, style?: Picker
     border: ${bw}px solid ${tooltipBorder};
     pointer-events: none;
   `;
-  tooltip.textContent = 'Drag to select an area (ESC to cancel)';
+  tooltip.textContent = AREA_PICKER_INSTRUCTION;
   document.body.appendChild(tooltip);
 
   let startX = 0;


### PR DESCRIPTION
## Summary
- replace the area picker overlay instruction with clearer draw/select-area wording
- assert the clarified copy locally and in live preview E2E coverage

Closes #126

## Testing
- npm run typecheck
- npm run lint (existing warnings only)
- npm test
- npm run build:widget
- git diff --check
- LIVE_TARGET=local PLAYWRIGHT_BASE_URL=http://localhost:8797 npx playwright test e2e/widget.spec.ts --project=chromium -g "select area button appears" --workers=1
- LIVE_TARGET=local PLAYWRIGHT_BASE_URL=http://localhost:8797 npx playwright test e2e/widget.live.spec.ts --project=chromium-live -g "select area button is available" --workers=1

Rendered proof: /tmp/bugdrop-issue-126-select-area.png