### PR TITLE
Clean up self-hosting config and CI checks

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -39,5 +39,8 @@ YOUR_PRIVATE_KEY_CONTENT_HERE
 # Maximum screenshot size in MB
 # MAX_SCREENSHOT_SIZE_MB=5
 
+# Optional: where "/" redirects for self-hosted deployments.
+# ROOT_REDIRECT_URL=https://example.com
+
 # RATE_LIMIT is intentionally not configured here.
 # Local development runs with ENVIRONMENT=development and can work without a KV namespace.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build build-widget build-all deploy test test-watch test-e2e test-e2e-ui test-e2e-shard test-live-cross-browser lint lint-fix format format-check typecheck knip audit check ci clean install install-playwright help
+.PHONY: dev build build-widget build-all deploy test test-watch test-e2e test-e2e-ui test-e2e-shard test-live-cross-browser lint lint-fix format format-check typecheck knip audit check-actions-node24 check ci clean install install-playwright help
 
 # Development
 dev:
@@ -67,8 +67,11 @@ typecheck:
 knip:
 	npx knip
 
+check-actions-node24:
+	npm run check:actions-node24
+
 # Combined Commands
-check: lint format-check typecheck knip audit
+check: lint format-check typecheck knip audit check-actions-node24
 	@echo "✓ All checks passed"
 
 ci: check test build-all test-e2e
@@ -113,9 +116,10 @@ help:
 	@echo "    make typecheck        - Run TypeScript type checking"
 	@echo "    make knip             - Check for dead code"
 	@echo "    make audit            - Run npm security audit"
+	@echo "    make check-actions-node24 - Verify GitHub Actions use Node 24-ready entries"
 	@echo ""
 	@echo "  Combined:"
-	@echo "    make check            - Run lint, typecheck, knip, and audit"
+	@echo "    make check            - Run lint, format check, typecheck, knip, audit, and Actions guard"
 	@echo "    make ci               - Run full CI pipeline locally"
 	@echo ""
 	@echo "  Utilities:"

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -176,6 +176,7 @@ The release tag (e.g., `v1.2.0`) becomes the version number for the widget files
 | `MAX_SCREENSHOT_SIZE_MB`       | No       | Max screenshot size in MB (default: `5`)                              |
 | `CATEGORY_LABELS`              | No       | JSON mapping from repos/categories to GitHub labels                   |
 | `ALLOW_CLIENT_CATEGORY_LABELS` | No       | Set to `true` to trust `data-category-labels` from your own pages     |
+| `ROOT_REDIRECT_URL`            | No       | Landing page URL for `/` redirects (default: `https://bugdrop.dev`)   |
 | `RATE_LIMIT`                   | No       | KV namespace binding for rate limiting (see section 5)                |
 
 ### Custom Category Labels
@@ -230,13 +231,21 @@ Only list the exact origins (scheme + host) of sites where you embed the BugDrop
 
 ### Root URL Redirect
 
-By default, the worker redirects `/` to `https://bugdrop.dev` (the upstream landing page). For your own deployment, edit `src/index.ts` and change the redirect URL to your own site, or replace it with a custom response:
+By default, the worker redirects `/` to `https://bugdrop.dev` (the upstream landing page). For self-hosted deployments, set `ROOT_REDIRECT_URL` instead of editing source code.
 
