### PR TITLE
Improve Select Element screenshots with visual context

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -3566,7 +3566,13 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     await host.locator('css=[data-action="skip"]').click();
     await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 5000 });
     expect(payloads).toHaveLength(1);
-    expect((payloads[0].metadata as { elementSelector?: string }).elementSelector).toContain('h1');
+    const metadata = payloads[0].metadata as {
+      elementSelector?: string;
+      fullElementSelector?: string;
+    };
+    expect(metadata.elementSelector).toContain('h1');
+    expect(metadata.fullElementSelector).toContain('html > body');
+    expect(metadata.fullElementSelector).toContain('h1');
 
     await host.locator('css=.bd-close').click();
     await host.locator('css=.bd-trigger').click();

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -14,6 +14,13 @@ declare global {
   interface Window {
     __hostKeystrokeCount?: number;
     __captureOpts?: CaptureOptions;
+    __captureTargetInfo?: {
+      tagName: string;
+      id: string;
+      className: string;
+      width: number;
+      height: number;
+    };
   }
 }
 
@@ -2354,6 +2361,21 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     }`;
   }
 
+  function targetSpyToPng() {
+    return `function(el, opts) {
+      window.__captureOpts = opts;
+      var rect = el.getBoundingClientRect();
+      window.__captureTargetInfo = {
+        tagName: el.tagName,
+        id: el.id || '',
+        className: typeof el.className === 'string' ? el.className : '',
+        width: rect.width,
+        height: rect.height
+      };
+      return Promise.resolve('${STUB_PNG}');
+    }`;
+  }
+
   function redactionAwarePng() {
     return `function(el, opts) {
       window.__captureOpts = opts;
@@ -3004,6 +3026,37 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
 
     const timeoutRejections = rejections.filter(m => m.includes('timed out'));
     expect(timeoutRejections).toHaveLength(0);
+  });
+
+  test('element capture uses a surrounding context target', async ({ page }) => {
+    await mockHtmlToImage(page, targetSpyToPng());
+    await page.goto('/test/annotation-style.html');
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="element"]').click();
+    await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
+
+    const selected = page.locator('.dot.green');
+    await expect(selected).toBeVisible();
+    const selectedBox = await selected.boundingBox();
+    expect(selectedBox).toBeTruthy();
+
+    await page.mouse.click(
+      selectedBox!.x + selectedBox!.width / 2,
+      selectedBox!.y + selectedBox!.height / 2
+    );
+
+    await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+
+    const targetInfo = await page.evaluate(() => window.__captureTargetInfo);
+    expect(targetInfo).toBeDefined();
+    if (!targetInfo) throw new Error('Missing capture target info');
+    expect(targetInfo.className).not.toContain('dot');
+    expect(targetInfo.width).toBeGreaterThan(selectedBox!.width * 4);
+    expect(targetInfo.height).toBeGreaterThan(selectedBox!.height * 4);
+
+    const captureOpts = await page.evaluate(() => window.__captureOpts);
+    expect(captureOpts?.pixelRatio).toBe(1);
   });
 
   test('shows error modal when capture times out', async ({ page }) => {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -601,6 +601,10 @@ function formatIssueBody(
     sections.push(`| **Element** | \`${payload.metadata.elementSelector}\` |`);
   }
 
+  if (payload.metadata.fullElementSelector) {
+    sections.push(`| **Full CSS path** | \`${payload.metadata.fullElementSelector}\` |`);
+  }
+
   sections.push('');
   sections.push('</details>');
   sections.push('');

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -549,6 +549,10 @@ function formatIssueBody(
   if (screenshotDataUrl) {
     sections.push('## Screenshot');
     sections.push(`![Screenshot](${screenshotDataUrl})`);
+    if (payload.metadata.elementSelector) {
+      sections.push('');
+      sections.push('_Selected element is indicated by the blue rounded highlight box._');
+    }
     sections.push('');
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface FeedbackPayload {
     viewport: { width: number; height: number };
     timestamp: string;
     elementSelector?: string;
+    fullElementSelector?: string;
     // Parsed system info
     browser?: { name: string; version: string };
     os?: { name: string; version: string };

--- a/src/widget/capture-flow.ts
+++ b/src/widget/capture-flow.ts
@@ -9,6 +9,8 @@ import { createElementPicker } from './picker';
 import { beginViewportCapture, getRedactionCount, isFullPageDisabled } from './screenshot';
 import { showScreenshotOptions, type ScreenshotChoice } from './screenshot-options';
 
+const MAX_FULL_SELECTOR_CLASSES = 3;
+
 export interface CaptureFlowConfig {
   screenshotMode: 'optional' | 'auto' | 'required';
   screenshotScale?: number;
@@ -25,6 +27,7 @@ export interface CaptureFlowConfig {
 export interface CaptureFlowResult {
   screenshot: string | null;
   elementSelector: string | null;
+  fullElementSelector: string | null;
   returnToForm: boolean;
 }
 
@@ -39,11 +42,17 @@ type ChosenCaptureResult =
       kind: 'captured';
       screenshot: string;
       elementSelector: string | null;
+      fullElementSelector: string | null;
       redactionCount: number;
       redactionUnavailable: boolean;
     }
   | { kind: 'returnToForm' }
-  | { kind: 'empty'; reason: EmptyCaptureReason; elementSelector: string | null };
+  | {
+      kind: 'empty';
+      reason: EmptyCaptureReason;
+      elementSelector: string | null;
+      fullElementSelector: string | null;
+    };
 
 export async function runScreenshotCaptureFlow(
   root: HTMLElement,
@@ -74,6 +83,7 @@ export async function runScreenshotCaptureFlow(
       return {
         screenshot: null,
         elementSelector: result.elementSelector,
+        fullElementSelector: result.fullElementSelector,
         returnToForm: false,
       };
     }
@@ -95,6 +105,7 @@ export async function runScreenshotCaptureFlow(
     return {
       screenshot: annotatedScreenshot,
       elementSelector: result.elementSelector,
+      fullElementSelector: result.fullElementSelector,
       returnToForm: false,
     };
   }
@@ -116,6 +127,7 @@ async function captureAutomaticScreenshot(
   return {
     screenshot: result.kind === 'ok' ? result.dataUrl : null,
     elementSelector: null,
+    fullElementSelector: null,
     returnToForm: false,
   };
 }
@@ -137,7 +149,12 @@ async function captureChosenScreenshot(
     case 'cancel':
       return { kind: 'returnToForm' };
     case 'skip':
-      return { kind: 'empty', reason: 'explicit-skip', elementSelector: null };
+      return {
+        kind: 'empty',
+        reason: 'explicit-skip',
+        elementSelector: null,
+        fullElementSelector: null,
+      };
     case 'viewport':
       return captureFromViewportChoice(root, screenshotChoice, screenshotRequired);
     case 'capture':
@@ -167,12 +184,18 @@ async function captureFromViewportChoice(
   );
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
-    return { kind: 'empty', reason: 'capture-failure-skip', elementSelector: null };
+    return {
+      kind: 'empty',
+      reason: 'capture-failure-skip',
+      elementSelector: null,
+      fullElementSelector: null,
+    };
   }
   return {
     kind: 'captured',
     screenshot: result.dataUrl,
     elementSelector: null,
+    fullElementSelector: null,
     redactionCount: 0,
     redactionUnavailable: true,
   };
@@ -188,12 +211,18 @@ async function captureFromFullPageChoice(
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
-    return { kind: 'empty', reason: 'capture-failure-skip', elementSelector: null };
+    return {
+      kind: 'empty',
+      reason: 'capture-failure-skip',
+      elementSelector: null,
+      fullElementSelector: null,
+    };
   }
   return {
     kind: 'captured',
     screenshot: result.dataUrl,
     elementSelector: null,
+    fullElementSelector: null,
     redactionCount: getRedactionCount(),
     redactionUnavailable: false,
   };
@@ -206,21 +235,33 @@ async function captureFromElementChoice(
 ): Promise<ChosenCaptureResult> {
   const element = await createElementPicker(getPickerStyle(config));
   if (!element) {
-    return { kind: 'empty', reason: 'selection-cancelled', elementSelector: null };
+    return {
+      kind: 'empty',
+      reason: 'selection-cancelled',
+      elementSelector: null,
+      fullElementSelector: null,
+    };
   }
 
   const elementSelector = getElementSelector(element);
+  const fullElementSelector = getFullElementSelector(element);
   const result = await captureWithLoading(root, element, config.screenshotScale, {
     allowSkip: !screenshotRequired,
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
-    return { kind: 'empty', reason: 'capture-failure-skip', elementSelector };
+    return {
+      kind: 'empty',
+      reason: 'capture-failure-skip',
+      elementSelector,
+      fullElementSelector,
+    };
   }
   return {
     kind: 'captured',
     screenshot: result.dataUrl,
     elementSelector,
+    fullElementSelector,
     redactionCount: getRedactionCount(element),
     redactionUnavailable: false,
   };
@@ -235,7 +276,12 @@ async function captureFromAreaChoice(
     redactionsAvailable: getRedactionCount() > 0,
   });
   if (!rect) {
-    return { kind: 'empty', reason: 'selection-cancelled', elementSelector: null };
+    return {
+      kind: 'empty',
+      reason: 'selection-cancelled',
+      elementSelector: null,
+      fullElementSelector: null,
+    };
   }
 
   const result = await captureAreaWithLoading(root, rect, config.screenshotScale, {
@@ -243,12 +289,18 @@ async function captureFromAreaChoice(
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
-    return { kind: 'empty', reason: 'capture-failure-skip', elementSelector: null };
+    return {
+      kind: 'empty',
+      reason: 'capture-failure-skip',
+      elementSelector: null,
+      fullElementSelector: null,
+    };
   }
   return {
     kind: 'captured',
     screenshot: result.dataUrl,
     elementSelector: null,
+    fullElementSelector: null,
     redactionCount: getRedactionCount(undefined, rect),
     redactionUnavailable: false,
   };
@@ -271,6 +323,7 @@ function emptyCaptureResult(): CaptureFlowResult {
   return {
     screenshot: null,
     elementSelector: null,
+    fullElementSelector: null,
     returnToForm: false,
   };
 }
@@ -311,4 +364,85 @@ function getElementSelector(element: Element): string {
   }
 
   return path.join(' > ');
+}
+
+function getFullElementSelector(element: Element): string {
+  const path: string[] = [];
+  let current: Element | null = element;
+
+  while (current) {
+    path.unshift(getFullSelectorSegment(current));
+    current = current.parentElement;
+  }
+
+  return path.join(' > ');
+}
+
+function getFullSelectorSegment(element: Element): string {
+  let selector = element.tagName.toLowerCase();
+
+  if (element.id) {
+    selector += `#${escapeCssIdentifier(element.id)}`;
+  }
+
+  const classes = getClassNames(element).slice(0, MAX_FULL_SELECTOR_CLASSES);
+  if (classes.length > 0) {
+    selector += `.${classes.map(escapeCssIdentifier).join('.')}`;
+  }
+
+  if (!element.id) {
+    const nthOfType = getNthOfType(element);
+    if (nthOfType > 1 || hasSameTagSibling(element)) {
+      selector += `:nth-of-type(${nthOfType})`;
+    }
+  }
+
+  return selector;
+}
+
+function getClassNames(element: Element): string[] {
+  const classNameStr =
+    typeof element.className === 'string'
+      ? element.className
+      : (element.className as SVGAnimatedString).baseVal || '';
+
+  return classNameStr.split(/\s+/).filter(Boolean);
+}
+
+function getNthOfType(element: Element): number {
+  let index = 1;
+  let sibling = element.previousElementSibling;
+
+  while (sibling) {
+    if (sibling.tagName === element.tagName) {
+      index += 1;
+    }
+    sibling = sibling.previousElementSibling;
+  }
+
+  return index;
+}
+
+function hasSameTagSibling(element: Element): boolean {
+  let sibling = element.previousElementSibling;
+  while (sibling) {
+    if (sibling.tagName === element.tagName) return true;
+    sibling = sibling.previousElementSibling;
+  }
+
+  sibling = element.nextElementSibling;
+  while (sibling) {
+    if (sibling.tagName === element.tagName) return true;
+    sibling = sibling.nextElementSibling;
+  }
+
+  return false;
+}
+
+function escapeCssIdentifier(value: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(value);
+  }
+
+  return value.replace(/[^a-zA-Z0-9_-]/g, char => `\\${char}`);
 }

--- a/src/widget/capture-flow.ts
+++ b/src/widget/capture-flow.ts
@@ -10,6 +10,8 @@ import { beginViewportCapture, getRedactionCount, isFullPageDisabled } from './s
 import { showScreenshotOptions, type ScreenshotChoice } from './screenshot-options';
 
 const MAX_FULL_SELECTOR_CLASSES = 3;
+const ELEMENT_CONTEXT_MAX_VIEWPORT_AREA_MULTIPLIER = 1.5;
+const ELEMENT_CONTEXT_MIN_PADDING_PX = 80;
 
 export interface CaptureFlowConfig {
   screenshotMode: 'optional' | 'auto' | 'required';
@@ -245,8 +247,18 @@ async function captureFromElementChoice(
 
   const elementSelector = getElementSelector(element);
   const fullElementSelector = getFullElementSelector(element);
-  const result = await captureWithLoading(root, element, config.screenshotScale, {
+  const captureTarget = getElementContextCaptureTarget(element);
+  const result = await captureWithLoading(root, captureTarget, config.screenshotScale, {
     allowSkip: !screenshotRequired,
+    captureOptions: {
+      highlightElement: element,
+      highlightStyle: {
+        accentColor: config.accentColor,
+        radius: config.radius,
+        borderWidth: config.borderWidth,
+      },
+      pixelRatio: 1,
+    },
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
@@ -262,7 +274,7 @@ async function captureFromElementChoice(
     screenshot: result.dataUrl,
     elementSelector,
     fullElementSelector,
-    redactionCount: getRedactionCount(element),
+    redactionCount: getRedactionCount(captureTarget),
     redactionUnavailable: false,
   };
 }
@@ -376,6 +388,43 @@ function getFullElementSelector(element: Element): string {
   }
 
   return path.join(' > ');
+}
+
+function getElementContextCaptureTarget(element: Element): Element {
+  const selectedRect = element.getBoundingClientRect();
+  if (!isUsableRect(selectedRect)) return element;
+
+  const viewportArea = Math.max(1, window.innerWidth * window.innerHeight);
+  const maxContextArea = viewportArea * ELEMENT_CONTEXT_MAX_VIEWPORT_AREA_MULTIPLIER;
+
+  let best: Element = element;
+  let current = element.parentElement;
+
+  while (current && current !== document.body && current !== document.documentElement) {
+    const rect = current.getBoundingClientRect();
+    const area = rect.width * rect.height;
+
+    if (isUsableRect(rect) && area <= maxContextArea && hasUsefulContext(rect, selectedRect)) {
+      best = current;
+    }
+
+    current = current.parentElement;
+  }
+
+  return best;
+}
+
+function isUsableRect(rect: DOMRect): boolean {
+  return rect.width > 0 && rect.height > 0;
+}
+
+function hasUsefulContext(candidate: DOMRect, selected: DOMRect): boolean {
+  const horizontalContext = candidate.width >= selected.width + ELEMENT_CONTEXT_MIN_PADDING_PX * 2;
+  const verticalContext = candidate.height >= selected.height + ELEMENT_CONTEXT_MIN_PADDING_PX * 2;
+  const selectedArea = selected.width * selected.height;
+  const candidateArea = candidate.width * candidate.height;
+
+  return horizontalContext || verticalContext || candidateArea >= selectedArea * 4;
 }
 
 function getFullSelectorSegment(element: Element): string {

--- a/src/widget/capture-loading.ts
+++ b/src/widget/capture-loading.ts
@@ -1,5 +1,9 @@
 import { MaskApplicationError } from './mask';
-import { captureAreaScreenshot, captureScreenshot } from './screenshot';
+import {
+  captureAreaScreenshot,
+  captureScreenshot,
+  type CaptureScreenshotOptions,
+} from './screenshot';
 import { createModal } from './ui';
 
 export type CaptureWithLoadingResult =
@@ -11,12 +15,12 @@ export async function captureWithLoading(
   root: HTMLElement,
   element?: Element,
   screenshotScale?: number,
-  opts?: { allowSkip?: boolean }
+  opts?: { allowSkip?: boolean; captureOptions?: CaptureScreenshotOptions }
 ): Promise<CaptureWithLoadingResult> {
   return capturePromiseWithLoading(
     root,
-    captureScreenshot(element, screenshotScale),
-    () => captureScreenshot(element, screenshotScale),
+    captureScreenshot(element, screenshotScale, opts?.captureOptions),
+    () => captureScreenshot(element, screenshotScale, opts?.captureOptions),
     opts
   );
 }
@@ -25,12 +29,12 @@ export async function captureAreaWithLoading(
   root: HTMLElement,
   rect: DOMRect,
   screenshotScale?: number,
-  opts?: { allowSkip?: boolean }
+  opts?: { allowSkip?: boolean; captureOptions?: CaptureScreenshotOptions }
 ): Promise<CaptureWithLoadingResult> {
   return capturePromiseWithLoading(
     root,
-    captureAreaScreenshot(rect, screenshotScale),
-    () => captureAreaScreenshot(rect, screenshotScale),
+    captureAreaScreenshot(rect, screenshotScale, opts?.captureOptions),
+    () => captureAreaScreenshot(rect, screenshotScale, opts?.captureOptions),
     opts
   );
 }

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -88,6 +88,7 @@ interface FeedbackData {
   category: FeedbackCategory;
   screenshot: string | null;
   elementSelector: string | null;
+  fullElementSelector: string | null;
   name?: string;
   email?: string;
 }
@@ -821,6 +822,7 @@ async function openFeedbackFlow(
       email: formResult.email,
       screenshot: screenshotResult.screenshot,
       elementSelector: screenshotResult.elementSelector,
+      fullElementSelector: screenshotResult.fullElementSelector,
     });
     break;
   }
@@ -1157,6 +1159,7 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
           },
           timestamp: new Date().toISOString(),
           elementSelector: data.elementSelector,
+          fullElementSelector: data.fullElementSelector,
           domNodeCount,
           fullPageDisabled: isFullPageDisabled(),
           // Parsed system info

--- a/src/widget/picker.ts
+++ b/src/widget/picker.ts
@@ -93,18 +93,21 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
 
   let currentElement: Element | null = null;
 
-  function onMouseMove(e: MouseEvent) {
-    // Get the element under the cursor, ignoring our picker elements
-    const elementsAtPoint = document.elementsFromPoint(e.clientX, e.clientY);
+  function getSelectableElementAtPoint(x: number, y: number): Element | undefined {
+    const elementsAtPoint = document.elementsFromPoint(x, y);
 
-    // Find the first element that's not our picker UI
-    const target = elementsAtPoint.find(el => {
+    return elementsAtPoint.find(el => {
       if (el === highlight || el === tooltip) return false;
       if (el.id === 'bugdrop-element-picker-highlight') return false;
       if (el.id === 'bugdrop-element-picker-tooltip') return false;
       if (el.closest('#bugdrop-host')) return false;
       return true;
     });
+  }
+
+  function onMouseMove(e: MouseEvent) {
+    // Get the element under the cursor, ignoring our picker elements
+    const target = getSelectableElementAtPoint(e.clientX, e.clientY);
 
     if (!target) return;
 
@@ -122,6 +125,7 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
   function onClick(e: MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
+    currentElement = getSelectableElementAtPoint(e.clientX, e.clientY) ?? currentElement;
     cleanup();
     resolve(currentElement);
   }

--- a/src/widget/screenshot.ts
+++ b/src/widget/screenshot.ts
@@ -11,6 +11,16 @@ const TRANSPARENT_IMAGE_PLACEHOLDER =
 export const FULL_PAGE_DISABLE_THRESHOLD = 10_000;
 export const SAFARI_FULL_PAGE_DISABLE_THRESHOLD = DOM_COMPLEXITY_THRESHOLD;
 
+export interface CaptureScreenshotOptions {
+  highlightElement?: Element;
+  highlightStyle?: {
+    accentColor?: string;
+    radius?: string;
+    borderWidth?: string;
+  };
+  pixelRatio?: number;
+}
+
 type DisplayMediaOptionsWithCurrentTab = DisplayMediaStreamOptions & {
   preferCurrentTab?: boolean;
 };
@@ -201,12 +211,18 @@ function withCaptureTimeout<T>(capturePromise: Promise<T>): Promise<T> {
 
 export async function captureScreenshot(
   element?: Element,
-  screenshotScale?: number
+  screenshotScale?: number,
+  captureOptions: CaptureScreenshotOptions = {}
 ): Promise<string> {
   const target = element || document.body;
   const isFullPage = !element;
+  const targetRect = element ? getDocumentRect(element) : getDocumentRect(document.body);
+  const highlightRect =
+    captureOptions.highlightElement && target.contains(captureOptions.highlightElement)
+      ? getDocumentRect(captureOptions.highlightElement)
+      : null;
 
-  const pixelRatio = getPixelRatio(isFullPage, screenshotScale);
+  const pixelRatio = captureOptions.pixelRatio ?? getPixelRatio(isFullPage, screenshotScale);
 
   const toPng = getToPng();
   const opts: HtmlToImageOptions = {
@@ -217,27 +233,40 @@ export async function captureScreenshot(
   };
 
   const redactionPlan = createRedactionPlan(target);
-  let originOffset = { x: 0, y: 0 };
-  if (element) {
-    const r = element.getBoundingClientRect();
-    originOffset = { x: r.left + window.scrollX, y: r.top + window.scrollY };
-  }
+  const originOffset = element ? { x: targetRect.x, y: targetRect.y } : { x: 0, y: 0 };
 
   const capturePromise = toPng(target as HTMLElement, opts);
   const dataUrl = await withCaptureTimeout(capturePromise);
-  return applyMaskToImage(
+  const maskedDataUrl = await applyMaskToImage(
     dataUrl,
     redactionPlan.targets.map(target => target.rect),
     pixelRatio,
     originOffset
   );
+
+  if (!highlightRect) {
+    return maskedDataUrl;
+  }
+
+  return applyHighlightToImage(
+    maskedDataUrl,
+    highlightRect,
+    targetRect,
+    captureOptions.highlightStyle
+  );
 }
 
 export async function captureAreaScreenshot(
   rect: DOMRect,
-  screenshotScale?: number
+  screenshotScale?: number,
+  captureOptions: CaptureScreenshotOptions = {}
 ): Promise<string> {
-  const pixelRatio = getPixelRatio(true, screenshotScale);
+  const pixelRatio = captureOptions.pixelRatio ?? getPixelRatio(true, screenshotScale);
+  const targetRect = { x: rect.x, y: rect.y, w: rect.width, h: rect.height };
+  const highlightRect =
+    captureOptions.highlightElement && document.body.contains(captureOptions.highlightElement)
+      ? getDocumentRect(captureOptions.highlightElement)
+      : null;
   const toPng = getToPng();
   const opts: HtmlToImageOptions = {
     cacheBust: false,
@@ -256,7 +285,7 @@ export async function captureAreaScreenshot(
 
   const dataUrl = await withCaptureTimeout(toPng(document.body, opts));
   const redactionPlan = createRedactionPlan(document.body);
-  return applyMaskToImage(
+  const maskedDataUrl = await applyMaskToImage(
     dataUrl,
     redactionPlan.targets.map(target => target.rect),
     pixelRatio,
@@ -264,6 +293,17 @@ export async function captureAreaScreenshot(
       x: rect.x,
       y: rect.y,
     }
+  );
+
+  if (!highlightRect) {
+    return maskedDataUrl;
+  }
+
+  return applyHighlightToImage(
+    maskedDataUrl,
+    highlightRect,
+    targetRect,
+    captureOptions.highlightStyle
   );
 }
 
@@ -279,6 +319,132 @@ function getToPng(): typeof htmlToImage.toPng {
     return window.__bugdropMockToPng;
   }
   return htmlToImage.toPng;
+}
+
+async function applyHighlightToImage(
+  dataUrl: string,
+  rect: { x: number; y: number; w: number; h: number },
+  targetRect: { x: number; y: number; w: number; h: number },
+  style: CaptureScreenshotOptions['highlightStyle'] = {}
+): Promise<string> {
+  if (rect.w <= 0 || rect.h <= 0) return dataUrl;
+
+  const img = await loadImage(dataUrl);
+  const canvas = document.createElement('canvas');
+  canvas.width = img.naturalWidth || img.width;
+  canvas.height = img.naturalHeight || img.height;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Failed to get canvas context for selected element highlight');
+  }
+
+  ctx.drawImage(img, 0, 0);
+
+  const scaleX = canvas.width / Math.max(1, targetRect.w);
+  const scaleY = canvas.height / Math.max(1, targetRect.h);
+  const averageScale = Math.max(1, (scaleX + scaleY) / 2);
+  const padding = 2 * averageScale;
+  const x = Math.max(0, Math.round((rect.x - targetRect.x) * scaleX - padding));
+  const y = Math.max(0, Math.round((rect.y - targetRect.y) * scaleY - padding));
+  const w = Math.min(canvas.width - x, Math.round(rect.w * scaleX + padding * 2));
+  const h = Math.min(canvas.height - y, Math.round(rect.h * scaleY + padding * 2));
+  const borderWidth = getHighlightBorderWidth(style.borderWidth, averageScale);
+  const radius = getHighlightRadius(style.radius, averageScale);
+  const accent = style.accentColor || '#14b8a6';
+
+  drawRoundedRect(ctx, x, y, w, h, radius);
+  ctx.fillStyle = colorMixWithTransparency(accent, 0.18);
+  ctx.fill();
+
+  ctx.lineWidth = Math.max(2, borderWidth + Math.round(4 * averageScale));
+  ctx.strokeStyle = colorMixWithTransparency(accent, 0.3);
+  ctx.stroke();
+
+  drawRoundedRect(ctx, x, y, w, h, radius);
+  ctx.lineWidth = borderWidth;
+  ctx.strokeStyle = accent;
+  ctx.stroke();
+
+  return canvas.toDataURL('image/png');
+}
+
+function drawRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  radius: number
+): void {
+  const r = Math.max(0, Math.min(radius, w / 2, h / 2));
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function getHighlightBorderWidth(borderWidth: string | undefined, pixelRatio: number): number {
+  const parsed = Number.parseFloat(borderWidth || '3');
+  return Math.max(1, Math.round((Number.isFinite(parsed) ? parsed : 3) * pixelRatio));
+}
+
+function getHighlightRadius(radius: string | undefined, pixelRatio: number): number {
+  const parsed = Number.parseFloat(radius || '6');
+  return Math.max(0, Math.round((Number.isFinite(parsed) ? parsed : 6) * pixelRatio));
+}
+
+function colorMixWithTransparency(color: string, alpha: number): string {
+  const fallback = `rgba(20, 184, 166, ${alpha})`;
+  const hexMatch = color.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (!hexMatch) {
+    const rgbMatch = color.match(
+      /^rgba?\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)(?:\s*,\s*\d+(?:\.\d+)?)?\s*\)$/i
+    );
+    if (!rgbMatch) return fallback;
+
+    const [, r, g, b] = rgbMatch;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  const hex = hexMatch[1];
+  const fullHex =
+    hex.length === 3
+      ? hex
+          .split('')
+          .map(char => `${char}${char}`)
+          .join('')
+      : hex;
+  const r = Number.parseInt(fullHex.slice(0, 2), 16);
+  const g = Number.parseInt(fullHex.slice(2, 4), 16);
+  const b = Number.parseInt(fullHex.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function getDocumentRect(element: Element): { x: number; y: number; w: number; h: number } {
+  const rect = element.getBoundingClientRect();
+  return {
+    x: rect.left + window.scrollX,
+    y: rect.top + window.scrollY,
+    w: rect.width,
+    h: rect.height,
+  };
+}
+
+function loadImage(dataUrl: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to load image for selected element highlight'));
+    img.src = dataUrl;
+  });
 }
 
 export async function cropScreenshot(

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1217,6 +1217,7 @@ describe('API Routes', () => {
         metadata: {
           ...validPayload.metadata,
           elementSelector: '#submit-button',
+          fullElementSelector: 'html > body > main > form#contact > button#submit-button',
         },
       };
 
@@ -1234,6 +1235,8 @@ describe('API Routes', () => {
       expect(issueBody).toContain('http://localhost:3000');
       expect(issueBody).toContain('1920×1080');
       expect(issueBody).toContain('#submit-button');
+      expect(issueBody).toContain('Full CSS path');
+      expect(issueBody).toContain('html > body > main > form#contact > button#submit-button');
       expect(issueBody).toContain('Submitted via');
     });
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1067,6 +1067,39 @@ describe('API Routes', () => {
       );
     });
 
+    it('should add a selected-element screenshot caption when an element was chosen', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      const uploadedUrl =
+        'https://raw.githubusercontent.com/testowner/testrepo/main/.feedback/screenshots/selected.png';
+      mockUploadScreenshotAsAsset.mockResolvedValue(uploadedUrl);
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const payloadWithSelectedElement = {
+        ...validPayload,
+        screenshot: validPngDataUrl,
+        metadata: {
+          ...validPayload.metadata,
+          elementSelector: '#book-now',
+        },
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payloadWithSelectedElement),
+      });
+      await app.fetch(req, mockEnv);
+
+      const issueBody = mockCreateIssue.mock.calls[0][4];
+      expect(issueBody).toContain(`![Screenshot](${uploadedUrl})`);
+      expect(issueBody).toContain(
+        '_Selected element is indicated by the blue rounded highlight box._'
+      );
+    });
+
     it('should use screenshot when provided (annotations handled client-side)', async () => {
       mockGetInstallationToken.mockResolvedValue('test-token');
       const uploadedUrl =

--- a/test/captureFlow.test.ts
+++ b/test/captureFlow.test.ts
@@ -43,6 +43,7 @@ async function loadCaptureFlowWithMocks(opts: {
 }
 
 afterEach(() => {
+  document.body.innerHTML = '';
   vi.doUnmock('../src/widget/screenshot-options');
   vi.doUnmock('../src/widget/picker');
   vi.doUnmock('../src/widget/area-picker');
@@ -79,7 +80,12 @@ describe('capture flow state decisions', () => {
       onComplexScreenshotSkipped
     );
 
-    expect(result).toEqual({ screenshot: null, elementSelector: null, returnToForm: false });
+    expect(result).toEqual({
+      screenshot: null,
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: false,
+    });
     expect(onComplexScreenshotSkipped).toHaveBeenCalledTimes(1);
   });
 
@@ -97,14 +103,37 @@ describe('capture flow state decisions', () => {
       onComplexScreenshotSkipped
     );
 
-    expect(result).toEqual({ screenshot: null, elementSelector: null, returnToForm: false });
+    expect(result).toEqual({
+      screenshot: null,
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: false,
+    });
     expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
   });
 
   it('keeps selected element metadata when element capture is skipped after failure', async () => {
-    const element = document.createElement('button');
-    element.id = 'target-button';
-    document.body.appendChild(element);
+    document.body.innerHTML = `
+      <div class="injected-before-page"></div>
+      <div class="another-injected-wrapper"></div>
+      <div id="page" class="site">
+        <div id="content" class="site-content">
+          <div id="primary" class="content-area">
+            <main id="main" class="site-main">
+              <article id="post-27" class="post-27 page">
+                <div class="inside-article">
+                  <div class="entry-content">
+                    <div class="gb-container gb-container-f0cc8c05"></div>
+                    <div class="gb-container gb-container-928af62b"></div>
+                  </div>
+                </div>
+              </article>
+            </main>
+          </div>
+        </div>
+      </div>
+    `;
+    const element = document.querySelector('.gb-container-928af62b')!;
     const { runScreenshotCaptureFlow } = await loadCaptureFlowWithMocks({
       screenshotChoice: { kind: 'element' },
       pickedElement: element,
@@ -121,9 +150,13 @@ describe('capture flow state decisions', () => {
 
     expect(result).toEqual({
       screenshot: null,
-      elementSelector: '#target-button',
+      elementSelector:
+        '#post-27 > div.inside-article > div.entry-content > div.gb-container.gb-container-928af62b',
+      fullElementSelector:
+        'html > body > div#page.site > div#content.site-content > div#primary.content-area > main#main.site-main > article#post-27.post-27.page > div.inside-article > div.entry-content > div.gb-container.gb-container-928af62b:nth-of-type(2)',
       returnToForm: false,
     });
+    expect(document.querySelector(result.fullElementSelector!)).toBe(element);
     expect(onComplexScreenshotSkipped).toHaveBeenCalledTimes(1);
   });
 
@@ -140,7 +173,12 @@ describe('capture flow state decisions', () => {
       onComplexScreenshotSkipped
     );
 
-    expect(result).toEqual({ screenshot: null, elementSelector: null, returnToForm: true });
+    expect(result).toEqual({
+      screenshot: null,
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: true,
+    });
     expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
   });
 
@@ -158,7 +196,12 @@ describe('capture flow state decisions', () => {
       onComplexScreenshotSkipped
     );
 
-    expect(result).toEqual({ screenshot: null, elementSelector: null, returnToForm: true });
+    expect(result).toEqual({
+      screenshot: null,
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: true,
+    });
     expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
   });
 
@@ -177,7 +220,12 @@ describe('capture flow state decisions', () => {
       onComplexScreenshotSkipped
     );
 
-    expect(result).toEqual({ screenshot: null, elementSelector: null, returnToForm: true });
+    expect(result).toEqual({
+      screenshot: null,
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: true,
+    });
     expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
   });
 

--- a/test/captureFlow.test.ts
+++ b/test/captureFlow.test.ts
@@ -16,6 +16,12 @@ async function loadCaptureFlowWithMocks(opts: {
   annotationResult?: string | 'retake' | 'cancel';
 }) {
   vi.resetModules();
+  const captureWithLoadingMock = vi
+    .fn()
+    .mockResolvedValue(opts.captureResult ?? { kind: 'skipped' });
+  const captureAreaWithLoadingMock = vi
+    .fn()
+    .mockResolvedValue(opts.captureResult ?? { kind: 'skipped' });
   vi.doMock('../src/widget/screenshot-options', () => ({
     showScreenshotOptions: vi.fn().mockResolvedValue(opts.screenshotChoice),
   }));
@@ -26,8 +32,8 @@ async function loadCaptureFlowWithMocks(opts: {
     createAreaPicker: vi.fn(),
   }));
   vi.doMock('../src/widget/capture-loading', () => ({
-    captureWithLoading: vi.fn().mockResolvedValue(opts.captureResult ?? { kind: 'skipped' }),
-    captureAreaWithLoading: vi.fn(),
+    captureWithLoading: captureWithLoadingMock,
+    captureAreaWithLoading: captureAreaWithLoadingMock,
     capturePromiseWithLoading: vi.fn().mockResolvedValue(opts.captureResult ?? { kind: 'skipped' }),
   }));
   vi.doMock('../src/widget/annotation-flow', () => ({
@@ -39,7 +45,11 @@ async function loadCaptureFlowWithMocks(opts: {
     isFullPageDisabled: vi.fn().mockReturnValue(false),
   }));
 
-  return import('../src/widget/capture-flow');
+  return {
+    ...(await import('../src/widget/capture-flow')),
+    captureWithLoadingMock,
+    captureAreaWithLoadingMock,
+  };
 }
 
 afterEach(() => {
@@ -158,6 +168,133 @@ describe('capture flow state decisions', () => {
     });
     expect(document.querySelector(result.fullElementSelector!)).toBe(element);
     expect(onComplexScreenshotSkipped).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures a surrounding container and highlights the selected element', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1200, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true });
+
+    const outerContext = document.createElement('article');
+    outerContext.className = 'listing-card';
+    outerContext.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 900,
+        bottom: 900,
+        width: 900,
+        height: 900,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const context = document.createElement('section');
+    context.className = 'field-group';
+    context.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 500,
+        bottom: 300,
+        width: 500,
+        height: 300,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const target = document.createElement('button');
+    target.id = 'book-now';
+    target.getBoundingClientRect = () =>
+      ({
+        x: 100,
+        y: 100,
+        top: 100,
+        left: 100,
+        right: 180,
+        bottom: 140,
+        width: 80,
+        height: 40,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+    context.appendChild(target);
+    outerContext.appendChild(context);
+    document.body.appendChild(outerContext);
+
+    const { runScreenshotCaptureFlow, captureWithLoadingMock } = await loadCaptureFlowWithMocks({
+      screenshotChoice: { kind: 'element' },
+      pickedElement: target,
+      captureResult: { kind: 'skipped' },
+    });
+    const root = document.createElement('div');
+
+    await runScreenshotCaptureFlow(root, baseConfig, true, vi.fn());
+
+    expect(captureWithLoadingMock).toHaveBeenCalledWith(root, outerContext, undefined, {
+      allowSkip: true,
+      captureOptions: {
+        highlightElement: target,
+        highlightStyle: {
+          accentColor: undefined,
+          borderWidth: undefined,
+          radius: undefined,
+        },
+        pixelRatio: 1,
+      },
+    });
+  });
+
+  it('passes the selected element when no larger fallback container is useful', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1200, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true });
+
+    const target = document.createElement('button');
+    target.id = 'book-now';
+    target.getBoundingClientRect = () =>
+      ({
+        x: 100,
+        y: 100,
+        top: 100,
+        left: 100,
+        right: 180,
+        bottom: 140,
+        width: 80,
+        height: 40,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    document.body.appendChild(target);
+
+    const { runScreenshotCaptureFlow, captureWithLoadingMock } = await loadCaptureFlowWithMocks({
+      screenshotChoice: { kind: 'element' },
+      pickedElement: target,
+      captureResult: { kind: 'skipped' },
+    });
+    const root = document.createElement('div');
+
+    await runScreenshotCaptureFlow(root, baseConfig, true, vi.fn());
+
+    expect(captureWithLoadingMock).toHaveBeenCalledWith(root, target, undefined, {
+      allowSkip: true,
+      captureOptions: {
+        highlightElement: target,
+        highlightStyle: {
+          accentColor: undefined,
+          borderWidth: undefined,
+          radius: undefined,
+        },
+        pixelRatio: 1,
+      },
+    });
   });
 
   it('returns to form when the user dismisses the screenshot options modal', async () => {

--- a/test/cropScreenshot.test.ts
+++ b/test/cropScreenshot.test.ts
@@ -239,10 +239,10 @@ describe('captureScreenshot integrates with mask pipeline', () => {
     (window as unknown as { Image: unknown }).Image = class FakeImage {
       onload: (() => void) | null = null;
       onerror: (() => void) | null = null;
-      naturalWidth = 1;
-      naturalHeight = 1;
-      width = 1;
-      height = 1;
+      naturalWidth = 800;
+      naturalHeight = 600;
+      width = 800;
+      height = 600;
       set src(_: string) {
         // Fire onload asynchronously so callers can set it first.
         Promise.resolve().then(() => this.onload?.());
@@ -251,9 +251,19 @@ describe('captureScreenshot integrates with mask pipeline', () => {
 
     // jsdom does not implement canvas 2D context; stub it to avoid "Failed to get canvas context".
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      beginPath: vi.fn(),
+      closePath: vi.fn(),
       drawImage: vi.fn(),
       fillRect: vi.fn(),
+      fill: vi.fn(),
+      lineTo: vi.fn(),
+      moveTo: vi.fn(),
+      quadraticCurveTo: vi.fn(),
+      stroke: vi.fn(),
+      strokeRect: vi.fn(),
       fillStyle: '',
+      lineWidth: 0,
+      strokeStyle: '',
     } as unknown as CanvasRenderingContext2D);
     vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(
       'data:image/png;base64,masked'
@@ -320,5 +330,71 @@ describe('captureScreenshot integrates with mask pipeline', () => {
 
     // applyMaskToImage must have run: only it produces the masked sentinel.
     await expect(captureScreenshot(target)).resolves.toBe('data:image/png;base64,masked');
+  });
+
+  it('captures a context element and draws a selected descendant highlight', async () => {
+    const context = document.createElement('section');
+    context.getBoundingClientRect = () =>
+      ({
+        x: 20,
+        y: 30,
+        width: 400,
+        height: 300,
+        top: 30,
+        left: 20,
+        bottom: 330,
+        right: 420,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const selected = document.createElement('button');
+    selected.getBoundingClientRect = () =>
+      ({
+        x: 120,
+        y: 90,
+        width: 80,
+        height: 40,
+        top: 90,
+        left: 120,
+        bottom: 130,
+        right: 200,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    context.appendChild(selected);
+    document.body.appendChild(context);
+
+    const STUB =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+    const toPng = vi.fn(() => Promise.resolve(STUB));
+    (window as unknown as { __bugdropMockToPng: typeof toPng }).__bugdropMockToPng = toPng;
+
+    const strokeRect = vi.fn();
+    vi.mocked(HTMLCanvasElement.prototype.getContext).mockReturnValue({
+      beginPath: vi.fn(),
+      closePath: vi.fn(),
+      drawImage: vi.fn(),
+      fillRect: vi.fn(),
+      fill: vi.fn(),
+      lineTo: vi.fn(),
+      moveTo: vi.fn(),
+      quadraticCurveTo: vi.fn(),
+      stroke: vi.fn(),
+      strokeRect,
+      fillStyle: '',
+      lineWidth: 0,
+      strokeStyle: '',
+    } as unknown as CanvasRenderingContext2D);
+
+    await expect(
+      captureScreenshot(context, undefined, { highlightElement: selected })
+    ).resolves.toBe('data:image/png;base64,masked');
+
+    expect(toPng).toHaveBeenCalledWith(context, expect.any(Object));
+    expect(strokeRect).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #172

Depends on #171.

## What changed
Select Element screenshots now capture a nearby surrounding container instead of cropping down to only the clicked element, then draw a rounded blue highlight around the selected element and explain that highlight under the uploaded screenshot.

## Why this shape (and not the obvious alternative)
The most tempting fix was to capture the whole visible viewport and highlight the chosen element inside it. That gives the most visual context, but on complex pages it can force html-to-image to walk and clone much more of the page than needed, which is exactly the path that has caused slow or failed captures before. A bounded ancestor keeps the useful context while avoiding the expensive viewport/full-page render path.

The highlight is drawn after capture rather than relying on the live picker overlay being included in the screenshot. The picker overlay exists outside the page content and is intentionally filtered out of captures; baking the highlight into the resulting image makes the evidence self-contained for humans and AI tools reading the GitHub issue later.

Element context captures are capped at 1x scale. That accepts a lower-resolution context image in exchange for much smaller uploads, which matters because these screenshots can include several cards or panels instead of a single button.

## What this enables / forecloses
This makes Select Element useful for AI-assisted triage: the issue now contains selector metadata, the surrounding visual context, and an explicit note that the blue rounded box marks the selected element.

## Risks we're accepting
The surrounding container is selected heuristically from the element's ancestors, capped by viewport area. Some pages may still pick a container that is broader or narrower than ideal, but the fallback stays bounded so Select Element does not regress into the slow full-page capture path.

---

## Test plan
- [x] `NODE_OPTIONS=--no-experimental-webstorage npm run validate` passed. ESLint reported existing file-length warnings for `src/widget/capture-flow.ts` and `src/widget/screenshot.ts`, but no errors.
- [x] `BUGDROP_TEST_HOOKS=1 npm run build:widget` passed.
- [x] `NODE_OPTIONS=--no-experimental-webstorage npx playwright test e2e/widget.spec.ts --project=chromium --grep "element capture uses a surrounding context target|real element capture|remembers complex-page skip after element capture failure skip"` passed after stopping a stale local `wrangler dev` process that was reusing port 8787.
- [x] `npm run build:widget` passed for the final non-test widget build.

---
