### PR TITLE
ci: deploy with Wrangler CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,11 +126,10 @@ jobs:
         run: VERSION=$(git describe --tags --abbrev=0) make build-all
 
       - name: Deploy to preview
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --env preview
+        run: npx wrangler deploy --env preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   # Live E2E tests against real cross-origin deployment (merge queue only)
   live-preview-tests:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
         run: VERSION=$(git describe --tags --abbrev=0) make build-all
 
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint:fix": "eslint --fix .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "check:actions-node24": "node -e \"const {execSync}=require('node:child_process'); const out=execSync('rg -n \\\\\\\"actions/(checkout|setup-node|cache|upload-artifact)@v4\\\\\\\" .github/workflows || true',{encoding:'utf8'}); if(out.trim()){ console.error(out); process.exit(1); } console.log('GitHub first-party actions are Node 24-ready');\"",
+    "check:actions-node24": "node -e \"const {execSync}=require('node:child_process'); const out=execSync('rg -n \\\\\\\"actions/(checkout|setup-node|cache|upload-artifact)@v4|cloudflare/wrangler-action\\\\\\\" .github/workflows || true',{encoding:'utf8'}); if(out.trim()){ console.error(out); process.exit(1); } console.log('GitHub Actions are Node 24-ready');\"",
     "validate": "npm run lint && npm run format:check && npm run typecheck && npm run test",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Summary
- Replace cloudflare/wrangler-action@v3 with direct npx wrangler deploy commands.
- Preserve the same Cloudflare API token/account ID secrets for preview and production deploys.
- Extend the Node 24 action guard to catch cloudflare/wrangler-action reintroduction.

## Test Plan
- npm run check:actions-node24
- ruby YAML parse for all .github/workflows/*.yml
- npm run format:check
- npm run validate
- pre-push typecheck

Notes: Cloudflare docs confirm CI deployments use CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID for non-interactive Wrangler auth.