### PR TITLE
feat: add BugDrop Sandbox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,12 +194,13 @@ jobs:
             body=$(curl -sSf "${WORKER_ORIGIN}${path}") || { echo "Fetch failed: $path"; exit 1; }
             grep -q -- "$expected" <<<"$body" || { echo "Wrong content for $path (expected: $expected)"; exit 1; }
           }
-          check /sandbox/             'BugDrop Sandbox'
-          check /sandbox/preview      'BugDrop Sandbox Preview'
-          check /sandbox/sandbox.css  'sandbox-shell'
-          check /sandbox/sandbox.js     'generateScriptTag'
+          check /sandbox/                 'id="sandbox-form"'
+          check /sandbox/preview          'BugDrop Sandbox Preview'
+          check /sandbox/sandbox.css      'sandbox-shell'
+          check /sandbox/sandbox.js       'generateScriptTag'
           check /sandbox/attribute-map.js 'data-repo'
-          check /widget.js            'bd-trigger'
+          check /sandbox/sanitizers.js    'sanitizeConfig'
+          check /widget.js                'bd-trigger'
 
       - name: Verify test venue is reachable
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,12 +185,21 @@ jobs:
           exit 1
 
       - name: Verify preview sandbox assets
+        env:
+          WORKER_ORIGIN: https://bugdrop-preview.neonwatty.workers.dev
         run: |
-          WORKER_ORIGIN="https://bugdrop-preview.neonwatty.workers.dev"
-          for path in /sandbox/ /sandbox/preview /sandbox/sandbox.css /sandbox/sandbox.js /widget.js; do
-            echo "Checking ${WORKER_ORIGIN}${path}..."
-            curl -sfo /dev/null "${WORKER_ORIGIN}${path}" || (echo "Missing preview asset: $path" && exit 1)
-          done
+          check() {
+            local path="$1" expected="$2"
+            echo "Checking ${WORKER_ORIGIN}${path} for '${expected}'..."
+            body=$(curl -sSf "${WORKER_ORIGIN}${path}") || { echo "Fetch failed: $path"; exit 1; }
+            grep -q -- "$expected" <<<"$body" || { echo "Wrong content for $path (expected: $expected)"; exit 1; }
+          }
+          check /sandbox/             'BugDrop Sandbox'
+          check /sandbox/preview      'BugDrop Sandbox Preview'
+          check /sandbox/sandbox.css  'sandbox-shell'
+          check /sandbox/sandbox.js     'generateScriptTag'
+          check /sandbox/attribute-map.js 'data-repo'
+          check /widget.js            'bd-trigger'
 
       - name: Verify test venue is reachable
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,14 @@ jobs:
           echo "Preview worker not ready after 300s"
           exit 1
 
+      - name: Verify preview sandbox assets
+        run: |
+          WORKER_ORIGIN="https://bugdrop-preview.neonwatty.workers.dev"
+          for path in /sandbox/ /sandbox/preview /sandbox/sandbox.css /sandbox/sandbox.js /widget.js; do
+            echo "Checking ${WORKER_ORIGIN}${path}..."
+            curl -sfo /dev/null "${WORKER_ORIGIN}${path}" || (echo "Missing preview asset: $path" && exit 1)
+          done
+
       - name: Verify test venue is reachable
         run: |
           VENUE_URL="${PLAYWRIGHT_BASE_URL}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,9 +75,10 @@ jobs:
             body=$(curl -sSf "${WORKER_ORIGIN}${path}") || { echo "Fetch failed: $path"; exit 1; }
             grep -q -- "$expected" <<<"$body" || { echo "Wrong content for $path (expected: $expected)"; exit 1; }
           }
-          check /sandbox/             'BugDrop Sandbox'
-          check /sandbox/preview      'BugDrop Sandbox Preview'
-          check /sandbox/sandbox.css  'sandbox-shell'
-          check /sandbox/sandbox.js     'generateScriptTag'
+          check /sandbox/                 'id="sandbox-form"'
+          check /sandbox/preview          'BugDrop Sandbox Preview'
+          check /sandbox/sandbox.css      'sandbox-shell'
+          check /sandbox/sandbox.js       'generateScriptTag'
           check /sandbox/attribute-map.js 'data-repo'
-          check /widget.js            'bd-trigger'
+          check /sandbox/sanitizers.js    'sanitizeConfig'
+          check /widget.js                'bd-trigger'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,9 +66,18 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Verify production sandbox assets
+        env:
+          WORKER_ORIGIN: https://bugdrop.neonwatty.workers.dev
         run: |
