### PR TITLE
Add full CSS path metadata for selected elements

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -3566,7 +3566,13 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     await host.locator('css=[data-action="skip"]').click();
     await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 5000 });
     expect(payloads).toHaveLength(1);
-    expect((payloads[0].metadata as { elementSelector?: string }).elementSelector).toContain('h1');
+    const metadata = payloads[0].metadata as {
+      elementSelector?: string;
+      fullElementSelector?: string;
+    };
+    expect(metadata.elementSelector).toContain('h1');
+    expect(metadata.fullElementSelector).toContain('html > body');
+    expect(metadata.fullElementSelector).toContain('h1');
 
     await host.locator('css=.bd-close').click();
     await host.locator('css=.bd-trigger').click();

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -3599,6 +3599,12 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 5000 });
     expect(payloads).toHaveLength(1);
     expect(payloads[0].screenshot).toBeNull();
+    const metadata = payloads[0].metadata as {
+      elementSelector?: string | null;
+      fullElementSelector?: string | null;
+    };
+    expect(metadata.elementSelector).toBeNull();
+    expect(metadata.fullElementSelector).toBeNull();
 
     await host.locator('css=.bd-close').click();
     await host.locator('css=.bd-trigger').click();
@@ -4792,6 +4798,63 @@ test.describe('Screenshot Masking', () => {
       metadata: payload.metadata as { elementSelector?: string; fullElementSelector?: string },
     };
   }
