### PR TITLE
test: cover production redaction failure UX

### DIFF
--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -612,6 +612,46 @@ test.describe('Screenshot Capture (Live)', () => {
       await countBlackPixelsInDataUrl(page, submittedScreenshot as string, latestRegion)
     ).toBeLessThan(20);
   });
+
+  test('privacy masking failure UX works on the deployed production widget', async ({ page }) => {
+    test.skip(
+      process.env.LIVE_TARGET !== 'production',
+      'The production failure fixture is hosted on the production Vercel venue.'
+    );
+
+    await mockInstalledRepo(page);
+    const payloads = await trackLiveFeedbackPayloads(page);
+    await page.goto('/redaction-failure.html');
+
+    const host = page.locator('#bugdrop-host');
+    await expect(host.locator('css=.bd-trigger')).toBeVisible({ timeout: 10_000 });
+    await host.locator('css=.bd-trigger').click();
+
+    await expect(host.locator('css=[data-action="continue"]')).toBeVisible({ timeout: 5_000 });
+    await host.locator('css=[data-action="continue"]').click();
+
+    await expect(host.locator('css=#title')).toBeVisible({ timeout: 5_000 });
+    await host.locator('css=#title').fill('Live privacy masking failure');
+    await host.locator('css=#include-screenshot').check();
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=[data-action="capture"]')).toBeVisible({ timeout: 5_000 });
+    await host.locator('css=[data-action="capture"]').click();
+
+    await expect(host.locator('css=.bd-title')).toHaveText('Privacy masking failed', {
+      timeout: 10_000,
+    });
+    await expect(host.locator('css=.bd-error-message__text')).toContainText(
+      'Automatic redaction of private fields could not be applied'
+    );
+    await expect(host.locator('css=button').filter({ hasText: 'Try Again' })).toHaveCount(0);
+
+    await host.locator('css=button').filter({ hasText: 'Continue without screenshot' }).click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10_000 });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].screenshot).toBeNull();
+  });
 });
 
 test.describe('Feedback Submission (Live)', () => {

--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -22,6 +22,7 @@ const expectedWidgetOrigin =
       ? 'https://bugdrop.neonwatty.workers.dev'
       : undefined);
 const expectedWidgetSha256 = process.env.EXPECTED_WIDGET_SHA256;
+const venuePath = process.env.LIVE_VENUE_PATH || '/';
 
 if (bypassSecret) {
   test.beforeEach(async ({ context }) => {
@@ -70,7 +71,7 @@ async function addCorsBlockedImage(page: Page) {
 
 async function openScreenshotOptions(page: Page, title: string) {
   await mockInstalledRepo(page);
-  await page.goto(process.env.LIVE_TARGET === 'preview' ? '/' : '/test/');
+  await page.goto(venuePath);
 
   const host = page.locator('#bugdrop-host');
   const button = host.locator('css=.bd-trigger');
@@ -263,7 +264,7 @@ test.describe('Widget Loading (Live)', () => {
       }
     });
 
-    await page.goto(process.env.LIVE_TARGET === 'preview' ? '/' : '/test/');
+    await page.goto(venuePath);
     await page.waitForTimeout(2000);
 
     // Widget host element should exist
@@ -286,7 +287,7 @@ test.describe('Widget Loading (Live)', () => {
   });
 
   test('venue loads the expected deployed widget asset', async ({ page, request }) => {
-    await page.goto(process.env.LIVE_TARGET === 'preview' ? '/' : '/test/');
+    await page.goto(venuePath);
 
     const widgetSrc = await page.evaluate(() => {
       return (
@@ -312,7 +313,7 @@ test.describe('Widget Loading (Live)', () => {
 
 test.describe('Feedback Button (Live)', () => {
   test('feedback button is visible and clickable', async ({ page }) => {
-    await page.goto(process.env.LIVE_TARGET === 'preview' ? '/' : '/test/');
+    await page.goto(venuePath);
 
     const button = page.locator('#bugdrop-host').locator('css=.bd-trigger');
     await expect(button).toBeVisible({ timeout: 10_000 });
@@ -489,7 +490,7 @@ test.describe('Screenshot Capture (Live)', () => {
       });
     });
 
-    await page.goto(process.env.LIVE_TARGET === 'preview' ? '/' : '/test/');
+    await page.goto(venuePath);
 
     const host = page.locator('#bugdrop-host');
     const button = host.locator('css=.bd-trigger');


### PR DESCRIPTION
## Summary
- Make live E2E use the production venue root by default, with LIVE_VENUE_PATH available for overrides.
- Add production live coverage for the privacy masking failure UX using the deployed redaction-failure fixture.

## Verification
- LIVE_TARGET=production PLAYWRIGHT_BASE_URL=https://bugdrop-widget-test.vercel.app EXPECTED_WIDGET_ORIGIN=https://bugdrop.neonwatty.workers.dev npx playwright test --project=chromium-live --workers=1
- Result: 15 passed
- npm run typecheck
