### PR TITLE
Remove private issue fixture URL

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2596,7 +2596,7 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
   }
 
   async function submitWithIssueResponse(page: Page, path: string, isPublic: boolean) {
-    const issueUrl = 'https://github.com/TheWebEng/ctle-theme/issues/496';
+    const issueUrl = 'https://github.com/example/project/issues/496';
 
     await page.route('**/feedback', async route => {
       await route.fulfill({


### PR DESCRIPTION
## What changed
Replaces a private customer/repository issue URL used in an E2E fixture with a neutral `github.com/example/project` URL.

## Why this shape
The test only needs a stable GitHub-looking issue URL to verify issue-link visibility behavior. A neutral example URL preserves the assertion without leaking customer or deployment-specific context into the public repository.

---

## Test plan
- [x] `NODE_OPTIONS=--no-experimental-webstorage npx vitest run test/api.test.ts` passed.

---
