### PR TITLE
feat: support configurable category labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,15 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
 
 ## Widget Options
 
-| Attribute       | Values                                               | Default          |
-| --------------- | ---------------------------------------------------- | ---------------- |
-| `data-repo`     | `owner/repo`                                         | **required**     |
-| `data-theme`    | `light`, `dark`, `auto`                              | `auto`           |
-| `data-position` | `bottom-right`, `bottom-left`                        | `bottom-right`   |
-| `data-color`    | Accent color for buttons/highlights (e.g. `#FF6B35`) | `#14b8a6` (teal) |
-| `data-label`    | Any string                                           | `Feedback`       |
-| `data-button`   | `true`, `false`                                      | `true`           |
+| Attribute              | Values                                               | Default          |
+| ---------------------- | ---------------------------------------------------- | ---------------- |
+| `data-repo`            | `owner/repo`                                         | **required**     |
+| `data-theme`           | `light`, `dark`, `auto`                              | `auto`           |
+| `data-position`        | `bottom-right`, `bottom-left`                        | `bottom-right`   |
+| `data-color`           | Accent color for buttons/highlights (e.g. `#FF6B35`) | `#14b8a6` (teal) |
+| `data-label`           | Any string                                           | `Feedback`       |
+| `data-category-labels` | JSON mapping for self-hosted category labels         | built-in labels  |
+| `data-button`          | `true`, `false`                                      | `true`           |
 
 See [full documentation](https://bugdrop.dev/docs/configuration) for all options including styling, submitter info, and dismissible button.
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -168,16 +168,36 @@ The release tag (e.g., `v1.2.0`) becomes the version number for the widget files
 
 ### Custom Category Labels
 
-For authoritative mappings, configure labels on the worker:
+For authoritative mappings, configure labels on the worker. Two JSON shapes are supported.
+
+**Flat** — applies to every repo your worker serves:
 
 ```toml
 [vars]
-CATEGORY_LABELS = '{"owner/repo":{"bug":["defect","frontend"],"feature":"product-feedback","question":"support"}}'
+CATEGORY_LABELS = '{"bug":["defect","frontend"],"feature":"product-feedback","question":"support"}'
 ```
 
-Self-hosted deployments can also opt into script-tag mappings by setting `ALLOW_CLIENT_CATEGORY_LABELS = "true"` and using `data-category-labels` on pages you control. Only enable this when your worker is locked down to trusted origins.
+**Per-repo** with optional `"*"` wildcard fallback:
+
+```toml
+[vars]
+CATEGORY_LABELS = '{"owner/repo":{"bug":["defect","frontend"]},"*":{"bug":"triage"}}'
+```
+
+The shape is detected automatically: top-level keys containing `/` or equal to `*` are treated as repos; otherwise the object is treated as flat.
+
+Validation rules:
+
+- Recognized categories: `bug`, `feature`, `question`. Unknown keys are dropped with a warning.
+- Each category accepts a single label or an array of **1-5** labels.
+- Each label must be **1-100 characters** after trimming. Whitespace-only labels are rejected.
+- Every issue also receives the `bugdrop` label automatically.
+
+Self-hosted deployments can also opt into script-tag mappings by setting `ALLOW_CLIENT_CATEGORY_LABELS = "true"` (case-sensitive — values like `"True"`, `"1"`, or `"yes"` keep the gate closed) and using `data-category-labels` on pages you control. Only enable this when your worker is locked down to trusted origins.
 
 When both are set, `CATEGORY_LABELS` takes precedence: the worker uses the server-side mapping and ignores `data-category-labels`. If `CATEGORY_LABELS` is set but unusable (malformed JSON, wrong shape, or a per-repo map with no entry for the current repo and no `"*"` fallback), the worker falls back to default GitHub labels and surfaces a warning in the issue body — it does **not** fall through to the browser-supplied mapping. This keeps a typo in your env config from silently handing label control back to the page.
+
+Warnings emitted during label resolution are also written to worker logs (visible via `wrangler tail`) and returned in the `/feedback` success response under `labelMappingWarnings` so monitoring can detect misconfigurations without parsing issue bodies.
 
 ### Locking Down Allowed Origins (Recommended)
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -154,15 +154,28 @@ The release tag (e.g., `v1.2.0`) becomes the version number for the widget files
 
 ### Environment Variables
 
-| Variable                 | Required | Description                                                           |
-| ------------------------ | -------- | --------------------------------------------------------------------- |
-| `GITHUB_APP_ID`          | Yes      | Your GitHub App's numeric ID                                          |
-| `GITHUB_PRIVATE_KEY`     | Yes      | Private key from GitHub App settings                                  |
-| `ENVIRONMENT`            | No       | `development` disables rate limiting; `production` enables all checks |
-| `ALLOWED_ORIGINS`        | No       | Comma-separated allowed domains (default: `*`)                        |
-| `GITHUB_APP_NAME`        | No       | Your app's URL slug for install links                                 |
-| `MAX_SCREENSHOT_SIZE_MB` | No       | Max screenshot size in MB (default: `5`)                              |
-| `RATE_LIMIT`             | No       | KV namespace binding for rate limiting (see section 5)                |
+| Variable                       | Required | Description                                                           |
+| ------------------------------ | -------- | --------------------------------------------------------------------- |
+| `GITHUB_APP_ID`                | Yes      | Your GitHub App's numeric ID                                          |
+| `GITHUB_PRIVATE_KEY`           | Yes      | Private key from GitHub App settings                                  |
+| `ENVIRONMENT`                  | No       | `development` disables rate limiting; `production` enables all checks |
+| `ALLOWED_ORIGINS`              | No       | Comma-separated allowed domains (default: `*`)                        |
+| `GITHUB_APP_NAME`              | No       | Your app's URL slug for install links                                 |
+| `MAX_SCREENSHOT_SIZE_MB`       | No       | Max screenshot size in MB (default: `5`)                              |
+| `CATEGORY_LABELS`              | No       | JSON mapping from repos/categories to GitHub labels                   |
+| `ALLOW_CLIENT_CATEGORY_LABELS` | No       | Set to `true` to trust `data-category-labels` from your own pages     |
+| `RATE_LIMIT`                   | No       | KV namespace binding for rate limiting (see section 5)                |
+
+### Custom Category Labels
+
+For authoritative mappings, configure labels on the worker:
+
+```toml
+[vars]
+CATEGORY_LABELS = '{"owner/repo":{"bug":["defect","frontend"],"feature":"product-feedback","question":"support"}}'
+```
+
+Self-hosted deployments can also opt into script-tag mappings by setting `ALLOW_CLIENT_CATEGORY_LABELS = "true"` and using `data-category-labels` on pages you control. Only enable this when your worker is locked down to trusted origins.
 
 ### Locking Down Allowed Origins (Recommended)
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -190,7 +190,7 @@ Validation rules:
 
 - Recognized categories: `bug`, `feature`, `question`. Unknown keys are dropped with a warning.
 - Each category accepts a single label or an array of **1-5** labels.
-- Each label must be **1-100 characters** after trimming. Whitespace-only labels are rejected.
+- Each label must be **1-50 characters** after trimming (matching GitHub's label-name limit). Whitespace-only labels and labels containing control characters (newlines, NUL, etc.) are rejected.
 - Every issue also receives the `bugdrop` label automatically.
 
 Self-hosted deployments can also opt into script-tag mappings by setting `ALLOW_CLIENT_CATEGORY_LABELS = "true"` (case-sensitive — values like `"True"`, `"1"`, or `"yes"` keep the gate closed) and using `data-category-labels` on pages you control. Only enable this when your worker is locked down to trusted origins.

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -177,6 +177,8 @@ CATEGORY_LABELS = '{"owner/repo":{"bug":["defect","frontend"],"feature":"product
 
 Self-hosted deployments can also opt into script-tag mappings by setting `ALLOW_CLIENT_CATEGORY_LABELS = "true"` and using `data-category-labels` on pages you control. Only enable this when your worker is locked down to trusted origins.
 
+When both are set, `CATEGORY_LABELS` takes precedence: the worker uses the server-side mapping and ignores `data-category-labels`. If `CATEGORY_LABELS` is set but unusable (malformed JSON, wrong shape, or a per-repo map with no entry for the current repo and no `"*"` fallback), the worker falls back to default GitHub labels and surfaces a warning in the issue body — it does **not** fall through to the browser-supplied mapping. This keeps a typo in your env config from silently handing label control back to the page.
+
 ### Locking Down Allowed Origins (Recommended)
 
 > **Security:** When self-hosting, you should always set `ALLOWED_ORIGINS` to only the domains where you embed the widget. The default `"*"` allows any website to submit requests to your worker — meaning anyone who discovers your worker URL could create issues on repos where your app is installed (subject to rate limits).

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -14,6 +14,7 @@ These attributes control the fundamental behavior of the widget.
 | `data-color` | `"#7c3aed"` | Primary accent color (any CSS color value) |
 | `data-icon` | *(default bug icon)* | Custom icon: URL to an image, `"none"` to hide, or omit for default |
 | `data-label` | `""` | Text label displayed next to the button icon |
+| `data-category-labels` | built-in labels | Self-hosted JSON mapping from built-in categories to GitHub labels |
 | `data-button` | `"true"` | Show the floating button: `"true"` or `"false"` |
 | `data-welcome` | `"Report a bug or request a feature"` | Welcome message displayed at the top of the form |
 
@@ -112,7 +113,7 @@ When a user dismisses the button:
 
 ## Feedback Categories
 
-Users can choose from three feedback categories when submitting a report. Each category maps to a specific GitHub label:
+Users can choose from three feedback categories when submitting a report. By default, each category maps to a specific GitHub label:
 
 | Category | Emoji | GitHub Label | Description |
 |----------|-------|-------------|-------------|
@@ -120,7 +121,31 @@ Users can choose from three feedback categories when submitting a report. Each c
 | Feature | :sparkles: | `enhancement` | A new feature or improvement request |
 | Question | :question: | `question` | A question about the product or usage |
 
-These categories are built into the widget and cannot be customized at this time. The corresponding GitHub labels are created automatically in your repository if they do not already exist.
+These categories are built into the widget. Self-hosted deployments can customize the GitHub labels applied by each category with `data-category-labels` when `ALLOW_CLIENT_CATEGORY_LABELS` is set to `"true"`:
+
+```html
+<script
+  src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="acme-corp/my-app"
+  data-category-labels='{"bug":["defect","frontend"],"feature":"product-feedback","question":"support"}'
+></script>
+```
+
+Each category can map to a single label string or an array of labels. Omitted categories keep their default labels, and every issue still receives the `bugdrop` label.
+
+Hosted deployments do not trust label mappings from public browser requests. Use server-side `CATEGORY_LABELS` configuration for authoritative mappings:
+
+```json
+{
+  "acme-corp/my-app": {
+    "bug": ["defect", "frontend"],
+    "feature": "product-feedback",
+    "question": "support"
+  }
+}
+```
+
+Only the built-in keys `bug`, `feature`, and `question` are recognized. Each category can use 1-5 labels, and each label must be 1-100 characters. If GitHub rejects a configured label, BugDrop retries the issue with default labels and adds a label mapping warning to the issue body.
 
 ## Automatic System Information
 

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -121,7 +121,44 @@ Users can choose from three feedback categories when submitting a report. By def
 | Feature | :sparkles: | `enhancement` | A new feature or improvement request |
 | Question | :question: | `question` | A question about the product or usage |
 
-These categories are built into the widget. Self-hosted deployments can customize the GitHub labels applied by each category with `data-category-labels` when `ALLOW_CLIENT_CATEGORY_LABELS` is set to `"true"`:
+These categories are built into the widget. Self-hosted deployments can customize which GitHub labels each category applies. There are two configuration paths:
+
+### Server-side mapping (recommended)
+
+Set `CATEGORY_LABELS` on your worker. The mapping is authoritative — clients cannot override it. Two shapes are supported:
+
+**Flat shape** — same labels for every repo your worker serves:
+
+```json
+{
+  "bug": ["defect", "frontend"],
+  "feature": "product-feedback",
+  "question": "support"
+}
+```
+
+**Per-repo shape** — different labels per repo, with an optional `"*"` wildcard fallback:
+
+```json
+{
+  "acme-corp/my-app": {
+    "bug": ["defect", "frontend"],
+    "feature": "product-feedback"
+  },
+  "acme-corp/docs": {
+    "bug": "docs-bug"
+  },
+  "*": {
+    "bug": "triage"
+  }
+}
+```
+
+The shape is detected automatically: keys containing `/` or equal to `*` mean per-repo; otherwise it's treated as flat.
+
+### Client-side mapping (self-hosts only, opt-in)
+
+Self-hosted deployments can also let pages set labels via the `data-category-labels` attribute. This is **disabled by default** because it lets any page that loads your worker dictate which labels appear on issues. Enable it by setting `ALLOW_CLIENT_CATEGORY_LABELS` to the literal string `"true"` (case-sensitive — values like `"True"`, `"1"`, or `"yes"` keep the gate closed):
 
 ```html
 <script
@@ -131,21 +168,26 @@ These categories are built into the widget. Self-hosted deployments can customiz
 ></script>
 ```
 
-Each category can map to a single label string or an array of labels. Omitted categories keep their default labels, and every issue still receives the `bugdrop` label.
+Only enable this when your worker's `ALLOWED_ORIGINS` is locked down to trusted domains.
 
-Hosted deployments do not trust label mappings from public browser requests. Use server-side `CATEGORY_LABELS` configuration for authoritative mappings:
+### Rules and behavior
 
-```json
-{
-  "acme-corp/my-app": {
-    "bug": ["defect", "frontend"],
-    "feature": "product-feedback",
-    "question": "support"
-  }
-}
-```
+- Recognized keys: `bug`, `feature`, `question`. Other keys are ignored with a warning.
+- Each category accepts a single label string or an array of 1-5 strings; each label must be 1-100 characters after trimming.
+- Every issue also receives the `bugdrop` label (always added).
+- **Precedence**: when both server and client mappings are present, `CATEGORY_LABELS` wins.
+- **Fail-closed on misconfig**: if `CATEGORY_LABELS` is set but unusable (malformed JSON, wrong shape, or a per-repo map with no entry for the current repo and no `"*"` fallback), the worker uses default labels and emits a warning — it does **not** silently fall back to `data-category-labels`. This keeps a typo from handing label control back to the browser.
+- **GitHub rejection retry**: if GitHub rejects a configured label (e.g. it doesn't exist in the repo), BugDrop retries once with default labels and embeds a label-mapping warning in the issue body.
+- **Warnings in the response**: if any warnings were emitted, the `/feedback` JSON success response includes a `labelMappingWarnings: string[]` field so callers can surface configuration issues programmatically.
 
-Only the built-in keys `bug`, `feature`, and `question` are recognized. Each category can use 1-5 labels, and each label must be 1-100 characters. If GitHub rejects a configured label, BugDrop retries the issue with default labels and adds a label mapping warning to the issue body.
+### Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Issues are filed with default labels (`bug`, `enhancement`, `question`) instead of yours | `CATEGORY_LABELS` JSON is malformed, the shape is wrong, or the per-repo map has no entry for this repo and no `"*"` fallback. Check the issue body for a `## Label mapping warning` section, or the worker logs for `[BugDrop] Category label config warnings`. |
+| `data-category-labels` is ignored | `ALLOW_CLIENT_CATEGORY_LABELS` is unset or not exactly the string `"true"`. Or `CATEGORY_LABELS` is also set, in which case it always wins. |
+| Some categories take effect but others don't | Unknown category keys (anything other than `bug`/`feature`/`question`) are dropped with a warning. Check spelling. |
+| GitHub returns a 422 | A configured label doesn't exist in the repo. BugDrop retries with default labels automatically; the issue still gets created and the rejection is recorded in the body. |
 
 ## Automatic System Information
 

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -173,7 +173,7 @@ Only enable this when your worker's `ALLOWED_ORIGINS` is locked down to trusted 
 ### Rules and behavior
 
 - Recognized keys: `bug`, `feature`, `question`. Other keys are ignored with a warning.
-- Each category accepts a single label string or an array of 1-5 strings; each label must be 1-100 characters after trimming.
+- Each category accepts a single label string or an array of 1-5 strings; each label must be 1-50 characters after trimming (GitHub's limit). Labels containing control characters are rejected.
 - Every issue also receives the `bugdrop` label (always added).
 - **Precedence**: when both server and client mappings are present, `CATEGORY_LABELS` wins.
 - **Fail-closed on misconfig**: if `CATEGORY_LABELS` is set but unusable (malformed JSON, wrong shape, or a per-repo map with no entry for the current repo and no `"*"` fallback), the worker uses default labels and emits a warning — it does **not** silently fall back to `data-category-labels`. This keeps a typo from handing label control back to the browser.

--- a/docs/website/faq.mdx
+++ b/docs/website/faq.mdx
@@ -101,9 +101,9 @@ BugDrop needs to initialize synchronously to ensure the widget is ready as early
 
 ## Configuration
 
-### Does BugDrop support custom labels?
+### Can I customize the feedback button label?
 
-Yes. The `data-label` attribute adds a text label next to the button icon:
+Yes. The `data-label` attribute changes the text displayed next to the button icon:
 
 ```html
 <script src="https://bugdrop.neonwatty.workers.dev/widget.js"
@@ -120,9 +120,21 @@ You can also set `data-icon="none"` to show only the text label without an icon:
   data-label="Report a Bug"></script>
 ```
 
+### Can I customize GitHub issue labels?
+
+Yes. Self-hosted deployments can map the three built-in categories to custom GitHub labels with `data-category-labels` when `ALLOW_CLIENT_CATEGORY_LABELS` is set to `"true"`:
+
+```html
+<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="owner/repo"
+  data-category-labels='{"bug":"defect","feature":["product-feedback","triage"],"question":"support"}'></script>
+```
+
+Hosted deployments use server-side `CATEGORY_LABELS` configuration instead of trusting labels from public browser requests. Every issue still receives the `bugdrop` label.
+
 ### Can I customize the feedback categories?
 
-The three categories (Bug, Feature Request, and Question) are built into the widget and cannot currently be customized through data attributes. Each category maps to a GitHub label (`bug`, `enhancement`, and `question` respectively). If you need custom categories, consider [self-hosting](/docs/self-hosting) and modifying the widget source code.
+The three categories (Bug, Feature Request, and Question) are built into the widget and cannot currently be renamed or replaced through data attributes. You can customize which GitHub labels those categories apply.
 
 ### Can I collect the user's name and email?
 

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2410,6 +2410,60 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     await expect(titleInput).toHaveValue(title);
   }
 
+  test('sends custom category label mapping while keeping built-in category UI', async ({
+    page,
+  }) => {
+    const payloads = await trackFeedbackPayloads(page);
+    const categoryLabels = encodeURIComponent(
+      JSON.stringify({
+        bug: ['defect', 'frontend'],
+        feature: 'product-feedback',
+        question: 'support',
+      })
+    );
+
+    await page.goto(`/test/?categoryLabels=${categoryLabels}`);
+    const host = await navigateToForm(page, 'Custom label mapping test');
+
+    await expect(host.locator('css=input[name="category"][value="bug"]')).toBeAttached();
+    await expect(host.locator('css=input[name="category"][value="feature"]')).toBeAttached();
+    await expect(host.locator('css=input[name="category"][value="question"]')).toBeAttached();
+
+    await host.locator('css=input[name="category"][value="feature"]').click();
+    await host.locator('css=#include-screenshot').uncheck();
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+    expect(payloads[0]?.category).toBe('feature');
+    expect(payloads[0]?.categoryLabels).toEqual({
+      bug: ['defect', 'frontend'],
+      feature: 'product-feedback',
+      question: 'support',
+    });
+  });
+
+  test('malformed category label mapping does not block submission', async ({ page }) => {
+    const payloads = await trackFeedbackPayloads(page);
+    const warnings: string[] = [];
+    page.on('console', msg => {
+      if (msg.type() === 'warning') warnings.push(msg.text());
+    });
+
+    await page.goto('/test/?categoryLabels=%7Bbad-json');
+    const host = await navigateToForm(page, 'Malformed label mapping test');
+
+    await host.locator('css=#include-screenshot').uncheck();
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+    expect(payloads[0]?.category).toBe('bug');
+    expect(payloads[0]?.categoryLabels).toBeUndefined();
+    expect(payloads[0]?.categoryLabelConfigError).toBeUndefined();
+    expect(warnings).toContain(
+      '[BugDrop] Invalid data-category-labels JSON. Using default GitHub labels.'
+    );
+  });
+
   async function countAnnotationPixels(canvas: ReturnType<Page['locator']>) {
     return canvas.evaluate(el => {
       const source = el as HTMLCanvasElement;

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2458,10 +2458,7 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
     expect(payloads[0]?.category).toBe('bug');
     expect(payloads[0]?.categoryLabels).toBeUndefined();
-    expect(payloads[0]?.categoryLabelConfigError).toBeUndefined();
-    expect(warnings).toContain(
-      '[BugDrop] Invalid data-category-labels JSON. Using default GitHub labels.'
-    );
+    expect(warnings.some(w => w.startsWith('[BugDrop] Invalid data-category-labels'))).toBe(true);
   });
 
   async function countAnnotationPixels(canvas: ReturnType<Page['locator']>) {

--- a/public/test/index.html
+++ b/public/test/index.html
@@ -611,7 +611,8 @@
           showName: 'data-show-name',
           requireName: 'data-require-name',
           showEmail: 'data-show-email',
-          requireEmail: 'data-require-email'
+          requireEmail: 'data-require-email',
+          categoryLabels: 'data-category-labels'
         };
         Object.keys(mapping).forEach(function (key) {
           var v = params.get(key);

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -3,6 +3,21 @@ import type { Env, GitHubIssue } from '../types';
 
 const GITHUB_API = 'https://api.github.com';
 
+/**
+ * Thrown when GitHub rejects an issue creation specifically due to invalid
+ * labels — the only failure for which the caller may safely retry with
+ * default labels. Distinguishing this from a generic API error prevents
+ * fragile substring matching on error messages.
+ */
+export class GitHubLabelError extends Error {
+  readonly status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'GitHubLabelError';
+    this.status = status;
+  }
+}
+
 const headers = (token: string) => ({
   Authorization: `Bearer ${token}`,
   Accept: 'application/vnd.github+json',
@@ -80,11 +95,31 @@ export async function createIssue(
   });
 
   if (!response.ok) {
-    const error = await response.text();
-    throw new Error(`Failed to create issue: ${response.status} - ${error}`);
+    const errorText = await response.text();
+    if (response.status === 422 && isLabelValidationFailure(errorText)) {
+      throw new GitHubLabelError(`GitHub rejected labels: ${errorText}`, response.status);
+    }
+    throw new Error(`Failed to create issue: ${response.status} - ${errorText}`);
   }
 
   return response.json();
+}
+
+/**
+ * GitHub returns 422 with `{"errors":[{"field":"labels",...}]}` when an issue
+ * is rejected for invalid/non-existent labels. Parse the structured response
+ * rather than substring-matching the message — substring matches over user-
+ * controlled error text drift silently.
+ */
+function isLabelValidationFailure(body: string): boolean {
+  try {
+    const parsed = JSON.parse(body) as {
+      errors?: Array<{ field?: unknown }>;
+    };
+    return Array.isArray(parsed.errors) && parsed.errors.some(e => e?.field === 'labels');
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -20,7 +20,10 @@ const DEFAULT_CATEGORY_LABELS: Record<FeedbackCategory, string[]> = {
 
 const CATEGORY_KEYS: FeedbackCategory[] = ['bug', 'feature', 'question'];
 const MAX_LABELS_PER_CATEGORY = 5;
-const MAX_LABEL_LENGTH = 100;
+// GitHub enforces a 50-char limit on label names; keep validation in lockstep
+// so over-long configured labels surface as a clear local warning rather than
+// going out, getting rejected, and triggering the GitHub-error fallback path.
+const MAX_LABEL_LENGTH = 50;
 
 // CORS middleware with origin whitelist
 api.use('*', async (c, next) => {
@@ -442,6 +445,16 @@ function normalizeLabelValue(
       };
     }
 
+    // Reject ASCII control characters (newlines, NUL, etc). A label like
+    // "foo\n## Compromised" passes length validation but breaks out of the
+    // inline-code span and injects markdown into the issue body.
+    if (hasControlChars(rawLabel)) {
+      return {
+        valid: false,
+        warning: `Invalid labels for category "${category}": labels cannot contain control characters.`,
+      };
+    }
+
     const label = rawLabel.trim();
     if (!label || label.length > MAX_LABEL_LENGTH) {
       return {
@@ -457,6 +470,14 @@ function normalizeLabelValue(
 
 function uniqueLabels(labels: string[]): string[] {
   return Array.from(new Set(labels));
+}
+
+function hasControlChars(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) return true;
+  }
+  return false;
 }
 
 function sameLabels(left: string[], right: string[]): boolean {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,11 +1,12 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
-import type { CategoryLabelConfig, Env, FeedbackCategory, FeedbackPayload } from '../types';
+import type { Env, FeedbackCategory, FeedbackPayload } from '../types';
 import {
   getInstallationToken,
   createIssue,
   uploadScreenshotAsAsset,
   isRepoPublic,
+  GitHubLabelError,
 } from '../lib/github';
 import { rateLimit, rateLimitByRepo } from '../middleware/rateLimit';
 
@@ -159,6 +160,15 @@ api.post('/feedback', async c => {
     }
 
     const labelResolution = resolveCategoryLabels(payload, c.env, payload.repo);
+    if (labelResolution.warnings.length > 0) {
+      // Surface warnings in worker logs so self-host operators see the misconfig
+      // even when no issue is filed. Otherwise these warnings only ever appear
+      // in successfully-created issue bodies.
+      console.warn('[BugDrop] Category label config warnings:', {
+        repo: payload.repo,
+        warnings: labelResolution.warnings,
+      });
+    }
 
     // Check repo visibility (for UI to decide whether to show issue link)
     const isPublic = await isRepoPublic(token, owner, repo);
@@ -168,7 +178,7 @@ api.post('/feedback', async c => {
     try {
       issue = await createIssue(token, owner, repo, payload.title, body, labelResolution.labels);
     } catch (error) {
-      if (!labelResolution.usedCustomLabels || !isLikelyLabelError(error)) {
+      if (!labelResolution.usedCustomLabels || !(error instanceof GitHubLabelError)) {
         throw error;
       }
 
@@ -178,7 +188,25 @@ api.post('/feedback', async c => {
         `GitHub rejected the configured labels (${formatLabelList(labelResolution.labels)}), so BugDrop retried with default labels (${formatLabelList(fallbackLabels)}).`,
       ];
       body = formatIssueBody(payload, screenshotUrl, warning);
-      issue = await createIssue(token, owner, repo, payload.title, body, fallbackLabels);
+      try {
+        issue = await createIssue(token, owner, repo, payload.title, body, fallbackLabels);
+      } catch (fallbackError) {
+        // Both configured AND default labels failed — surface a distinct error
+        // so operators can tell this from a single-call failure. Without this,
+        // the outer catch reports only the second error and loses the retry
+        // context entirely.
+        console.error('[BugDrop] Both configured and default labels failed.', {
+          configured: labelResolution.labels,
+          fallback: fallbackLabels,
+          originalError: error,
+          fallbackError,
+        });
+        const fallbackMessage =
+          fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+        throw new Error(
+          `Failed to create issue with both configured labels (${formatLabelList(labelResolution.labels)}) and default labels (${formatLabelList(fallbackLabels)}): ${fallbackMessage}`
+        );
+      }
     }
 
     return c.json({
@@ -186,6 +214,9 @@ api.post('/feedback', async c => {
       issueNumber: issue.number,
       issueUrl: issue.html_url,
       isPublic,
+      ...(labelResolution.warnings.length > 0
+        ? { labelMappingWarnings: labelResolution.warnings }
+        : {}),
     });
   } catch (error) {
     console.error('Error creating feedback:', error);
@@ -204,7 +235,6 @@ type LabelResolution = {
   warnings: string[];
   usedCustomLabels: boolean;
 };
-type CategoryLabelMappingByRepo = Record<string, CategoryLabelConfig>;
 
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
@@ -258,37 +288,29 @@ function validateScreenshotDataUrl(dataUrl: string, maxSizeMB: number): Screensh
 
 function resolveCategoryLabels(payload: FeedbackPayload, env: Env, repo: string): LabelResolution {
   const selectedCategory = isFeedbackCategory(payload.category) ? payload.category : 'bug';
-  const labelsByCategory: Record<FeedbackCategory, string[]> = {
-    bug: [...DEFAULT_CATEGORY_LABELS.bug],
-    feature: [...DEFAULT_CATEGORY_LABELS.feature],
-    question: [...DEFAULT_CATEGORY_LABELS.question],
-  };
+  const labelsByCategory: Record<FeedbackCategory, string[]> = { ...DEFAULT_CATEGORY_LABELS };
   const warnings: string[] = [];
   const configuredLabels = getConfiguredCategoryLabels(payload, env, repo, warnings);
   let selectedCategoryWasCustomized = false;
 
   if (configuredLabels !== undefined) {
-    if (!isPlainObject(configuredLabels)) {
-      warnings.push('Invalid category label mapping: expected an object.');
-    } else {
-      for (const key of Object.keys(configuredLabels)) {
-        if (!isFeedbackCategory(key)) {
-          warnings.push(`Unknown category label mapping key ignored: \`${safeInlineCode(key)}\`.`);
-          continue;
-        }
+    for (const key of Object.keys(configuredLabels)) {
+      if (!isFeedbackCategory(key)) {
+        warnings.push(`Unknown category label mapping key ignored: \`${safeInlineCode(key)}\`.`);
+        continue;
+      }
 
-        const normalized = normalizeLabelValue(configuredLabels[key], key);
-        if (normalized.valid) {
-          labelsByCategory[key] = normalized.labels;
-          if (key === selectedCategory) {
-            selectedCategoryWasCustomized = !sameLabels(
-              normalized.labels,
-              DEFAULT_CATEGORY_LABELS[selectedCategory]
-            );
-          }
-        } else {
-          warnings.push(normalized.warning);
+      const normalized = normalizeLabelValue(configuredLabels[key], key);
+      if (normalized.valid) {
+        labelsByCategory[key] = normalized.labels;
+        if (key === selectedCategory) {
+          selectedCategoryWasCustomized = !sameLabels(
+            normalized.labels,
+            DEFAULT_CATEGORY_LABELS[selectedCategory]
+          );
         }
+      } else {
+        warnings.push(normalized.warning);
       }
     }
   }
@@ -300,48 +322,88 @@ function resolveCategoryLabels(payload: FeedbackPayload, env: Env, repo: string)
   };
 }
 
+// Discriminated result of parsing CATEGORY_LABELS so the caller cannot conflate
+// "env unset" with "env set but unusable" — the latter must fail closed even when
+// ALLOW_CLIENT_CATEGORY_LABELS is true.
+type EnvCategoryConfigResult =
+  | { kind: 'unset' }
+  | { kind: 'config'; value: Record<string, unknown> }
+  | { kind: 'malformed'; warning: string }
+  | { kind: 'invalid-shape'; warning: string }
+  | { kind: 'no-match'; warning: string };
+
 function getConfiguredCategoryLabels(
   payload: FeedbackPayload,
   env: Env,
   repo: string,
   warnings: string[]
-): unknown {
-  const envLabels = parseEnvCategoryLabels(env.CATEGORY_LABELS, repo, warnings);
-  if (envLabels !== undefined) {
-    return envLabels;
-  }
+): Record<string, unknown> | undefined {
+  const envResult = parseEnvCategoryLabels(env.CATEGORY_LABELS, repo);
 
-  if (env.ALLOW_CLIENT_CATEGORY_LABELS === 'true') {
-    return payload.categoryLabels;
+  switch (envResult.kind) {
+    case 'config':
+      return envResult.value;
+    case 'malformed':
+    case 'invalid-shape':
+    case 'no-match':
+      // Env was set but unusable — fail closed. Do NOT fall through to the
+      // client mapping even when ALLOW_CLIENT_CATEGORY_LABELS=true: the operator
+      // explicitly configured server authority, and a typo must not silently
+      // hand label control back to the browser.
+      warnings.push(envResult.warning);
+      return undefined;
+    case 'unset':
+      if (env.ALLOW_CLIENT_CATEGORY_LABELS !== 'true') return undefined;
+      if (payload.categoryLabels === undefined) return undefined;
+      if (!isPlainObject(payload.categoryLabels)) {
+        warnings.push('Invalid category label mapping: expected an object.');
+        return undefined;
+      }
+      return payload.categoryLabels;
   }
-
-  return undefined;
 }
 
 function parseEnvCategoryLabels(
   rawValue: string | undefined,
-  repo: string,
-  warnings: string[]
-): unknown {
-  if (!rawValue) return undefined;
+  repo: string
+): EnvCategoryConfigResult {
+  if (!rawValue) return { kind: 'unset' };
 
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(rawValue) as unknown;
-    if (!isPlainObject(parsed)) {
-      warnings.push('Invalid server category label config: expected a JSON object.');
-      return undefined;
-    }
-
-    if (hasAnyCategoryKey(parsed)) {
-      return parsed;
-    }
-
-    const byRepo = parsed as CategoryLabelMappingByRepo;
-    return byRepo[repo] ?? byRepo['*'];
+    parsed = JSON.parse(rawValue);
   } catch {
-    warnings.push('Invalid server category label config: malformed JSON.');
-    return undefined;
+    return { kind: 'malformed', warning: 'Invalid server category label config: malformed JSON.' };
   }
+
+  if (!isPlainObject(parsed)) {
+    return {
+      kind: 'invalid-shape',
+      warning: 'Invalid server category label config: expected a JSON object.',
+    };
+  }
+
+  // Disambiguate flat vs per-repo by syntax, not by guessing: per-repo keys are
+  // either the wildcard `*` or contain a `/` (owner/repo). Category keys never do.
+  const isPerRepoShape = Object.keys(parsed).some(k => k === '*' || k.includes('/'));
+  if (!isPerRepoShape) {
+    return { kind: 'config', value: parsed };
+  }
+
+  const match = parsed[repo] ?? parsed['*'];
+  if (match === undefined) {
+    return {
+      kind: 'no-match',
+      warning: `Server category label config has no mapping for \`${safeInlineCode(repo)}\` and no \`*\` fallback.`,
+    };
+  }
+  if (!isPlainObject(match)) {
+    return {
+      kind: 'invalid-shape',
+      warning: `Invalid server category label config for \`${safeInlineCode(repo)}\`: expected an object.`,
+    };
+  }
+  return { kind: 'config', value: match };
 }
 
 function getDefaultLabelsForCategory(category: FeedbackCategory | undefined): string[] {
@@ -405,18 +467,8 @@ function isFeedbackCategory(value: unknown): value is FeedbackCategory {
   return typeof value === 'string' && CATEGORY_KEYS.includes(value as FeedbackCategory);
 }
 
-function isPlainObject(value: unknown): value is CategoryLabelConfig {
+function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function hasAnyCategoryKey(value: CategoryLabelConfig): boolean {
-  return CATEGORY_KEYS.some(key => Object.prototype.hasOwnProperty.call(value, key));
-}
-
-function isLikelyLabelError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  const normalized = message.toLowerCase();
-  return normalized.includes('label');
 }
 
 function formatLabelList(labels: string[]): string {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
-import type { Env, FeedbackPayload } from '../types';
+import type { CategoryLabelConfig, Env, FeedbackCategory, FeedbackPayload } from '../types';
 import {
   getInstallationToken,
   createIssue,
@@ -10,6 +10,16 @@ import {
 import { rateLimit, rateLimitByRepo } from '../middleware/rateLimit';
 
 const api = new Hono<{ Bindings: Env }>();
+
+const DEFAULT_CATEGORY_LABELS: Record<FeedbackCategory, string[]> = {
+  bug: ['bug'],
+  feature: ['enhancement'],
+  question: ['question'],
+};
+
+const CATEGORY_KEYS: FeedbackCategory[] = ['bug', 'feature', 'question'];
+const MAX_LABELS_PER_CATEGORY = 5;
+const MAX_LABEL_LENGTH = 100;
 
 // CORS middleware with origin whitelist
 api.use('*', async (c, next) => {
@@ -148,25 +158,28 @@ api.post('/feedback', async c => {
       }
     }
 
-    // Build issue body
-    const body = formatIssueBody(payload, screenshotUrl);
+    const labelResolution = resolveCategoryLabels(payload, c.env, payload.repo);
 
     // Check repo visibility (for UI to decide whether to show issue link)
     const isPublic = await isRepoPublic(token, owner, repo);
 
-    // Map category to GitHub label
-    const categoryLabels: Record<string, string> = {
-      bug: 'bug',
-      feature: 'enhancement',
-      question: 'question',
-    };
-    const categoryLabel = payload.category ? categoryLabels[payload.category] || 'bug' : 'bug';
+    let body = formatIssueBody(payload, screenshotUrl, labelResolution.warnings);
+    let issue;
+    try {
+      issue = await createIssue(token, owner, repo, payload.title, body, labelResolution.labels);
+    } catch (error) {
+      if (!labelResolution.usedCustomLabels || !isLikelyLabelError(error)) {
+        throw error;
+      }
 
-    // Create issue with category label
-    const issue = await createIssue(token, owner, repo, payload.title, body, [
-      categoryLabel,
-      'bugdrop',
-    ]);
+      const fallbackLabels = buildIssueLabels(getDefaultLabelsForCategory(payload.category));
+      const warning = [
+        ...labelResolution.warnings,
+        `GitHub rejected the configured labels (${formatLabelList(labelResolution.labels)}), so BugDrop retried with default labels (${formatLabelList(fallbackLabels)}).`,
+      ];
+      body = formatIssueBody(payload, screenshotUrl, warning);
+      issue = await createIssue(token, owner, repo, payload.title, body, fallbackLabels);
+    }
 
     return c.json({
       success: true,
@@ -186,6 +199,12 @@ api.post('/feedback', async c => {
 });
 
 type ScreenshotValidationResult = { valid: true } | { valid: false; error: string };
+type LabelResolution = {
+  labels: string[];
+  warnings: string[];
+  usedCustomLabels: boolean;
+};
+type CategoryLabelMappingByRepo = Record<string, CategoryLabelConfig>;
 
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
@@ -237,6 +256,177 @@ function validateScreenshotDataUrl(dataUrl: string, maxSizeMB: number): Screensh
   return { valid: true };
 }
 
+function resolveCategoryLabels(payload: FeedbackPayload, env: Env, repo: string): LabelResolution {
+  const selectedCategory = isFeedbackCategory(payload.category) ? payload.category : 'bug';
+  const labelsByCategory: Record<FeedbackCategory, string[]> = {
+    bug: [...DEFAULT_CATEGORY_LABELS.bug],
+    feature: [...DEFAULT_CATEGORY_LABELS.feature],
+    question: [...DEFAULT_CATEGORY_LABELS.question],
+  };
+  const warnings: string[] = [];
+  const configuredLabels = getConfiguredCategoryLabels(payload, env, repo, warnings);
+  let selectedCategoryWasCustomized = false;
+
+  if (configuredLabels !== undefined) {
+    if (!isPlainObject(configuredLabels)) {
+      warnings.push('Invalid category label mapping: expected an object.');
+    } else {
+      for (const key of Object.keys(configuredLabels)) {
+        if (!isFeedbackCategory(key)) {
+          warnings.push(`Unknown category label mapping key ignored: \`${safeInlineCode(key)}\`.`);
+          continue;
+        }
+
+        const normalized = normalizeLabelValue(configuredLabels[key], key);
+        if (normalized.valid) {
+          labelsByCategory[key] = normalized.labels;
+          if (key === selectedCategory) {
+            selectedCategoryWasCustomized = !sameLabels(
+              normalized.labels,
+              DEFAULT_CATEGORY_LABELS[selectedCategory]
+            );
+          }
+        } else {
+          warnings.push(normalized.warning);
+        }
+      }
+    }
+  }
+
+  return {
+    labels: buildIssueLabels(labelsByCategory[selectedCategory]),
+    warnings,
+    usedCustomLabels: selectedCategoryWasCustomized,
+  };
+}
+
+function getConfiguredCategoryLabels(
+  payload: FeedbackPayload,
+  env: Env,
+  repo: string,
+  warnings: string[]
+): unknown {
+  const envLabels = parseEnvCategoryLabels(env.CATEGORY_LABELS, repo, warnings);
+  if (envLabels !== undefined) {
+    return envLabels;
+  }
+
+  if (env.ALLOW_CLIENT_CATEGORY_LABELS === 'true') {
+    return payload.categoryLabels;
+  }
+
+  return undefined;
+}
+
+function parseEnvCategoryLabels(
+  rawValue: string | undefined,
+  repo: string,
+  warnings: string[]
+): unknown {
+  if (!rawValue) return undefined;
+
+  try {
+    const parsed = JSON.parse(rawValue) as unknown;
+    if (!isPlainObject(parsed)) {
+      warnings.push('Invalid server category label config: expected a JSON object.');
+      return undefined;
+    }
+
+    if (hasAnyCategoryKey(parsed)) {
+      return parsed;
+    }
+
+    const byRepo = parsed as CategoryLabelMappingByRepo;
+    return byRepo[repo] ?? byRepo['*'];
+  } catch {
+    warnings.push('Invalid server category label config: malformed JSON.');
+    return undefined;
+  }
+}
+
+function getDefaultLabelsForCategory(category: FeedbackCategory | undefined): string[] {
+  return DEFAULT_CATEGORY_LABELS[isFeedbackCategory(category) ? category : 'bug'];
+}
+
+function buildIssueLabels(categoryLabels: string[]): string[] {
+  return uniqueLabels([...categoryLabels, 'bugdrop']);
+}
+
+function normalizeLabelValue(
+  value: unknown,
+  category: FeedbackCategory
+): { valid: true; labels: string[] } | { valid: false; warning: string } {
+  const rawLabels = typeof value === 'string' ? [value] : Array.isArray(value) ? value : null;
+  if (!rawLabels) {
+    return {
+      valid: false,
+      warning: `Invalid labels for category "${category}": expected a string or string array.`,
+    };
+  }
+
+  if (rawLabels.length === 0 || rawLabels.length > MAX_LABELS_PER_CATEGORY) {
+    return {
+      valid: false,
+      warning: `Invalid labels for category "${category}": expected 1-${MAX_LABELS_PER_CATEGORY} labels.`,
+    };
+  }
+
+  const labels: string[] = [];
+  for (const rawLabel of rawLabels) {
+    if (typeof rawLabel !== 'string') {
+      return {
+        valid: false,
+        warning: `Invalid labels for category "${category}": all labels must be strings.`,
+      };
+    }
+
+    const label = rawLabel.trim();
+    if (!label || label.length > MAX_LABEL_LENGTH) {
+      return {
+        valid: false,
+        warning: `Invalid labels for category "${category}": labels must be 1-${MAX_LABEL_LENGTH} characters.`,
+      };
+    }
+    labels.push(label);
+  }
+
+  return { valid: true, labels: uniqueLabels(labels) };
+}
+
+function uniqueLabels(labels: string[]): string[] {
+  return Array.from(new Set(labels));
+}
+
+function sameLabels(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((label, index) => label === right[index]);
+}
+
+function isFeedbackCategory(value: unknown): value is FeedbackCategory {
+  return typeof value === 'string' && CATEGORY_KEYS.includes(value as FeedbackCategory);
+}
+
+function isPlainObject(value: unknown): value is CategoryLabelConfig {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasAnyCategoryKey(value: CategoryLabelConfig): boolean {
+  return CATEGORY_KEYS.some(key => Object.prototype.hasOwnProperty.call(value, key));
+}
+
+function isLikelyLabelError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+  return normalized.includes('label');
+}
+
+function formatLabelList(labels: string[]): string {
+  return labels.map(label => `\`${safeInlineCode(label)}\``).join(', ');
+}
+
+function safeInlineCode(value: string): string {
+  return value.replace(/[`\\]/g, '');
+}
+
 function base64ToBytes(base64: string): Uint8Array {
   const binary = atob(base64);
   const bytes = new Uint8Array(binary.length);
@@ -254,7 +444,11 @@ function hasPngSignature(bytes: Uint8Array): boolean {
 /**
  * Format the issue body with markdown
  */
-function formatIssueBody(payload: FeedbackPayload, screenshotDataUrl?: string): string {
+function formatIssueBody(
+  payload: FeedbackPayload,
+  screenshotDataUrl?: string,
+  labelWarnings: string[] = []
+): string {
   const sections: string[] = [];
 
   // Submitter info (if provided)
@@ -282,6 +476,14 @@ function formatIssueBody(payload: FeedbackPayload, screenshotDataUrl?: string): 
   if (screenshotDataUrl) {
     sections.push('## Screenshot');
     sections.push(`![Screenshot](${screenshotDataUrl})`);
+    sections.push('');
+  }
+
+  if (labelWarnings.length > 0) {
+    sections.push('## Label mapping warning');
+    for (const warning of labelWarnings) {
+      sections.push(`- ${warning}`);
+    }
     sections.push('');
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface Env {
 }
 
 export type FeedbackCategory = 'bug' | 'feature' | 'question';
-export type CategoryLabelConfig = Partial<Record<FeedbackCategory, string | string[]>>;
+type CategoryLabelConfig = Partial<Record<FeedbackCategory, string | string[]>>;
 
 export interface FeedbackPayload {
   repo: string; // "owner/repo" format

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,19 +8,23 @@ export interface Env {
   ALLOWED_ORIGINS: string; // Comma-separated list of allowed origins, or "*" for dev
   GITHUB_APP_NAME: string; // Your GitHub App name for install URL
   MAX_SCREENSHOT_SIZE_MB: string; // Max screenshot size in MB (default: 5)
+  CATEGORY_LABELS?: string; // Optional JSON category-label mapping keyed by repo or "*"
+  ALLOW_CLIENT_CATEGORY_LABELS?: string; // Self-host escape hatch for script-tag mappings
 
   // Bindings
   ASSETS: Fetcher;
   RATE_LIMIT?: KVNamespace; // Optional: for rate limiting (create with wrangler kv:namespace create RATE_LIMIT)
 }
 
-type FeedbackCategory = 'bug' | 'feature' | 'question';
+export type FeedbackCategory = 'bug' | 'feature' | 'question';
+export type CategoryLabelConfig = Partial<Record<FeedbackCategory, string | string[]>>;
 
 export interface FeedbackPayload {
   repo: string; // "owner/repo" format
   title: string;
   description: string;
   category?: FeedbackCategory; // Feedback type (maps to GitHub labels)
+  categoryLabels?: CategoryLabelConfig; // Optional self-host category-to-GitHub-label mapping
   screenshot?: string; // base64 data URL
   annotations?: string; // base64 annotated image
   submitter?: {

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -286,18 +286,47 @@ function rememberComplexScreenshotSkip(config: WidgetConfig, formResult: Feedbac
 function parseCategoryLabels(rawValue: string | undefined): CategoryLabelConfig | undefined {
   if (!rawValue) return undefined;
 
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(rawValue);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      console.warn('[BugDrop] Invalid data-category-labels JSON. Using default GitHub labels.');
-      return undefined;
-    }
-
-    return parsed as CategoryLabelConfig;
-  } catch {
-    console.warn('[BugDrop] Invalid data-category-labels JSON. Using default GitHub labels.');
+    parsed = JSON.parse(rawValue);
+  } catch (err) {
+    const detail = err instanceof Error ? `: ${err.message}` : '';
+    console.warn(
+      `[BugDrop] Invalid data-category-labels JSON${detail}. Using default GitHub labels.`
+    );
     return undefined;
   }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    console.warn(
+      '[BugDrop] Invalid data-category-labels: expected a JSON object. Using default GitHub labels.'
+    );
+    return undefined;
+  }
+
+  // Validate per-category shape so misconfig surfaces in browser DevTools rather
+  // than only inside the issue body the operator may never read. The server
+  // re-validates regardless — this layer exists for operator feedback.
+  const knownCategories: FeedbackCategory[] = ['bug', 'feature', 'question'];
+  const result: CategoryLabelConfig = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!knownCategories.includes(key as FeedbackCategory)) {
+      console.warn(
+        `[BugDrop] Invalid data-category-labels: unknown category "${key}" (expected ${knownCategories.join(', ')}). Ignoring.`
+      );
+      continue;
+    }
+    if (typeof value === 'string') {
+      result[key as FeedbackCategory] = value;
+    } else if (Array.isArray(value) && value.every(v => typeof v === 'string')) {
+      result[key as FeedbackCategory] = value;
+    } else {
+      console.warn(
+        `[BugDrop] Invalid data-category-labels: value for "${key}" must be a string or string array. Ignoring.`
+      );
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 // Read config from script tag (fallback to src-based lookup for async/defer)

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -21,6 +21,9 @@ import {
   type ThemeMode,
 } from './theme';
 
+type FeedbackCategory = 'bug' | 'feature' | 'question';
+type CategoryLabelConfig = Partial<Record<FeedbackCategory, string | string[]>>;
+
 interface WidgetConfig {
   repo: string;
   apiUrl: string;
@@ -43,6 +46,8 @@ interface WidgetConfig {
   iconUrl?: string;
   // Custom trigger button label text (default: 'Feedback')
   label?: string;
+  // Optional mapping from built-in feedback categories to GitHub labels
+  categoryLabels?: CategoryLabelConfig;
   // Tier 1 styling customization
   font?: string; // 'inherit' to use host page font, or a custom font-family string
   radius?: string; // Border radius in px (e.g., '0', '8', '16')
@@ -278,6 +283,23 @@ function rememberComplexScreenshotSkip(config: WidgetConfig, formResult: Feedbac
   formResult.includeScreenshot = false;
 }
 
+function parseCategoryLabels(rawValue: string | undefined): CategoryLabelConfig | undefined {
+  if (!rawValue) return undefined;
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      console.warn('[BugDrop] Invalid data-category-labels JSON. Using default GitHub labels.');
+      return undefined;
+    }
+
+    return parsed as CategoryLabelConfig;
+  } catch {
+    console.warn('[BugDrop] Invalid data-category-labels JSON. Using default GitHub labels.');
+    return undefined;
+  }
+}
+
 // Read config from script tag (fallback to src-based lookup for async/defer)
 const script = (document.currentScript ||
   document.querySelector('script[src*="bugdrop"][src*="widget"]')) as HTMLScriptElement;
@@ -312,6 +334,7 @@ const config: WidgetConfig = {
   iconUrl: script?.dataset.icon || undefined,
   // Custom trigger label
   label: script?.dataset.label || undefined,
+  categoryLabels: parseCategoryLabels(script?.dataset.categoryLabels),
   // Tier 1 styling customization
   font: script?.dataset.font || undefined,
   radius: script?.dataset.radius || undefined,
@@ -1022,8 +1045,6 @@ function showWelcomeScreen(root: HTMLElement): Promise<boolean> {
   });
 }
 
-type FeedbackCategory = 'bug' | 'feature' | 'question';
-
 interface FeedbackFormResult {
   title: string;
   description: string;
@@ -1396,6 +1417,7 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
         title: data.title,
         description: data.description,
         category: data.category,
+        categoryLabels: config.categoryLabels,
         screenshot: data.screenshot,
         submitter,
         metadata: {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -8,11 +8,21 @@ const mockCreateIssue = vi.fn();
 const mockUploadScreenshotAsAsset = vi.fn();
 const mockIsRepoPublic = vi.fn();
 
+class TestGitHubLabelError extends Error {
+  readonly status: number;
+  constructor(message: string, status = 422) {
+    super(message);
+    this.name = 'GitHubLabelError';
+    this.status = status;
+  }
+}
+
 vi.mock('../src/lib/github', () => ({
   getInstallationToken: (...args: unknown[]) => mockGetInstallationToken(...args),
   createIssue: (...args: unknown[]) => mockCreateIssue(...args),
   uploadScreenshotAsAsset: (...args: unknown[]) => mockUploadScreenshotAsAsset(...args),
   isRepoPublic: (...args: unknown[]) => mockIsRepoPublic(...args),
+  GitHubLabelError: TestGitHubLabelError,
 }));
 
 // Import API routes after mocking
@@ -401,7 +411,7 @@ describe('API Routes', () => {
     it('should retry with default labels and issue warning when GitHub rejects configured labels', async () => {
       mockGetInstallationToken.mockResolvedValue('test-token');
       mockCreateIssue
-        .mockRejectedValueOnce(new Error('422 Validation Failed: label does not exist'))
+        .mockRejectedValueOnce(new TestGitHubLabelError('GitHub rejected labels'))
         .mockResolvedValueOnce({
           number: 42,
           html_url: 'https://github.com/testowner/testrepo/issues/42',
@@ -433,6 +443,32 @@ describe('API Routes', () => {
       expect(mockCreateIssue.mock.calls[1][4]).toContain('GitHub rejected the configured labels');
     });
 
+    it('should surface a distinctive error when both configured and default labels fail', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue
+        .mockRejectedValueOnce(new TestGitHubLabelError('GitHub rejected configured labels'))
+        .mockRejectedValueOnce(new Error('rate limit exceeded on retry'));
+
+      const envWithLabels = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({ feature: 'bad-label' }),
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...validPayload, category: 'feature' }),
+      });
+      const res = await app.fetch(req, envWithLabels);
+      const data = (await res.json()) as { error: string };
+
+      expect(res.status).toBe(500);
+      expect(data.error).toContain('configured labels');
+      expect(data.error).toContain('default labels');
+      expect(data.error).toContain('rate limit exceeded on retry');
+      expect(mockCreateIssue).toHaveBeenCalledTimes(2);
+    });
+
     it('should not retry non-label GitHub validation errors', async () => {
       mockGetInstallationToken.mockResolvedValue('test-token');
       mockCreateIssue.mockRejectedValue(new Error('422 Validation Failed: title is invalid'));
@@ -452,6 +488,382 @@ describe('API Routes', () => {
 
       expect(res.status).toBe(500);
       expect(mockCreateIssue).toHaveBeenCalledTimes(1);
+    });
+
+    it('should honor client-provided category labels when ALLOW_CLIENT_CATEGORY_LABELS=true', async () => {
+      const envWithOptIn = {
+        ...mockEnv,
+        ALLOW_CLIENT_CATEGORY_LABELS: 'true',
+      };
+      const payload = {
+        ...validPayload,
+        category: 'bug' as const,
+        categoryLabels: { bug: 'security' },
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const res = await app.fetch(req, envWithOptIn);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        'test-token',
+        'testowner',
+        'testrepo',
+        'Test feedback',
+        expect.any(String),
+        ['security', 'bugdrop']
+      );
+    });
+
+    it('should validate client category labels shape when opt-in is enabled', async () => {
+      const envWithOptIn = {
+        ...mockEnv,
+        ALLOW_CLIENT_CATEGORY_LABELS: 'true',
+      };
+      const payload = {
+        ...validPayload,
+        category: 'bug' as const,
+        // Array, not an object — must be rejected with a warning, defaults used.
+        categoryLabels: ['security'] as unknown as Record<string, string>,
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const res = await app.fetch(req, envWithOptIn);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('## Label mapping warning');
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('expected an object');
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['bug', 'bugdrop']);
+    });
+
+    it.each(['TRUE', 'True', '1', 'yes', ' true ', ''])(
+      'should reject ALLOW_CLIENT_CATEGORY_LABELS=%j (only the literal "true" opens the gate)',
+      async value => {
+        const envWithLooseFlag = {
+          ...mockEnv,
+          ALLOW_CLIENT_CATEGORY_LABELS: value,
+        };
+        const payload = {
+          ...validPayload,
+          category: 'bug' as const,
+          categoryLabels: { bug: 'security' },
+        };
+
+        const req = new Request('http://localhost/feedback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const res = await app.fetch(req, envWithLooseFlag);
+
+        expect(res.status).toBe(200);
+        expect(mockCreateIssue.mock.calls[0][5]).toEqual(['bug', 'bugdrop']);
+      }
+    );
+
+    it('should prefer CATEGORY_LABELS over client categoryLabels even when ALLOW_CLIENT_CATEGORY_LABELS=true', async () => {
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({ bug: 'server-defect' }),
+        ALLOW_CLIENT_CATEGORY_LABELS: 'true',
+      };
+      const payload = {
+        ...validPayload,
+        category: 'bug' as const,
+        categoryLabels: { bug: 'client-injected' },
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['server-defect', 'bugdrop']);
+    });
+
+    it('should fail closed (use defaults, not client labels) when CATEGORY_LABELS is malformed JSON', async () => {
+      // Self-hoster typo in env JSON must NOT silently delegate to the browser
+      // even when ALLOW_CLIENT_CATEGORY_LABELS=true. Otherwise, a single typo
+      // subverts the entire server-authoritative model.
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: '{"bug":"defect"', // missing closing brace
+        ALLOW_CLIENT_CATEGORY_LABELS: 'true',
+      };
+      const payload = {
+        ...validPayload,
+        category: 'bug' as const,
+        categoryLabels: { bug: 'client-injected' },
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['bug', 'bugdrop']);
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('malformed JSON');
+    });
+
+    it('should fail closed when CATEGORY_LABELS is valid JSON but not an object', async () => {
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: '["bug","feature"]',
+        ALLOW_CLIENT_CATEGORY_LABELS: 'true',
+      };
+      const payload = {
+        ...validPayload,
+        category: 'bug' as const,
+        categoryLabels: { bug: 'client-injected' },
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['bug', 'bugdrop']);
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('expected a JSON object');
+    });
+
+    it('should select labels from a per-repo CATEGORY_LABELS map', async () => {
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          'testowner/testrepo': { feature: 'product-feedback' },
+          'other/repo': { feature: 'wrong-feedback' },
+        }),
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...validPayload, category: 'feature' }),
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['product-feedback', 'bugdrop']);
+    });
+
+    it('should fall back to "*" entry when repo is not in per-repo CATEGORY_LABELS map', async () => {
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          'other/repo': { feature: 'specific' },
+          '*': { feature: 'wildcard' },
+        }),
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...validPayload, category: 'feature' }),
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['wildcard', 'bugdrop']);
+    });
+
+    it('should include labelMappingWarnings in the success response when warnings are present', async () => {
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          bug: 'defect',
+          features: 'product-feedback', // typo — unknown key
+        }),
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...validPayload, category: 'bug' }),
+      });
+      const res = await app.fetch(req, env);
+      const data = (await res.json()) as { labelMappingWarnings?: string[] };
+
+      expect(res.status).toBe(200);
+      expect(data.labelMappingWarnings).toBeDefined();
+      expect(data.labelMappingWarnings?.[0]).toMatch(/Unknown category label mapping key/);
+    });
+
+    it('should omit labelMappingWarnings from the success response when there are none', async () => {
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, mockEnv);
+      const data = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(data).not.toHaveProperty('labelMappingWarnings');
+    });
+
+    it('should warn and fall back to defaults when CATEGORY_LABELS array contains a non-string', async () => {
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({ bug: ['ok', 123] }),
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['bug', 'bugdrop']);
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('all labels must be strings');
+    });
+
+    it('should reject CATEGORY_LABELS arrays exceeding 5 labels', async () => {
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          bug: ['a', 'b', 'c', 'd', 'e', 'f'],
+        }),
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['bug', 'bugdrop']);
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('expected 1-5 labels');
+    });
+
+    it('should accept exactly 5 labels (boundary)', async () => {
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          bug: ['a', 'b', 'c', 'd', 'e'],
+        }),
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['a', 'b', 'c', 'd', 'e', 'bugdrop']);
+    });
+
+    it('should reject CATEGORY_LABELS labels longer than 100 characters', async () => {
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          bug: 'x'.repeat(101),
+        }),
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['bug', 'bugdrop']);
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('1-100 characters');
+    });
+
+    it('should trim whitespace and reject whitespace-only labels', async () => {
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          bug: '  defect  ',
+          feature: '   ',
+        }),
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...validPayload, category: 'bug' }),
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['defect', 'bugdrop']);
+      // The whitespace-only feature mapping must produce a length warning.
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('1-100 characters');
+    });
+
+    it('should ignore __proto__ and constructor keys in CATEGORY_LABELS', async () => {
+      // JSON.parse sets __proto__ as an own enumerable property (not the
+      // prototype), so Object.keys walks it. isFeedbackCategory then rejects
+      // it, producing a warning. Pin this behavior so a future refactor to
+      // for...in (which walks the prototype chain) gets caught.
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS:
+          '{"__proto__":{"bug":"pwn"},"constructor":{"bug":"also-pwn"},"bug":"defect"}',
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['defect', 'bugdrop']);
+      expect(({} as Record<string, unknown>).bug).toBeUndefined();
+    });
+
+    it('should fail closed with a warning when per-repo CATEGORY_LABELS has no match and no wildcard', async () => {
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          'other/repo': { feature: 'specific' },
+        }),
+        ALLOW_CLIENT_CATEGORY_LABELS: 'true',
+      };
+      const payload = {
+        ...validPayload,
+        category: 'feature' as const,
+        categoryLabels: { feature: 'client-injected' },
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['enhancement', 'bugdrop']);
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('no mapping for');
     });
 
     it('should return 400 when repo is missing', async () => {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -37,8 +37,16 @@ describe('API Routes', () => {
   };
 
   beforeEach(async () => {
-    vi.clearAllMocks();
+    mockGetInstallationToken.mockReset();
+    mockCreateIssue.mockReset();
+    mockUploadScreenshotAsAsset.mockReset();
+    mockIsRepoPublic.mockReset();
     // Set default mock return values
+    mockGetInstallationToken.mockResolvedValue('test-token');
+    mockCreateIssue.mockResolvedValue({
+      number: 42,
+      html_url: 'https://github.com/testowner/testrepo/issues/42',
+    });
     mockIsRepoPublic.mockResolvedValue(true);
     app = await createApiRoutes();
   });
@@ -184,6 +192,266 @@ describe('API Routes', () => {
         expect.stringContaining('This is a test feedback'),
         ['bug', 'bugdrop']
       );
+    });
+
+    it('should ignore client-provided category labels unless explicitly enabled', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const payload = {
+        ...validPayload,
+        category: 'bug' as const,
+        categoryLabels: {
+          bug: 'security',
+        },
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const res = await app.fetch(req, mockEnv);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        'test-token',
+        'testowner',
+        'testrepo',
+        'Test feedback',
+        expect.any(String),
+        ['bug', 'bugdrop']
+      );
+    });
+
+    it('should create issue with server-configured category label string mapping', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const envWithLabels = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          feature: 'product-feedback',
+        }),
+      };
+      const payload = {
+        ...validPayload,
+        category: 'feature' as const,
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const res = await app.fetch(req, envWithLabels);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        'test-token',
+        'testowner',
+        'testrepo',
+        'Test feedback',
+        expect.any(String),
+        ['product-feedback', 'bugdrop']
+      );
+    });
+
+    it('should create issue with server-configured category label array mapping', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const envWithLabels = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          bug: ['defect', 'frontend', 'defect'],
+        }),
+      };
+      const payload = {
+        ...validPayload,
+        category: 'bug' as const,
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const res = await app.fetch(req, envWithLabels);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        'test-token',
+        'testowner',
+        'testrepo',
+        'Test feedback',
+        expect.any(String),
+        ['defect', 'frontend', 'bugdrop']
+      );
+    });
+
+    it('should keep default labels for categories omitted from server mapping', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const envWithLabels = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          bug: 'defect',
+        }),
+      };
+      const payload = {
+        ...validPayload,
+        category: 'question' as const,
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      await app.fetch(req, envWithLabels);
+
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        'test-token',
+        'testowner',
+        'testrepo',
+        'Test feedback',
+        expect.any(String),
+        ['question', 'bugdrop']
+      );
+    });
+
+    it('should fallback to default labels and include issue warning for invalid server mapping', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const envWithLabels = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          bug: '',
+        }),
+      };
+      const payload = {
+        ...validPayload,
+        category: 'bug' as const,
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      await app.fetch(req, envWithLabels);
+
+      const issueBody = mockCreateIssue.mock.calls[0][4];
+      expect(issueBody).toContain('## Label mapping warning');
+      expect(issueBody).toContain('Invalid labels for category "bug"');
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        'test-token',
+        'testowner',
+        'testrepo',
+        'Test feedback',
+        expect.any(String),
+        ['bug', 'bugdrop']
+      );
+    });
+
+    it('should warn on unknown server mapping keys', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const envWithLabels = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          bug: 'defect',
+          features: 'product-feedback',
+        }),
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...validPayload, category: 'feature' }),
+      });
+      await app.fetch(req, envWithLabels);
+
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('Unknown category label mapping key');
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['enhancement', 'bugdrop']);
+    });
+
+    it('should retry with default labels and issue warning when GitHub rejects configured labels', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue
+        .mockRejectedValueOnce(new Error('422 Validation Failed: label does not exist'))
+        .mockResolvedValueOnce({
+          number: 42,
+          html_url: 'https://github.com/testowner/testrepo/issues/42',
+        });
+
+      const envWithLabels = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          feature: 'bad-label',
+        }),
+      };
+      const payload = {
+        ...validPayload,
+        category: 'feature' as const,
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const res = await app.fetch(req, envWithLabels);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue).toHaveBeenCalledTimes(2);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['bad-label', 'bugdrop']);
+      expect(mockCreateIssue.mock.calls[1][5]).toEqual(['enhancement', 'bugdrop']);
+      expect(mockCreateIssue.mock.calls[1][4]).toContain('## Label mapping warning');
+      expect(mockCreateIssue.mock.calls[1][4]).toContain('GitHub rejected the configured labels');
+    });
+
+    it('should not retry non-label GitHub validation errors', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue.mockRejectedValue(new Error('422 Validation Failed: title is invalid'));
+
+      const envWithLabels = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({
+          feature: 'product-feedback',
+        }),
+      };
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...validPayload, category: 'feature' }),
+      });
+      const res = await app.fetch(req, envWithLabels);
+
+      expect(res.status).toBe(500);
+      expect(mockCreateIssue).toHaveBeenCalledTimes(1);
     });
 
     it('should return 400 when repo is missing', async () => {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -775,11 +775,11 @@ describe('API Routes', () => {
       expect(mockCreateIssue.mock.calls[0][5]).toEqual(['a', 'b', 'c', 'd', 'e', 'bugdrop']);
     });
 
-    it('should reject CATEGORY_LABELS labels longer than 100 characters', async () => {
+    it('should reject CATEGORY_LABELS labels longer than 50 characters (GitHub limit)', async () => {
       const env = {
         ...mockEnv,
         CATEGORY_LABELS: JSON.stringify({
-          bug: 'x'.repeat(101),
+          bug: 'x'.repeat(51),
         }),
       };
 
@@ -792,7 +792,80 @@ describe('API Routes', () => {
 
       expect(res.status).toBe(200);
       expect(mockCreateIssue.mock.calls[0][5]).toEqual(['bug', 'bugdrop']);
-      expect(mockCreateIssue.mock.calls[0][4]).toContain('1-100 characters');
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('1-50 characters');
+    });
+
+    it('should accept exactly 50-character labels (boundary)', async () => {
+      const exactly50 = 'x'.repeat(50);
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({ bug: exactly50 }),
+      };
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, env);
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual([exactly50, 'bugdrop']);
+    });
+
+    it('should reject labels with embedded newlines (markdown injection guard)', async () => {
+      // Without the control-char guard, "foo\n## Compromised" would break out
+      // of the inline-code span when rendered into the issue body markdown
+      // and inject a heading into the maintainer's tracker.
+      const malicious = 'foo\n\n## Compromised\n\n- evil';
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({ bug: malicious }),
+      };
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, env);
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['bug', 'bugdrop']);
+      const issueBody = mockCreateIssue.mock.calls[0][4];
+      expect(issueBody).toContain('cannot contain control characters');
+      // Defensive: confirm the malicious markdown didn't slip through anywhere.
+      expect(issueBody).not.toContain('## Compromised');
+    });
+
+    it('should reject labels containing NUL byte', async () => {
+      const malicious = 'foo' + String.fromCharCode(0) + 'bar';
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({ bug: malicious }),
+      };
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, env);
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['bug', 'bugdrop']);
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('cannot contain control characters');
+    });
+
+    it('should reject labels containing DEL (0x7f)', async () => {
+      const malicious = 'foo' + String.fromCharCode(0x7f) + 'bar';
+      const env = {
+        ...mockEnv,
+        CATEGORY_LABELS: JSON.stringify({ bug: malicious }),
+      };
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, env);
+      expect(res.status).toBe(200);
+      expect(mockCreateIssue.mock.calls[0][5]).toEqual(['bug', 'bugdrop']);
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('cannot contain control characters');
     });
 
     it('should trim whitespace and reject whitespace-only labels', async () => {
@@ -814,7 +887,7 @@ describe('API Routes', () => {
       expect(res.status).toBe(200);
       expect(mockCreateIssue.mock.calls[0][5]).toEqual(['defect', 'bugdrop']);
       // The whitespace-only feature mapping must produce a length warning.
-      expect(mockCreateIssue.mock.calls[0][4]).toContain('1-100 characters');
+      expect(mockCreateIssue.mock.calls[0][4]).toContain('1-50 characters');
     });
 
     it('should ignore __proto__ and constructor keys in CATEGORY_LABELS', async () => {


### PR DESCRIPTION
## Summary
- add server-authoritative category-to-GitHub-label mapping via CATEGORY_LABELS
- keep built-in category UI while allowing string or array label mappings
- ignore browser-provided mappings by default; self-hosts can opt in with ALLOW_CLIENT_CATEGORY_LABELS=true
- add fallback warning when configured labels are invalid or rejected by GitHub

## Testing
- npm run typecheck
- npm run format:check
- npm run lint (existing warnings only)
- npm test
- npm run build:widget
- LIVE_TARGET=local PLAYWRIGHT_BASE_URL=http://localhost:8798 npx playwright test e2e/widget.spec.ts --project=chromium -g "custom category label mapping|malformed category label mapping" --workers=1

Visual proof: /tmp/bugdrop-category-labels-form.png

## Security note
The first draft trusted categoryLabels from the public browser payload. After independent review, this PR makes hosted mappings server-authoritative and only trusts data-category-labels when a self-hosted worker explicitly enables ALLOW_CLIENT_CATEGORY_LABELS=true.