-```ts
-// src/index.ts — change this route handler:
-app.get('/', c => {
-  return c.redirect('https://your-site.com', 301);
-});
+`ROOT_REDIRECT_URL` must be an `http` or `https` URL. Invalid values are ignored with a worker log warning, and `/` falls back to `https://bugdrop.dev`.
+
+Local `.dev.vars`:
+
+```bash
+ROOT_REDIRECT_URL=https://example.com
+```
+
+Production `wrangler.toml`:
+
+```toml
+[vars]
+ROOT_REDIRECT_URL = "https://example.com"
 ```
 
 ## Commands

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2,6 +2,21 @@ import { readdir, readFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { test, expect, type Page } from '@playwright/test';
 
+type CaptureOptions = Record<string, unknown> & {
+  pixelRatio?: number;
+  cacheBust?: boolean;
+  imagePlaceholder?: string;
+  width?: number;
+  height?: number;
+};
+
+declare global {
+  interface Window {
+    __hostKeystrokeCount?: number;
+    __captureOpts?: CaptureOptions;
+  }
+}
+
 /**
  * E2E tests for BugDrop
  * Tests run against wrangler dev server at http://localhost:8787
@@ -430,11 +445,11 @@ test.describe('Widget Interaction', () => {
     await page.goto('/test/');
 
     // Wait for BugDrop API to be available, then open programmatically
-    await page.waitForFunction(() => typeof (window as any).BugDrop !== 'undefined', {
+    await page.waitForFunction(() => typeof window.BugDrop !== 'undefined', {
       timeout: 5000,
     });
     await page.evaluate(() => {
-      (window as any).BugDrop?.open();
+      window.BugDrop?.open();
     });
 
     // Form should appear directly (no welcome screen)
@@ -1345,10 +1360,10 @@ test.describe('Keyboard Event Isolation', () => {
 
     // Track host-page keydown events that fire while BugDrop is open
     await page.evaluate(() => {
-      (window as any).__hostKeystrokeCount = 0;
+      window.__hostKeystrokeCount = 0;
       document.addEventListener('keydown', () => {
         if (document.getElementById('bugdrop-host')) {
-          (window as any).__hostKeystrokeCount++;
+          window.__hostKeystrokeCount = (window.__hostKeystrokeCount ?? 0) + 1;
         }
       });
     });
@@ -1384,7 +1399,7 @@ test.describe('Keyboard Event Isolation', () => {
     await expect(descInput).toHaveValue('Also testing textarea');
 
     // Host page should NOT have received any keystrokes
-    const leakedCount = await page.evaluate(() => (window as any).__hostKeystrokeCount);
+    const leakedCount = await page.evaluate(() => window.__hostKeystrokeCount ?? 0);
     expect(leakedCount).toBe(0);
   });
 });
@@ -2868,7 +2883,11 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     await expect(annotationCanvas).toBeVisible({ timeout: 10000 });
 
     // Verify pixelRatio was reduced to 1 due to complex DOM
-    const captureOpts = await page.evaluate(() => (window as any).__captureOpts);
+    const captureOpts = await page.evaluate(() => window.__captureOpts);
+    expect(captureOpts).toBeDefined();
+    if (!captureOpts) {
+      throw new Error('Missing capture options');
+    }
     expect(captureOpts.pixelRatio).toBe(1);
     expect(captureOpts.cacheBust).toBe(false);
     expect(captureOpts.imagePlaceholder).toMatch(/^data:image\/gif;base64,/);
@@ -2889,7 +2908,11 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     await expect(annotationCanvas).toBeVisible({ timeout: 10000 });
 
     // pixelRatio should be >= 2 (default min scale)
-    const captureOpts = await page.evaluate(() => (window as any).__captureOpts);
+    const captureOpts = await page.evaluate(() => window.__captureOpts);
+    expect(captureOpts).toBeDefined();
+    if (!captureOpts) {
+      throw new Error('Missing capture options');
+    }
     expect(captureOpts.pixelRatio).toBeGreaterThanOrEqual(2);
   });
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,17 @@ export default tseslint.config(
         },
       ],
       '@typescript-eslint/no-explicit-any': 'warn',
+    },
+  },
+  {
+    files: ['src/**/*.ts'],
+    ignores: [
+      'src/widget/ui.ts',
+      'src/widget/index.ts',
+      'src/widget/annotator.ts',
+      'src/routes/api.ts',
+    ],
+    rules: {
       'max-lines': ['warn', { max: 300, skipBlankLines: true, skipComments: true }],
       'max-lines-per-function': ['warn', { max: 150, skipBlankLines: true, skipComments: true }],
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,9 +35,27 @@ app.use('*', logger());
 // Mount API routes
 app.route('/api', api);
 
+export function resolveRootRedirectUrl(rawUrl?: string): string {
+  if (!rawUrl) {
+    return 'https://bugdrop.dev';
+  }
+
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return rawUrl;
+    }
+  } catch {
+    // Fall through to the hosted default.
+  }
+
+  console.warn(`[BugDrop] Ignoring invalid ROOT_REDIRECT_URL: ${rawUrl}`);
+  return 'https://bugdrop.dev';
+}
+
 // Redirect to landing page on Vercel
 app.get('/', c => {
-  return c.redirect('https://bugdrop.dev', 301);
+  return c.redirect(resolveRootRedirectUrl(c.env.ROOT_REDIRECT_URL), 301);
 });
 
 // Serve widget.js from static assets

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface Env {
   MAX_SCREENSHOT_SIZE_MB: string; // Max screenshot size in MB (default: 5)
   CATEGORY_LABELS?: string; // Optional JSON category-label mapping keyed by repo or "*"
   ALLOW_CLIENT_CATEGORY_LABELS?: string; // Self-host escape hatch for script-tag mappings
+  ROOT_REDIRECT_URL?: string; // Optional landing page for self-hosted deployments
 
   // Bindings
   ASSETS: Fetcher;

--- a/test/rootRedirect.test.ts
+++ b/test/rootRedirect.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveRootRedirectUrl } from '../src/index';
+
+describe('resolveRootRedirectUrl', () => {
+  it('uses the hosted site by default', () => {
+    expect(resolveRootRedirectUrl()).toBe('https://bugdrop.dev');
+  });
+
+  it('uses a configured HTTP or HTTPS URL', () => {
+    expect(resolveRootRedirectUrl('https://example.com')).toBe('https://example.com');
+    expect(resolveRootRedirectUrl('http://localhost:8787')).toBe('http://localhost:8787');
+  });
+
+  it('falls back when the configured value is invalid', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    expect(resolveRootRedirectUrl('javascript:alert(1)')).toBe('https://bugdrop.dev');
+    expect(resolveRootRedirectUrl('not a url')).toBe('https://bugdrop.dev');
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add the GitHub Actions Node 24 guard to `make check`
- add configurable `ROOT_REDIRECT_URL` support and self-hosting docs
- type E2E browser globals and scope structural lint warnings to reduce CI annotation noise

## Test plan
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test`
- `npm run build:widget`
- `make check`
- `npx playwright test e2e/widget.spec.ts --project=chromium`