-          WORKER_ORIGIN="https://bugdrop.neonwatty.workers.dev"
-          for path in /sandbox/ /sandbox/preview /sandbox/sandbox.css /sandbox/sandbox.js /widget.js; do
-            echo "Checking ${WORKER_ORIGIN}${path}..."
-            curl -sfo /dev/null "${WORKER_ORIGIN}${path}" || (echo "Missing production asset: $path" && exit 1)
-          done
+          check() {
+            local path="$1" expected="$2"
+            echo "Checking ${WORKER_ORIGIN}${path} for '${expected}'..."
+            body=$(curl -sSf "${WORKER_ORIGIN}${path}") || { echo "Fetch failed: $path"; exit 1; }
+            grep -q -- "$expected" <<<"$body" || { echo "Wrong content for $path (expected: $expected)"; exit 1; }
+          }
+          check /sandbox/             'BugDrop Sandbox'
+          check /sandbox/preview      'BugDrop Sandbox Preview'
+          check /sandbox/sandbox.css  'sandbox-shell'
+          check /sandbox/sandbox.js     'generateScriptTag'
+          check /sandbox/attribute-map.js 'data-repo'
+          check /widget.js            'bd-trigger'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,3 +64,11 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Verify production sandbox assets
+        run: |
+          WORKER_ORIGIN="https://bugdrop.neonwatty.workers.dev"
+          for path in /sandbox/ /sandbox/preview /sandbox/sandbox.css /sandbox/sandbox.js /widget.js; do
+            echo "Checking ${WORKER_ORIGIN}${path}..."
+            curl -sfo /dev/null "${WORKER_ORIGIN}${path}" || (echo "Missing production asset: $path" && exit 1)
+          done

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Version](https://img.shields.io/badge/version-1.11.0-14b8a6)](./CHANGELOG.md)
 [![Security Policy](https://img.shields.io/badge/Security-Policy-blue)](./SECURITY.md)
 [![Live Demo](https://img.shields.io/badge/Demo-Try_It_Live-ff9e64)](https://bugdrop-widget-test.vercel.app)
+[![Sandbox](https://img.shields.io/badge/Sandbox-Configure_Widget-7c3aed)](https://bugdrop.neonwatty.workers.dev/sandbox/)
 [![GitHub Marketplace](https://img.shields.io/badge/GitHub%20Marketplace-Install-2ea44f?logo=github)](https://github.com/marketplace/bugdrop-in-app-feedback-to-github-issues)
 [![Product Hunt](https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1141615&theme=light&t=1778415221018)](https://www.producthunt.com/products/bugdrop-2?utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-bugdrop-2)
 
@@ -54,6 +55,8 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
 | `data-button`          | `true`, `false`                                      | `true`           |
 
 See [full documentation](https://bugdrop.dev/docs/configuration) for all options including styling, submitter info, and dismissible button.
+
+Use the [BugDrop Sandbox](https://bugdrop.neonwatty.workers.dev/sandbox/) to preview settings, check GitHub App installation, test screenshot masking, and generate a script tag.
 
 ## Documentation
 

--- a/docs/website/ci-testing.mdx
+++ b/docs/website/ci-testing.mdx
@@ -45,7 +45,7 @@ const EXPECTED = {
   requireEmail: false,
   buttonDismissible: false,
   showRestore: true,
-  welcomeMessage: "Report a bug or request a feature",
+  welcome: "once",
 };
 
 const URL = "https://your-site.com"; // Replace with your site URL
@@ -114,17 +114,17 @@ test.describe("BugDrop Widget", () => {
     expect(bgColor).toBeTruthy();
   });
 
-  test("displays correct welcome message", async ({ page }) => {
+  test("uses expected welcome behavior", async ({ page }) => {
     const btn = await shadowEl(page, "bug-drop-widget", ".floating-btn");
     await (btn as any).click();
 
-    const welcomeText = await page.evaluate(() => {
+    const welcomeVisible = await page.evaluate(() => {
       const host = document.querySelector("bug-drop-widget");
       const welcome = host?.shadowRoot?.querySelector(".welcome-message, h2");
-      return welcome?.textContent?.trim();
+      return Boolean(welcome);
     });
 
-    expect(welcomeText).toContain(EXPECTED.welcomeMessage);
+    expect(welcomeVisible).toBe(EXPECTED.welcome !== "never");
   });
 
   test("shows/hides name field based on config", async ({ page }) => {
@@ -249,7 +249,7 @@ The test suite covers three areas:
 - **Opens and closes the form** -- Clicks the button, verifies the form appears, then closes it
 - **Correct position** -- Validates the button is in the expected corner (bottom-right or bottom-left)
 - **Correct accent color** -- Checks the button's background color
-- **Welcome message** -- Opens the form and verifies the correct welcome text is displayed
+- **Welcome screen** -- Opens the form and verifies the expected welcome behavior
 - **Name/email field visibility** -- Confirms fields show or hide based on your configuration
 
 ### Accessibility Tests (WCAG AA)
@@ -272,7 +272,7 @@ const EXPECTED = {
   requireEmail: false,      // data-require-email
   buttonDismissible: false, // data-button-dismissible
   showRestore: true,        // data-show-restore
-  welcomeMessage: "Report a bug or request a feature", // data-welcome
+  welcome: "once",           // data-welcome
 };
 ```
 

--- a/docs/website/ci-testing.mdx
+++ b/docs/website/ci-testing.mdx
@@ -120,7 +120,9 @@ test.describe("BugDrop Widget", () => {
 
     // The welcome modal carries the `.bd-welcome` class; the feedback form does not.
     // For `welcome: "once"`, the welcome modal only appears on the first open per repo;
-    // clear localStorage in `beforeEach` if you want this test to assert it deterministically.
+    // the "seen" flag is stored under localStorage keys prefixed with `bugdrop_welcomed_`,
+    // so for a deterministic test add `await page.evaluate(() => localStorage.clear())`
+    // (or `localStorage.removeItem('bugdrop_welcomed_<owner>/<repo>')`) in beforeEach.
     const welcomeVisible = await page.evaluate(() => {
       const host = document.querySelector("bug-drop-widget");
       return Boolean(host?.shadowRoot?.querySelector(".bd-welcome"));

--- a/docs/website/ci-testing.mdx
+++ b/docs/website/ci-testing.mdx
@@ -118,10 +118,12 @@ test.describe("BugDrop Widget", () => {
     const btn = await shadowEl(page, "bug-drop-widget", ".floating-btn");
     await (btn as any).click();
 
+    // The welcome modal carries the `.bd-welcome` class; the feedback form does not.
+    // For `welcome: "once"`, the welcome modal only appears on the first open per repo;
+    // clear localStorage in `beforeEach` if you want this test to assert it deterministically.
     const welcomeVisible = await page.evaluate(() => {
       const host = document.querySelector("bug-drop-widget");
-      const welcome = host?.shadowRoot?.querySelector(".welcome-message, h2");
-      return Boolean(welcome);
+      return Boolean(host?.shadowRoot?.querySelector(".bd-welcome"));
     });
 
     expect(welcomeVisible).toBe(EXPECTED.welcome !== "never");

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -9,14 +9,14 @@ These attributes control the fundamental behavior of the widget.
 | Attribute | Default | Description |
 |-----------|---------|-------------|
 | `data-repo` | **(required)** | GitHub repository in `owner/repo` format |
-| `data-theme` | `"light"` | Widget theme: `"light"` or `"dark"` |
+| `data-theme` | `"auto"` | Widget theme: `"auto"`, `"light"`, or `"dark"` |
 | `data-position` | `"bottom-right"` | Button position: `"bottom-right"` or `"bottom-left"` |
 | `data-color` | `"#7c3aed"` | Primary accent color (any CSS color value) |
 | `data-icon` | *(default bug icon)* | Custom icon: URL to an image, `"none"` to hide, or omit for default |
 | `data-label` | `""` | Text label displayed next to the button icon |
 | `data-category-labels` | built-in labels | Self-hosted JSON mapping from built-in categories to GitHub labels |
 | `data-button` | `"true"` | Show the floating button: `"true"` or `"false"` |
-| `data-welcome` | `"Report a bug or request a feature"` | Welcome message displayed at the top of the form |
+| `data-welcome` | `"once"` | Welcome screen behavior: `"once"`, `"always"`, `"never"`, or `"false"` |
 
 ### Basic Example
 
@@ -27,7 +27,7 @@ These attributes control the fundamental behavior of the widget.
   data-theme="dark"
   data-position="bottom-left"
   data-color="#ef4444"
-  data-welcome="Found a bug? Let us know!"
+  data-welcome="always"
 ></script>
 ```
 
@@ -35,11 +35,16 @@ These attributes control the fundamental behavior of the widget.
 
 The `data-theme` attribute controls the overall color scheme of the widget:
 
-- **`light`** (default) -- White background with dark text. Suitable for most sites.
+- **`auto`** (default) -- Follows the user's system color scheme.
+- **`light`** -- White background with dark text. Suitable for most sites.
 - **`dark`** -- Dark background with light text. Ideal for sites with dark color schemes.
 
 ```html
-<!-- Light theme (default) -->
+<!-- Auto theme (default) -->
+<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="owner/repo" data-theme="auto"></script>
+
+<!-- Light theme -->
 <script src="https://bugdrop.neonwatty.workers.dev/widget.js"
   data-repo="owner/repo" data-theme="light"></script>
 
@@ -54,6 +59,24 @@ The `data-position` attribute controls where the floating button appears:
 
 - **`bottom-right`** (default) -- Fixed to the bottom-right corner
 - **`bottom-left`** -- Fixed to the bottom-left corner
+
+### Welcome Screen Options
+
+The `data-welcome` attribute controls when the built-in welcome screen appears:
+
+- **`once`** (default) -- Show the welcome screen once per repository, then skip it on future opens in the same browser.
+- **`always`** -- Show the welcome screen every time the user opens the widget.
+- **`never`** or **`false`** -- Skip the welcome screen and open the feedback form directly.
+
+```html
+<!-- Always show the welcome screen -->
+<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="owner/repo" data-welcome="always"></script>
+
+<!-- Skip the welcome screen -->
+<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="owner/repo" data-welcome="never"></script>
+```
 
 ## Submitter Information
 
@@ -307,7 +330,7 @@ Here is a script tag using many configuration options together:
   data-theme="dark"
   data-position="bottom-left"
   data-color="#6366f1"
-  data-welcome="We'd love to hear from you!"
+  data-welcome="always"
   data-show-name="true"
   data-show-email="true"
   data-require-email="true"
@@ -318,7 +341,7 @@ Here is a script tag using many configuration options together:
 ></script>
 ```
 
-This configuration creates a dark-themed widget in the bottom-left corner with an indigo accent color, collects the submitter's name and email (email required), and shows a "Feedback" label on the button. The button is dismissible for 2 hours with a restore link.
+This configuration creates a dark-themed widget in the bottom-left corner with an indigo accent color, always shows the built-in welcome screen, collects the submitter's name and email (email required), and shows a "Feedback" label on the button. The button is dismissible for 2 hours with a restore link.
 
 ## Next Steps
 

--- a/docs/website/getting-started.mdx
+++ b/docs/website/getting-started.mdx
@@ -50,6 +50,7 @@ That is it. No servers to run, no databases to manage, no user accounts required
 Ready to get started? Here is where to go next:
 
 - **[Installation](/docs/installation)** -- Step-by-step setup guide to add BugDrop to your site
+- **[Sandbox](https://bugdrop.neonwatty.workers.dev/sandbox/)** -- Preview settings, check installation, and generate your script tag
 - **[Configuration](/docs/configuration)** -- All widget attributes for customizing behavior
 - **[Styling](/docs/styling)** -- Theme your widget with colors, fonts, borders, and shadows
 - **[JavaScript API](/docs/javascript-api)** -- Programmatic control with `window.BugDrop`

--- a/docs/website/installation.mdx
+++ b/docs/website/installation.mdx
@@ -65,11 +65,15 @@ You can add data attributes to customize the widget's appearance and behavior:
   data-theme="dark"
   data-position="bottom-left"
   data-color="#6366f1"
-  data-welcome="We'd love your feedback!"
+  data-welcome="always"
 ></script>
 ```
 
 See the [Configuration](/docs/configuration) and [Styling](/docs/styling) docs for all available attributes.
+
+### Try it in the Sandbox
+
+Use the [BugDrop Sandbox](https://bugdrop.neonwatty.workers.dev/sandbox/) to preview widget behavior, check GitHub App installation, test screenshot masking, and generate a script tag before adding BugDrop to your app.
 
 ## Protecting sensitive data
 
@@ -84,7 +88,7 @@ want to appear in submitted screenshots, mark those elements with `data-bugdrop-
 
 BugDrop covers each marked element with an opaque rectangle on the captured screenshot.
 Password inputs and credit-card autocomplete fields are masked automatically. See
-[Screenshot masking](/security#screenshot-masking) on the Security page for details.
+[Screenshot masking](/docs/security#screenshot-masking) on the Security page for details.
 
 ## Step 3: You Are Done
 
@@ -174,6 +178,7 @@ You can also test by clicking the bug button and submitting a test report. Check
 
 ## Next Steps
 
+- [Try the Sandbox](https://bugdrop.neonwatty.workers.dev/sandbox/) to generate and test your script tag
 - [Configure the widget](/docs/configuration) with custom attributes
 - [Style the widget](/docs/styling) to match your site's design
 - [Use the JavaScript API](/docs/javascript-api) for advanced integrations

--- a/e2e/sandbox.spec.ts
+++ b/e2e/sandbox.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('BugDrop Sandbox', () => {
+  test('serves sandbox route assets from the Worker', async ({ request }) => {
+    for (const path of [
+      '/sandbox/',
+      '/sandbox/preview',
+      '/sandbox/sandbox.css',
+      '/sandbox/sandbox.js',
+      '/widget.js',
+    ]) {
+      const response = await request.get(path);
+      expect(response.ok(), `${path} should resolve`).toBe(true);
+    }
+  });
+
+  test('generates a script tag and loads the configured preview widget', async ({ page }) => {
+    const widgetRequests: string[] = [];
+    page.on('request', request => {
+      if (request.url().endsWith('/widget.js')) widgetRequests.push(request.url());
+    });
+
+    await page.route('**/api/check/**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true, repo: 'mean-weasel/bugdrop' }),
+      });
+    });
+
+    await page.goto('/sandbox/');
+
+    await expect(page.getByRole('heading', { name: 'BugDrop Sandbox' })).toBeVisible();
+    await expect(page.locator('#sandbox-preview')).toHaveAttribute('sandbox', /allow-scripts/);
+    await expect(page.locator('#script-code')).toContainText('data-repo="mean-weasel/bugdrop"');
+
+    await page.locator('#repo').fill('acme/app');
+    await page.locator('#theme').selectOption('dark');
+    await page.locator('#position').selectOption('bottom-left');
+    await page.locator('#screenshot').selectOption('required');
+    await page.locator('#label').fill('Send Feedback');
+    await page.locator('#icon').fill('none');
+    await page.locator('#screenshotScale').fill('3');
+    await page.locator('#radius').fill('10px');
+    await page.locator('#categoryLabels').fill('{"bug":["defect"],"feature":"idea"}');
+
+    const scriptCode = page.locator('#script-code');
+    await expect(scriptCode).toContainText('data-repo="acme/app"');
+    await expect(scriptCode).toContainText('data-theme="dark"');
+    await expect(scriptCode).toContainText('data-position="bottom-left"');
+    await expect(scriptCode).toContainText('data-screenshot="required"');
+    await expect(scriptCode).toContainText('data-label="Send Feedback"');
+    await expect(scriptCode).toContainText('data-icon="none"');
+    await expect(scriptCode).toContainText('data-screenshot-scale="3"');
+    await expect(scriptCode).toContainText('data-radius="10px"');
+    await expect(scriptCode).toContainText(
+      'data-category-labels="{&quot;bug&quot;:[&quot;defect&quot;],&quot;feature&quot;:&quot;idea&quot;}"'
+    );
+    await expect(scriptCode).not.toContainText('async');
+    await expect(scriptCode).not.toContainText('defer');
+
+    const frame = page.frameLocator('#sandbox-preview');
+    await expect(frame.locator('#bugdrop-host').locator('css=.bd-trigger')).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(frame.locator('[data-bugdrop-mask]')).toHaveCount(3);
+    expect(widgetRequests.some(url => url === `${new URL(page.url()).origin}/widget.js`)).toBe(
+      true
+    );
+  });
+
+  test('validates and encodes repo paths before checking installation', async ({ page }) => {
+    const checkRequests: string[] = [];
+    await page.route('**/api/check/**', async route => {
+      checkRequests.push(route.request().url());
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: false, repo: 'acme/app' }),
+      });
+    });
+
+    await page.goto('/sandbox/');
+
+    await page.locator('#repo').fill('not-a-repo');
+    await expect(page.locator('#repo-feedback')).toHaveText(
+      'Repository must use GitHub owner/repo format with letters, numbers, dots, underscores, or hyphens.'
+    );
+
+    await page.locator('#repo').fill('acme/app?x=1');
+    await expect(page.locator('#repo-feedback')).toHaveText(
+      'Repository must use GitHub owner/repo format with letters, numbers, dots, underscores, or hyphens.'
+    );
+
+    await page.locator('#repo').fill('acme/app');
+    await expect(page.locator('#repo-feedback')).toHaveText('Ready to check installation.');
+    await page.locator('#check-installation').click();
+    await expect(page.locator('#repo-feedback')).toHaveText(
+      'BugDrop is not installed on acme/app.'
+    );
+    expect(checkRequests).toContain(`${new URL(page.url()).origin}/api/check/acme/app`);
+  });
+
+  test('ignores stale installation checks when repo changes', async ({ page }) => {
+    await page.route('**/api/check/slow/repo', async route => {
+      await new Promise(resolve => setTimeout(resolve, 250));
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true, repo: 'slow/repo' }),
+      });
+    });
+    await page.route('**/api/check/fast/repo', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: false, repo: 'fast/repo' }),
+      });
+    });
+
+    await page.goto('/sandbox/');
+    await page.locator('#repo').fill('slow/repo');
+    await page.locator('#check-installation').click();
+    await page.locator('#repo').fill('fast/repo');
+    await page.locator('#check-installation').click();
+
+    await expect(page.locator('#repo-feedback')).toHaveText(
+      'BugDrop is not installed on fast/repo.'
+    );
+    await page.waitForTimeout(300);
+    await expect(page.locator('#repo-feedback')).toHaveText(
+      'BugDrop is not installed on fast/repo.'
+    );
+  });
+
+  test('required contact fields imply visible contact fields in generated script', async ({
+    page,
+  }) => {
+    await page.goto('/sandbox/');
+
+    await page.locator('#requireEmail').check();
+    await page.locator('#requireName').check();
+
+    const scriptCode = page.locator('#script-code');
+    await expect(scriptCode).toContainText('data-show-email="true"');
+    await expect(scriptCode).toContainText('data-require-email="true"');
+    await expect(scriptCode).toContainText('data-show-name="true"');
+    await expect(scriptCode).toContainText('data-require-name="true"');
+  });
+
+  test('reports clipboard failures without throwing', async ({ page }) => {
+    await page.goto('/sandbox/');
+    await page.evaluate(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: undefined,
+      });
+    });
+
+    await page.locator('#copy-script').click();
+    await expect(page.locator('#copy-script')).toHaveText('Copy failed');
+  });
+});

--- a/e2e/sandbox.spec.ts
+++ b/e2e/sandbox.spec.ts
@@ -167,13 +167,55 @@ test.describe('BugDrop Sandbox', () => {
 
     // User edits the repo without clicking check again, then the slow response returns.
     await page.locator('#repo').fill('other/repo');
+    const slowResponse = page.waitForResponse(r => r.url().includes('/api/check/slow/repo'));
     releaseSlow?.();
+    // Wait for the slow handler to actually fulfill so the stale-discard guard has
+    // run; without this the negative-match could pass trivially before the handler
+    // had any chance to write to repo-feedback.
+    await slowResponse;
 
     // Validation feedback (from input handler) is fine; what must NOT happen is the
     // stale "installed on slow/repo" text overwriting it.
-    await expect(page.locator('#repo-feedback')).not.toHaveText(/installed on slow\/repo/, {
-      timeout: 2000,
+    await expect(page.locator('#repo-feedback')).not.toHaveText(/installed on slow\/repo/);
+  });
+
+  test('surfaces HTTP detail when installation check returns 500', async ({ page }) => {
+    await page.route('**/api/check/**', async route => {
+      await route.fulfill({ status: 500, contentType: 'text/plain', body: 'boom' });
     });
+    await page.goto('/sandbox/');
+    await page.locator('#repo').fill('acme/app');
+    await page.locator('#check-installation').click();
+    await expect(page.locator('#repo-feedback')).toContainText(
+      /Installation check failed \(HTTP 500/
+    );
+    await expect(page.locator('#repo-feedback')).toHaveClass(/error/);
+  });
+
+  test('surfaces HTTP detail when API returns malformed JSON', async ({ page }) => {
+    await page.route('**/api/check/**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '<html>not json</html>',
+      });
+    });
+    await page.goto('/sandbox/');
+    await page.locator('#repo').fill('acme/app');
+    await page.locator('#check-installation').click();
+    await expect(page.locator('#repo-feedback')).toContainText(
+      /Installation check failed \(HTTP 200: invalid JSON response/
+    );
+  });
+
+  test('preview shows error banner when widget.js fails to load', async ({ page }) => {
+    await page.route('**/widget.js', route => route.fulfill({ status: 404, body: '' }));
+    await page.goto('/sandbox/');
+    const frame = page.frameLocator('#sandbox-preview');
+    await expect(frame.locator('#bd-preview-error')).toBeVisible({ timeout: 10_000 });
+    await expect(frame.locator('#bd-preview-error')).toContainText(
+      'failed to load from /widget.js'
+    );
   });
 
   test('required contact fields imply visible contact fields in generated script', async ({

--- a/e2e/sandbox.spec.ts
+++ b/e2e/sandbox.spec.ts
@@ -2,15 +2,19 @@ import { test, expect } from '@playwright/test';
 
 test.describe('BugDrop Sandbox', () => {
   test('serves sandbox route assets from the Worker', async ({ request }) => {
-    for (const path of [
-      '/sandbox/',
-      '/sandbox/preview',
-      '/sandbox/sandbox.css',
-      '/sandbox/sandbox.js',
-      '/widget.js',
-    ]) {
+    const cases: Array<{ path: string; contentType: RegExp }> = [
+      { path: '/sandbox/', contentType: /html/ },
+      { path: '/sandbox/preview', contentType: /html/ },
+      { path: '/sandbox/attribute-map.js', contentType: /javascript/ },
+      { path: '/sandbox/sanitizers.js', contentType: /javascript/ },
+      { path: '/sandbox/sandbox.css', contentType: /css/ },
+      { path: '/sandbox/sandbox.js', contentType: /javascript/ },
+      { path: '/widget.js', contentType: /javascript/ },
+    ];
+    for (const { path, contentType } of cases) {
       const response = await request.get(path);
       expect(response.ok(), `${path} should resolve`).toBe(true);
+      expect(response.headers()['content-type'], `${path} content-type`).toMatch(contentType);
     }
   });
 
@@ -102,8 +106,12 @@ test.describe('BugDrop Sandbox', () => {
   });
 
   test('ignores stale installation checks when repo changes', async ({ page }) => {
+    let releaseSlow: (() => void) | undefined;
+    const slowReleased = new Promise<void>(resolve => {
+      releaseSlow = resolve;
+    });
     await page.route('**/api/check/slow/repo', async route => {
-      await new Promise(resolve => setTimeout(resolve, 250));
+      await slowReleased;
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -121,16 +129,51 @@ test.describe('BugDrop Sandbox', () => {
     await page.goto('/sandbox/');
     await page.locator('#repo').fill('slow/repo');
     await page.locator('#check-installation').click();
+    await expect(page.locator('#repo-feedback')).toHaveText('Checking GitHub App installation...');
     await page.locator('#repo').fill('fast/repo');
     await page.locator('#check-installation').click();
+    await expect(page.locator('#repo-feedback')).toHaveText(
+      'BugDrop is not installed on fast/repo.'
+    );
 
-    await expect(page.locator('#repo-feedback')).toHaveText(
-      'BugDrop is not installed on fast/repo.'
-    );
-    await page.waitForTimeout(300);
-    await expect(page.locator('#repo-feedback')).toHaveText(
-      'BugDrop is not installed on fast/repo.'
-    );
+    // Now release the slow request; its callback must not clobber the fast result.
+    releaseSlow?.();
+    // Drive the deterministic guarantee: poll for stability rather than wall-clock wait.
+    await expect
+      .poll(() => page.locator('#repo-feedback').textContent(), { timeout: 2000 })
+      .toBe('BugDrop is not installed on fast/repo.');
+  });
+
+  test('discards stale check when repo input changes mid-flight (no second click)', async ({
+    page,
+  }) => {
+    let releaseSlow: (() => void) | undefined;
+    const slowReleased = new Promise<void>(resolve => {
+      releaseSlow = resolve;
+    });
+    await page.route('**/api/check/slow/repo', async route => {
+      await slowReleased;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true, repo: 'slow/repo' }),
+      });
+    });
+
+    await page.goto('/sandbox/');
+    await page.locator('#repo').fill('slow/repo');
+    await page.locator('#check-installation').click();
+    await expect(page.locator('#repo-feedback')).toHaveText('Checking GitHub App installation...');
+
+    // User edits the repo without clicking check again, then the slow response returns.
+    await page.locator('#repo').fill('other/repo');
+    releaseSlow?.();
+
+    // Validation feedback (from input handler) is fine; what must NOT happen is the
+    // stale "installed on slow/repo" text overwriting it.
+    await expect(page.locator('#repo-feedback')).not.toHaveText(/installed on slow\/repo/, {
+      timeout: 2000,
+    });
   });
 
   test('required contact fields imply visible contact fields in generated script', async ({
@@ -146,6 +189,25 @@ test.describe('BugDrop Sandbox', () => {
     await expect(scriptCode).toContainText('data-require-email="true"');
     await expect(scriptCode).toContainText('data-show-name="true"');
     await expect(scriptCode).toContainText('data-require-name="true"');
+  });
+
+  test('surfaces an "ignored invalid values" notice when sanitizers reject input', async ({
+    page,
+  }) => {
+    await page.goto('/sandbox/');
+    const notice = page.locator('#sanitize-feedback');
+    await expect(notice).toBeHidden();
+
+    // Inject a value the CSS-token sanitizer rejects.
+    await page.locator('#color').fill('red"; onerror="alert(1)');
+
+    await expect(notice).toBeVisible();
+    await expect(notice).toContainText(/Ignored invalid values for: .*Accent color/);
+    await expect(page.locator('#script-code')).not.toContainText('data-color');
+
+    // Restoring a valid value clears the notice.
+    await page.locator('#color').fill('#7c3aed');
+    await expect(notice).toBeHidden();
   });
 
   test('reports clipboard failures without throwing', async ({ page }) => {

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -233,6 +233,9 @@ test.describe('Widget Interaction', () => {
     await button.click();
     const getStartedBtn = page.locator('#bugdrop-host').locator('css=[data-action="continue"]');
     await expect(getStartedBtn).toBeVisible({ timeout: 5000 });
+    // The welcome modal carries the `bd-welcome` class — the docs example test in
+    // docs/website/ci-testing.mdx targets this selector, so lock it in here.
+    await expect(page.locator('#bugdrop-host').locator('css=.bd-welcome')).toBeVisible();
     await getStartedBtn.click();
 
     // Form should appear

--- a/public/sandbox/attribute-map.js
+++ b/public/sandbox/attribute-map.js
@@ -1,0 +1,30 @@
+// Single source of truth for the widget's camelCase → data-* attribute mapping.
+// Imported by sandbox.js (config UI) and preview.html (iframe). Keep in sync
+// with the consumers in src/widget/index.ts (script.dataset.* reads).
+export const ATTRIBUTE_MAP = Object.freeze({
+  repo: 'data-repo',
+  theme: 'data-theme',
+  position: 'data-position',
+  color: 'data-color',
+  label: 'data-label',
+  icon: 'data-icon',
+  screenshot: 'data-screenshot',
+  welcome: 'data-welcome',
+  showName: 'data-show-name',
+  requireName: 'data-require-name',
+  showEmail: 'data-show-email',
+  requireEmail: 'data-require-email',
+  buttonDismissible: 'data-button-dismissible',
+  dismissDuration: 'data-dismiss-duration',
+  showRestore: 'data-show-restore',
+  showButton: 'data-button',
+  screenshotScale: 'data-screenshot-scale',
+  font: 'data-font',
+  radius: 'data-radius',
+  bg: 'data-bg',
+  text: 'data-text',
+  borderWidth: 'data-border-width',
+  borderColor: 'data-border-color',
+  shadow: 'data-shadow',
+  categoryLabels: 'data-category-labels',
+});

--- a/public/sandbox/index.html
+++ b/public/sandbox/index.html
@@ -152,6 +152,8 @@
           </div>
           <iframe id="sandbox-preview" title="BugDrop sandbox preview" sandbox="allow-scripts allow-forms allow-popups"></iframe>
 
+          <div id="sanitize-feedback" class="sanitize-feedback" role="status" hidden></div>
+
           <section class="script-output" aria-label="Generated script tag">
             <div class="script-header">
               <div>
@@ -164,13 +166,13 @@
           </section>
 
           <section class="safety-note">
-            <h2>Redaction Check</h2>
-            <p>The preview includes fields marked with <code>data-bugdrop-mask</code>. Screenshot masking is best-effort visual masking for elements developers mark; it is not automatic secret detection.</p>
+            <h2>Screenshot Masking</h2>
+            <p>The preview includes fields marked with <code>data-bugdrop-mask</code>. Masking also covers a small set of built-in defaults (<code>input[type="password"]</code> and credit-card autocomplete fields). It is best-effort visual masking, not automatic secret detection.</p>
           </section>
         </section>
       </div>
     </section>
   </main>
-  <script src="./sandbox.js"></script>
+  <script type="module" src="./sandbox.js"></script>
 </body>
 </html>

--- a/public/sandbox/index.html
+++ b/public/sandbox/index.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BugDrop Sandbox</title>
+  <link rel="stylesheet" href="./sandbox.css">
+</head>
+<body>
+  <main class="sandbox-shell">
+    <section class="workspace">
+      <header class="workspace-header">
+        <div>
+          <h1>BugDrop Sandbox</h1>
+          <p>Configure the widget, preview it on a realistic page, and generate the script tag.</p>
+        </div>
+        <a class="docs-link" href="https://bugdrop.dev/docs/installation">Installation docs</a>
+      </header>
+
+      <div class="layout-grid">
+        <aside class="controls-panel" aria-label="Widget configuration">
+          <form id="sandbox-form">
+            <section class="control-section">
+              <h2>Setup</h2>
+              <label class="field">
+                <span>GitHub repository</span>
+                <input id="repo" name="repo" value="mean-weasel/bugdrop" autocomplete="off" spellcheck="false">
+              </label>
+              <div id="repo-feedback" class="repo-feedback" role="status">Ready to check installation.</div>
+              <button class="secondary-button" id="check-installation" type="button">Check installation</button>
+            </section>
+
+            <section class="control-section">
+              <h2>Behavior</h2>
+              <label class="field">
+                <span>Screenshot mode</span>
+                <select id="screenshot" name="screenshot">
+                  <option value="optional">Optional</option>
+                  <option value="required">Required</option>
+                  <option value="auto">Auto</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Welcome screen behavior</span>
+                <select id="welcome" name="welcome">
+                  <option value="once">Once</option>
+                  <option value="always">Always</option>
+                  <option value="never">Never</option>
+                </select>
+              </label>
+              <div class="checkbox-grid">
+                <label><input id="showName" name="showName" type="checkbox"> Show name</label>
+                <label><input id="requireName" name="requireName" type="checkbox"> Require name</label>
+                <label><input id="showEmail" name="showEmail" type="checkbox"> Show email</label>
+                <label><input id="requireEmail" name="requireEmail" type="checkbox"> Require email</label>
+                <label><input id="buttonDismissible" name="buttonDismissible" type="checkbox"> Dismissible button</label>
+                <label><input id="showButton" name="showButton" type="checkbox" checked> Floating button</label>
+              </div>
+              <label class="field">
+                <span>Dismiss duration</span>
+                <input id="dismissDuration" name="dismissDuration" placeholder="session or minutes" autocomplete="off" spellcheck="false">
+              </label>
+              <div class="checkbox-grid">
+                <label><input id="showRestore" name="showRestore" type="checkbox" checked> Show restore tab</label>
+              </div>
+            </section>
+
+            <section class="control-section">
+              <h2>Screenshots</h2>
+              <label class="field">
+                <span>Screenshot scale</span>
+                <input id="screenshotScale" name="screenshotScale" value="2" inputmode="decimal" autocomplete="off">
+              </label>
+            </section>
+
+            <section class="control-section">
+              <h2>Style</h2>
+              <label class="field">
+                <span>Theme</span>
+                <select id="theme" name="theme">
+                  <option value="auto">Auto</option>
+                  <option value="light">Light</option>
+                  <option value="dark">Dark</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Position</span>
+                <select id="position" name="position">
+                  <option value="bottom-right">Bottom right</option>
+                  <option value="bottom-left">Bottom left</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Accent color</span>
+                <input id="color" name="color" value="#7c3aed" autocomplete="off" spellcheck="false">
+              </label>
+              <label class="field">
+                <span>Button label</span>
+                <input id="label" name="label" value="Feedback" autocomplete="off">
+              </label>
+              <label class="field">
+                <span>Icon</span>
+                <input id="icon" name="icon" placeholder="default, none, or https://..." autocomplete="off" spellcheck="false">
+              </label>
+              <label class="field">
+                <span>Font</span>
+                <input id="font" name="font" placeholder="inherit" autocomplete="off" spellcheck="false">
+              </label>
+              <label class="field">
+                <span>Radius</span>
+                <input id="radius" name="radius" placeholder="8px" autocomplete="off" spellcheck="false">
+              </label>
+              <label class="field">
+                <span>Background color</span>
+                <input id="bg" name="bg" placeholder="#ffffff" autocomplete="off" spellcheck="false">
+              </label>
+              <label class="field">
+                <span>Text color</span>
+                <input id="text" name="text" placeholder="#111827" autocomplete="off" spellcheck="false">
+              </label>
+              <label class="field">
+                <span>Border width</span>
+                <input id="borderWidth" name="borderWidth" placeholder="1px" autocomplete="off" spellcheck="false">
+              </label>
+              <label class="field">
+                <span>Border color</span>
+                <input id="borderColor" name="borderColor" placeholder="#e5e7eb" autocomplete="off" spellcheck="false">
+              </label>
+              <label class="field">
+                <span>Shadow</span>
+                <input id="shadow" name="shadow" placeholder="0 8px 30px rgba(0,0,0,0.12)" autocomplete="off" spellcheck="false">
+              </label>
+            </section>
+
+            <section class="control-section">
+              <h2>Advanced</h2>
+              <label class="field">
+                <span>Category labels JSON</span>
+                <textarea id="categoryLabels" name="categoryLabels" placeholder='{"bug":["defect"],"feature":"product-feedback"}' spellcheck="false"></textarea>
+              </label>
+            </section>
+          </form>
+        </aside>
+
+        <section class="preview-column">
+          <div class="preview-toolbar">
+            <div>
+              <h2>Preview</h2>
+              <p>Reloads with the selected script attributes.</p>
+            </div>
+            <button class="secondary-button" id="refresh-preview" type="button">Refresh preview</button>
+          </div>
+          <iframe id="sandbox-preview" title="BugDrop sandbox preview" sandbox="allow-scripts allow-forms allow-popups"></iframe>
+
+          <section class="script-output" aria-label="Generated script tag">
+            <div class="script-header">
+              <div>
+                <h2>Script Tag</h2>
+                <p>Paste this before the closing body tag in your app.</p>
+              </div>
+              <button id="copy-script" type="button" aria-live="polite">Copy</button>
+            </div>
+            <pre><code id="script-code"></code></pre>
+          </section>
+
+          <section class="safety-note">
+            <h2>Redaction Check</h2>
+            <p>The preview includes fields marked with <code>data-bugdrop-mask</code>. Screenshot masking is best-effort visual masking for elements developers mark; it is not automatic secret detection.</p>
+          </section>
+        </section>
+      </div>
+    </section>
+  </main>
+  <script src="./sandbox.js"></script>
+</body>
+</html>

--- a/public/sandbox/preview.html
+++ b/public/sandbox/preview.html
@@ -432,7 +432,11 @@
   </div>
 
   <script>
-    const attributeMap = {
+    // NOTE: This map duplicates ./attribute-map.js because this document runs in
+    // a same-origin iframe with sandbox="allow-scripts" (no allow-same-origin),
+    // which places it in an opaque origin and blocks ES module imports via CORS.
+    // Keep in sync with ./attribute-map.js and the consumers in src/widget/index.ts.
+    const ATTRIBUTE_MAP = {
       repo: 'data-repo',
       theme: 'data-theme',
       position: 'data-position',
@@ -459,16 +463,29 @@
       shadow: 'data-shadow',
       categoryLabels: 'data-category-labels',
     };
-    const allowedKeys = new Set(Object.keys(attributeMap));
+
+    const allowedKeys = new Set(Object.keys(ATTRIBUTE_MAP));
     const params = new URLSearchParams(window.location.search);
     const script = document.createElement('script');
     script.src = `${window.location.origin}/widget.js`;
     script.async = false;
 
+    script.addEventListener('error', () => {
+      const banner = document.createElement('div');
+      banner.setAttribute('role', 'alert');
+      banner.style.cssText =
+        'position:fixed;bottom:12px;left:12px;right:12px;padding:12px;' +
+        'background:#7f1d1d;color:#fff;border-radius:8px;font-family:system-ui;' +
+        'box-shadow:0 8px 24px rgba(0,0,0,0.2);z-index:9999;';
+      banner.textContent =
+        'BugDrop widget failed to load from /widget.js. Check the network tab and CSP.';
+      document.body.append(banner);
+    });
+
     for (const [key, value] of params.entries()) {
       if (key === 'v') continue;
       if (!allowedKeys.has(key)) continue;
-      script.setAttribute(attributeMap[key] || key, value);
+      script.setAttribute(ATTRIBUTE_MAP[key], value);
     }
 
     document.body.append(script);

--- a/public/sandbox/preview.html
+++ b/public/sandbox/preview.html
@@ -1,0 +1,477 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BugDrop Sandbox Preview</title>
+  <style>
+    :root {
+      --bg: #f8fafc;
+      --ink: #162033;
+      --muted: #64748b;
+      --line: #dbe3ee;
+      --surface: #ffffff;
+      --accent: #2563eb;
+      --success: #0f766e;
+      --warning: #b45309;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      color: var(--ink);
+      background: var(--bg);
+      font-family:
+        Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: 0;
+    }
+
+    button,
+    input,
+    textarea {
+      font: inherit;
+    }
+
+    .app-shell {
+      min-height: 100vh;
+    }
+
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 2;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+      padding: 16px 24px;
+      background: rgba(255, 255, 255, 0.88);
+      border-bottom: 1px solid var(--line);
+      backdrop-filter: blur(14px);
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-weight: 760;
+    }
+
+    .brand-mark {
+      width: 30px;
+      height: 30px;
+      border-radius: 8px;
+      background: var(--accent);
+      box-shadow: inset 0 -8px 16px rgba(0, 0, 0, 0.18);
+    }
+
+    .nav-actions {
+      display: flex;
+      gap: 10px;
+    }
+
+    .nav-actions button {
+      min-height: 36px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 0 12px;
+      color: var(--ink);
+      background: #fff;
+    }
+
+    .hero {
+      display: grid;
+      grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+      gap: 28px;
+      padding: 44px 24px 28px;
+      max-width: 1180px;
+      margin: 0 auto;
+    }
+
+    h1,
+    h2,
+    h3,
+    p {
+      margin: 0;
+    }
+
+    h1 {
+      max-width: 680px;
+      font-size: clamp(2.3rem, 6vw, 5.2rem);
+      line-height: 0.96;
+      letter-spacing: 0;
+      font-weight: 780;
+    }
+
+    .hero-copy p {
+      max-width: 620px;
+      margin-top: 18px;
+      color: var(--muted);
+      font-size: 1.08rem;
+      line-height: 1.65;
+    }
+
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 28px;
+    }
+
+    .primary-action,
+    .secondary-action {
+      min-height: 44px;
+      border-radius: 8px;
+      padding: 0 16px;
+      font-weight: 700;
+    }
+
+    .primary-action {
+      color: #fff;
+      background: var(--accent);
+      border: 1px solid var(--accent);
+    }
+
+    .secondary-action {
+      color: var(--ink);
+      background: #fff;
+      border: 1px solid var(--line);
+    }
+
+    .metric-panel {
+      align-self: stretch;
+      padding: 22px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: 0 18px 40px rgba(22, 32, 51, 0.09);
+    }
+
+    .metric-panel h2 {
+      font-size: 0.84rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .metrics {
+      display: grid;
+      gap: 12px;
+      margin-top: 18px;
+    }
+
+    .metric {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 48px;
+      padding: 0 14px;
+      background: #f8fafc;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      font-weight: 680;
+    }
+
+    .metric span {
+      color: var(--muted);
+      font-weight: 560;
+    }
+
+    .content-grid {
+      display: grid;
+      grid-template-columns: 1fr 360px;
+      gap: 24px;
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 10px 24px 90px;
+    }
+
+    .work-area,
+    .account-panel,
+    .notes-panel {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+    }
+
+    .work-area {
+      min-height: 520px;
+      overflow: hidden;
+    }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 18px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .section-header h2 {
+      font-size: 1rem;
+      font-weight: 760;
+    }
+
+    .status {
+      color: var(--success);
+      font-size: 0.84rem;
+      font-weight: 700;
+    }
+
+    .task-list {
+      display: grid;
+      gap: 1px;
+      background: var(--line);
+    }
+
+    .task-row {
+      display: grid;
+      grid-template-columns: 1fr 120px 100px;
+      gap: 14px;
+      align-items: center;
+      min-height: 72px;
+      padding: 0 18px;
+      background: #fff;
+    }
+
+    .task-title {
+      font-weight: 700;
+    }
+
+    .task-meta {
+      margin-top: 4px;
+      color: var(--muted);
+      font-size: 0.86rem;
+    }
+
+    .pill {
+      justify-self: start;
+      border-radius: 999px;
+      padding: 5px 10px;
+      background: #eff6ff;
+      color: #1d4ed8;
+      font-size: 0.8rem;
+      font-weight: 730;
+    }
+
+    .priority {
+      color: var(--warning);
+      font-size: 0.84rem;
+      font-weight: 720;
+    }
+
+    .sidebar {
+      display: grid;
+      gap: 18px;
+      align-content: start;
+    }
+
+    .account-panel,
+    .notes-panel {
+      padding: 18px;
+    }
+
+    .account-panel h2,
+    .notes-panel h2 {
+      font-size: 1rem;
+    }
+
+    .form-stack {
+      display: grid;
+      gap: 12px;
+      margin-top: 16px;
+    }
+
+    label {
+      display: grid;
+      gap: 6px;
+      color: var(--muted);
+      font-size: 0.84rem;
+      font-weight: 650;
+    }
+
+    input,
+    textarea {
+      width: 100%;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 10px 11px;
+      color: var(--ink);
+      background: #fff;
+    }
+
+    textarea {
+      min-height: 94px;
+      resize: vertical;
+    }
+
+    .notes-panel p {
+      color: var(--muted);
+      margin-top: 12px;
+      line-height: 1.55;
+    }
+
+    @media (max-width: 820px) {
+      .hero,
+      .content-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .topbar {
+        align-items: flex-start;
+        flex-direction: column;
+      }
+
+      .task-row {
+        grid-template-columns: 1fr;
+        gap: 8px;
+        padding: 16px 18px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="app-shell">
+    <header class="topbar">
+      <div class="brand"><span class="brand-mark" aria-hidden="true"></span>Acme Console</div>
+      <nav class="nav-actions" aria-label="Preview navigation">
+        <button type="button">Dashboard</button>
+        <button type="button">Settings</button>
+      </nav>
+    </header>
+
+    <section class="hero">
+      <div class="hero-copy">
+        <h1>Ship feedback from the page where users notice it.</h1>
+        <p>This preview page gives the widget real layout, forms, private fields, scroll depth, and UI density for setup testing.</p>
+        <div class="hero-actions">
+          <button class="primary-action" type="button">Start review</button>
+          <button class="secondary-action" type="button">View queue</button>
+        </div>
+      </div>
+      <aside class="metric-panel">
+        <h2>Release Health</h2>
+        <div class="metrics">
+          <div class="metric"><span>Open reports</span>18</div>
+          <div class="metric"><span>Median triage</span>42m</div>
+          <div class="metric"><span>Screenshot rate</span>71%</div>
+        </div>
+      </aside>
+    </section>
+
+    <section class="content-grid">
+      <main class="work-area">
+        <div class="section-header">
+          <h2>Recent Feedback</h2>
+          <span class="status">Live queue</span>
+        </div>
+        <div class="task-list">
+          <article class="task-row">
+            <div>
+              <div class="task-title">Checkout total changes after coupon edit</div>
+              <div class="task-meta">Reported from /billing/checkout</div>
+            </div>
+            <span class="pill">Bug</span>
+            <span class="priority">High</span>
+          </article>
+          <article class="task-row">
+            <div>
+              <div class="task-title">Add export option for filtered events</div>
+              <div class="task-meta">Reported from /events</div>
+            </div>
+            <span class="pill">Feature</span>
+            <span class="priority">Medium</span>
+          </article>
+          <article class="task-row">
+            <div>
+              <div class="task-title">Clarify which workspace owns audit logs</div>
+              <div class="task-meta">Reported from /settings/security</div>
+            </div>
+            <span class="pill">Question</span>
+            <span class="priority">Low</span>
+          </article>
+          <article class="task-row">
+            <div>
+              <div class="task-title">Keyboard focus skips the invite role selector</div>
+              <div class="task-meta">Reported from /team/invites</div>
+            </div>
+            <span class="pill">Bug</span>
+            <span class="priority">High</span>
+          </article>
+        </div>
+      </main>
+
+      <aside class="sidebar">
+        <section class="account-panel">
+          <h2>Account Details</h2>
+          <div class="form-stack">
+            <label>
+              Customer name
+              <input value="Jordan Watts">
+            </label>
+            <label>
+              API key
+              <input data-bugdrop-mask value="sk_live_sandbox_example_42">
+            </label>
+            <label>
+              Payment method
+              <input data-bugdrop-mask value="Visa ending in 4242">
+            </label>
+          </div>
+        </section>
+        <section class="notes-panel">
+          <h2>Private Notes</h2>
+          <p data-bugdrop-mask>Enterprise renewal negotiation details and account-specific implementation notes.</p>
+          <p>Unmarked content remains visible in screenshots. Use this page to check what your users will see before installing the script.</p>
+        </section>
+      </aside>
+    </section>
+  </div>
+
+  <script>
+    const attributeMap = {
+      repo: 'data-repo',
+      theme: 'data-theme',
+      position: 'data-position',
+      color: 'data-color',
+      label: 'data-label',
+      icon: 'data-icon',
+      screenshot: 'data-screenshot',
+      welcome: 'data-welcome',
+      showName: 'data-show-name',
+      requireName: 'data-require-name',
+      showEmail: 'data-show-email',
+      requireEmail: 'data-require-email',
+      buttonDismissible: 'data-button-dismissible',
+      dismissDuration: 'data-dismiss-duration',
+      showRestore: 'data-show-restore',
+      showButton: 'data-button',
+      screenshotScale: 'data-screenshot-scale',
+      font: 'data-font',
+      radius: 'data-radius',
+      bg: 'data-bg',
+      text: 'data-text',
+      borderWidth: 'data-border-width',
+      borderColor: 'data-border-color',
+      shadow: 'data-shadow',
+      categoryLabels: 'data-category-labels',
+    };
+    const allowedKeys = new Set(Object.keys(attributeMap));
+    const params = new URLSearchParams(window.location.search);
+    const script = document.createElement('script');
+    script.src = `${window.location.origin}/widget.js`;
+    script.async = false;
+
+    for (const [key, value] of params.entries()) {
+      if (key === 'v') continue;
+      if (!allowedKeys.has(key)) continue;
+      script.setAttribute(attributeMap[key] || key, value);
+    }
+
+    document.body.append(script);
+  </script>
+</body>
+</html>

--- a/public/sandbox/preview.html
+++ b/public/sandbox/preview.html
@@ -432,10 +432,14 @@
   </div>
 
   <script>
-    // NOTE: This map duplicates ./attribute-map.js because this document runs in
-    // a same-origin iframe with sandbox="allow-scripts" (no allow-same-origin),
-    // which places it in an opaque origin and blocks ES module imports via CORS.
-    // Keep in sync with ./attribute-map.js and the consumers in src/widget/index.ts.
+    // NOTE: This map duplicates ./attribute-map.js. The iframe is loaded with
+    // sandbox="allow-scripts" (without allow-same-origin), which places its
+    // document in an opaque origin. From an opaque origin, even same-URL ES
+    // module fetches are treated as cross-origin and require CORS response
+    // headers from the asset server — Workers Assets does not emit those for
+    // static files, so the module import fails. Keeping a duplicate map here
+    // (with this comment) avoids weakening the iframe sandbox. Keep in sync
+    // with ./attribute-map.js and the consumers in src/widget/index.ts.
     const ATTRIBUTE_MAP = {
       repo: 'data-repo',
       theme: 'data-theme',
@@ -470,16 +474,33 @@
     script.src = `${window.location.origin}/widget.js`;
     script.async = false;
 
-    script.addEventListener('error', () => {
+    let bannerShown = false;
+    function showBanner(text) {
+      if (bannerShown) return;
+      bannerShown = true;
       const banner = document.createElement('div');
+      banner.id = 'bd-preview-error';
       banner.setAttribute('role', 'alert');
       banner.style.cssText =
         'position:fixed;bottom:12px;left:12px;right:12px;padding:12px;' +
         'background:#7f1d1d;color:#fff;border-radius:8px;font-family:system-ui;' +
         'box-shadow:0 8px 24px rgba(0,0,0,0.2);z-index:9999;';
-      banner.textContent =
-        'BugDrop widget failed to load from /widget.js. Check the network tab and CSP.';
+      banner.textContent = text;
       document.body.append(banner);
+    }
+
+    // Catches network-level script load failures (404, CSP, etc.). Runtime
+    // exceptions thrown inside the bundle land in window.onerror below.
+    script.addEventListener('error', () => {
+      showBanner('BugDrop widget failed to load from /widget.js. Check the network tab and CSP.');
+    });
+
+    // Catches uncaught runtime errors from the widget bundle so a broken
+    // widget.js doesn't silently render as the unmodified static template.
+    window.addEventListener('error', event => {
+      if (event?.filename && event.filename.includes('/widget.js')) {
+        showBanner('BugDrop widget threw during initialization. Check the browser console.');
+      }
     });
 
     for (const [key, value] of params.entries()) {

--- a/public/sandbox/sandbox.css
+++ b/public/sandbox/sandbox.css
@@ -1,5 +1,5 @@
 :root {
-  color-scheme: light;
+  color-scheme: light dark;
   --bg: #f7f8fb;
   --panel: #ffffff;
   --panel-subtle: #f1f4f8;
@@ -212,6 +212,17 @@ select:focus {
 
 .repo-feedback.error {
   color: var(--danger);
+}
+
+.sanitize-feedback {
+  margin: 12px 0 0;
+  padding: 10px 12px;
+  border: 1px solid rgba(180, 83, 9, 0.32);
+  border-radius: 8px;
+  background: rgba(180, 83, 9, 0.08);
+  color: var(--warning);
+  font-size: 0.84rem;
+  line-height: 1.4;
 }
 
 .checkbox-grid {

--- a/public/sandbox/sandbox.css
+++ b/public/sandbox/sandbox.css
@@ -1,0 +1,311 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f8fb;
+  --panel: #ffffff;
+  --panel-subtle: #f1f4f8;
+  --text: #172033;
+  --muted: #617089;
+  --border: #d9e0ea;
+  --strong-border: #b7c2d1;
+  --accent: #7c3aed;
+  --accent-strong: #5b21b6;
+  --success: #0f766e;
+  --warning: #9a3412;
+  --danger: #b91c1c;
+  --shadow: 0 18px 44px rgba(23, 32, 51, 0.11);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(180deg, rgba(124, 58, 237, 0.08), transparent 360px),
+    var(--bg);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  letter-spacing: 0;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+button,
+.docs-link {
+  min-height: 40px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 0 14px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 650;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+button {
+  color: #fff;
+  background: var(--accent);
+}
+
+button:hover {
+  background: var(--accent-strong);
+}
+
+.secondary-button,
+.docs-link {
+  color: var(--text);
+  background: var(--panel);
+  border-color: var(--border);
+}
+
+.secondary-button:hover,
+.docs-link:hover {
+  background: var(--panel-subtle);
+}
+
+.sandbox-shell {
+  min-height: 100vh;
+  padding: 28px;
+}
+
+.workspace {
+  width: min(1480px, 100%);
+  margin: 0 auto;
+}
+
+.workspace-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 22px;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 4vw, 3.75rem);
+  line-height: 1;
+  font-weight: 760;
+}
+
+.workspace-header p,
+.preview-toolbar p,
+.script-header p,
+.safety-note p {
+  color: var(--muted);
+  margin-top: 8px;
+  line-height: 1.5;
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.controls-panel,
+.script-output,
+.safety-note {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.controls-panel {
+  position: sticky;
+  top: 20px;
+  max-height: calc(100vh - 40px);
+  overflow: auto;
+}
+
+.control-section {
+  padding: 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.control-section:last-child {
+  border-bottom: 0;
+}
+
+h2 {
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 780;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.field {
+  display: grid;
+  gap: 7px;
+  margin-top: 14px;
+}
+
+.field span {
+  color: var(--muted);
+  font-size: 0.84rem;
+  font-weight: 650;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  color: var(--text);
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0 11px;
+  outline: none;
+}
+
+input,
+select {
+  min-height: 40px;
+}
+
+textarea {
+  min-height: 88px;
+  padding-top: 10px;
+  resize: vertical;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.14);
+}
+
+.repo-feedback {
+  margin: 10px 0 12px;
+  min-height: 20px;
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.4;
+}
+
+.repo-feedback.ok {
+  color: var(--success);
+}
+
+.repo-feedback.warn {
+  color: var(--warning);
+}
+
+.repo-feedback.error {
+  color: var(--danger);
+}
+
+.checkbox-grid {
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.checkbox-grid label {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 560;
+}
+
+.checkbox-grid input {
+  width: 16px;
+  min-height: 16px;
+  accent-color: var(--accent);
+}
+
+.preview-column {
+  display: grid;
+  gap: 18px;
+}
+
+.preview-toolbar,
+.script-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+#sandbox-preview {
+  width: 100%;
+  min-height: 680px;
+  border: 1px solid var(--strong-border);
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: var(--shadow);
+}
+
+.script-output,
+.safety-note {
+  padding: 18px;
+}
+
+pre {
+  margin: 16px 0 0;
+  padding: 16px;
+  overflow: auto;
+  color: #e5e7eb;
+  background: #111827;
+  border-radius: 8px;
+  font-size: 0.84rem;
+  line-height: 1.55;
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+.safety-note code {
+  color: var(--accent-strong);
+  background: rgba(124, 58, 237, 0.08);
+  border-radius: 4px;
+  padding: 2px 4px;
+}
+
+@media (max-width: 980px) {
+  .sandbox-shell {
+    padding: 18px;
+  }
+
+  .workspace-header,
+  .preview-toolbar,
+  .script-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .layout-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .controls-panel {
+    position: static;
+    max-height: none;
+  }
+
+  #sandbox-preview {
+    min-height: 620px;
+  }
+}

--- a/public/sandbox/sandbox.js
+++ b/public/sandbox/sandbox.js
@@ -30,6 +30,12 @@ const BOOLEAN_FIELDS = new Set([
   'showButton',
 ]);
 
+// User-facing labels for fields whose sanitizer can reject input (coerce non-empty
+// input to ''). Used by describeRejectedFields to build the sanitize-feedback notice.
+// Enum-fallback fields (theme/position/screenshot/welcome) are intentionally absent
+// since they always return a non-empty default. Boolean fields are also absent.
+// IMPORTANT: when adding a new sanitizer in sanitizers.js whose output can be '',
+// add the matching key here so its rejection is surfaced to the user.
 const FIELD_LABELS = {
   repo: 'GitHub repository',
   color: 'Accent color',
@@ -52,6 +58,9 @@ function readConfig() {
   for (const key of Object.keys(ATTRIBUTE_MAP)) {
     const field = form[key];
     if (!field) {
+      // ATTRIBUTE_MAP drift: a config key has no matching form input. Surface
+      // this loudly so a regression is visible rather than silently sending '' .
+      console.warn(`[BugDrop sandbox] no form field for config key "${key}"`);
       config[key] = '';
       continue;
     }
@@ -191,7 +200,12 @@ async function checkInstallation() {
       const detail = await response.text().catch(() => '');
       throw new Error(`HTTP ${response.status}${detail ? `: ${detail.slice(0, 80)}` : ''}`);
     }
-    const result = await response.json();
+    let result;
+    try {
+      result = await response.json();
+    } catch (parseErr) {
+      throw new Error(`HTTP ${response.status}: invalid JSON response`, { cause: parseErr });
+    }
     if (requestId !== installationCheckId || readConfig().repo !== repo) return;
 
     repoFeedback.className = `repo-feedback ${result.installed ? 'ok' : 'warn'}`;

--- a/public/sandbox/sandbox.js
+++ b/public/sandbox/sandbox.js
@@ -1,0 +1,305 @@
+const form = document.querySelector('#sandbox-form');
+const preview = document.querySelector('#sandbox-preview');
+const scriptCode = document.querySelector('#script-code');
+const repoFeedback = document.querySelector('#repo-feedback');
+const copyButton = document.querySelector('#copy-script');
+const checkButton = document.querySelector('#check-installation');
+const refreshButton = document.querySelector('#refresh-preview');
+const GITHUB_REPO_PATTERN =
+  /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\/[A-Za-z0-9._-]{1,100}$/;
+const SAFE_TEXT_PATTERN = /^[\w .,:;!?@#%&()[\]/'"_+=-]{0,120}$/;
+let installationCheckId = 0;
+
+const SCRIPT_ATTRIBUTE_MAP = {
+  repo: 'data-repo',
+  theme: 'data-theme',
+  position: 'data-position',
+  color: 'data-color',
+  label: 'data-label',
+  icon: 'data-icon',
+  screenshot: 'data-screenshot',
+  welcome: 'data-welcome',
+  showName: 'data-show-name',
+  requireName: 'data-require-name',
+  showEmail: 'data-show-email',
+  requireEmail: 'data-require-email',
+  buttonDismissible: 'data-button-dismissible',
+  dismissDuration: 'data-dismiss-duration',
+  showRestore: 'data-show-restore',
+  showButton: 'data-button',
+  screenshotScale: 'data-screenshot-scale',
+  font: 'data-font',
+  radius: 'data-radius',
+  bg: 'data-bg',
+  text: 'data-text',
+  borderWidth: 'data-border-width',
+  borderColor: 'data-border-color',
+  shadow: 'data-shadow',
+  categoryLabels: 'data-category-labels',
+};
+
+function readConfig() {
+  return {
+    repo: form.repo.value.trim(),
+    theme: form.theme.value,
+    position: form.position.value,
+    color: form.color.value.trim(),
+    label: form.label.value.trim(),
+    icon: form.icon.value,
+    screenshot: form.screenshot.value,
+    welcome: form.welcome.value,
+    showName: form.showName.checked,
+    requireName: form.requireName.checked,
+    showEmail: form.showEmail.checked,
+    requireEmail: form.requireEmail.checked,
+    buttonDismissible: form.buttonDismissible.checked,
+    dismissDuration: form.dismissDuration.value.trim(),
+    showRestore: form.showRestore.checked,
+    showButton: form.showButton.checked,
+    screenshotScale: form.screenshotScale.value.trim(),
+    font: form.font.value.trim(),
+    radius: form.radius.value.trim(),
+    bg: form.bg.value.trim(),
+    text: form.text.value.trim(),
+    borderWidth: form.borderWidth.value.trim(),
+    borderColor: form.borderColor.value.trim(),
+    shadow: form.shadow.value.trim(),
+    categoryLabels: form.categoryLabels.value.trim(),
+  };
+}
+
+function normalizeConfig(config) {
+  return {
+    ...config,
+    showName: config.requireName || config.showName,
+    showEmail: config.requireEmail || config.showEmail,
+  };
+}
+
+function sanitizeConfig(config) {
+  const normalized = normalizeConfig(config);
+  const validRepo = isValidRepo(normalized.repo) ? normalized.repo : '';
+
+  return {
+    ...normalized,
+    repo: validRepo,
+    theme: ['auto', 'light', 'dark'].includes(normalized.theme) ? normalized.theme : 'auto',
+    position: ['bottom-right', 'bottom-left'].includes(normalized.position)
+      ? normalized.position
+      : 'bottom-right',
+    screenshot: ['optional', 'required', 'auto'].includes(normalized.screenshot)
+      ? normalized.screenshot
+      : 'optional',
+    welcome: ['once', 'always', 'never'].includes(normalized.welcome)
+      ? normalized.welcome
+      : 'once',
+    color: sanitizeCssToken(normalized.color, 80),
+    label: sanitizePlainText(normalized.label, 80),
+    icon: sanitizeIcon(normalized.icon),
+    dismissDuration: sanitizeDismissDuration(normalized.dismissDuration),
+    screenshotScale: sanitizeScreenshotScale(normalized.screenshotScale),
+    font: sanitizeCssToken(normalized.font, 120),
+    radius: sanitizeCssToken(normalized.radius, 40),
+    bg: sanitizeCssToken(normalized.bg, 80),
+    text: sanitizeCssToken(normalized.text, 80),
+    borderWidth: sanitizeCssToken(normalized.borderWidth, 40),
+    borderColor: sanitizeCssToken(normalized.borderColor, 80),
+    shadow: sanitizeCssToken(normalized.shadow, 120),
+    categoryLabels: sanitizeCategoryLabels(normalized.categoryLabels),
+  };
+}
+
+function getWidgetSrc() {
+  return `${window.location.origin}/widget.js`;
+}
+
+function getScriptAttributes(config) {
+  const attrs = {
+    repo: config.repo,
+    theme: config.theme,
+    position: config.position,
+    color: config.color,
+    label: config.label,
+    icon: config.icon,
+    screenshot: config.screenshot,
+    welcome: config.welcome === 'once' ? '' : config.welcome,
+    showName: config.showName ? 'true' : '',
+    requireName: config.requireName ? 'true' : '',
+    showEmail: config.showEmail ? 'true' : '',
+    requireEmail: config.requireEmail ? 'true' : '',
+    buttonDismissible: config.buttonDismissible ? 'true' : '',
+    dismissDuration: config.dismissDuration,
+    showRestore: config.showRestore ? '' : 'false',
+    showButton: config.showButton ? '' : 'false',
+    screenshotScale: config.screenshotScale === '2' ? '' : config.screenshotScale,
+    font: config.font,
+    radius: config.radius,
+    bg: config.bg,
+    text: config.text,
+    borderWidth: config.borderWidth,
+    borderColor: config.borderColor,
+    shadow: config.shadow,
+    categoryLabels: config.categoryLabels,
+  };
+
+  return Object.entries(attrs).filter(([, value]) => value !== '');
+}
+
+function generateScriptTag(config) {
+  const lines = [`<script`, `  src="${getWidgetSrc()}"`];
+
+  for (const [key, value] of getScriptAttributes(config)) {
+    lines.push(`  ${SCRIPT_ATTRIBUTE_MAP[key]}="${escapeAttribute(value)}"`);
+  }
+
+  lines[lines.length - 1] = `${lines[lines.length - 1]}></script>`;
+  return lines.join('\n');
+}
+
+function escapeAttribute(value) {
+  return String(value).replaceAll('&', '&amp;').replaceAll('"', '&quot;');
+}
+
+function isValidRepo(repo) {
+  return GITHUB_REPO_PATTERN.test(repo) && !repo.endsWith('.git');
+}
+
+function getRepoPath(repo) {
+  const [owner, name] = repo.split('/');
+  return `${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+}
+
+function sanitizePlainText(value, maxLength) {
+  const trimmed = value.trim().slice(0, maxLength);
+  return SAFE_TEXT_PATTERN.test(trimmed) ? trimmed : '';
+}
+
+function sanitizeCssToken(value, maxLength) {
+  const trimmed = value.trim().slice(0, maxLength);
+  return /^[^<>"`{}]*$/.test(trimmed) ? trimmed : '';
+}
+
+function sanitizeIcon(value) {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === 'none') return trimmed;
+
+  try {
+    const url = new URL(trimmed);
+    return ['https:', 'http:'].includes(url.protocol) ? url.toString() : '';
+  } catch {
+    return '';
+  }
+}
+
+function sanitizeDismissDuration(value) {
+  if (!value || value === 'session') return value;
+  return /^\d{1,5}$/.test(value) ? value : '';
+}
+
+function sanitizeScreenshotScale(value) {
+  if (!value) return '';
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 1 && parsed <= 4 ? String(parsed) : '';
+}
+
+function sanitizeCategoryLabels(value) {
+  if (!value) return '';
+
+  try {
+    JSON.parse(value);
+    return value.length <= 1000 ? value : '';
+  } catch {
+    return '';
+  }
+}
+
+function updateRequiredImplications() {
+  if (form.requireName.checked) form.showName.checked = true;
+  if (form.requireEmail.checked) form.showEmail.checked = true;
+}
+
+function updatePreview() {
+  updateRequiredImplications();
+  const rawConfig = normalizeConfig(readConfig());
+  const config = sanitizeConfig(rawConfig);
+  const params = new URLSearchParams();
+
+  for (const [key, value] of getScriptAttributes(config)) {
+    params.set(key, value);
+  }
+
+  scriptCode.textContent = generateScriptTag(config);
+  preview.src = `./preview?${params.toString()}&v=${Date.now()}`;
+  validateRepo(rawConfig.repo, false);
+}
+
+function validateRepo(repo, announceSuccess) {
+  repoFeedback.className = 'repo-feedback';
+
+  if (!repo) {
+    repoFeedback.classList.add('error');
+    repoFeedback.textContent = 'Enter a repository in owner/repo format.';
+    return false;
+  }
+
+  if (!isValidRepo(repo)) {
+    repoFeedback.classList.add('error');
+    repoFeedback.textContent =
+      'Repository must use GitHub owner/repo format with letters, numbers, dots, underscores, or hyphens.';
+    return false;
+  }
+
+  repoFeedback.classList.add('ok');
+  repoFeedback.textContent = announceSuccess
+    ? 'Repository format looks valid.'
+    : 'Ready to check installation.';
+
+  return true;
+}
+
+async function checkInstallation() {
+  const { repo } = readConfig();
+  if (!validateRepo(repo, false)) return;
+
+  const requestId = ++installationCheckId;
+  repoFeedback.className = 'repo-feedback';
+  repoFeedback.textContent = 'Checking GitHub App installation...';
+
+  try {
+    const response = await fetch(`/api/check/${getRepoPath(repo)}`);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const result = await response.json();
+    if (requestId !== installationCheckId || readConfig().repo !== repo) return;
+
+    repoFeedback.className = `repo-feedback ${result.installed ? 'ok' : 'warn'}`;
+    repoFeedback.textContent = result.installed
+      ? `BugDrop is installed on ${result.repo}.`
+      : `BugDrop is not installed on ${result.repo}.`;
+  } catch {
+    if (requestId !== installationCheckId || readConfig().repo !== repo) return;
+    repoFeedback.className = 'repo-feedback error';
+    repoFeedback.textContent = 'Unable to reach the BugDrop API from this page.';
+  }
+}
+
+async function copyScript() {
+  try {
+    if (!navigator.clipboard?.writeText) throw new Error('Clipboard API unavailable');
+    await navigator.clipboard.writeText(scriptCode.textContent);
+    copyButton.textContent = 'Copied';
+  } catch {
+    copyButton.textContent = 'Copy failed';
+  }
+
+  window.setTimeout(() => {
+    copyButton.textContent = 'Copy';
+  }, 1400);
+}
+
+form.addEventListener('input', updatePreview);
+form.addEventListener('change', updatePreview);
+checkButton.addEventListener('click', checkInstallation);
+refreshButton.addEventListener('click', updatePreview);
+copyButton.addEventListener('click', copyScript);
+
+updatePreview();

--- a/public/sandbox/sandbox.js
+++ b/public/sandbox/sandbox.js
@@ -1,112 +1,68 @@
+import { ATTRIBUTE_MAP } from './attribute-map.js';
+import {
+  escapeAttribute,
+  isValidRepo,
+  getRepoPath,
+  normalizeConfig,
+  sanitizeConfig,
+} from './sanitizers.js';
+
 const form = document.querySelector('#sandbox-form');
 const preview = document.querySelector('#sandbox-preview');
 const scriptCode = document.querySelector('#script-code');
 const repoFeedback = document.querySelector('#repo-feedback');
+const sanitizeFeedback = document.querySelector('#sanitize-feedback');
 const copyButton = document.querySelector('#copy-script');
 const checkButton = document.querySelector('#check-installation');
 const refreshButton = document.querySelector('#refresh-preview');
-const GITHUB_REPO_PATTERN =
-  /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\/[A-Za-z0-9._-]{1,100}$/;
-const SAFE_TEXT_PATTERN = /^[\w .,:;!?@#%&()[\]/'"_+=-]{0,120}$/;
+
+// Monotonic id; in-flight installation checks are discarded when this advances
+// or when the repo input changes mid-flight.
 let installationCheckId = 0;
 
-const SCRIPT_ATTRIBUTE_MAP = {
-  repo: 'data-repo',
-  theme: 'data-theme',
-  position: 'data-position',
-  color: 'data-color',
-  label: 'data-label',
-  icon: 'data-icon',
-  screenshot: 'data-screenshot',
-  welcome: 'data-welcome',
-  showName: 'data-show-name',
-  requireName: 'data-require-name',
-  showEmail: 'data-show-email',
-  requireEmail: 'data-require-email',
-  buttonDismissible: 'data-button-dismissible',
-  dismissDuration: 'data-dismiss-duration',
-  showRestore: 'data-show-restore',
-  showButton: 'data-button',
-  screenshotScale: 'data-screenshot-scale',
-  font: 'data-font',
-  radius: 'data-radius',
-  bg: 'data-bg',
-  text: 'data-text',
-  borderWidth: 'data-border-width',
-  borderColor: 'data-border-color',
-  shadow: 'data-shadow',
-  categoryLabels: 'data-category-labels',
+const BOOLEAN_FIELDS = new Set([
+  'showName',
+  'requireName',
+  'showEmail',
+  'requireEmail',
+  'buttonDismissible',
+  'showRestore',
+  'showButton',
+]);
+
+const FIELD_LABELS = {
+  repo: 'GitHub repository',
+  color: 'Accent color',
+  label: 'Button label',
+  icon: 'Icon',
+  dismissDuration: 'Dismiss duration',
+  screenshotScale: 'Screenshot scale',
+  font: 'Font',
+  radius: 'Radius',
+  bg: 'Background color',
+  text: 'Text color',
+  borderWidth: 'Border width',
+  borderColor: 'Border color',
+  shadow: 'Shadow',
+  categoryLabels: 'Category labels',
 };
 
 function readConfig() {
-  return {
-    repo: form.repo.value.trim(),
-    theme: form.theme.value,
-    position: form.position.value,
-    color: form.color.value.trim(),
-    label: form.label.value.trim(),
-    icon: form.icon.value,
-    screenshot: form.screenshot.value,
-    welcome: form.welcome.value,
-    showName: form.showName.checked,
-    requireName: form.requireName.checked,
-    showEmail: form.showEmail.checked,
-    requireEmail: form.requireEmail.checked,
-    buttonDismissible: form.buttonDismissible.checked,
-    dismissDuration: form.dismissDuration.value.trim(),
-    showRestore: form.showRestore.checked,
-    showButton: form.showButton.checked,
-    screenshotScale: form.screenshotScale.value.trim(),
-    font: form.font.value.trim(),
-    radius: form.radius.value.trim(),
-    bg: form.bg.value.trim(),
-    text: form.text.value.trim(),
-    borderWidth: form.borderWidth.value.trim(),
-    borderColor: form.borderColor.value.trim(),
-    shadow: form.shadow.value.trim(),
-    categoryLabels: form.categoryLabels.value.trim(),
-  };
-}
-
-function normalizeConfig(config) {
-  return {
-    ...config,
-    showName: config.requireName || config.showName,
-    showEmail: config.requireEmail || config.showEmail,
-  };
-}
-
-function sanitizeConfig(config) {
-  const normalized = normalizeConfig(config);
-  const validRepo = isValidRepo(normalized.repo) ? normalized.repo : '';
-
-  return {
-    ...normalized,
-    repo: validRepo,
-    theme: ['auto', 'light', 'dark'].includes(normalized.theme) ? normalized.theme : 'auto',
-    position: ['bottom-right', 'bottom-left'].includes(normalized.position)
-      ? normalized.position
-      : 'bottom-right',
-    screenshot: ['optional', 'required', 'auto'].includes(normalized.screenshot)
-      ? normalized.screenshot
-      : 'optional',
-    welcome: ['once', 'always', 'never'].includes(normalized.welcome)
-      ? normalized.welcome
-      : 'once',
-    color: sanitizeCssToken(normalized.color, 80),
-    label: sanitizePlainText(normalized.label, 80),
-    icon: sanitizeIcon(normalized.icon),
-    dismissDuration: sanitizeDismissDuration(normalized.dismissDuration),
-    screenshotScale: sanitizeScreenshotScale(normalized.screenshotScale),
-    font: sanitizeCssToken(normalized.font, 120),
-    radius: sanitizeCssToken(normalized.radius, 40),
-    bg: sanitizeCssToken(normalized.bg, 80),
-    text: sanitizeCssToken(normalized.text, 80),
-    borderWidth: sanitizeCssToken(normalized.borderWidth, 40),
-    borderColor: sanitizeCssToken(normalized.borderColor, 80),
-    shadow: sanitizeCssToken(normalized.shadow, 120),
-    categoryLabels: sanitizeCategoryLabels(normalized.categoryLabels),
-  };
+  const config = {};
+  for (const key of Object.keys(ATTRIBUTE_MAP)) {
+    const field = form[key];
+    if (!field) {
+      config[key] = '';
+      continue;
+    }
+    if (BOOLEAN_FIELDS.has(key)) {
+      config[key] = field.checked;
+    } else {
+      const value = field.value;
+      config[key] = typeof value === 'string' ? value.trim() : value;
+    }
+  }
+  return config;
 }
 
 function getWidgetSrc() {
@@ -149,73 +105,36 @@ function generateScriptTag(config) {
   const lines = [`<script`, `  src="${getWidgetSrc()}"`];
 
   for (const [key, value] of getScriptAttributes(config)) {
-    lines.push(`  ${SCRIPT_ATTRIBUTE_MAP[key]}="${escapeAttribute(value)}"`);
+    lines.push(`  ${ATTRIBUTE_MAP[key]}="${escapeAttribute(value)}"`);
   }
 
   lines[lines.length - 1] = `${lines[lines.length - 1]}></script>`;
   return lines.join('\n');
 }
 
-function escapeAttribute(value) {
-  return String(value).replaceAll('&', '&amp;').replaceAll('"', '&quot;');
-}
-
-function isValidRepo(repo) {
-  return GITHUB_REPO_PATTERN.test(repo) && !repo.endsWith('.git');
-}
-
-function getRepoPath(repo) {
-  const [owner, name] = repo.split('/');
-  return `${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
-}
-
-function sanitizePlainText(value, maxLength) {
-  const trimmed = value.trim().slice(0, maxLength);
-  return SAFE_TEXT_PATTERN.test(trimmed) ? trimmed : '';
-}
-
-function sanitizeCssToken(value, maxLength) {
-  const trimmed = value.trim().slice(0, maxLength);
-  return /^[^<>"`{}]*$/.test(trimmed) ? trimmed : '';
-}
-
-function sanitizeIcon(value) {
-  const trimmed = value.trim();
-  if (!trimmed || trimmed === 'none') return trimmed;
-
-  try {
-    const url = new URL(trimmed);
-    return ['https:', 'http:'].includes(url.protocol) ? url.toString() : '';
-  } catch {
-    return '';
-  }
-}
-
-function sanitizeDismissDuration(value) {
-  if (!value || value === 'session') return value;
-  return /^\d{1,5}$/.test(value) ? value : '';
-}
-
-function sanitizeScreenshotScale(value) {
-  if (!value) return '';
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed >= 1 && parsed <= 4 ? String(parsed) : '';
-}
-
-function sanitizeCategoryLabels(value) {
-  if (!value) return '';
-
-  try {
-    JSON.parse(value);
-    return value.length <= 1000 ? value : '';
-  } catch {
-    return '';
-  }
-}
-
 function updateRequiredImplications() {
   if (form.requireName.checked) form.showName.checked = true;
   if (form.requireEmail.checked) form.showEmail.checked = true;
+}
+
+function describeRejectedFields(raw, sanitized) {
+  const rejected = [];
+  for (const [key, label] of Object.entries(FIELD_LABELS)) {
+    const before = typeof raw[key] === 'string' ? raw[key] : '';
+    if (before && !sanitized[key]) rejected.push(label);
+  }
+  return rejected;
+}
+
+function renderSanitizeFeedback(rejected) {
+  if (!sanitizeFeedback) return;
+  if (rejected.length === 0) {
+    sanitizeFeedback.textContent = '';
+    sanitizeFeedback.hidden = true;
+    return;
+  }
+  sanitizeFeedback.textContent = `Ignored invalid values for: ${rejected.join(', ')}.`;
+  sanitizeFeedback.hidden = false;
 }
 
 function updatePreview() {
@@ -230,6 +149,7 @@ function updatePreview() {
 
   scriptCode.textContent = generateScriptTag(config);
   preview.src = `./preview?${params.toString()}&v=${Date.now()}`;
+  renderSanitizeFeedback(describeRejectedFields(rawConfig, config));
   validateRepo(rawConfig.repo, false);
 }
 
@@ -267,7 +187,10 @@ async function checkInstallation() {
 
   try {
     const response = await fetch(`/api/check/${getRepoPath(repo)}`);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      throw new Error(`HTTP ${response.status}${detail ? `: ${detail.slice(0, 80)}` : ''}`);
+    }
     const result = await response.json();
     if (requestId !== installationCheckId || readConfig().repo !== repo) return;
 
@@ -275,10 +198,14 @@ async function checkInstallation() {
     repoFeedback.textContent = result.installed
       ? `BugDrop is installed on ${result.repo}.`
       : `BugDrop is not installed on ${result.repo}.`;
-  } catch {
+  } catch (err) {
     if (requestId !== installationCheckId || readConfig().repo !== repo) return;
+    console.warn('[BugDrop sandbox] installation check failed:', err);
+    const message = err instanceof Error ? err.message : '';
     repoFeedback.className = 'repo-feedback error';
-    repoFeedback.textContent = 'Unable to reach the BugDrop API from this page.';
+    repoFeedback.textContent = message.startsWith('HTTP')
+      ? `Installation check failed (${message}). Try again or open an issue.`
+      : 'Unable to reach the BugDrop API from this page.';
   }
 }
 
@@ -287,7 +214,8 @@ async function copyScript() {
     if (!navigator.clipboard?.writeText) throw new Error('Clipboard API unavailable');
     await navigator.clipboard.writeText(scriptCode.textContent);
     copyButton.textContent = 'Copied';
-  } catch {
+  } catch (err) {
+    console.warn('[BugDrop sandbox] clipboard write failed:', err);
     copyButton.textContent = 'Copy failed';
   }
 

--- a/public/sandbox/sanitizers.js
+++ b/public/sandbox/sanitizers.js
@@ -35,7 +35,11 @@ export function sanitizeIcon(value) {
   if (!trimmed || trimmed === 'none') return trimmed;
   try {
     const url = new URL(trimmed);
-    return ['https:', 'http:'].includes(url.protocol) ? url.toString() : '';
+    if (!['https:', 'http:'].includes(url.protocol)) return '';
+    // Reject embedded credentials (e.g. https://user:pass@host) — they would
+    // leak into the generated script's data-icon attribute.
+    if (url.username || url.password) return '';
+    return url.toString();
   } catch {
     return '';
   }
@@ -52,6 +56,8 @@ export function sanitizeScreenshotScale(value) {
   return Number.isFinite(parsed) && parsed >= 1 && parsed <= 4 ? String(parsed) : '';
 }
 
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 export function sanitizeCategoryLabels(value) {
   if (!value) return '';
   if (value.length > 1000) return '';
@@ -65,6 +71,9 @@ export function sanitizeCategoryLabels(value) {
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
     return '';
   }
+  // Reject prototype-pollution-style keys; downstream consumers may still
+  // process this JSON, so don't let those keys survive validation.
+  if (Object.keys(parsed).some(key => FORBIDDEN_KEYS.has(key))) return '';
   return value;
 }
 

--- a/public/sandbox/sanitizers.js
+++ b/public/sandbox/sanitizers.js
@@ -1,0 +1,107 @@
+// Pure sanitization/validation helpers for the sandbox config UI.
+// All inputs are user-typed; outputs are safe to embed in script tag attributes
+// and URL parameters. Invalid inputs coerce to '' (the generator omits them).
+
+const GITHUB_REPO_PATTERN =
+  /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\/[A-Za-z0-9._-]{1,100}$/;
+const SAFE_TEXT_PATTERN = /^[\w .,:;!?@#%&()[\]/'"_+=-]{0,120}$/;
+const CSS_TOKEN_REJECT = /[<>"`{}\r\n\t]/;
+
+export function escapeAttribute(value) {
+  return String(value).replaceAll('&', '&amp;').replaceAll('"', '&quot;');
+}
+
+export function isValidRepo(repo) {
+  return GITHUB_REPO_PATTERN.test(repo) && !repo.endsWith('.git');
+}
+
+export function getRepoPath(repo) {
+  const [owner, name] = repo.split('/');
+  return `${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+}
+
+export function sanitizePlainText(value, maxLength) {
+  const trimmed = value.trim().slice(0, maxLength);
+  return SAFE_TEXT_PATTERN.test(trimmed) ? trimmed : '';
+}
+
+export function sanitizeCssToken(value, maxLength) {
+  const trimmed = value.trim().slice(0, maxLength);
+  return !CSS_TOKEN_REJECT.test(trimmed) ? trimmed : '';
+}
+
+export function sanitizeIcon(value) {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === 'none') return trimmed;
+  try {
+    const url = new URL(trimmed);
+    return ['https:', 'http:'].includes(url.protocol) ? url.toString() : '';
+  } catch {
+    return '';
+  }
+}
+
+export function sanitizeDismissDuration(value) {
+  if (!value || value === 'session') return value;
+  return /^\d{1,5}$/.test(value) ? value : '';
+}
+
+export function sanitizeScreenshotScale(value) {
+  if (!value) return '';
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 1 && parsed <= 4 ? String(parsed) : '';
+}
+
+export function sanitizeCategoryLabels(value) {
+  if (!value) return '';
+  if (value.length > 1000) return '';
+  let parsed;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return '';
+  }
+  // Widget expects a non-null, non-array object. Other JSON shapes are rejected.
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return '';
+  }
+  return value;
+}
+
+export function normalizeConfig(config) {
+  return {
+    ...config,
+    showName: config.requireName || config.showName,
+    showEmail: config.requireEmail || config.showEmail,
+  };
+}
+
+const THEMES = ['auto', 'light', 'dark'];
+const POSITIONS = ['bottom-right', 'bottom-left'];
+const SCREENSHOTS = ['optional', 'required', 'auto'];
+const WELCOMES = ['once', 'always', 'never'];
+
+export function sanitizeConfig(config) {
+  const normalized = normalizeConfig(config);
+  return {
+    ...normalized,
+    repo: isValidRepo(normalized.repo) ? normalized.repo : '',
+    theme: THEMES.includes(normalized.theme) ? normalized.theme : 'auto',
+    position: POSITIONS.includes(normalized.position) ? normalized.position : 'bottom-right',
+    screenshot: SCREENSHOTS.includes(normalized.screenshot) ? normalized.screenshot : 'optional',
+    welcome: WELCOMES.includes(normalized.welcome) ? normalized.welcome : 'once',
+    color: sanitizeCssToken(normalized.color, 80),
+    label: sanitizePlainText(normalized.label, 80),
+    icon: sanitizeIcon(normalized.icon),
+    dismissDuration: sanitizeDismissDuration(normalized.dismissDuration),
+    screenshotScale: sanitizeScreenshotScale(normalized.screenshotScale),
+    font: sanitizeCssToken(normalized.font, 120),
+    radius: sanitizeCssToken(normalized.radius, 40),
+    bg: sanitizeCssToken(normalized.bg, 80),
+    text: sanitizeCssToken(normalized.text, 80),
+    borderWidth: sanitizeCssToken(normalized.borderWidth, 40),
+    borderColor: sanitizeCssToken(normalized.borderColor, 80),
+    shadow: sanitizeCssToken(normalized.shadow, 120),
+    categoryLabels: sanitizeCategoryLabels(normalized.categoryLabels),
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,36 @@ app.use('*', logger());
 // Mount API routes
 app.route('/api', api);
 
+function fetchAsset(c: { req: { url: string; raw: Request }; env: Env }, pathname: string) {
+  const url = new URL(c.req.url);
+  url.pathname = pathname;
+  return c.env.ASSETS.fetch(new Request(url, c.req.raw));
+}
+
+app.get('/sandbox', c => {
+  return c.redirect('/sandbox/', 301);
+});
+
+app.get('/sandbox/', c => {
+  return fetchAsset(c, '/sandbox/index.html');
+});
+
+app.get('/sandbox/preview', c => {
+  return fetchAsset(c, '/sandbox/preview.html');
+});
+
+app.get('/sandbox/preview.html', c => {
+  return fetchAsset(c, '/sandbox/preview.html');
+});
+
+app.get('/sandbox/sandbox.css', c => {
+  return fetchAsset(c, '/sandbox/sandbox.css');
+});
+
+app.get('/sandbox/sandbox.js', c => {
+  return fetchAsset(c, '/sandbox/sandbox.js');
+});
+
 // Redirect to landing page on Vercel
 app.get('/', c => {
   return c.redirect('https://bugdrop.dev', 301);

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,35 +35,9 @@ app.use('*', logger());
 // Mount API routes
 app.route('/api', api);
 
-function fetchAsset(c: { req: { url: string; raw: Request }; env: Env }, pathname: string) {
-  const url = new URL(c.req.url);
-  url.pathname = pathname;
-  return c.env.ASSETS.fetch(new Request(url, c.req.raw));
-}
-
-app.get('/sandbox', c => {
-  return c.redirect('/sandbox/', 301);
-});
-
-app.get('/sandbox/', c => {
-  return fetchAsset(c, '/sandbox/index.html');
-});
-
-app.get('/sandbox/preview', c => {
-  return fetchAsset(c, '/sandbox/preview.html');
-});
-
-app.get('/sandbox/preview.html', c => {
-  return fetchAsset(c, '/sandbox/preview.html');
-});
-
-app.get('/sandbox/sandbox.css', c => {
-  return fetchAsset(c, '/sandbox/sandbox.css');
-});
-
-app.get('/sandbox/sandbox.js', c => {
-  return fetchAsset(c, '/sandbox/sandbox.js');
-});
+// /sandbox needs a trailing-slash redirect; everything under /sandbox/* is served
+// directly by Wrangler Assets (see [assets] in wrangler.toml) without invoking the Worker.
+app.get('/sandbox', c => c.redirect('/sandbox/', 301));
 
 // Redirect to landing page on Vercel
 app.get('/', c => {

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -1057,7 +1057,8 @@ function showWelcomeScreen(root: HTMLElement): Promise<boolean> {
           <button class="bd-btn bd-btn-primary" data-action="continue">Get Started</button>
         </div>
       `,
-      true
+      true,
+      'bd-welcome'
     );
 
     const closeBtn = modal.querySelector('.bd-close') as HTMLElement;

--- a/test/sandboxSanitizers.test.ts
+++ b/test/sandboxSanitizers.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from 'vitest';
+import {
+  escapeAttribute,
+  isValidRepo,
+  getRepoPath,
+  sanitizePlainText,
+  sanitizeCssToken,
+  sanitizeIcon,
+  sanitizeDismissDuration,
+  sanitizeScreenshotScale,
+  sanitizeCategoryLabels,
+  normalizeConfig,
+  sanitizeConfig,
+  // @ts-expect-error — plain JS module, no type declarations
+} from '../public/sandbox/sanitizers.js';
+
+describe('escapeAttribute', () => {
+  it('escapes & before " so order is correct', () => {
+    expect(escapeAttribute('&"')).toBe('&amp;&quot;');
+  });
+
+  it('replaces all occurrences, not just the first', () => {
+    expect(escapeAttribute('a&b&c"d"e')).toBe('a&amp;b&amp;c&quot;d&quot;e');
+  });
+
+  it('coerces non-strings via String()', () => {
+    expect(escapeAttribute(42)).toBe('42');
+    expect(escapeAttribute(true)).toBe('true');
+  });
+});
+
+describe('isValidRepo', () => {
+  it('accepts valid owner/repo names', () => {
+    expect(isValidRepo('mean-weasel/bugdrop')).toBe(true);
+    expect(isValidRepo('acme/app.io')).toBe(true);
+    expect(isValidRepo('Acme/my_repo')).toBe(true);
+    expect(isValidRepo('a/b')).toBe(true);
+  });
+
+  it('rejects names ending with .git', () => {
+    expect(isValidRepo('acme/app.git')).toBe(false);
+  });
+
+  it('rejects formats without exactly one slash', () => {
+    expect(isValidRepo('justone')).toBe(false);
+    expect(isValidRepo('one/two/three')).toBe(false);
+    expect(isValidRepo('')).toBe(false);
+  });
+
+  it('rejects unsafe characters', () => {
+    expect(isValidRepo('acme/app?x=1')).toBe(false);
+    expect(isValidRepo('acme/app#frag')).toBe(false);
+    expect(isValidRepo('acme/<script>')).toBe(false);
+    expect(isValidRepo('acme /app')).toBe(false);
+  });
+
+  it('accepts owner at exactly 39 chars and rejects 40', () => {
+    const owner39 = 'a' + 'b'.repeat(37) + 'c';
+    const owner40 = 'a' + 'b'.repeat(38) + 'c';
+    expect(owner39.length).toBe(39);
+    expect(owner40.length).toBe(40);
+    expect(isValidRepo(`${owner39}/repo`)).toBe(true);
+    expect(isValidRepo(`${owner40}/repo`)).toBe(false);
+  });
+
+  it('accepts repo name up to 100 chars and rejects 101', () => {
+    const repo100 = 'r'.repeat(100);
+    const repo101 = 'r'.repeat(101);
+    expect(isValidRepo(`acme/${repo100}`)).toBe(true);
+    expect(isValidRepo(`acme/${repo101}`)).toBe(false);
+  });
+});
+
+describe('getRepoPath', () => {
+  it('encodes both segments with encodeURIComponent', () => {
+    expect(getRepoPath('acme/app')).toBe('acme/app');
+  });
+
+  it('encodes characters that need URL escaping', () => {
+    // Owner/name pulled apart and re-encoded; would only hit this path post-validation
+    expect(getRepoPath('a c/d e')).toBe('a%20c/d%20e');
+  });
+});
+
+describe('sanitizePlainText', () => {
+  it('returns trimmed value when it matches SAFE_TEXT_PATTERN', () => {
+    expect(sanitizePlainText('  Send Feedback  ', 80)).toBe('Send Feedback');
+  });
+
+  it('returns empty string for newlines, <, >, or non-ASCII', () => {
+    expect(sanitizePlainText('line1\nline2', 80)).toBe('');
+    expect(sanitizePlainText('<script>', 80)).toBe('');
+    expect(sanitizePlainText('hello>world', 80)).toBe('');
+    expect(sanitizePlainText('Send 💬', 80)).toBe('');
+  });
+
+  it('preserves all characters in SAFE_TEXT_PATTERN', () => {
+    expect(sanitizePlainText('Word . , : ; ! ? @ # % & ( ) [ ] / \' " _ + = -', 80)).toBe(
+      'Word . , : ; ! ? @ # % & ( ) [ ] / \' " _ + = -'
+    );
+  });
+
+  it('truncates to maxLength before validation', () => {
+    expect(sanitizePlainText('abcdef', 3)).toBe('abc');
+  });
+});
+
+describe('sanitizeCssToken', () => {
+  it('rejects values containing <, >, ", backtick, {, or }', () => {
+    expect(sanitizeCssToken('red<', 80)).toBe('');
+    expect(sanitizeCssToken('red>', 80)).toBe('');
+    expect(sanitizeCssToken('red"', 80)).toBe('');
+    expect(sanitizeCssToken('red`', 80)).toBe('');
+    expect(sanitizeCssToken('red{', 80)).toBe('');
+    expect(sanitizeCssToken('red}', 80)).toBe('');
+  });
+
+  it('rejects embedded whitespace control chars that would break <pre> display', () => {
+    expect(sanitizeCssToken('red\nbackground:url(evil)', 80)).toBe('');
+    expect(sanitizeCssToken('red\rbg', 80)).toBe('');
+    expect(sanitizeCssToken('a\tb', 80)).toBe('');
+  });
+
+  it('still trims surrounding whitespace before validating', () => {
+    expect(sanitizeCssToken('  red  ', 80)).toBe('red');
+    expect(sanitizeCssToken('red\n', 80)).toBe('red');
+  });
+
+  it('preserves valid CSS tokens', () => {
+    expect(sanitizeCssToken('#7c3aed', 80)).toBe('#7c3aed');
+    expect(sanitizeCssToken('0 8px 30px rgba(0,0,0,0.12)', 120)).toBe(
+      '0 8px 30px rgba(0,0,0,0.12)'
+    );
+    expect(sanitizeCssToken('inherit', 120)).toBe('inherit');
+  });
+
+  it('truncates to maxLength before validation', () => {
+    expect(sanitizeCssToken('a'.repeat(200), 5)).toBe('aaaaa');
+  });
+});
+
+describe('sanitizeIcon', () => {
+  it('rejects javascript:, data:, and file: URLs', () => {
+    expect(sanitizeIcon('javascript:alert(1)')).toBe('');
+    expect(sanitizeIcon('data:image/png;base64,xxx')).toBe('');
+    expect(sanitizeIcon('file:///etc/passwd')).toBe('');
+  });
+
+  it('accepts http and https URLs', () => {
+    expect(sanitizeIcon('https://example.com/icon.svg')).toBe('https://example.com/icon.svg');
+    expect(sanitizeIcon('http://example.com/icon.svg')).toBe('http://example.com/icon.svg');
+  });
+
+  it('returns "none" verbatim and "" for empty', () => {
+    expect(sanitizeIcon('none')).toBe('none');
+    expect(sanitizeIcon('')).toBe('');
+    expect(sanitizeIcon('   ')).toBe('');
+  });
+
+  it('returns "" for malformed URLs', () => {
+    expect(sanitizeIcon('not-a-url')).toBe('');
+    expect(sanitizeIcon('htps://typo.com')).toBe('');
+    expect(sanitizeIcon('//missing-scheme.com')).toBe('');
+  });
+});
+
+describe('sanitizeDismissDuration', () => {
+  it('preserves "session" and empty', () => {
+    expect(sanitizeDismissDuration('session')).toBe('session');
+    expect(sanitizeDismissDuration('')).toBe('');
+  });
+
+  it('preserves 1-5 digit numeric strings', () => {
+    expect(sanitizeDismissDuration('1')).toBe('1');
+    expect(sanitizeDismissDuration('99999')).toBe('99999');
+  });
+
+  it('rejects negative, decimal, exponential, or non-digit input', () => {
+    expect(sanitizeDismissDuration('-5')).toBe('');
+    expect(sanitizeDismissDuration('12.5')).toBe('');
+    expect(sanitizeDismissDuration('1e9')).toBe('');
+    expect(sanitizeDismissDuration('abc')).toBe('');
+  });
+
+  it('rejects 6+ digit numeric strings', () => {
+    expect(sanitizeDismissDuration('100000')).toBe('');
+  });
+});
+
+describe('sanitizeScreenshotScale', () => {
+  it('clamps to [1,4] inclusive and rejects out-of-range', () => {
+    expect(sanitizeScreenshotScale('1')).toBe('1');
+    expect(sanitizeScreenshotScale('4')).toBe('4');
+    expect(sanitizeScreenshotScale('0.99')).toBe('');
+    expect(sanitizeScreenshotScale('4.01')).toBe('');
+    expect(sanitizeScreenshotScale('100')).toBe('');
+  });
+
+  it('rejects NaN, Infinity, and empty input', () => {
+    expect(sanitizeScreenshotScale('NaN')).toBe('');
+    expect(sanitizeScreenshotScale('Infinity')).toBe('');
+    expect(sanitizeScreenshotScale('')).toBe('');
+    expect(sanitizeScreenshotScale('abc')).toBe('');
+  });
+
+  it('preserves valid decimal values', () => {
+    expect(sanitizeScreenshotScale('2.5')).toBe('2.5');
+  });
+});
+
+describe('sanitizeCategoryLabels', () => {
+  it('returns empty for whitespace-only or empty input', () => {
+    expect(sanitizeCategoryLabels('')).toBe('');
+  });
+
+  it('returns empty for malformed JSON', () => {
+    expect(sanitizeCategoryLabels('{not json')).toBe('');
+    expect(sanitizeCategoryLabels("{'single': 'quotes'}")).toBe('');
+    expect(sanitizeCategoryLabels('{"trailing":,}')).toBe('');
+  });
+
+  it('returns empty for non-object JSON (string, number, null, array)', () => {
+    expect(sanitizeCategoryLabels('null')).toBe('');
+    expect(sanitizeCategoryLabels('"a string"')).toBe('');
+    expect(sanitizeCategoryLabels('42')).toBe('');
+    expect(sanitizeCategoryLabels('[]')).toBe('');
+    expect(sanitizeCategoryLabels('[1,2]')).toBe('');
+  });
+
+  it('passes through valid object JSON', () => {
+    const value = '{"bug":["defect"],"feature":"idea"}';
+    expect(sanitizeCategoryLabels(value)).toBe(value);
+  });
+
+  it('returns empty when value exceeds 1000 characters', () => {
+    const oversize = '{"a":"' + 'x'.repeat(995) + '"}';
+    expect(oversize.length).toBeGreaterThan(1000);
+    expect(sanitizeCategoryLabels(oversize)).toBe('');
+  });
+});
+
+describe('normalizeConfig', () => {
+  it('forces showName=true when requireName=true', () => {
+    const result = normalizeConfig({ requireName: true, showName: false });
+    expect(result.showName).toBe(true);
+  });
+
+  it('forces showEmail=true when requireEmail=true', () => {
+    const result = normalizeConfig({ requireEmail: true, showEmail: false });
+    expect(result.showEmail).toBe(true);
+  });
+
+  it('preserves showName when require is false', () => {
+    const result = normalizeConfig({ requireName: false, showName: true });
+    expect(result.showName).toBe(true);
+  });
+});
+
+describe('sanitizeConfig', () => {
+  const base = {
+    repo: 'mean-weasel/bugdrop',
+    theme: 'auto',
+    position: 'bottom-right',
+    color: '',
+    label: '',
+    icon: '',
+    screenshot: 'optional',
+    welcome: 'once',
+    showName: false,
+    requireName: false,
+    showEmail: false,
+    requireEmail: false,
+    buttonDismissible: false,
+    dismissDuration: '',
+    showRestore: true,
+    showButton: true,
+    screenshotScale: '',
+    font: '',
+    radius: '',
+    bg: '',
+    text: '',
+    borderWidth: '',
+    borderColor: '',
+    shadow: '',
+    categoryLabels: '',
+  };
+
+  it('falls back to default theme when invalid', () => {
+    expect(sanitizeConfig({ ...base, theme: 'rainbow' }).theme).toBe('auto');
+  });
+
+  it('falls back to default position when invalid', () => {
+    expect(sanitizeConfig({ ...base, position: 'top-left' }).position).toBe('bottom-right');
+  });
+
+  it('falls back to default screenshot mode when invalid', () => {
+    expect(sanitizeConfig({ ...base, screenshot: 'maybe' }).screenshot).toBe('optional');
+  });
+
+  it('falls back to default welcome when invalid', () => {
+    expect(sanitizeConfig({ ...base, welcome: 'sometimes' }).welcome).toBe('once');
+  });
+
+  it('clears repo when invalid', () => {
+    expect(sanitizeConfig({ ...base, repo: 'not a repo' }).repo).toBe('');
+  });
+
+  it('applies require → show implication via normalizeConfig', () => {
+    const result = sanitizeConfig({ ...base, requireEmail: true, showEmail: false });
+    expect(result.showEmail).toBe(true);
+  });
+});

--- a/test/sandboxSanitizers.test.ts
+++ b/test/sandboxSanitizers.test.ts
@@ -162,6 +162,12 @@ describe('sanitizeIcon', () => {
     expect(sanitizeIcon('htps://typo.com')).toBe('');
     expect(sanitizeIcon('//missing-scheme.com')).toBe('');
   });
+
+  it('rejects URLs with embedded credentials', () => {
+    expect(sanitizeIcon('https://user:pass@example.com/icon.svg')).toBe('');
+    expect(sanitizeIcon('https://user@example.com/icon.svg')).toBe('');
+    expect(sanitizeIcon('http://:pass@example.com/icon.svg')).toBe('');
+  });
 });
 
 describe('sanitizeDismissDuration', () => {
@@ -236,6 +242,12 @@ describe('sanitizeCategoryLabels', () => {
     const oversize = '{"a":"' + 'x'.repeat(995) + '"}';
     expect(oversize.length).toBeGreaterThan(1000);
     expect(sanitizeCategoryLabels(oversize)).toBe('');
+  });
+
+  it('rejects prototype-pollution-style keys', () => {
+    expect(sanitizeCategoryLabels('{"__proto__":{"polluted":true}}')).toBe('');
+    expect(sanitizeCategoryLabels('{"constructor":{"prototype":{}}}')).toBe('');
+    expect(sanitizeCategoryLabels('{"prototype":"x"}')).toBe('');
   });
 });
 


### PR DESCRIPTION
## Summary
- add a hosted BugDrop Sandbox for configuring, previewing, and generating widget script tags
- add sandbox preview routes, iframe isolation, repo validation, install-check handling, and copy failure state
- document the sandbox and align data-welcome docs with runtime behavior
- add local E2E coverage and preview/production asset smoke checks

## Validation
- npm run build:widget
- npm run validate
- npm run test:e2e -- --project=chromium e2e/sandbox.spec.ts
- npm run test:e2e -- --project=chromium
- Playwright desktop/mobile rendered smoke check of /sandbox/

Closes #151