### PR TITLE
Add configurable issue link visibility

### DIFF
--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -17,6 +17,7 @@ These attributes control the fundamental behavior of the widget.
 | `data-category-labels` | built-in labels | Self-hosted JSON mapping from built-in categories to GitHub labels |
 | `data-button` | `"true"` | Show the floating button: `"true"` or `"false"` |
 | `data-welcome` | `"Report a bug or request a feature"` | Welcome message displayed at the top of the form |
+| `data-show-issue-link` | `"public"` | Show the GitHub issue link after submission: `"public"`, `"always"`, or `"never"` |
 
 ### Basic Example
 
@@ -54,6 +55,25 @@ The `data-position` attribute controls where the floating button appears:
 
 - **`bottom-right`** (default) -- Fixed to the bottom-right corner
 - **`bottom-left`** -- Fixed to the bottom-left corner
+
+## Issue Link Visibility
+
+Control whether the success confirmation links to the GitHub Issue that was created.
+
+| Value | Behavior |
+|-------|----------|
+| `"public"` | Default. Show the issue number and GitHub link for public repositories only. Private repository submissions use a generic success message. |
+| `"always"` | Show the issue number and GitHub link whenever the server returns an issue URL, including private repositories. Use this only for trusted internal users who already have GitHub access to the target repository. |
+| `"never"` | Show the issue number for public repositories, but do not show a GitHub link. Private repository submissions use a generic success message. |
+
+```html
+<!-- Show private repository issue links to trusted internal users -->
+<script
+  src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="owner/private-repo"
+  data-show-issue-link="always"
+></script>
+```
 
 ## Submitter Information
 

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2580,6 +2580,77 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     });
   }
 
+  async function submitWithIssueResponse(page: Page, path: string, isPublic: boolean) {
+    const issueUrl = 'https://github.com/TheWebEng/ctle-theme/issues/496';
+
+    await page.route('**/feedback', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          issueNumber: 496,
+          issueUrl,
+          isPublic,
+        }),
+      });
+    });
+
+    await page.goto(path);
+    const host = await navigateToForm(page, 'Private repo link test');
+
+    await host.locator('css=#include-screenshot').uncheck();
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+    return { host, issueUrl };
+  }
+
+  test('keeps private repo issue links hidden by default', async ({ page }) => {
+    const { host } = await submitWithIssueResponse(page, '/test/', false);
+
+    await expect(host.locator('css=.bd-success-issue')).toContainText(
+      'Your feedback has been submitted successfully.'
+    );
+    await expect(host.locator('css=.bd-issue-link')).toHaveCount(0);
+  });
+
+  test('shows public repo issue links by default', async ({ page }) => {
+    const { host, issueUrl } = await submitWithIssueResponse(page, '/test/', true);
+
+    await expect(host.locator('css=.bd-success-issue')).toContainText('Issue #496');
+
+    const issueLink = host.locator('css=.bd-issue-link');
+    await expect(issueLink).toBeVisible();
+    await expect(issueLink).toHaveAttribute('href', issueUrl);
+  });
+
+  test('shows private repo issue link when configured to always show issue links', async ({
+    page,
+  }) => {
+    const { host, issueUrl } = await submitWithIssueResponse(
+      page,
+      '/test/?showIssueLink=always',
+      false
+    );
+
+    await expect(host.locator('css=.bd-success-issue')).toContainText('Issue #496');
+
+    const issueLink = host.locator('css=.bd-issue-link');
+    await expect(issueLink).toBeVisible();
+    await expect(issueLink).toHaveAttribute('href', issueUrl);
+    await expect(issueLink).toHaveAttribute('target', '_blank');
+  });
+
+  test('hides public repo issue link when configured to never show issue links', async ({
+    page,
+  }) => {
+    const { host } = await submitWithIssueResponse(page, '/test/?showIssueLink=never', true);
+
+    await expect(host.locator('css=.bd-success-issue')).toContainText('Issue #496');
+    await expect(host.locator('css=.bd-issue-link')).toHaveCount(0);
+  });
+
   test('sends custom category label mapping while keeping built-in category UI', async ({
     page,
   }) => {

--- a/public/test/index.html
+++ b/public/test/index.html
@@ -608,6 +608,7 @@
         showEmail: 'showEmail',
         requireEmail: 'requireEmail',
         categoryLabels: 'categoryLabels',
+        showIssueLink: 'showIssueLink',
       },
     });
   </script>

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -1,6 +1,6 @@
 import { getDomNodeCount, getRedactionCount, isFullPageDisabled } from './screenshot';
 import { runScreenshotCaptureFlow } from './capture-flow';
