### PR TITLE
Add user screenshot redaction

### DIFF
--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -147,9 +147,11 @@ Control how screenshots are collected during the feedback flow.
 
 ### Screenshot Modes
 
-- **`optional`** -- Shows the screenshot checkbox checked by default. Users can choose full page, element, area, annotate, or skip.
-- **`auto`** -- Automatically captures a full-page screenshot after the form is submitted, without showing the manual screenshot picker.
-- **`required`** -- Requires a screenshot before submission. Users can choose full page, element, or area, but cannot skip the screenshot step.
+- **`optional`** -- Shows the screenshot checkbox checked by default. Users can choose full page, element, area, annotate, redact, or skip.
+- **`auto`** -- Automatically captures a full-page screenshot after the form is submitted, without showing the manual screenshot picker or redaction step.
+- **`required`** -- Requires a screenshot before submission. Users can choose full page, element, or area, then annotate or redact before submitting.
+
+Manual redaction is controlled by the person submitting feedback. Use developer-configured masking for fields that should never appear in screenshots, especially with automatic screenshots.
 
 ```html
 <!-- Automatically attach a full-page screenshot -->

--- a/docs/website/faq.mdx
+++ b/docs/website/faq.mdx
@@ -45,12 +45,13 @@ Since BugDrop uses Shadow DOM for isolation, it does not conflict with any frame
 BugDrop uses [html2canvas](https://html2canvas.hertzen.com/) to capture screenshots entirely on the client side. When a user clicks the screenshot button:
 
 1. html2canvas renders the current page to an HTML Canvas element in the user's browser
-2. The canvas is converted to a PNG image
-3. The image is sent to the BugDrop API along with the form submission
-4. The API commits the image to the `bugdrop-screenshots` branch in your GitHub repository
-5. A link to the screenshot is included in the GitHub Issue
+2. In optional and required manual screenshot flows, the user can annotate the screenshot and cover sensitive regions with opaque blocks
+3. The canvas is converted to a PNG image
+4. The image is sent to the BugDrop API along with the form submission
+5. The API commits the image to the `bugdrop-screenshots` branch in your GitHub repository
+6. A link to the screenshot is included in the GitHub Issue
 
-No server-side rendering or page access is involved. The screenshot captures exactly what the user sees in their browser at the time of submission.
+No server-side rendering or page access is involved. The initial capture is rendered from the current page in the user's browser. In manual flows, the submitted PNG may include user annotations or opaque redaction blocks. Auto screenshots upload without a user redaction step.
 
 ### Are screenshots stored securely?
 

--- a/docs/website/security.mdx
+++ b/docs/website/security.mdx
@@ -55,9 +55,12 @@ Treat screenshots as unauthenticated user-generated content. The hosted service 
 
 Screenshots are captured client-side using [html2canvas](https://html2canvas.hertzen.com/), which renders the current page to a canvas element in the user's browser. The canvas is then converted to a PNG image and uploaded. This means:
 
-- The screenshot captures what the user actually sees
+- The initial screenshot capture is rendered from what the user actually sees
 - No server-side rendering or page access is required
 - The screenshot is generated entirely in the user's browser before being sent to the API
+- Users can redact additional screenshot regions before submitting when using the manual screenshot flow
+
+Manual redaction is user-driven and does not automatically detect sensitive content. It complements, but does not replace, developer-configured masking for fields that should never appear in screenshots, especially when using automatic screenshots.
 
 Because clients are untrusted, the API validates screenshot uploads server-side before storing them. BugDrop currently accepts PNG data URLs only and rejects SVG, malformed base64, oversized payloads, and data that does not have a PNG file signature.
 

--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -82,6 +82,19 @@ async function openScreenshotOptions(page: Page, title: string) {
   return host;
 }
 
+async function trackLiveFeedbackPayloads(page: Page) {
+  const payloads: Array<Record<string, unknown>> = [];
+  await page.route('**/feedback', async route => {
+    payloads.push(route.request().postDataJSON());
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, issueNumber: 1, issueUrl: '#', isPublic: false }),
+    });
+  });
+  return payloads;
+}
+
 async function countRedPixelsInRegion(
   canvas: Locator,
   region: { left: number; top: number; right: number; bottom: number }
@@ -116,6 +129,93 @@ async function countRedPixelsInRegion(
 
     return red;
   }, region);
+}
+
+async function countBlackPixelsInRegion(
+  canvas: Locator,
+  region: { left: number; top: number; right: number; bottom: number }
+) {
+  return canvas.evaluate((el, targetRegion) => {
+    const source = el as HTMLCanvasElement;
+    const ctx = source.getContext('2d');
+    if (!ctx) {
+      throw new Error('Missing canvas context');
+    }
+
+    const xStart = Math.floor(source.width * targetRegion.left);
+    const xEnd = Math.ceil(source.width * targetRegion.right);
+    const yStart = Math.floor(source.height * targetRegion.top);
+    const yEnd = Math.ceil(source.height * targetRegion.bottom);
+    const { data, width } = ctx.getImageData(xStart, yStart, xEnd - xStart, yEnd - yStart);
+    let black = 0;
+
+    for (let y = 0; y < yEnd - yStart; y++) {
+      for (let x = 0; x < width; x++) {
+        const i = (y * width + x) * 4;
+        const r = data[i];
+        const g = data[i + 1];
+        const b = data[i + 2];
+        const a = data[i + 3];
+
+        if (a > 200 && r < 20 && g < 20 && b < 20) {
+          black++;
+        }
+      }
+    }
+
+    return black;
+  }, region);
+}
+
+async function countBlackPixelsInDataUrl(
+  page: Page,
+  dataUrl: string,
+  region: { left: number; top: number; right: number; bottom: number }
+) {
+  return page.evaluate(
+    async target => {
+      const img = new Image();
+      await new Promise<void>((resolve, reject) => {
+        img.onload = () => resolve();
+        img.onerror = () => reject(new Error('Failed to load screenshot payload'));
+        img.src = target.dataUrl;
+      });
+
+      const source = document.createElement('canvas');
+      source.width = img.width;
+      source.height = img.height;
+      const ctx = source.getContext('2d');
+      if (!ctx) {
+        throw new Error('Missing canvas context');
+      }
+
+      ctx.drawImage(img, 0, 0);
+
+      const xStart = Math.floor(source.width * target.region.left);
+      const xEnd = Math.ceil(source.width * target.region.right);
+      const yStart = Math.floor(source.height * target.region.top);
+      const yEnd = Math.ceil(source.height * target.region.bottom);
+      const { data, width } = ctx.getImageData(xStart, yStart, xEnd - xStart, yEnd - yStart);
+      let black = 0;
+
+      for (let y = 0; y < yEnd - yStart; y++) {
+        for (let x = 0; x < width; x++) {
+          const i = (y * width + x) * 4;
+          const r = data[i];
+          const g = data[i + 1];
+          const b = data[i + 2];
+          const a = data[i + 3];
+
+          if (a > 200 && r < 20 && g < 20 && b < 20) {
+            black++;
+          }
+        }
+      }
+
+      return black;
+    },
+    { dataUrl, region }
+  );
 }
 
 async function dragOnCanvas(
@@ -421,6 +521,49 @@ test.describe('Screenshot Capture (Live)', () => {
 
     expect(await countRedPixelsInRegion(canvas, firstRegion)).toBeGreaterThan(20);
     expect(await countRedPixelsInRegion(canvas, latestRegion)).toBeLessThan(5);
+  });
+
+  test('redaction works on the deployed preview widget', async ({ page }) => {
+    const payloads = await trackLiveFeedbackPayloads(page);
+    await mockLiveScreenshotCapture(page);
+    const host = await openScreenshotOptions(page, 'Live preview redaction');
+
+    const captureBtn = host.locator('css=[data-action="capture"]');
+    await expect(captureBtn).toBeVisible({ timeout: 5_000 });
+    await captureBtn.click();
+
+    const canvas = host.locator('css=#annotation-canvas canvas');
+    await expect(host.locator('css=.bd-modal--annotator')).toBeVisible({ timeout: 10_000 });
+    await expect(canvas).toBeVisible({ timeout: 10_000 });
+    await expect.poll(() => canvas.evaluate(el => (el as HTMLCanvasElement).width)).toBe(600);
+
+    await host.locator('css=[data-tool="redact"]').click();
+    await dragOnCanvas(page, canvas, { x: 0.18, y: 0.28 }, { x: 0.42, y: 0.68 });
+    await dragOnCanvas(page, canvas, { x: 0.58, y: 0.28 }, { x: 0.82, y: 0.68 });
+
+    const firstRegion = { left: 0.1, top: 0.18, right: 0.48, bottom: 0.78 };
+    const latestRegion = { left: 0.52, top: 0.18, right: 0.9, bottom: 0.78 };
+
+    expect(await countBlackPixelsInRegion(canvas, firstRegion)).toBeGreaterThan(1000);
+    expect(await countBlackPixelsInRegion(canvas, latestRegion)).toBeGreaterThan(1000);
+
+    await host.locator('css=[data-action="undo"]').click();
+
+    expect(await countBlackPixelsInRegion(canvas, firstRegion)).toBeGreaterThan(1000);
+    expect(await countBlackPixelsInRegion(canvas, latestRegion)).toBeLessThan(20);
+
+    await host.locator('css=[data-action="done"]').click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10_000 });
+
+    expect(payloads).toHaveLength(1);
+    const submittedScreenshot = payloads[0].screenshot;
+    expect(typeof submittedScreenshot).toBe('string');
+    expect(
+      await countBlackPixelsInDataUrl(page, submittedScreenshot as string, firstRegion)
+    ).toBeGreaterThan(1000);
+    expect(
+      await countBlackPixelsInDataUrl(page, submittedScreenshot as string, latestRegion)
+    ).toBeLessThan(20);
   });
 });
 

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2477,6 +2477,42 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     }, region);
   }
 
+  async function countBlackPixelsInRegion(
+    canvas: ReturnType<Page['locator']>,
+    region: { left: number; top: number; right: number; bottom: number }
+  ) {
+    return canvas.evaluate((el, targetRegion) => {
+      const source = el as HTMLCanvasElement;
+      const ctx = source.getContext('2d');
+      if (!ctx) {
+        throw new Error('Missing canvas context');
+      }
+
+      const xStart = Math.floor(source.width * targetRegion.left);
+      const xEnd = Math.ceil(source.width * targetRegion.right);
+      const yStart = Math.floor(source.height * targetRegion.top);
+      const yEnd = Math.ceil(source.height * targetRegion.bottom);
+      const { data, width } = ctx.getImageData(xStart, yStart, xEnd - xStart, yEnd - yStart);
+      let black = 0;
+
+      for (let y = 0; y < yEnd - yStart; y++) {
+        for (let x = 0; x < width; x++) {
+          const i = (y * width + x) * 4;
+          const r = data[i];
+          const g = data[i + 1];
+          const b = data[i + 2];
+          const a = data[i + 3];
+
+          if (a > 200 && r < 20 && g < 20 && b < 20) {
+            black++;
+          }
+        }
+      }
+
+      return black;
+    }, region);
+  }
+
   async function countRedPixelsInDataUrl(
     page: Page,
     dataUrl: string,
@@ -2523,6 +2559,57 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
         }
 
         return red;
+      },
+      { dataUrl, region }
+    );
+  }
+
+  async function countBlackPixelsInDataUrl(
+    page: Page,
+    dataUrl: string,
+    region: { left: number; top: number; right: number; bottom: number }
+  ) {
+    return page.evaluate(
+      async target => {
+        const img = new Image();
+        await new Promise<void>((resolve, reject) => {
+          img.onload = () => resolve();
+          img.onerror = () => reject(new Error('Failed to load screenshot payload'));
+          img.src = target.dataUrl;
+        });
+
+        const source = document.createElement('canvas');
+        source.width = img.width;
+        source.height = img.height;
+        const ctx = source.getContext('2d');
+        if (!ctx) {
+          throw new Error('Missing canvas context');
+        }
+
+        ctx.drawImage(img, 0, 0);
+
+        const xStart = Math.floor(source.width * target.region.left);
+        const xEnd = Math.ceil(source.width * target.region.right);
+        const yStart = Math.floor(source.height * target.region.top);
+        const yEnd = Math.ceil(source.height * target.region.bottom);
+        const { data, width } = ctx.getImageData(xStart, yStart, xEnd - xStart, yEnd - yStart);
+        let black = 0;
+
+        for (let y = 0; y < yEnd - yStart; y++) {
+          for (let x = 0; x < width; x++) {
+            const i = (y * width + x) * 4;
+            const r = data[i];
+            const g = data[i + 1];
+            const b = data[i + 2];
+            const a = data[i + 3];
+
+            if (a > 200 && r < 20 && g < 20 && b < 20) {
+              black++;
+            }
+          }
+        }
+
+        return black;
       },
       { dataUrl, region }
     );
@@ -3327,6 +3414,94 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
       expect(await countRedPixelsInRegion(canvas, latestRegion)).toBeLessThan(5);
     });
   }
+
+  test('redact tool bakes black regions into the submitted screenshot', async ({ page }) => {
+    const payloads = await trackFeedbackPayloads(page);
+    await mockHtmlToImage(page, reporterLikePng('undo'));
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/test/');
+    await navigateToFullPageCapture(page);
+
+    const host = page.locator('#bugdrop-host');
+    const canvas = host.locator('css=#annotation-canvas canvas');
+    await expect(host.locator('css=.bd-modal--annotator')).toBeVisible({ timeout: 10000 });
+    await expect(canvas).toBeVisible();
+    await expect.poll(() => canvas.evaluate(el => (el as HTMLCanvasElement).width)).toBe(600);
+    await expect(host.locator('css=[data-tool="redact"]')).toBeVisible();
+
+    const annotationRegion = { left: 0.08, top: 0.18, right: 0.32, bottom: 0.78 };
+    const redactionRegion = { left: 0.52, top: 0.18, right: 0.9, bottom: 0.78 };
+    const baselineBlackPixels = await countBlackPixelsInRegion(canvas, redactionRegion);
+
+    await host.locator('css=[data-tool="draw"]').click();
+    await dragOnCanvas(page, canvas, { x: 0.14, y: 0.28 }, { x: 0.3, y: 0.68 });
+
+    await host.locator('css=[data-tool="redact"]').click();
+    await dragOnCanvas(page, canvas, { x: 0.82, y: 0.68 }, { x: 0.58, y: 0.28 });
+
+    expect(await countRedPixelsInRegion(canvas, annotationRegion)).toBeGreaterThan(20);
+    expect(await countBlackPixelsInRegion(canvas, redactionRegion)).toBeGreaterThan(
+      baselineBlackPixels + 1000
+    );
+
+    await host.locator('css=[data-action="done"]').click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+
+    expect(payloads).toHaveLength(1);
+    const submittedScreenshot = payloads[0].screenshot;
+    expect(typeof submittedScreenshot).toBe('string');
+
+    expect(
+      await countRedPixelsInDataUrl(page, submittedScreenshot as string, annotationRegion)
+    ).toBeGreaterThan(20);
+    expect(
+      await countBlackPixelsInDataUrl(page, submittedScreenshot as string, redactionRegion)
+    ).toBeGreaterThan(baselineBlackPixels + 1000);
+  });
+
+  test('undo button removes the latest redaction without removing earlier redactions', async ({
+    page,
+  }) => {
+    const payloads = await trackFeedbackPayloads(page);
+    await mockHtmlToImage(page, reporterLikePng('undo'));
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/test/');
+    await navigateToFullPageCapture(page);
+
+    const host = page.locator('#bugdrop-host');
+    const canvas = host.locator('css=#annotation-canvas canvas');
+    await expect(host.locator('css=.bd-modal--annotator')).toBeVisible({ timeout: 10000 });
+    await expect(canvas).toBeVisible();
+    await expect.poll(() => canvas.evaluate(el => (el as HTMLCanvasElement).width)).toBe(600);
+
+    await host.locator('css=[data-tool="redact"]').click();
+    await dragOnCanvas(page, canvas, { x: 0.18, y: 0.28 }, { x: 0.42, y: 0.68 });
+    await dragOnCanvas(page, canvas, { x: 0.58, y: 0.28 }, { x: 0.82, y: 0.68 });
+
+    const firstRegion = { left: 0.1, top: 0.18, right: 0.48, bottom: 0.78 };
+    const latestRegion = { left: 0.52, top: 0.18, right: 0.9, bottom: 0.78 };
+
+    expect(await countBlackPixelsInRegion(canvas, firstRegion)).toBeGreaterThan(1000);
+    expect(await countBlackPixelsInRegion(canvas, latestRegion)).toBeGreaterThan(1000);
+
+    await host.locator('css=[data-action="undo"]').click();
+
+    expect(await countBlackPixelsInRegion(canvas, firstRegion)).toBeGreaterThan(1000);
+    expect(await countBlackPixelsInRegion(canvas, latestRegion)).toBeLessThan(20);
+
+    await host.locator('css=[data-action="done"]').click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+
+    expect(payloads).toHaveLength(1);
+    const submittedScreenshot = payloads[0].screenshot;
+    expect(typeof submittedScreenshot).toBe('string');
+    expect(
+      await countBlackPixelsInDataUrl(page, submittedScreenshot as string, firstRegion)
+    ).toBeGreaterThan(1000);
+    expect(
+      await countBlackPixelsInDataUrl(page, submittedScreenshot as string, latestRegion)
+    ).toBeLessThan(20);
+  });
 
   test('undo preserves mixed annotation history in the submitted screenshot for issue #128', async ({
     page,

--- a/src/widget/annotator.ts
+++ b/src/widget/annotator.ts
@@ -1,4 +1,4 @@
-export type Tool = 'draw' | 'arrow' | 'rect' | 'text';
+export type Tool = 'draw' | 'arrow' | 'rect' | 'redact';
 
 interface Point {
   x: number;
@@ -6,9 +6,12 @@ interface Point {
 }
 
 const ANNOTATION_COLOR = '#ff0000';
+const REDACTION_COLOR = '#000000';
 const VISIBLE_ANNOTATION_LINE_WIDTH = 5.5;
 const ARROW_HEAD_ANGLE = Math.PI / 7;
 const MIN_ANNOTATION_DISTANCE = 2;
+const MIN_REDACTION_SIZE = 4;
+const REDACTION_PADDING = 1;
 
 export function createAnnotator(
   container: HTMLElement,
@@ -81,9 +84,11 @@ export function createAnnotator(
     const rect = canvas.getBoundingClientRect();
     const scaleX = img.width / rect.width;
     const scaleY = img.height / rect.height;
+    const x = (e.clientX - rect.left) * scaleX;
+    const y = (e.clientY - rect.top) * scaleY;
     return {
-      x: (e.clientX - rect.left) * scaleX,
-      y: (e.clientY - rect.top) * scaleY,
+      x: Math.max(0, Math.min(canvas.width, x)),
+      y: Math.max(0, Math.min(canvas.height, y)),
     };
   }
 
@@ -137,6 +142,39 @@ export function createAnnotator(
     ctx.strokeRect(from.x, from.y, to.x - from.x, to.y - from.y);
   }
 
+  function getRectBounds(from: Point, to: Point) {
+    const x = Math.min(from.x, to.x);
+    const y = Math.min(from.y, to.y);
+    const width = Math.abs(to.x - from.x);
+    const height = Math.abs(to.y - from.y);
+    return { x, y, width, height };
+  }
+
+  function getRedactionBounds(from: Point, to: Point) {
+    const { x, y, width, height } = getRectBounds(from, to);
+    const left = Math.max(0, Math.floor(x) - REDACTION_PADDING);
+    const top = Math.max(0, Math.floor(y) - REDACTION_PADDING);
+    const right = Math.min(canvas.width, Math.ceil(x + width) + REDACTION_PADDING);
+    const bottom = Math.min(canvas.height, Math.ceil(y + height) + REDACTION_PADDING);
+    return {
+      x: left,
+      y: top,
+      width: Math.max(0, right - left),
+      height: Math.max(0, bottom - top),
+    };
+  }
+
+  function isMeaningfulRedaction(from: Point, to: Point) {
+    const { width, height } = getRedactionBounds(from, to);
+    return width >= MIN_REDACTION_SIZE && height >= MIN_REDACTION_SIZE;
+  }
+
+  function drawRedaction(from: Point, to: Point) {
+    const { x, y, width, height } = getRedactionBounds(from, to);
+    ctx.fillStyle = REDACTION_COLOR;
+    ctx.fillRect(x, y, width, height);
+  }
+
   function handleMouseDown(e: MouseEvent) {
     const base = getLatestState();
     if (!base) return;
@@ -158,13 +196,15 @@ export function createAnnotator(
       points.push(point);
       hasDrawnStroke = hasDrawnStroke || getDistance(points[0], point) >= MIN_ANNOTATION_DISTANCE;
     } else {
-      // Preview for arrow/rect
+      // Preview for shape-like tools.
       restoreState(draftBase);
 
       if (currentTool === 'arrow') {
         drawArrow(points[0], point);
       } else if (currentTool === 'rect') {
         drawRect(points[0], point);
+      } else if (currentTool === 'redact') {
+        drawRedaction(points[0], point);
       }
     }
   }
@@ -178,7 +218,9 @@ export function createAnnotator(
     const point = getCanvasPoint(e);
     const start = points[0];
     const isMeaningfulAnnotation =
-      hasDrawnStroke || getDistance(start, point) >= MIN_ANNOTATION_DISTANCE;
+      currentTool === 'redact'
+        ? isMeaningfulRedaction(start, point)
+        : hasDrawnStroke || getDistance(start, point) >= MIN_ANNOTATION_DISTANCE;
 
     if (!isMeaningfulAnnotation) {
       restoreState(draftBase);
@@ -192,6 +234,9 @@ export function createAnnotator(
     } else if (currentTool === 'rect') {
       restoreState(draftBase);
       drawRect(start, point);
+    } else if (currentTool === 'redact') {
+      restoreState(draftBase);
+      drawRedaction(start, point);
     } else if (currentTool === 'draw' && !hasDrawnStroke) {
       drawLine(start, point);
     }

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -1179,7 +1179,7 @@ function getScreenshotFormControl(
   if (config.screenshotMode === 'auto') {
     return `
       <p style="margin: 8px 0 0; color: var(--bd-text-secondary); font-size: 0.95rem;">
