### PR TITLE
Fix screenshot capture with no-CORS third-party images

### DIFF
--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -58,6 +58,25 @@ async function mockInstalledRepo(page: Page) {
   });
 }
 
+async function addCorsBlockedImage(page: Page) {
+  await page.route('https://third-party.test/no-cors-badge.svg', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/svg+xml',
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="180" height="44"><rect width="180" height="44" fill="#14b8a6"/><text x="16" y="28" fill="white" font-size="16">No CORS Badge</text></svg>',
+    });
+  });
+
+  await page.evaluate(() => {
+    const img = document.createElement('img');
+    img.alt = 'Third-party badge without CORS headers';
+    img.src = 'https://third-party.test/no-cors-badge.svg';
+    img.style.display = 'block';
+    img.style.margin = '24px';
+    document.body.prepend(img);
+  });
+}
+
 async function openScreenshotOptions(page: Page, title: string) {
   await mockInstalledRepo(page);
   await page.goto(process.env.LIVE_TARGET === 'preview' ? '/' : '/test/');
@@ -441,7 +460,7 @@ test.describe('Screenshot Capture (Live)', () => {
     await continueBtn.click();
 
     // Screenshot capture options should appear
-    const fullPageBtn = page.locator('#bugdrop-host').locator('css=[data-action="fullpage"]');
+    const fullPageBtn = page.locator('#bugdrop-host').locator('css=[data-action="capture"]');
     const elementBtn = page.locator('#bugdrop-host').locator('css=[data-action="element"]');
 
     // At least one screenshot option should be available
@@ -493,6 +512,20 @@ test.describe('Screenshot Capture (Live)', () => {
 
     await page.keyboard.press('Escape');
     await expect(page.locator('#bugdrop-area-picker-overlay')).not.toBeVisible({ timeout: 3_000 });
+  });
+
+  test('full-page capture reaches annotation with a third-party no-CORS image', async ({
+    page,
+  }) => {
+    const host = await openScreenshotOptions(page, 'Live preview no-CORS capture');
+    await addCorsBlockedImage(page);
+
+    const captureBtn = host.locator('css=[data-action="capture"]');
+    await expect(captureBtn).toBeVisible({ timeout: 5_000 });
+    await captureBtn.click();
+
+    await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 30_000 });
+    await expect(host.locator('css=.bd-error-message__text')).not.toBeAttached();
   });
 
   test('annotation undo works on the deployed preview widget', async ({ page }) => {

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2410,6 +2410,25 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     await expect(titleInput).toHaveValue(title);
   }
 
+  async function addCorsBlockedImage(page: Page) {
+    await page.route('https://third-party.test/no-cors-badge.svg', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'image/svg+xml',
+        body: '<svg xmlns="http://www.w3.org/2000/svg" width="180" height="44"><rect width="180" height="44" fill="#14b8a6"/><text x="16" y="28" fill="white" font-size="16">No CORS Badge</text></svg>',
+      });
+    });
+
+    await page.evaluate(() => {
+      const img = document.createElement('img');
+      img.alt = 'Third-party badge without CORS headers';
+      img.src = 'https://third-party.test/no-cors-badge.svg';
+      img.style.display = 'block';
+      img.style.margin = '24px';
+      document.body.prepend(img);
+    });
+  }
+
   test('sends custom category label mapping while keeping built-in category UI', async ({
     page,
   }) => {
@@ -2700,6 +2719,8 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     // Verify pixelRatio was reduced to 1 due to complex DOM
     const captureOpts = await page.evaluate(() => (window as any).__captureOpts);
     expect(captureOpts.pixelRatio).toBe(1);
+    expect(captureOpts.cacheBust).toBe(false);
+    expect(captureOpts.imagePlaceholder).toMatch(/^data:image\/gif;base64,/);
   });
 
   test('uses normal pixelRatio on simple pages', async ({ page }) => {
@@ -3721,6 +3742,19 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
 
     const annotationCanvas = page.locator('#bugdrop-host').locator('css=#annotation-canvas');
     await expect(annotationCanvas).toBeVisible({ timeout: 30000 });
+  });
+
+  test('real full-page capture tolerates third-party images without CORS headers', async ({
+    page,
+  }) => {
+    await page.goto('/test/');
+    await addCorsBlockedImage(page);
+
+    await navigateToFullPageCapture(page);
+
+    const host = page.locator('#bugdrop-host');
+    await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 30000 });
+    await expect(host.locator('css=.bd-error-message__text')).not.toBeAttached();
   });
 });
 

--- a/src/widget/screenshot.ts
+++ b/src/widget/screenshot.ts
@@ -3,6 +3,8 @@ import { collectMaskRects, applyMaskToImage } from './mask';
 
 const CAPTURE_TIMEOUT_MS = 15_000;
 const DOM_COMPLEXITY_THRESHOLD = 3_000;
+const TRANSPARENT_IMAGE_PLACEHOLDER =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 export const FULL_PAGE_DISABLE_THRESHOLD = 10_000;
 
 type DisplayMediaOptionsWithCurrentTab = DisplayMediaStreamOptions & {
@@ -193,7 +195,8 @@ export async function captureScreenshot(
     htmlToImage.toPng;
 
   const opts = {
-    cacheBust: true,
+    cacheBust: false,
+    imagePlaceholder: TRANSPARENT_IMAGE_PLACEHOLDER,
     pixelRatio,
     filter: (node: HTMLElement) => node.id !== 'bugdrop-host',
   };


### PR DESCRIPTION
## Summary
- add a transparent fallback image for html-to-image resource fetch failures
- disable capture-time cache busting so third-party CDN/signed image URLs are not mutated
- add local and live-preview regression coverage for full-page capture with a no-CORS third-party image
- fix the live screenshot option selector to use `data-action="capture"`

## Testing
- `npm run build:widget`
- `npm run typecheck`
- `npx eslint src/widget/screenshot.ts e2e/widget.spec.ts e2e/widget.live.spec.ts` (warnings only from existing max-lines/no-explicit-any rules)
- `npx playwright test e2e/widget.spec.ts -g "third-party images without CORS|real bundled html-to-image captures|reduces pixelRatio" --project=chromium`
- `npx playwright test e2e/widget.live.spec.ts -g "screenshot option is available|full-page capture reaches annotation" --project=chromium-live`

## Notes
The new live-preview test should fail against the currently deployed preview worker until this branch is deployed there, then pass in merge queue after `deploy-preview` runs.