-import { injectStyles, createModal, showSuccessModal } from './ui';
+import { injectStyles, createModal, showSuccessModal, type IssueLinkVisibility } from './ui';
 import {
   resolveTheme,
   applyThemeClass,
@@ -61,6 +61,7 @@ interface WidgetConfig {
   // Screenshot configuration
   screenshotMode: 'optional' | 'auto' | 'required';
   screenshotScale?: number; // Minimum pixel ratio for captures (default: 2)
+  issueLinkVisibility: IssueLinkVisibility;
 }
 
 // BugDrop JavaScript API interface
@@ -357,6 +358,14 @@ const shadow = sanitizeShadowPreset(rawShadow);
 if (rawShadow && !shadow) {
   console.warn('[BugDrop] Invalid data-shadow. Expected "soft", "hard", or "none".');
 }
+const rawShowIssueLink = script?.dataset.showIssueLink;
+const issueLinkVisibility: IssueLinkVisibility =
+  rawShowIssueLink === 'always' || rawShowIssueLink === 'never' ? rawShowIssueLink : 'public';
+if (rawShowIssueLink && rawShowIssueLink !== 'public' && rawShowIssueLink !== issueLinkVisibility) {
+  console.warn(
+    `[BugDrop] Invalid data-show-issue-link "${rawShowIssueLink}". Expected "public", "always", or "never".`
+  );
+}
 const config: WidgetConfig = {
   repo: script?.dataset.repo || '',
   apiUrl: script?.src.replace(/\/widget(?:\.v[\d.]+)?\.js$/, '/api') || '',
@@ -409,6 +418,7 @@ const config: WidgetConfig = {
     return 'optional' as const;
   })(),
   screenshotScale,
+  issueLinkVisibility,
 };
 
 // Validate config