+
+  test('successful element capture submits a queryable full CSS path for dynamic repeated DOM', async ({
+    page,
+  }) => {
+    const stubPng =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+    await page.addInitScript(png => {
+      (
+        window as Window & {
+          __bugdropMockToPng?: () => Promise<string>;
+        }
+      ).__bugdropMockToPng = () => Promise.resolve(png);
+    }, stubPng);
+    await page.addInitScript(() => {
+      window.addEventListener('DOMContentLoaded', () => {
+        const fixture = document.createElement('section');
+        fixture.id = 'dynamic-selector-fixture';
+        fixture.style.cssText = [
+          'position: fixed',
+          'left: 72px',
+          'top: 96px',
+          'z-index: 10',
+          'display: grid',
+          'gap: 8px',
+        ].join(';');
+        fixture.innerHTML = Array.from(
+          { length: 3 },
+          (_, index) => `
+            <article class="dynamic-card 3xl:panel" data-card-index="${index + 1}">
+              <button class="action primary" data-dynamic-target="${index + 1}">
+                Action ${index + 1}
+              </button>
+            </article>
+          `
+        ).join('');
+        document.body.append(fixture);
+      });
+    });
+
+    const { metadata } = await submitFeedbackWithElementCapture(
+      page,
+      '/test/',
+      '[data-dynamic-target="2"]'
+    );
+
+    expect(metadata.elementSelector).toContain('#dynamic-selector-fixture');
+    expect(metadata.elementSelector).toContain('button.action.primary');
+    expect(metadata.fullElementSelector).toContain('html > body');
+    expect(metadata.fullElementSelector).toContain('article.dynamic-card');
+    expect(metadata.fullElementSelector).toContain(':nth-of-type(2)');
+    expect(
+      await page.evaluate(selector => {
+        const target = document.querySelector('[data-dynamic-target="2"]');
+        return Boolean(selector) && document.querySelector(selector) === target;
+      }, metadata.fullElementSelector)
+    ).toBe(true);
+  });
 
   test('element-scoped capture masks descendant inside picked element', async ({ page }) => {
     // Click inside the top padding of #unmasked-parent (above the first <p> child)

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -3573,6 +3573,11 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     expect(metadata.elementSelector).toContain('h1');
     expect(metadata.fullElementSelector).toContain('html > body');
     expect(metadata.fullElementSelector).toContain('h1');
+    expect(
+      await page.evaluate(selector => {
+        return document.querySelector(selector) === document.querySelector('h1');
+      }, metadata.fullElementSelector)
+    ).toBe(true);
 
     await host.locator('css=.bd-close').click();
     await host.locator('css=.bd-trigger').click();
@@ -4708,7 +4713,11 @@ test.describe('Screenshot Masking', () => {
     fixturePath: string,
     selector: string,
     clickOffset?: { x: number; y: number }
-  ): Promise<{ screenshot: string; imageSize: { w: number; h: number } }> {
+  ): Promise<{
+    screenshot: string;
+    imageSize: { w: number; h: number };
+    metadata: { elementSelector?: string; fullElementSelector?: string };
+  }> {
     let payload: Record<string, unknown> | null = null;
     await page.route('**/api/check/**', async route =>
       route.fulfill({
@@ -4777,18 +4786,29 @@ test.describe('Screenshot Masking', () => {
       screenshot
     );
 
-    return { screenshot, imageSize };
+    return {
+      screenshot,
+      imageSize,
+      metadata: payload.metadata as { elementSelector?: string; fullElementSelector?: string },
+    };
   }
 
   test('element-scoped capture masks descendant inside picked element', async ({ page }) => {
     // Click inside the top padding of #unmasked-parent (above the first <p> child)
     // so the picker's elementsFromPoint resolves the parent, not a child element.
     // The 16px top padding gives ~8px of safe click area before the first child.
-    const { screenshot, imageSize } = await submitFeedbackWithElementCapture(
+    const { screenshot, imageSize, metadata } = await submitFeedbackWithElementCapture(
       page,
       '/test/masking-nested.html',
       '#unmasked-parent',
       { x: 40, y: 8 } // 8px from top = within the 16px top padding
+    );
+    expect(metadata.elementSelector).toBe('#unmasked-parent');
+    expect(metadata.fullElementSelector).toContain('html > body');
+    expect(metadata.fullElementSelector).toContain('div#unmasked-parent');
+    await expect(page.locator(`css=${metadata.fullElementSelector}`)).toHaveAttribute(
+      'id',
+      'unmasked-parent'
     );
 
     // Measure child geometry relative to the parent using the image's own scale.

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -598,11 +598,13 @@ function formatIssueBody(
   sections.push(`| **Timestamp** | ${payload.metadata.timestamp} |`);
 
   if (payload.metadata.elementSelector) {
-    sections.push(`| **Element** | \`${payload.metadata.elementSelector}\` |`);
+    sections.push(`| **Element** | ${formatMarkdownTableCode(payload.metadata.elementSelector)} |`);
   }
 
   if (payload.metadata.fullElementSelector) {
-    sections.push(`| **Full CSS path** | \`${payload.metadata.fullElementSelector}\` |`);
+    sections.push(
+      `| **Full CSS path** | ${formatMarkdownTableCode(payload.metadata.fullElementSelector)} |`
+    );
   }
 
   sections.push('');
@@ -612,6 +614,17 @@ function formatIssueBody(
   sections.push('*Submitted via [BugDrop](https://github.com/mean-weasel/bugdrop)*');
 
   return sections.join('\n');
+}
+
+function formatMarkdownTableCode(value: string): string {
+  const tableSafeValue = value.replace(/\|/g, '\\|');
+  if (!tableSafeValue.includes('`')) {
+    return `\`${tableSafeValue}\``;
+  }
+
+  const longestBacktickRun = Math.max(...tableSafeValue.match(/`+/g)!.map(match => match.length));
+  const fence = '`'.repeat(longestBacktickRun + 1);
+  return `${fence} ${tableSafeValue} ${fence}`;
 }
 
 export default api;

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -601,6 +601,10 @@ function formatIssueBody(
     sections.push(`| **Element** | \`${payload.metadata.elementSelector}\` |`);
   }
 
+  if (payload.metadata.fullElementSelector) {
+    sections.push(`| **Full CSS path** | \`${payload.metadata.fullElementSelector}\` |`);
+  }
+
   sections.push('');
   sections.push('</details>');
   sections.push('');

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface FeedbackPayload {
     viewport: { width: number; height: number };
     timestamp: string;
     elementSelector?: string;
+    fullElementSelector?: string;
     // Parsed system info
     browser?: { name: string; version: string };
     os?: { name: string; version: string };

--- a/src/widget/capture-flow.ts
+++ b/src/widget/capture-flow.ts
@@ -9,6 +9,8 @@ import { createElementPicker } from './picker';
 import { beginViewportCapture, getRedactionCount, isFullPageDisabled } from './screenshot';
 import { showScreenshotOptions, type ScreenshotChoice } from './screenshot-options';
 
+const MAX_FULL_SELECTOR_CLASSES = 3;
+
 export interface CaptureFlowConfig {
   screenshotMode: 'optional' | 'auto' | 'required';
   screenshotScale?: number;
@@ -25,6 +27,7 @@ export interface CaptureFlowConfig {
 export interface CaptureFlowResult {
   screenshot: string | null;
   elementSelector: string | null;
+  fullElementSelector: string | null;
   returnToForm: boolean;
 }
 
@@ -39,11 +42,17 @@ type ChosenCaptureResult =
       kind: 'captured';
       screenshot: string;
       elementSelector: string | null;
+      fullElementSelector: string | null;
       redactionCount: number;
       redactionUnavailable: boolean;
     }
   | { kind: 'returnToForm' }
-  | { kind: 'empty'; reason: EmptyCaptureReason; elementSelector: string | null };
+  | {
+      kind: 'empty';
+      reason: EmptyCaptureReason;
+      elementSelector: string | null;
+      fullElementSelector: string | null;
+    };
 
 export async function runScreenshotCaptureFlow(
   root: HTMLElement,
@@ -74,6 +83,7 @@ export async function runScreenshotCaptureFlow(
       return {
         screenshot: null,
         elementSelector: result.elementSelector,
+        fullElementSelector: result.fullElementSelector,
         returnToForm: false,
       };
     }
@@ -95,6 +105,7 @@ export async function runScreenshotCaptureFlow(
     return {
       screenshot: annotatedScreenshot,
       elementSelector: result.elementSelector,
+      fullElementSelector: result.fullElementSelector,
       returnToForm: false,
     };
   }
@@ -116,6 +127,7 @@ async function captureAutomaticScreenshot(
   return {
     screenshot: result.kind === 'ok' ? result.dataUrl : null,
     elementSelector: null,
+    fullElementSelector: null,
     returnToForm: false,
   };
 }
@@ -137,7 +149,12 @@ async function captureChosenScreenshot(
     case 'cancel':
       return { kind: 'returnToForm' };
     case 'skip':
-      return { kind: 'empty', reason: 'explicit-skip', elementSelector: null };
+      return {
+        kind: 'empty',
+        reason: 'explicit-skip',
+        elementSelector: null,
+        fullElementSelector: null,
+      };
     case 'viewport':
       return captureFromViewportChoice(root, screenshotChoice, screenshotRequired);
     case 'capture':
@@ -167,12 +184,18 @@ async function captureFromViewportChoice(
   );
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
-    return { kind: 'empty', reason: 'capture-failure-skip', elementSelector: null };
+    return {
+      kind: 'empty',
+      reason: 'capture-failure-skip',
+      elementSelector: null,
+      fullElementSelector: null,
+    };
   }
   return {
     kind: 'captured',
     screenshot: result.dataUrl,
     elementSelector: null,
+    fullElementSelector: null,
     redactionCount: 0,
     redactionUnavailable: true,
   };
@@ -188,12 +211,18 @@ async function captureFromFullPageChoice(
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
-    return { kind: 'empty', reason: 'capture-failure-skip', elementSelector: null };
+    return {
+      kind: 'empty',
+      reason: 'capture-failure-skip',
+      elementSelector: null,
+      fullElementSelector: null,
+    };
   }
   return {
     kind: 'captured',
     screenshot: result.dataUrl,
     elementSelector: null,
+    fullElementSelector: null,
     redactionCount: getRedactionCount(),
     redactionUnavailable: false,
   };
@@ -206,21 +235,33 @@ async function captureFromElementChoice(
 ): Promise<ChosenCaptureResult> {
   const element = await createElementPicker(getPickerStyle(config));
   if (!element) {
-    return { kind: 'empty', reason: 'selection-cancelled', elementSelector: null };
+    return {
+      kind: 'empty',
+      reason: 'selection-cancelled',
+      elementSelector: null,
+      fullElementSelector: null,
+    };
   }
 
   const elementSelector = getElementSelector(element);
+  const fullElementSelector = getFullElementSelector(element);
   const result = await captureWithLoading(root, element, config.screenshotScale, {
     allowSkip: !screenshotRequired,
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
-    return { kind: 'empty', reason: 'capture-failure-skip', elementSelector };
+    return {
+      kind: 'empty',
+      reason: 'capture-failure-skip',
+      elementSelector,
+      fullElementSelector,
+    };
   }
   return {
     kind: 'captured',
     screenshot: result.dataUrl,
     elementSelector,
+    fullElementSelector,
     redactionCount: getRedactionCount(element),
     redactionUnavailable: false,
   };
@@ -235,7 +276,12 @@ async function captureFromAreaChoice(
     redactionsAvailable: getRedactionCount() > 0,
   });
   if (!rect) {
-    return { kind: 'empty', reason: 'selection-cancelled', elementSelector: null };
+    return {
+      kind: 'empty',
+      reason: 'selection-cancelled',
+      elementSelector: null,
+      fullElementSelector: null,
+    };
   }
 
   const result = await captureAreaWithLoading(root, rect, config.screenshotScale, {
@@ -243,12 +289,18 @@ async function captureFromAreaChoice(
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
-    return { kind: 'empty', reason: 'capture-failure-skip', elementSelector: null };
+    return {
+      kind: 'empty',
+      reason: 'capture-failure-skip',
+      elementSelector: null,
+      fullElementSelector: null,
+    };
   }
   return {
     kind: 'captured',
     screenshot: result.dataUrl,
     elementSelector: null,
+    fullElementSelector: null,
     redactionCount: getRedactionCount(undefined, rect),
     redactionUnavailable: false,
   };
@@ -271,6 +323,7 @@ function emptyCaptureResult(): CaptureFlowResult {
   return {
     screenshot: null,
     elementSelector: null,
+    fullElementSelector: null,
     returnToForm: false,
   };
 }
@@ -311,4 +364,85 @@ function getElementSelector(element: Element): string {
   }
 
   return path.join(' > ');
+}
+
+function getFullElementSelector(element: Element): string {
+  const path: string[] = [];
+  let current: Element | null = element;
+
+  while (current) {
+    path.unshift(getFullSelectorSegment(current));
+    current = current.parentElement;
+  }
+
+  return path.join(' > ');
+}
+
+function getFullSelectorSegment(element: Element): string {
+  let selector = element.tagName.toLowerCase();
+
+  if (element.id) {
+    selector += `#${escapeCssIdentifier(element.id)}`;
+  }
+
+  const classes = getClassNames(element).slice(0, MAX_FULL_SELECTOR_CLASSES);
+  if (classes.length > 0) {
+    selector += `.${classes.map(escapeCssIdentifier).join('.')}`;
+  }
+
+  if (!element.id) {
+    const nthOfType = getNthOfType(element);
+    if (nthOfType > 1 || hasSameTagSibling(element)) {
+      selector += `:nth-of-type(${nthOfType})`;
+    }
+  }
+
+  return selector;
+}
+
+function getClassNames(element: Element): string[] {
+  const classNameStr =
+    typeof element.className === 'string'
+      ? element.className
+      : (element.className as SVGAnimatedString).baseVal || '';
+
+  return classNameStr.split(/\s+/).filter(Boolean);
+}
+
+function getNthOfType(element: Element): number {
+  let index = 1;
+  let sibling = element.previousElementSibling;
+
+  while (sibling) {
+    if (sibling.tagName === element.tagName) {
+      index += 1;
+    }
+    sibling = sibling.previousElementSibling;
+  }
+
+  return index;
+}
+
+function hasSameTagSibling(element: Element): boolean {
+  let sibling = element.previousElementSibling;
+  while (sibling) {
+    if (sibling.tagName === element.tagName) return true;
+    sibling = sibling.previousElementSibling;
+  }
+
+  sibling = element.nextElementSibling;
+  while (sibling) {
+    if (sibling.tagName === element.tagName) return true;
+    sibling = sibling.nextElementSibling;
+  }
+
+  return false;
+}
+
+function escapeCssIdentifier(value: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(value);
+  }
+
+  return value.replace(/[^a-zA-Z0-9_-]/g, char => `\\${char}`);
 }

--- a/src/widget/capture-flow.ts
+++ b/src/widget/capture-flow.ts
@@ -6,10 +6,9 @@ import {
   captureWithLoading,
 } from './capture-loading';
 import { createElementPicker } from './picker';
+import { getElementSelector, getFullElementSelector } from './selector-metadata';
 import { beginViewportCapture, getRedactionCount, isFullPageDisabled } from './screenshot';
 import { showScreenshotOptions, type ScreenshotChoice } from './screenshot-options';
-
-const MAX_FULL_SELECTOR_CLASSES = 3;
 
 export interface CaptureFlowConfig {
   screenshotMode: 'optional' | 'auto' | 'required';
@@ -37,22 +36,19 @@ export type EmptyCaptureReason =
   | 'capture-failure-skip'
   | 'selection-cancelled';
 
+type ElementMetadata = Pick<CaptureFlowResult, 'elementSelector' | 'fullElementSelector'>;
 type ChosenCaptureResult =
-  | {
+  | ({
       kind: 'captured';
       screenshot: string;
-      elementSelector: string | null;
-      fullElementSelector: string | null;
       redactionCount: number;
       redactionUnavailable: boolean;
-    }
+    } & ElementMetadata)
   | { kind: 'returnToForm' }
-  | {
+  | ({
       kind: 'empty';
       reason: EmptyCaptureReason;
-      elementSelector: string | null;
-      fullElementSelector: string | null;
-    };
+    } & ElementMetadata);
 
 export async function runScreenshotCaptureFlow(
   root: HTMLElement,
@@ -149,12 +145,7 @@ async function captureChosenScreenshot(
     case 'cancel':
       return { kind: 'returnToForm' };
     case 'skip':
-      return {
-        kind: 'empty',
-        reason: 'explicit-skip',
-        elementSelector: null,
-        fullElementSelector: null,
-      };
+      return emptyChosenCaptureResult('explicit-skip');
     case 'viewport':
       return captureFromViewportChoice(root, screenshotChoice, screenshotRequired);
     case 'capture':
@@ -184,12 +175,7 @@ async function captureFromViewportChoice(
   );
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
-    return {
-      kind: 'empty',
-      reason: 'capture-failure-skip',
-      elementSelector: null,
-      fullElementSelector: null,
-    };
+    return emptyChosenCaptureResult('capture-failure-skip');
   }
   return {
     kind: 'captured',
@@ -211,12 +197,7 @@ async function captureFromFullPageChoice(
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
-    return {
-      kind: 'empty',
-      reason: 'capture-failure-skip',
-      elementSelector: null,
-      fullElementSelector: null,
-    };
+    return emptyChosenCaptureResult('capture-failure-skip');
   }
   return {
     kind: 'captured',
@@ -235,33 +216,24 @@ async function captureFromElementChoice(
 ): Promise<ChosenCaptureResult> {
   const element = await createElementPicker(getPickerStyle(config));
   if (!element) {
-    return {
-      kind: 'empty',
-      reason: 'selection-cancelled',
-      elementSelector: null,
-      fullElementSelector: null,
-    };
+    return emptyChosenCaptureResult('selection-cancelled');
   }
 
-  const elementSelector = getElementSelector(element);
-  const fullElementSelector = getFullElementSelector(element);
+  const elementMetadata = {
+    elementSelector: getElementSelector(element),
+    fullElementSelector: getFullElementSelector(element),
+  };
   const result = await captureWithLoading(root, element, config.screenshotScale, {
     allowSkip: !screenshotRequired,
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
-    return {
-      kind: 'empty',
-      reason: 'capture-failure-skip',
-      elementSelector,
-      fullElementSelector,
-    };
+    return emptyChosenCaptureResult('capture-failure-skip', elementMetadata);
   }
   return {
     kind: 'captured',
     screenshot: result.dataUrl,
-    elementSelector,
-    fullElementSelector,
+    ...elementMetadata,
     redactionCount: getRedactionCount(element),
     redactionUnavailable: false,
   };
@@ -276,12 +248,7 @@ async function captureFromAreaChoice(
     redactionsAvailable: getRedactionCount() > 0,
   });
   if (!rect) {
-    return {
-      kind: 'empty',
-      reason: 'selection-cancelled',
-      elementSelector: null,
-      fullElementSelector: null,
-    };
+    return emptyChosenCaptureResult('selection-cancelled');
   }
 
   const result = await captureAreaWithLoading(root, rect, config.screenshotScale, {
@@ -289,12 +256,7 @@ async function captureFromAreaChoice(
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
-    return {
-      kind: 'empty',
-      reason: 'capture-failure-skip',
-      elementSelector: null,
-      fullElementSelector: null,
-    };
+    return emptyChosenCaptureResult('capture-failure-skip');
   }
   return {
     kind: 'captured',
@@ -322,127 +284,22 @@ function getPickerStyle(config: CaptureFlowConfig) {
 function emptyCaptureResult(): CaptureFlowResult {
   return {
     screenshot: null,
-    elementSelector: null,
-    fullElementSelector: null,
+    ...emptyElementMetadata(),
     returnToForm: false,
   };
 }
 
+function emptyChosenCaptureResult(
+  reason: EmptyCaptureReason,
+  metadata: ElementMetadata = emptyElementMetadata()
+): ChosenCaptureResult {
+  return { kind: 'empty', reason, ...metadata };
+}
+
+function emptyElementMetadata(): ElementMetadata {
+  return { elementSelector: null, fullElementSelector: null };
+}
+
 function assertNever(value: never): never {
   throw new Error(`Unhandled screenshot choice: ${JSON.stringify(value)}`);
-}
-
-function getElementSelector(element: Element): string {
-  const path: string[] = [];
-  let current: Element | null = element;
-
-  while (current && current !== document.body) {
-    let selector = current.tagName.toLowerCase();
-
-    if (current.id) {
-      selector = `#${current.id}`;
-      path.unshift(selector);
-      break;
-    }
-
-    if (current.className) {
-      const classNameStr =
-        typeof current.className === 'string'
-          ? current.className
-          : (current.className as SVGAnimatedString).baseVal || '';
-      const classes = classNameStr
-        .split(' ')
-        .filter(c => c)
-        .slice(0, 2);
-      if (classes.length) {
-        selector += `.${classes.join('.')}`;
-      }
-    }
-
-    path.unshift(selector);
-    current = current.parentElement;
-  }
-
-  return path.join(' > ');
-}
-
-function getFullElementSelector(element: Element): string {
-  const path: string[] = [];
-  let current: Element | null = element;
-
-  while (current) {
-    path.unshift(getFullSelectorSegment(current));
-    current = current.parentElement;
-  }
-
-  return path.join(' > ');
-}
-
-function getFullSelectorSegment(element: Element): string {
-  let selector = element.tagName.toLowerCase();
-
-  if (element.id) {
-    selector += `#${escapeCssIdentifier(element.id)}`;
-  }
-
-  const classes = getClassNames(element).slice(0, MAX_FULL_SELECTOR_CLASSES);
-  if (classes.length > 0) {
-    selector += `.${classes.map(escapeCssIdentifier).join('.')}`;
-  }
-
-  if (!element.id) {
-    const nthOfType = getNthOfType(element);
-    if (nthOfType > 1 || hasSameTagSibling(element)) {
-      selector += `:nth-of-type(${nthOfType})`;
-    }
-  }
-
-  return selector;
-}
-
-function getClassNames(element: Element): string[] {
-  const classNameStr =
-    typeof element.className === 'string'
-      ? element.className
-      : (element.className as SVGAnimatedString).baseVal || '';
-
-  return classNameStr.split(/\s+/).filter(Boolean);
-}
-
-function getNthOfType(element: Element): number {
-  let index = 1;
-  let sibling = element.previousElementSibling;
-
-  while (sibling) {
-    if (sibling.tagName === element.tagName) {
-      index += 1;
-    }
-    sibling = sibling.previousElementSibling;
-  }
-
-  return index;
-}
-
-function hasSameTagSibling(element: Element): boolean {
-  let sibling = element.previousElementSibling;
-  while (sibling) {
-    if (sibling.tagName === element.tagName) return true;
-    sibling = sibling.previousElementSibling;
-  }
-
-  sibling = element.nextElementSibling;
-  while (sibling) {
-    if (sibling.tagName === element.tagName) return true;
-    sibling = sibling.nextElementSibling;
-  }
-
-  return false;
-}
-
-function escapeCssIdentifier(value: string): string {
-  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
-    return CSS.escape(value);
-  }
-
-  return value.replace(/[^a-zA-Z0-9_-]/g, char => `\\${char}`);
 }

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -88,6 +88,7 @@ interface FeedbackData {
   category: FeedbackCategory;
   screenshot: string | null;
   elementSelector: string | null;
+  fullElementSelector: string | null;
   name?: string;
   email?: string;
 }
@@ -821,6 +822,7 @@ async function openFeedbackFlow(
       email: formResult.email,
       screenshot: screenshotResult.screenshot,
       elementSelector: screenshotResult.elementSelector,
+      fullElementSelector: screenshotResult.fullElementSelector,
     });
     break;
   }
@@ -1157,6 +1159,7 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
           },
           timestamp: new Date().toISOString(),
           elementSelector: data.elementSelector,
+          fullElementSelector: data.fullElementSelector,
           domNodeCount,
           fullPageDisabled: isFullPageDisabled(),
           // Parsed system info

--- a/src/widget/selector-metadata.ts
+++ b/src/widget/selector-metadata.ts
@@ -4,10 +4,15 @@ const MAX_FULL_SELECTOR_SEGMENT_LENGTH = 128;
 
 export function getElementSelector(element: Element): string {
   const path: string[] = [];
+  const body = element.ownerDocument.body;
   let current: Element | null = element;
 
-  while (current && current !== document.body) {
-    let selector = current.tagName.toLowerCase();
+  if (current === body) {
+    return getTagSelector(current);
+  }
+
+  while (current && current !== body) {
+    let selector = getTagSelector(current);
 
     if (current.id) {
       selector = `#${escapeCssIdentifier(current.id)}`;
@@ -57,7 +62,7 @@ function getFullSelectorSegment(element: Element): string {
 }
 
 function buildFullSelectorSegment(element: Element): string {
-  let selector = element.tagName.toLowerCase();
+  let selector = getTagSelector(element);
 
   if (element.id) {
     selector += `#${escapeCssIdentifier(element.id)}`;
@@ -76,11 +81,15 @@ function buildFullSelectorSegment(element: Element): string {
 }
 
 function buildStructuralSelectorSegment(element: Element): string {
-  return `${element.tagName.toLowerCase()}${getNthOfTypeSuffix(element)}`;
+  return `${getTagSelector(element)}${getNthOfTypeSuffix(element)}`;
 }
 
 function getClassNames(element: Element): string[] {
   return Array.from(element.classList).filter(Boolean);
+}
+
+function getTagSelector(element: Element): string {
+  return escapeCssIdentifier(element.localName || element.tagName.toLowerCase());
 }
 
 function limitSelectorLength(

--- a/src/widget/selector-metadata.ts
+++ b/src/widget/selector-metadata.ts
@@ -1,0 +1,214 @@
+const MAX_FULL_SELECTOR_CLASSES = 3;
+const MAX_FULL_SELECTOR_LENGTH = 1024;
+const MAX_FULL_SELECTOR_SEGMENT_LENGTH = 128;
+
+export function getElementSelector(element: Element): string {
+  const path: string[] = [];
+  let current: Element | null = element;
+
+  while (current && current !== document.body) {
+    let selector = current.tagName.toLowerCase();
+
+    if (current.id) {
+      selector = `#${escapeCssIdentifier(current.id)}`;
+      path.unshift(selector);
+      break;
+    }
+
+    const classes = getClassNames(current).slice(0, 2);
+    if (classes.length) {
+      selector += `.${classes.map(escapeCssIdentifier).join('.')}`;
+    }
+
+    path.unshift(selector);
+    current = current.parentElement;
+  }
+
+  return path.join(' > ');
+}
+
+export function getFullElementSelector(element: Element): string {
+  const ancestors = getAncestors(element);
+  const path = ancestors.map(getFullSelectorSegment);
+  const structuralPath = ancestors.map(buildStructuralSelectorSegment);
+
+  return limitSelectorLength(path, structuralPath, element);
+}
+
+function getAncestors(element: Element): Element[] {
+  const ancestors: Element[] = [];
+  let current: Element | null = element;
+
+  while (current) {
+    ancestors.unshift(current);
+    current = current.parentElement;
+  }
+
+  return ancestors;
+}
+
+function getFullSelectorSegment(element: Element): string {
+  const selector = buildFullSelectorSegment(element);
+  if (selector.length <= MAX_FULL_SELECTOR_SEGMENT_LENGTH) {
+    return selector;
+  }
+
+  return buildStructuralSelectorSegment(element);
+}
+
+function buildFullSelectorSegment(element: Element): string {
+  let selector = element.tagName.toLowerCase();
+
+  if (element.id) {
+    selector += `#${escapeCssIdentifier(element.id)}`;
+  }
+
+  const classes = getClassNames(element).slice(0, MAX_FULL_SELECTOR_CLASSES);
+  if (classes.length > 0) {
+    selector += `.${classes.map(escapeCssIdentifier).join('.')}`;
+  }
+
+  if (!element.id) {
+    selector += getNthOfTypeSuffix(element);
+  }
+
+  return selector;
+}
+
+function buildStructuralSelectorSegment(element: Element): string {
+  return `${element.tagName.toLowerCase()}${getNthOfTypeSuffix(element)}`;
+}
+
+function getClassNames(element: Element): string[] {
+  return Array.from(element.classList).filter(Boolean);
+}
+
+function limitSelectorLength(
+  path: string[],
+  structuralPath: string[],
+  selectedElement: Element
+): string {
+  const fullSelector = path.join(' > ');
+  if (fullSelector.length <= MAX_FULL_SELECTOR_LENGTH) {
+    return fullSelector;
+  }
+
+  const boundedSelector =
+    findBoundedMatchingSelector(path, selectedElement) ||
+    findBoundedMatchingSelector(structuralPath, selectedElement);
+
+  return boundedSelector || buildStructuralSelectorSegment(selectedElement);
+}
+
+function findBoundedMatchingSelector(path: string[], selectedElement: Element): string | null {
+  for (let start = path.length - 1; start >= 0; start -= 1) {
+    const candidate = path.slice(start).join(' > ');
+    if (candidate.length > MAX_FULL_SELECTOR_LENGTH) {
+      continue;
+    }
+    if (selectorMatchesElement(candidate, selectedElement)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function selectorMatchesElement(selector: string, element: Element): boolean {
+  try {
+    return element.ownerDocument.querySelector(selector) === element;
+  } catch {
+    return false;
+  }
+}
+
+function getNthOfTypeSuffix(element: Element): string {
+  const nthOfType = getNthOfType(element);
+  return nthOfType > 1 || hasSameTagSibling(element) ? `:nth-of-type(${nthOfType})` : '';
+}
+
+function getNthOfType(element: Element): number {
+  let index = 1;
+  let sibling = element.previousElementSibling;
+
+  while (sibling) {
+    if (sibling.tagName === element.tagName) {
+      index += 1;
+    }
+    sibling = sibling.previousElementSibling;
+  }
+
+  return index;
+}
+
+function hasSameTagSibling(element: Element): boolean {
+  let sibling = element.previousElementSibling;
+  while (sibling) {
+    if (sibling.tagName === element.tagName) return true;
+    sibling = sibling.previousElementSibling;
+  }
+
+  sibling = element.nextElementSibling;
+  while (sibling) {
+    if (sibling.tagName === element.tagName) return true;
+    sibling = sibling.nextElementSibling;
+  }
+
+  return false;
+}
+
+function escapeCssIdentifier(value: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(value);
+  }
+
+  return escapeCssIdentifierFallback(value);
+}
+
+function escapeCssIdentifierFallback(value: string): string {
+  let result = '';
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value.charAt(index);
+    const codeUnit = value.charCodeAt(index);
+    const isFirst = index === 0;
+    const isSecond = index === 1;
+    const firstCodeUnit = value.charCodeAt(0);
+
+    if (codeUnit === 0x0000) {
+      result += '\uFFFD';
+      continue;
+    }
+
+    if (
+      (codeUnit >= 0x0001 && codeUnit <= 0x001f) ||
+      codeUnit === 0x007f ||
+      (isFirst && codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+      (isSecond && codeUnit >= 0x0030 && codeUnit <= 0x0039 && firstCodeUnit === 0x002d)
+    ) {
+      result += `\\${codeUnit.toString(16)} `;
+      continue;
+    }
+
+    if (isFirst && codeUnit === 0x002d && value.length === 1) {
+      result += '\\-';
+      continue;
+    }
+
+    if (
+      codeUnit >= 0x0080 ||
+      codeUnit === 0x002d ||
+      codeUnit === 0x005f ||
+      (codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+      (codeUnit >= 0x0041 && codeUnit <= 0x005a) ||
+      (codeUnit >= 0x0061 && codeUnit <= 0x007a)
+    ) {
+      result += char;
+      continue;
+    }
+
+    result += `\\${char}`;
+  }
+
+  return result;
+}

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1268,6 +1268,95 @@ describe('API Routes', () => {
       expect(issueBody).not.toContain('Full CSS path');
     });
 
+    it('should omit selector rows when no element metadata is present', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+      await app.fetch(req, mockEnv);
+
+      const issueBody = mockCreateIssue.mock.calls[0][4];
+      expect(issueBody).toContain('System Info');
+      expect(issueBody).not.toContain('| **Element** |');
+      expect(issueBody).not.toContain('| **Full CSS path** |');
+    });
+
+    it('should include full CSS path even when compact selector metadata is absent', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const payloadWithFullSelectorOnly = {
+        ...validPayload,
+        metadata: {
+          ...validPayload.metadata,
+          fullElementSelector: 'html > body > main > button#submit-button',
+        },
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payloadWithFullSelectorOnly),
+      });
+      await app.fetch(req, mockEnv);
+
+      const issueBody = mockCreateIssue.mock.calls[0][4];
+      expect(issueBody).not.toContain('| **Element** |');
+      expect(issueBody).toContain(
+        '| **Full CSS path** | `html > body > main > button#submit-button` |'
+      );
+    });
+
+    it('should preserve selector metadata when screenshot upload fails', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockUploadScreenshotAsAsset.mockRejectedValue(new Error('upload failed'));
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const payloadWithScreenshotAndSelectors = {
+        ...validPayload,
+        screenshot: validPngDataUrl,
+        metadata: {
+          ...validPayload.metadata,
+          elementSelector: '#submit-button',
+          fullElementSelector: 'html > body > main > button#submit-button',
+        },
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payloadWithScreenshotAndSelectors),
+      });
+      const res = await app.fetch(req, mockEnv);
+
+      expect(res.status).toBe(200);
+      expect(mockUploadScreenshotAsAsset).toHaveBeenCalledWith(
+        'test-token',
+        'testowner',
+        'testrepo',
+        validPngDataUrl
+      );
+      const issueBody = mockCreateIssue.mock.calls[0][4];
+      expect(issueBody).not.toContain('## Screenshot');
+      expect(issueBody).toContain('| **Element** | `#submit-button` |');
+      expect(issueBody).toContain(
+        '| **Full CSS path** | `html > body > main > button#submit-button` |'
+      );
+    });
+
     it.each([
       [
         'button#save\\`now',

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1235,10 +1235,82 @@ describe('API Routes', () => {
       expect(issueBody).toContain('http://localhost:3000');
       expect(issueBody).toContain('1920×1080');
       expect(issueBody).toContain('#submit-button');
-      expect(issueBody).toContain('Full CSS path');
-      expect(issueBody).toContain('html > body > main > form#contact > button#submit-button');
+      expect(issueBody).toContain(
+        '| **Full CSS path** | `html > body > main > form#contact > button#submit-button` |'
+      );
       expect(issueBody).toContain('Submitted via');
     });
+
+    it('should omit full CSS path row when metadata is absent', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const payloadWithSelector = {
+        ...validPayload,
+        metadata: {
+          ...validPayload.metadata,
+          elementSelector: '#submit-button',
+        },
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payloadWithSelector),
+      });
+      await app.fetch(req, mockEnv);
+
+      const issueBody = mockCreateIssue.mock.calls[0][4];
+      expect(issueBody).toContain('| **Element** | `#submit-button` |');
+      expect(issueBody).not.toContain('Full CSS path');
+    });
+
+    it.each([
+      [
+        'button#save\\`now',
+        'html > body > button#save\\`now.action\\|primary',
+        '| **Element** | `` button#save\\`now `` |',
+        '| **Full CSS path** | `` html > body > button#save\\`now.action\\\\|primary `` |',
+      ],
+      [
+        'button#save\\``now',
+        'html > body > button#save\\```now.action\\|primary',
+        '| **Element** | ``` button#save\\``now ``` |',
+        '| **Full CSS path** | ```` html > body > button#save\\```now.action\\\\|primary ```` |',
+      ],
+    ])(
+      'should format selector metadata safely in markdown tables for %s',
+      async (elementSelector, fullElementSelector, expectedElementRow, expectedFullPathRow) => {
+        mockGetInstallationToken.mockResolvedValue('test-token');
+        mockCreateIssue.mockResolvedValue({
+          number: 42,
+          html_url: 'https://github.com/testowner/testrepo/issues/42',
+        });
+
+        const payloadWithMarkdownSensitiveSelector = {
+          ...validPayload,
+          metadata: {
+            ...validPayload.metadata,
+            elementSelector,
+            fullElementSelector,
+          },
+        };
+
+        const req = new Request('http://localhost/feedback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payloadWithMarkdownSensitiveSelector),
+        });
+        await app.fetch(req, mockEnv);
+
+        const issueBody = mockCreateIssue.mock.calls[0][4];
+        expect(issueBody).toContain(expectedElementRow);
+        expect(issueBody).toContain(expectedFullPathRow);
+      }
+    );
 
     it('should include submitter info in issue body when provided', async () => {
       mockGetInstallationToken.mockResolvedValue('test-token');

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1217,6 +1217,7 @@ describe('API Routes', () => {
         metadata: {
           ...validPayload.metadata,
           elementSelector: '#submit-button',
+          fullElementSelector: 'html > body > main > form#contact > button#submit-button',
         },
       };
 
@@ -1234,6 +1235,8 @@ describe('API Routes', () => {
       expect(issueBody).toContain('http://localhost:3000');
       expect(issueBody).toContain('1920×1080');
       expect(issueBody).toContain('#submit-button');
+      expect(issueBody).toContain('Full CSS path');
+      expect(issueBody).toContain('html > body > main > form#contact > button#submit-button');
       expect(issueBody).toContain('Submitted via');
     });
 

--- a/test/captureFlow.test.ts
+++ b/test/captureFlow.test.ts
@@ -160,6 +160,41 @@ describe('capture flow state decisions', () => {
     expect(onComplexScreenshotSkipped).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps full selected element metadata after successful element capture', async () => {
+    document.body.innerHTML = `
+      <main id="content">
+        <section class="card">
+          <button id="save-button" class="primary action">Save</button>
+        </section>
+      </main>
+    `;
+    const element = document.querySelector('#save-button')!;
+    const { runScreenshotCaptureFlow } = await loadCaptureFlowWithMocks({
+      screenshotChoice: { kind: 'element' },
+      pickedElement: element,
+      captureResult: { kind: 'ok', dataUrl: 'data:image/png;base64,BBBB' },
+      annotationResult: 'data:image/png;base64,ANNOTATED',
+    });
+    const onComplexScreenshotSkipped = vi.fn();
+
+    const result = await runScreenshotCaptureFlow(
+      document.createElement('div'),
+      baseConfig,
+      true,
+      onComplexScreenshotSkipped
+    );
+
+    expect(result).toEqual({
+      screenshot: 'data:image/png;base64,ANNOTATED',
+      elementSelector: '#save-button',
+      fullElementSelector:
+        'html > body > main#content > section.card > button#save-button.primary.action',
+      returnToForm: false,
+    });
+    expect(document.querySelector(result.fullElementSelector!)).toBe(element);
+    expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
+  });
+
   it('returns to form when the user dismisses the screenshot options modal', async () => {
     const { runScreenshotCaptureFlow } = await loadCaptureFlowWithMocks({
       screenshotChoice: { kind: 'cancel' },

--- a/test/captureFlow.test.ts
+++ b/test/captureFlow.test.ts
@@ -43,6 +43,7 @@ async function loadCaptureFlowWithMocks(opts: {
 }
 
 afterEach(() => {
+  document.body.innerHTML = '';
   vi.doUnmock('../src/widget/screenshot-options');
   vi.doUnmock('../src/widget/picker');
   vi.doUnmock('../src/widget/area-picker');
@@ -79,7 +80,12 @@ describe('capture flow state decisions', () => {
       onComplexScreenshotSkipped
     );
 
-    expect(result).toEqual({ screenshot: null, elementSelector: null, returnToForm: false });
+    expect(result).toEqual({
+      screenshot: null,
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: false,
+    });
     expect(onComplexScreenshotSkipped).toHaveBeenCalledTimes(1);
   });
 
@@ -97,14 +103,37 @@ describe('capture flow state decisions', () => {
       onComplexScreenshotSkipped
     );
 
-    expect(result).toEqual({ screenshot: null, elementSelector: null, returnToForm: false });
+    expect(result).toEqual({
+      screenshot: null,
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: false,
+    });
     expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
   });
 
   it('keeps selected element metadata when element capture is skipped after failure', async () => {
-    const element = document.createElement('button');
-    element.id = 'target-button';
-    document.body.appendChild(element);
+    document.body.innerHTML = `
+      <div class="injected-before-page"></div>
+      <div class="another-injected-wrapper"></div>
+      <div id="page" class="site">
+        <div id="content" class="site-content">
+          <div id="primary" class="content-area">
+            <main id="main" class="site-main">
+              <article id="post-27" class="post-27 page">
+                <div class="inside-article">
+                  <div class="entry-content">
+                    <div class="gb-container gb-container-f0cc8c05"></div>
+                    <div class="gb-container gb-container-928af62b"></div>
+                  </div>
+                </div>
+              </article>
+            </main>
+          </div>
+        </div>
+      </div>
+    `;
+    const element = document.querySelector('.gb-container-928af62b')!;
     const { runScreenshotCaptureFlow } = await loadCaptureFlowWithMocks({
       screenshotChoice: { kind: 'element' },
       pickedElement: element,
@@ -121,9 +150,13 @@ describe('capture flow state decisions', () => {
 
     expect(result).toEqual({
       screenshot: null,
-      elementSelector: '#target-button',
+      elementSelector:
+        '#post-27 > div.inside-article > div.entry-content > div.gb-container.gb-container-928af62b',
+      fullElementSelector:
+        'html > body > div#page.site > div#content.site-content > div#primary.content-area > main#main.site-main > article#post-27.post-27.page > div.inside-article > div.entry-content > div.gb-container.gb-container-928af62b:nth-of-type(2)',
       returnToForm: false,
     });
+    expect(document.querySelector(result.fullElementSelector!)).toBe(element);
     expect(onComplexScreenshotSkipped).toHaveBeenCalledTimes(1);
   });
 
@@ -140,7 +173,12 @@ describe('capture flow state decisions', () => {
       onComplexScreenshotSkipped
     );
 
-    expect(result).toEqual({ screenshot: null, elementSelector: null, returnToForm: true });
+    expect(result).toEqual({
+      screenshot: null,
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: true,
+    });
     expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
   });
 
@@ -158,7 +196,12 @@ describe('capture flow state decisions', () => {
       onComplexScreenshotSkipped
     );
 
-    expect(result).toEqual({ screenshot: null, elementSelector: null, returnToForm: true });
+    expect(result).toEqual({
+      screenshot: null,
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: true,
+    });
     expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
   });
 
@@ -177,7 +220,12 @@ describe('capture flow state decisions', () => {
       onComplexScreenshotSkipped
     );
 
-    expect(result).toEqual({ screenshot: null, elementSelector: null, returnToForm: true });
+    expect(result).toEqual({
+      screenshot: null,
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: true,
+    });
     expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
   });
 

--- a/test/captureFlow.test.ts
+++ b/test/captureFlow.test.ts
@@ -10,28 +10,56 @@ const baseConfig = {
 };
 
 async function loadCaptureFlowWithMocks(opts: {
-  screenshotChoice: ScreenshotChoice;
+  screenshotChoice?: ScreenshotChoice;
+  screenshotChoices?: ScreenshotChoice[];
   pickedElement?: Element | null;
+  pickedElements?: Array<Element | null>;
   captureResult?: CaptureWithLoadingResult;
+  captureResults?: CaptureWithLoadingResult[];
   annotationResult?: string | 'retake' | 'cancel';
+  annotationResults?: Array<string | 'retake' | 'cancel'>;
 }) {
   vi.resetModules();
+  const screenshotOptionsMock = vi.fn();
+  for (const choice of opts.screenshotChoices ?? []) {
+    screenshotOptionsMock.mockResolvedValueOnce(choice);
+  }
+  screenshotOptionsMock.mockResolvedValue(opts.screenshotChoice ?? { kind: 'skip' });
+
+  const elementPickerMock = vi.fn();
+  for (const element of opts.pickedElements ?? []) {
+    elementPickerMock.mockResolvedValueOnce(element);
+  }
+  elementPickerMock.mockResolvedValue(opts.pickedElement ?? null);
+
+  const captureMock = vi.fn();
+  for (const result of opts.captureResults ?? []) {
+    captureMock.mockResolvedValueOnce(result);
+  }
+  captureMock.mockResolvedValue(opts.captureResult ?? { kind: 'skipped' });
+
+  const annotationMock = vi.fn();
+  for (const result of opts.annotationResults ?? []) {
+    annotationMock.mockResolvedValueOnce(result);
+  }
+  annotationMock.mockResolvedValue(opts.annotationResult ?? 'annotated-image');
+
   vi.doMock('../src/widget/screenshot-options', () => ({
-    showScreenshotOptions: vi.fn().mockResolvedValue(opts.screenshotChoice),
+    showScreenshotOptions: screenshotOptionsMock,
   }));
   vi.doMock('../src/widget/picker', () => ({
-    createElementPicker: vi.fn().mockResolvedValue(opts.pickedElement ?? null),
+    createElementPicker: elementPickerMock,
   }));
   vi.doMock('../src/widget/area-picker', () => ({
     createAreaPicker: vi.fn(),
   }));
   vi.doMock('../src/widget/capture-loading', () => ({
-    captureWithLoading: vi.fn().mockResolvedValue(opts.captureResult ?? { kind: 'skipped' }),
+    captureWithLoading: captureMock,
     captureAreaWithLoading: vi.fn(),
-    capturePromiseWithLoading: vi.fn().mockResolvedValue(opts.captureResult ?? { kind: 'skipped' }),
+    capturePromiseWithLoading: captureMock,
   }));
   vi.doMock('../src/widget/annotation-flow', () => ({
-    showAnnotationStep: vi.fn().mockResolvedValue(opts.annotationResult ?? 'annotated-image'),
+    showAnnotationStep: annotationMock,
   }));
   vi.doMock('../src/widget/screenshot', () => ({
     beginViewportCapture: vi.fn(),
@@ -192,6 +220,74 @@ describe('capture flow state decisions', () => {
       returnToForm: false,
     });
     expect(document.querySelector(result.fullElementSelector!)).toBe(element);
+    expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
+  });
+
+  it('uses the latest selected element metadata after annotation retake', async () => {
+    document.body.innerHTML = `
+      <main>
+        <button id="first-button" class="primary">First</button>
+        <button id="second-button" class="secondary">Second</button>
+      </main>
+    `;
+    const firstElement = document.querySelector('#first-button')!;
+    const secondElement = document.querySelector('#second-button')!;
+    const { runScreenshotCaptureFlow } = await loadCaptureFlowWithMocks({
+      screenshotChoices: [{ kind: 'element' }, { kind: 'element' }],
+      pickedElements: [firstElement, secondElement],
+      captureResults: [
+        { kind: 'ok', dataUrl: 'data:image/png;base64,FIRST' },
+        { kind: 'ok', dataUrl: 'data:image/png;base64,SECOND' },
+      ],
+      annotationResults: ['retake', 'data:image/png;base64,ANNOTATED_SECOND'],
+    });
+    const onComplexScreenshotSkipped = vi.fn();
+
+    const result = await runScreenshotCaptureFlow(
+      document.createElement('div'),
+      baseConfig,
+      true,
+      onComplexScreenshotSkipped
+    );
+
+    expect(result).toEqual({
+      screenshot: 'data:image/png;base64,ANNOTATED_SECOND',
+      elementSelector: '#second-button',
+      fullElementSelector: 'html > body > main > button#second-button.secondary',
+      returnToForm: false,
+    });
+    expect(result.fullElementSelector).not.toContain('first-button');
+    expect(document.querySelector(result.fullElementSelector!)).toBe(secondElement);
+    expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
+  });
+
+  it('drops selected element metadata when element capture is cancelled', async () => {
+    document.body.innerHTML = `
+      <main>
+        <button id="cancelled-button" class="primary">Cancel target</button>
+      </main>
+    `;
+    const element = document.querySelector('#cancelled-button')!;
+    const { runScreenshotCaptureFlow } = await loadCaptureFlowWithMocks({
+      screenshotChoice: { kind: 'element' },
+      pickedElement: element,
+      captureResult: { kind: 'cancelled' },
+    });
+    const onComplexScreenshotSkipped = vi.fn();
+
+    const result = await runScreenshotCaptureFlow(
+      document.createElement('div'),
+      baseConfig,
+      true,
+      onComplexScreenshotSkipped
+    );
+
+    expect(result).toEqual({
+      screenshot: null,
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: true,
+    });
     expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
   });
 

--- a/test/selectorMetadata.test.ts
+++ b/test/selectorMetadata.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { getElementSelector, getFullElementSelector } from '../src/widget/selector-metadata';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('selector metadata', () => {
+  it('escapes short and full selectors without CSS.escape', () => {
+    const originalCss = globalThis.CSS;
+    Object.defineProperty(globalThis, 'CSS', {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      document.body.innerHTML = `
+        <main>
+          <button id="123 save" class="0primary action">Save</button>
+        </main>
+      `;
+      const element = document.querySelector('button')!;
+
+      expect(document.querySelector(getElementSelector(element))).toBe(element);
+      expect(document.querySelector(getFullElementSelector(element))).toBe(element);
+    } finally {
+      Object.defineProperty(globalThis, 'CSS', {
+        configurable: true,
+        value: originalCss,
+      });
+    }
+  });
+
+  it.each(['-', '-1target', 'line\nbreak', 'delete\u007fchar'])(
+    'escapes fallback identifier edge case %s',
+    value => {
+      const originalCss = globalThis.CSS;
+      Object.defineProperty(globalThis, 'CSS', {
+        configurable: true,
+        value: undefined,
+      });
+
+      try {
+        const element = document.createElement('button');
+        element.setAttribute('id', value);
+        document.body.appendChild(element);
+
+        expect(document.querySelector(getElementSelector(element))).toBe(element);
+        expect(document.querySelector(getFullElementSelector(element))).toBe(element);
+      } finally {
+        Object.defineProperty(globalThis, 'CSS', {
+          configurable: true,
+          value: originalCss,
+        });
+      }
+    }
+  );
+
+  it('uses structural segments instead of truncating long identifiers', () => {
+    const longId = `target-${'x'.repeat(180)}`;
+    document.body.innerHTML = `
+      <main>
+        <section>
+          <button id="${longId}">Save</button>
+        </section>
+      </main>
+    `;
+    const element = document.querySelector('button')!;
+
+    expect(document.querySelector(getElementSelector(element))).toBe(element);
+    expect(getFullElementSelector(element)).toBe('html > body > main > section > button');
+  });
+
+  it('bounds deep full selectors while keeping the target queryable', () => {
+    let html = '<main>';
+    for (let i = 0; i < 180; i += 1) {
+      html += `<div class="segment-${i} utility-class-${i} generated-token-${i}">`;
+    }
+    html += '<button id="deep-target">Save</button>';
+    html += '</div>'.repeat(180);
+    html += '</main>';
+    document.body.innerHTML = html;
+    const element = document.querySelector('#deep-target')!;
+
+    const selector = getFullElementSelector(element);
+
+    expect(selector.length).toBeLessThanOrEqual(1024);
+    expect(selector).toContain('button#deep-target');
+    expect(document.querySelector(selector)).toBe(element);
+  });
+
+  it('keeps bounded selectors unambiguous across repeated deep branches', () => {
+    const buildBranch = (index: number) => {
+      let html = `<section class="branch branch-${index}">`;
+      for (let i = 0; i < 90; i += 1) {
+        html += `<div class="level-${i} utility-${i} token-${i}">`;
+      }
+      html += `<button class="target">Save ${index}</button>`;
+      html += '</div>'.repeat(90);
+      html += '</section>';
+      return html;
+    };
+    document.body.innerHTML = `<main>${buildBranch(0)}${buildBranch(1)}</main>`;
+    const element = document.querySelectorAll('button.target')[1]!;
+
+    const selector = getFullElementSelector(element);
+
+    expect(selector.length).toBeLessThanOrEqual(1024);
+    expect(document.querySelector(selector)).toBe(element);
+  });
+
+  it('handles SVG classes, class truncation, and first same-tag siblings', () => {
+    document.body.innerHTML = `
+      <main>
+        <svg>
+          <g class="first second third fourth"></g>
+          <g class="target icon state"></g>
+        </svg>
+      </main>
+    `;
+    const element = document.querySelector('g')!;
+    const selector = getFullElementSelector(element);
+
+    expect(selector).toContain('g.first.second.third:nth-of-type(1)');
+    expect(selector).not.toContain('fourth');
+    expect(document.querySelector(selector)).toBe(element);
+  });
+});

--- a/test/selectorMetadata.test.ts
+++ b/test/selectorMetadata.test.ts
@@ -72,6 +72,18 @@ describe('selector metadata', () => {
     expect(getFullElementSelector(element)).toBe('html > body > main > section > button');
   });
 
+  it('returns queryable selectors for document edge elements', () => {
+    expect(getElementSelector(document.body)).toBe('body');
+    expect(document.querySelector(getElementSelector(document.body))).toBe(document.body);
+    expect(document.querySelector(getFullElementSelector(document.body))).toBe(document.body);
+    expect(document.querySelector(getElementSelector(document.documentElement))).toBe(
+      document.documentElement
+    );
+    expect(document.querySelector(getFullElementSelector(document.documentElement))).toBe(
+      document.documentElement
+    );
+  });
+
   it('bounds deep full selectors while keeping the target queryable', () => {
     let html = '<main>';
     for (let i = 0; i < 180; i += 1) {
@@ -125,5 +137,39 @@ describe('selector metadata', () => {
     expect(selector).toContain('g.first.second.third:nth-of-type(1)');
     expect(selector).not.toContain('fourth');
     expect(document.querySelector(selector)).toBe(element);
+  });
+
+  it('preserves case-sensitive SVG tag selectors', () => {
+    document.body.innerHTML = `
+      <main>
+        <svg>
+          <defs>
+            <linearGradient class="brand-gradient">
+              <stop></stop>
+            </linearGradient>
+          </defs>
+        </svg>
+      </main>
+    `;
+    const element = document.querySelector('linearGradient')!;
+
+    const selector = getFullElementSelector(element);
+
+    expect(selector).toContain('linearGradient.brand-gradient');
+    expect(document.querySelector(selector)).toBe(element);
+  });
+
+  it('escapes colon-containing tag names in full selectors', () => {
+    const wrapper = document.createElement('main');
+    const first = document.createElement('foo:bar');
+    const second = document.createElement('foo:bar');
+    second.className = 'target';
+    wrapper.append(first, second);
+    document.body.appendChild(wrapper);
+
+    const selector = getFullElementSelector(second);
+
+    expect(selector).toContain('foo\\:bar.target:nth-of-type(2)');
+    expect(document.querySelector(selector)).toBe(second);
   });
 });


### PR DESCRIPTION
Closes #170

## What changed

Element-picker submissions now include a second metadata row, `Full CSS path`, alongside the existing concise `Element` selector. The existing selector stays unchanged so current issue formatting and consumers are not disrupted.

## Why this shape

The existing selector intentionally stops at the first ID, which keeps the issue compact but drops the layout context above that ID. That is especially limiting when the issue is handed to someone who was not present when the report was created, including AI coding agents that need to infer where a selected node sits in the page.

The new path is diagnostic context rather than a promise of perfect replay. It walks from `html` to the selected element, caps classes per segment to keep long class lists readable, escapes CSS identifiers, and only adds `:nth-of-type(...)` where there is no ID anchor. That avoids making stable ID-based ancestors brittle because of session-specific injected siblings such as admin bars, cookie banners, optimization scripts, or the widget itself.

## What this enables

Maintainers get a fuller view of the selected element's document location without asking reporters for another reproduction pass or adding any extra step to the widget flow.

## Risks we're accepting

The full path can still drift if the page DOM changes after submission. That is acceptable here because the field is intended to improve debugging context, not to guarantee that the selector can always be pasted into DevTools days later.

---

## Test plan

- [x] `NODE_OPTIONS=--no-experimental-webstorage make test` — 13 files, 229 tests passed
- [x] `npm run build` — passed
- [x] `npm run build:widget` — passed after normal build
- [x] `BUGDROP_TEST_HOOKS=1 npm run build:widget && NODE_OPTIONS=--no-experimental-webstorage npx playwright test e2e/widget.spec.ts --project=chromium --grep "remembers complex-page skip after element capture failure skip" && npm run build:widget` — targeted browser submission test passed, then rebuilt the normal widget bundle
- [x] `npm audit --audit-level=critical` — found 0 vulnerabilities
- [x] `npm run check:actions-node24` — passed
- [x] `NODE_OPTIONS=--no-experimental-webstorage BUGDROP_TEST_HOOKS=1 make ci` — stopped at existing upstream `knip` output for `semantic-release` / `.github/workflows/deploy.yml`; lint, format check, and typecheck completed before that blocker

---