-        📸 A screenshot will be attached automatically.
+        📸 A screenshot will be attached automatically without preview or manual redaction.
       </p>
     `;
   }
@@ -1302,12 +1302,16 @@ function showAnnotationStep(
   return new Promise(resolve => {
     const modal = createModal(
       root,
-      'Annotate Screenshot',
+      'Review Screenshot',
       `
+        <p style="margin: 0 0 12px; color: var(--bd-text-secondary); font-size: 13px;">
+          Cover sensitive areas before submitting. Redactions are baked into the uploaded image.
+        </p>
         <div class="bd-tools">
           <button class="bd-tool active" data-tool="draw">✏️ Draw</button>
           <button class="bd-tool" data-tool="arrow">➡️ Arrow</button>
           <button class="bd-tool" data-tool="rect">▢ Rectangle</button>
+          <button class="bd-tool" data-tool="redact">Redact</button>
           <button class="bd-tool" data-action="undo">↶ Undo</button>
         </div>
         <div id="annotation-canvas" class="bd-annotation-stage"></div>


### PR DESCRIPTION
## Summary
- add a Redact tool to screenshot review so users can cover sensitive regions before submitting
- bake redactions into the final PNG while preserving undo/retake behavior
- clarify auto screenshot mode skips preview/manual redaction in UI and docs

## Testing
- npm run typecheck
- npm run build:widget
- npm test
- npm run lint
- npm run format:check
- LIVE_TARGET=local PLAYWRIGHT_BASE_URL=http://localhost:8797 npx playwright test e2e/widget.spec.ts --grep "redact|redaction|auto mode captures" --project=chromium
- LIVE_TARGET=local PLAYWRIGHT_BASE_URL=http://localhost:8797 npx playwright test e2e/widget.live.spec.ts --grep "redaction" --project=chromium-live

## Preview E2E
- adds chromium-live coverage that exercises the deployed preview widget redaction path, submits feedback, and verifies the submitted screenshot payload contains the baked redaction