@@ -1175,7 +1185,13 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
     const result = await response.json();
 
     if (result.success) {
-      await showSuccessModal(root, result.issueNumber, result.issueUrl, result.isPublic ?? false);
+      await showSuccessModal(
+        root,
+        result.issueNumber,
+        result.issueUrl,
+        result.isPublic ?? false,
+        config.issueLinkVisibility
+      );
     } else {
       showSubmitError(root, config, data, result.error || 'Failed to submit');
     }

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -25,6 +25,21 @@ interface WidgetConfig {
 
 export type IssueLinkVisibility = 'public' | 'always' | 'never';
 
+export function shouldRenderIssueLink(
+  issueUrl: string | undefined,
+  isPublic: boolean,
+  issueLinkVisibility: IssueLinkVisibility
+): boolean {
+  const safeIssueUrl = sanitizeUrl(issueUrl);
+  return Boolean(
+    safeIssueUrl &&
+    safeIssueUrl !== 'none' &&
+    safeIssueUrl !== '#' &&
+    issueLinkVisibility !== 'never' &&
+    (isPublic || issueLinkVisibility === 'always')
+  );
+}
+
 export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
   const pos = config.position === 'bottom-left' ? 'left: 20px' : 'right: 20px';
   const resolved = resolveTheme(config.theme);
@@ -1117,11 +1132,7 @@ export function showSuccessModal(
 ): Promise<void> {
   return new Promise(resolve => {
     const safeIssueUrl = sanitizeUrl(issueUrl);
-    const hasIssueUrl = Boolean(safeIssueUrl && safeIssueUrl !== 'none' && safeIssueUrl !== '#');
-    const shouldShowIssueLink =
-      hasIssueUrl &&
-      issueLinkVisibility !== 'never' &&
-      (isPublic || issueLinkVisibility === 'always');
+    const shouldShowIssueLink = shouldRenderIssueLink(issueUrl, isPublic, issueLinkVisibility);
     const issueLink =
       shouldShowIssueLink && safeIssueUrl
         ? `<a href="${escapeHtml(safeIssueUrl)}" target="_blank" rel="noopener noreferrer" class="bd-issue-link">

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -23,6 +23,8 @@ interface WidgetConfig {
   shadow?: string;
 }
 
+export type IssueLinkVisibility = 'public' | 'always' | 'never';
+
 export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
   const pos = config.position === 'bottom-left' ? 'left: 20px' : 'right: 20px';
   const resolved = resolveTheme(config.theme);
@@ -1110,25 +1112,32 @@ export function showSuccessModal(
   container: HTMLElement,
   issueNumber: number,
   issueUrl: string,
-  isPublic: boolean
+  isPublic: boolean,
+  issueLinkVisibility: IssueLinkVisibility = 'public'
 ): Promise<void> {
   return new Promise(resolve => {
     const safeIssueUrl = sanitizeUrl(issueUrl);
-    const issueInfo = isPublic
-      ? `
-        <p class="bd-success-issue">Issue <strong>#${issueNumber}</strong> has been created.</p>
-        ${
-          safeIssueUrl
-            ? `<a href="${escapeHtml(safeIssueUrl)}" target="_blank" rel="noopener noreferrer" class="bd-issue-link">
+    const hasIssueUrl = Boolean(safeIssueUrl && safeIssueUrl !== 'none' && safeIssueUrl !== '#');
+    const shouldShowIssueLink =
+      hasIssueUrl &&
+      issueLinkVisibility !== 'never' &&
+      (isPublic || issueLinkVisibility === 'always');
+    const issueLink =
+      shouldShowIssueLink && safeIssueUrl
+        ? `<a href="${escapeHtml(safeIssueUrl)}" target="_blank" rel="noopener noreferrer" class="bd-issue-link">
           <svg viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
             <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"/>
           </svg>
           View on GitHub
         </a>`
-            : ''
-        }
+        : '';
+    const issueInfo =
+      isPublic || (issueLinkVisibility === 'always' && shouldShowIssueLink)
+        ? `
+        <p class="bd-success-issue">Issue <strong>#${issueNumber}</strong> has been created.</p>
+        ${issueLink}
       `
-      : `<p class="bd-success-issue">Your feedback has been submitted successfully.</p>`;
+        : `<p class="bd-success-issue">Your feedback has been submitted successfully.</p>`;
 
     const modal = createModal(
       container,

--- a/test/issueLinkVisibility.test.ts
+++ b/test/issueLinkVisibility.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { shouldRenderIssueLink } from '../src/widget/ui';
+
+describe('shouldRenderIssueLink', () => {
+  it.each([
+    [
+      'private repo with default visibility',
+      'https://github.com/acme/private/issues/1',
+      false,
+      'public',
+      false,
+    ],
+    [
+      'public repo with default visibility',
+      'https://github.com/acme/public/issues/1',
+      true,
+      'public',
+      true,
+    ],
+    [
+      'private repo with always visibility',
+      'https://github.com/acme/private/issues/1',
+      false,
+      'always',
+      true,
+    ],
+    [
+      'public repo with never visibility',
+      'https://github.com/acme/public/issues/1',
+      true,
+      'never',
+      false,
+    ],
+    [
+      'private repo with never visibility',
+      'https://github.com/acme/private/issues/1',
+      false,
+      'never',
+      false,
+    ],
+    ['always visibility without an issue URL', undefined, false, 'always', false],
+    ['always visibility with sentinel hash URL', '#', false, 'always', false],
+    ['always visibility with sentinel none URL', 'none', false, 'always', false],
+    ['always visibility with unsafe URL', 'javascript:alert(1)', false, 'always', false],
+  ] as const)('%s', (_label, issueUrl, isPublic, issueLinkVisibility, expected) => {
+    expect(shouldRenderIssueLink(issueUrl, isPublic, issueLinkVisibility)).toBe(expected);
+  });
+});


### PR DESCRIPTION
Fixes #168

## What changed
Adds a `data-show-issue-link` widget option so deployments can choose when the success confirmation links to the GitHub Issue that was created. The default remains `public`, preserving the existing behavior where private repositories get the generic success message.

## Why this shape (and not the obvious alternative)
The tempting change is to show `issueUrl` whenever the API returns it. That works for internal QA/admin workflows, but it would change the default behavior for existing deployments that embed BugDrop on pages where visitors may not have GitHub access. Making this explicit configuration keeps the current public/private split intact while letting trusted deployments opt into private-repo links.

The option also includes `never`, not just `always`, because some deployments may want public issue creation without sending users onward to GitHub from the success state.

## What this enables / forecloses
Internal-only BugDrop installs can now send logged-in reviewers directly to the created issue, even when the repository is private, without forking the widget or changing server behavior.

---

## Test plan
- `NODE_OPTIONS=--no-experimental-webstorage make ci` from a clean worktree based on `mean-weasel/main`: passed.
- This includes formatting, type checking, dead-code checks, audit, unit tests (`217 passed`), widget build, TypeScript build, and the full Chromium E2E suite (`176 passed`).

---
