### PR TITLE
Fix feedback form field order

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -1982,6 +1982,70 @@ test.describe('Feedback Categories', () => {
     await expect(questionOption).toBeAttached();
   });
 
+  test('feedback form fields progress from category to details and submitter info', async ({
+    page,
+  }) => {
+    await page.route('**/api/check/**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/test/?showName=true&showEmail=true');
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+    await expect(host.locator('css=#title')).toBeVisible({ timeout: 5000 });
+
+    const fieldOrder = await host.locator('css=#feedback-form').evaluate(form =>
+      Array.from(form.children)
+        .map(child => {
+          if (!(child instanceof HTMLElement)) return null;
+          if (child.querySelector('.bd-category-selector')) return 'category';
+          if (child.querySelector('#title')) return 'title';
+          if (child.querySelector('#description')) return 'description';
+          if (child.querySelector('#name')) return 'name';
+          if (child.querySelector('#email')) return 'email';
+          if (child.querySelector('#include-screenshot')) return 'screenshot';
+          if (child.classList.contains('bd-actions')) return 'actions';
+          return null;
+        })
+        .filter(Boolean)
+    );
+
+    expect(fieldOrder).toEqual([
+      'category',
+      'title',
+      'description',
+      'name',
+      'email',
+      'screenshot',
+      'actions',
+    ]);
+
+    const formFields = [
+      host.locator('css=.bd-category-selector'),
+      host.locator('css=#title'),
+      host.locator('css=#description'),
+      host.locator('css=#name'),
+      host.locator('css=#email'),
+      host.locator('css=#include-screenshot'),
+    ];
+    const boxes = await Promise.all(formFields.map(locator => locator.boundingBox()));
+
+    expect(boxes.every(Boolean)).toBe(true);
+    for (let i = 1; i < boxes.length; i += 1) {
+      expect(boxes[i]!.y).toBeGreaterThan(boxes[i - 1]!.y);
+    }
+
+    const categoryBox = await host.locator('css=.bd-category-selector').boundingBox();
+    expect(categoryBox?.height).toBeLessThan(60);
+  });
+
   test('bug category is selected by default', async ({ page }) => {
     // Mock installation check
     await page.route('**/api/check/**', async route => {

--- a/public/test/index.html
+++ b/public/test/index.html
@@ -604,7 +604,15 @@
         var script = document.getElementById('bugdrop-script');
         if (!script) return;
         var params = new URLSearchParams(location.search);
-        var mapping = { theme: 'data-theme', bg: 'data-bg', screenshot: 'data-screenshot' };
+        var mapping = {
+          theme: 'data-theme',
+          bg: 'data-bg',
+          screenshot: 'data-screenshot',
+          showName: 'data-show-name',
+          requireName: 'data-require-name',
+          showEmail: 'data-show-email',
+          requireEmail: 'data-require-email'
+        };
         Object.keys(mapping).forEach(function (key) {
           var v = params.get(key);
           if (v != null) script.setAttribute(mapping[key], v);

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -1021,12 +1021,6 @@ function showFeedbackFormWithScreenshotOption(
       'Send Feedback',
       `
         <form id="feedback-form">
-          ${nameFieldHtml}
-          ${emailFieldHtml}
-          <div class="bd-form-group">
-            <label class="bd-label" for="title">Title *</label>
-            <input type="text" id="title" class="bd-input" required placeholder="Brief description of the issue or suggestion" value="${escapeHtml(initialValues?.title || '')}" />
-          </div>
           <div class="bd-form-group">
             <label class="bd-label">Category</label>
             <div class="bd-category-selector" style="display: flex; gap: 8px; margin-top: 6px;">
@@ -1045,9 +1039,15 @@ function showFeedbackFormWithScreenshotOption(
             </div>
           </div>
           <div class="bd-form-group">
+            <label class="bd-label" for="title">Title *</label>
+            <input type="text" id="title" class="bd-input" required placeholder="Brief description of the issue or suggestion" value="${escapeHtml(initialValues?.title || '')}" />
+          </div>
+          <div class="bd-form-group">
             <label class="bd-label" for="description">Description</label>
             <textarea id="description" class="bd-textarea" placeholder="Provide additional details, steps to reproduce, or context...">${escapeHtml(initialValues?.description || '')}</textarea>
           </div>
+          ${nameFieldHtml}
+          ${emailFieldHtml}
           ${getScreenshotFormControl(config, initialValues)}
           <div class="bd-actions">
             <button type="button" class="bd-btn bd-btn-secondary" data-action="cancel">Cancel</button>

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -932,6 +932,17 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
         min-height: 48px;
       }
 
+      .bd-category-option {
+        gap: 4px !important;
+        padding: 8px !important;
+        min-width: 0;
+      }
+
+      .bd-category-option span {
+        font-size: 0.85rem !important;
+        white-space: nowrap;
+      }
+
       .bd-textarea {
         min-height: 120px;
       }


### PR DESCRIPTION
## Summary
- Reorder the feedback form to start with Category, then Title and Description, followed by optional submitter info and the screenshot option
- Keep validation and submission behavior unchanged
- Tighten mobile category-option spacing so the first field remains compact

Closes #125

## Testing
- npm run typecheck
- npm run lint (existing warnings only)
- npm test
- npm run build:widget
- git diff --check
- LIVE_TARGET=local PLAYWRIGHT_BASE_URL=http://localhost:8798 npx playwright test e2e/widget.spec.ts --project=chromium -g "feedback form fields progress" --workers=1
- Rendered desktop and mobile screenshots of the reordered form with optional name/email enabled