### PR TITLE
Improve Select Element screenshots with visual context

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,16 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
 
 ## Widget Options
 
-| Attribute              | Values                                               | Default          |
-| ---------------------- | ---------------------------------------------------- | ---------------- |
-| `data-repo`            | `owner/repo`                                         | **required**     |
-| `data-theme`           | `light`, `dark`, `auto`                              | `auto`           |
-| `data-position`        | `bottom-right`, `bottom-left`                        | `bottom-right`   |
-| `data-color`           | Accent color for buttons/highlights (e.g. `#FF6B35`) | `#14b8a6` (teal) |
-| `data-label`           | Any string                                           | `Feedback`       |
-| `data-category-labels` | JSON mapping for self-hosted category labels         | built-in labels  |
-| `data-button`          | `true`, `false`                                      | `true`           |
+| Attribute                       | Values                                               | Default          |
+| ------------------------------- | ---------------------------------------------------- | ---------------- |
+| `data-repo`                     | `owner/repo`                                         | **required**     |
+| `data-theme`                    | `light`, `dark`, `auto`                              | `auto`           |
+| `data-position`                 | `bottom-right`, `bottom-left`                        | `bottom-right`   |
+| `data-color`                    | Accent color for buttons/highlights (e.g. `#FF6B35`) | `#14b8a6` (teal) |
+| `data-label`                    | Any string                                           | `Feedback`       |
+| `data-category-labels`          | JSON mapping for self-hosted category labels         | built-in labels  |
+| `data-button`                   | `true`, `false`                                      | `true`           |
+| `data-element-context-max-area` | Viewport-area multiplier for Select Element context  | `0`              |
 
 See [full documentation](https://bugdrop.dev/docs/configuration) for all options including styling, submitter info, and dismissible button.
 

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -9,11 +9,11 @@ These attributes control the fundamental behavior of the widget.
 | Attribute | Default | Description |
 |-----------|---------|-------------|
 | `data-repo` | **(required)** | GitHub repository in `owner/repo` format |
-| `data-theme` | `"light"` | Widget theme: `"light"` or `"dark"` |
+| `data-theme` | `"auto"` | Widget theme: `"light"`, `"dark"`, or `"auto"` |
 | `data-position` | `"bottom-right"` | Button position: `"bottom-right"` or `"bottom-left"` |
-| `data-color` | `"#7c3aed"` | Primary accent color (any CSS color value) |
+| `data-color` | `"#14b8a6"` | Primary accent color (any CSS color value) |
 | `data-icon` | *(default bug icon)* | Custom icon: URL to an image, `"none"` to hide, or omit for default |
-| `data-label` | `""` | Text label displayed next to the button icon |
+| `data-label` | `"Feedback"` | Text label displayed next to the button icon |
 | `data-category-labels` | built-in labels | Self-hosted JSON mapping from built-in categories to GitHub labels |
 | `data-button` | `"true"` | Show the floating button: `"true"` or `"false"` |
 | `data-welcome` | `"Report a bug or request a feature"` | Welcome message displayed at the top of the form |
@@ -36,11 +36,16 @@ These attributes control the fundamental behavior of the widget.
 
 The `data-theme` attribute controls the overall color scheme of the widget:
 
-- **`light`** (default) -- White background with dark text. Suitable for most sites.
+- **`auto`** (default) -- Follows the user's system color scheme.
+- **`light`** -- White background with dark text. Suitable for most sites.
 - **`dark`** -- Dark background with light text. Ideal for sites with dark color schemes.
 
 ```html
-<!-- Light theme (default) -->
+<!-- Auto theme (default) -->
+<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="owner/repo" data-theme="auto"></script>
+
+<!-- Light theme -->
 <script src="https://bugdrop.neonwatty.workers.dev/widget.js"
   data-repo="owner/repo" data-theme="light"></script>
 
@@ -231,6 +236,7 @@ Control how screenshots are collected during the feedback flow.
 |-----------|---------|-------------|
 | `data-screenshot` | `"optional"` | Screenshot mode: `"optional"`, `"auto"`, or `"required"` |
 | `data-screenshot-scale` | `"2"` | Minimum pixel ratio for screenshot captures |
+| `data-element-context-max-area` | `"0"` | Maximum surrounding container size for Select Element captures, expressed as a multiple of the visible viewport area |
 
 ### Screenshot Modes
 
@@ -239,6 +245,35 @@ Control how screenshots are collected during the feedback flow.
 - **`required`** -- Requires a screenshot before submission. Users can choose full page, element, or area, then annotate or redact before submitting.
 
 Manual redaction is controlled by the person submitting feedback. Use developer-configured masking for fields that should be visually covered in supported screenshot modes, especially with automatic screenshots. Auto mode warns users that a full-page screenshot will be attached, but it does not show the manual picker or annotation review step.
+
+### Select Element screenshots
+
+When a user chooses **Select Element**, BugDrop captures the selected element and draws a rounded border around it. The border is drawn with a small 2px inner gap so it does not sit directly on top of the selected element. This keeps the default behavior tight and predictable.
+
+The highlight uses the same styling controls as the widget:
+
+- `data-color` controls the highlight color.
+- `data-radius` controls the rounded corners.
+- `data-border-width` controls the highlight border thickness.
+
+GitHub issues include a screenshot caption that identifies the selected element border and includes the exact resolved highlight color.
+
+The amount of surrounding context is controlled by one attribute:
+
+```html
+<script
+  src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="owner/repo"
+  data-element-context-max-area="1.5"
+></script>
+```
+
+- Omit `data-element-context-max-area`, or set it to `"0"`, to capture only the selected element.
+- Increase `data-element-context-max-area` to allow larger surrounding containers. This can provide more context for triage and AI-assisted review, but may create larger images and slower captures.
+
+Select Element captures are capped at 1x pixel ratio even when `data-screenshot-scale` is higher. This keeps context screenshots small enough for practical issue uploads.
+
+The screenshot review step also links to this configuration section when a Select Element screenshot is being reviewed, so teams can discover the context setting during testing.
 
 ### Developer-configured screenshot masking
 

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -258,6 +258,8 @@ The highlight uses the same styling controls as the widget:
 
 GitHub issues include a screenshot caption that identifies the selected element border and includes the exact resolved highlight color.
 
+Selected-element reports also include CSS selector metadata for the chosen element, including a full CSS path. Avoid putting secrets, customer identifiers, or other private data in DOM IDs or class names if issue visibility is broader than your internal team.
+
 The amount of surrounding context is controlled by one attribute:
 
 ```html

--- a/docs/website/styling.mdx
+++ b/docs/website/styling.mdx
@@ -16,6 +16,8 @@ All styling is done through data attributes on the script tag. No CSS files to i
 | `data-border-color` | Theme-dependent | Border color of the form container |
 | `data-shadow` | `"0 8px 30px rgba(0,0,0,0.12)"` | Box shadow of the form container |
 
+These same visual settings are also used by Select Element screenshots. When a user selects an element, BugDrop draws a border-only rounded highlight around that element using `data-color`, `data-radius`, and `data-border-width`. The captured highlight includes a small 2px inner gap so the border does not sit directly on top of the selected element. The GitHub issue caption mentions the exact resolved highlight color.
+
 ### Defaults by Theme
 
 The `data-theme` attribute sets sensible defaults for colors, which you can then override individually:

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -1,6 +1,7 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { test, expect, type Page } from '@playwright/test';
+import { DEFAULT_ACCENT_COLOR } from '../src/defaults';
 
 type CaptureOptions = Record<string, unknown> & {
   pixelRatio?: number;
@@ -14,6 +15,13 @@ declare global {
   interface Window {
     __hostKeystrokeCount?: number;
     __captureOpts?: CaptureOptions;
+    __captureTargetInfo?: {
+      tagName: string;
+      id: string;
+      className: string;
+      width: number;
+      height: number;
+    };
   }
 }
 
@@ -2354,6 +2362,21 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     }`;
   }
 
+  function targetSpyToPng() {
+    return `function(el, opts) {
+      window.__captureOpts = opts;
+      var rect = el.getBoundingClientRect();
+      window.__captureTargetInfo = {
+        tagName: el.tagName,
+        id: el.id || '',
+        className: typeof el.className === 'string' ? el.className : '',
+        width: rect.width,
+        height: rect.height
+      };
+      return Promise.resolve('${STUB_PNG}');
+    }`;
+  }
+
   function redactionAwarePng() {
     return `function(el, opts) {
       window.__captureOpts = opts;
@@ -2581,7 +2604,7 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
       await route.fulfill({
         status: 200,
         contentType: 'image/svg+xml',
-        body: '<svg xmlns="http://www.w3.org/2000/svg" width="180" height="44"><rect width="180" height="44" fill="#14b8a6"/><text x="16" y="28" fill="white" font-size="16">No CORS Badge</text></svg>',
+        body: `<svg xmlns="http://www.w3.org/2000/svg" width="180" height="44"><rect width="180" height="44" fill="${DEFAULT_ACCENT_COLOR}"/><text x="16" y="28" fill="white" font-size="16">No CORS Badge</text></svg>`,
       });
     });
 
@@ -3004,6 +3027,72 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
 
     const timeoutRejections = rejections.filter(m => m.includes('timed out'));
     expect(timeoutRejections).toHaveLength(0);
+  });
+
+  test('element capture uses a surrounding context target', async ({ page }) => {
+    await mockHtmlToImage(page, targetSpyToPng());
+    await page.goto('/test/annotation-style.html?elementContextMaxArea=1.5');
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="element"]').click();
+    await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
+
+    const selected = page.locator('.dot.green');
+    await expect(selected).toBeVisible();
+    const selectedBox = await selected.boundingBox();
+    expect(selectedBox).toBeTruthy();
+
+    await page.mouse.click(
+      selectedBox!.x + selectedBox!.width / 2,
+      selectedBox!.y + selectedBox!.height / 2
+    );
+
+    await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+
+    const targetInfo = await page.evaluate(() => window.__captureTargetInfo);
+    expect(targetInfo).toBeDefined();
+    if (!targetInfo) throw new Error('Missing capture target info');
+    expect(targetInfo.className).not.toContain('dot');
+    expect(targetInfo.width).toBeGreaterThan(selectedBox!.width * 4);
+    expect(targetInfo.height).toBeGreaterThan(selectedBox!.height * 4);
+
+    const captureOpts = await page.evaluate(() => window.__captureOpts);
+    expect(captureOpts?.pixelRatio).toBe(1);
+
+    const selectedElementNote = host.locator('css=.bd-selected-element-note');
+    await expect(selectedElementNote).toContainText('data-element-context-max-area');
+    await expect(selectedElementNote.locator('css=a')).toHaveAttribute(
+      'href',
+      'https://bugdrop.dev/docs/configuration#select-element-screenshots'
+    );
+  });
+
+  test('element context max-area setting can keep captures tightly scoped', async ({ page }) => {
+    await mockHtmlToImage(page, targetSpyToPng());
+    await page.goto('/test/annotation-style.html?elementContextMaxArea=0');
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="element"]').click();
+    await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
+
+    const selected = page.locator('.dot.green');
+    await expect(selected).toBeVisible();
+    const selectedBox = await selected.boundingBox();
+    expect(selectedBox).toBeTruthy();
+
+    await page.mouse.click(
+      selectedBox!.x + selectedBox!.width / 2,
+      selectedBox!.y + selectedBox!.height / 2
+    );
+
+    await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+
+    const targetInfo = await page.evaluate(() => window.__captureTargetInfo);
+    expect(targetInfo).toBeDefined();
+    if (!targetInfo) throw new Error('Missing capture target info');
+    expect(targetInfo.className).toContain('dot');
+    expect(targetInfo.width).toBeLessThanOrEqual(selectedBox!.width + 1);
+    expect(targetInfo.height).toBeLessThanOrEqual(selectedBox!.height + 1);
   });
 
   test('shows error modal when capture times out', async ({ page }) => {
@@ -3566,7 +3655,12 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     await host.locator('css=[data-action="skip"]').click();
     await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 5000 });
     expect(payloads).toHaveLength(1);
-    expect((payloads[0].metadata as { elementSelector?: string }).elementSelector).toContain('h1');
+    const metadata = payloads[0].metadata as {
+      elementSelector?: string;
+      selectedElementHighlightColor?: string;
+    };
+    expect(metadata.elementSelector).toContain('h1');
+    expect(metadata.selectedElementHighlightColor).toBe(DEFAULT_ACCENT_COLOR);
 
     await host.locator('css=.bd-close').click();
     await host.locator('css=.bd-trigger').click();

--- a/knip.json
+++ b/knip.json
@@ -3,5 +3,6 @@
   "entry": ["src/index.ts", "src/widget/index.ts", "scripts/build-widget.js"],
   "project": ["src/**/*.ts", "scripts/**/*.js"],
   "ignore": [],
-  "ignoreDependencies": ["esbuild"]
+  "ignoreBinaries": ["semantic-release"],
+  "ignoreDependencies": ["esbuild", "semantic-release"]
 }

--- a/public/test/annotation-style.html
+++ b/public/test/annotation-style.html
@@ -131,6 +131,9 @@
           theme: 'dark',
           color: '#ff9e64',
         },
+        queryDataset: {
+          elementContextMaxArea: 'elementContextMaxArea',
+        },
       });
     </script>
   </body>

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,0 +1,16 @@
+export const DEFAULT_ACCENT_COLOR = '#14b8a6';
+export const DEFAULT_SELECTED_ELEMENT_CONTEXT_MAX_VIEWPORT_AREA_MULTIPLIER = 0;
+export const DEFAULT_SELECTED_ELEMENT_CONTEXT_MIN_PADDING_PX = 80;
+export const DEFAULT_SELECTED_ELEMENT_SCREENSHOT_PIXEL_RATIO = 1;
+
+export function resolveAccentColor(accentColor?: string | null): string {
+  return accentColor || DEFAULT_ACCENT_COLOR;
+}
+
+export function getAccentHoverColor(accentColor: string): string {
+  return `color-mix(in srgb, ${accentColor} 85%, black)`;
+}
+
+export function resolveSelectedElementContextMaxArea(value?: number | null): number {
+  return value ?? DEFAULT_SELECTED_ELEMENT_CONTEXT_MAX_VIEWPORT_AREA_MULTIPLIER;
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -9,6 +9,7 @@ import {
   GitHubLabelError,
 } from '../lib/github';
 import { rateLimit, rateLimitByRepo } from '../middleware/rateLimit';
+import { resolveAccentColor } from '../defaults';
 
 const api = new Hono<{ Bindings: Env }>();
 
@@ -549,6 +550,12 @@ function formatIssueBody(
   if (screenshotDataUrl) {
     sections.push('## Screenshot');
     sections.push(`![Screenshot](${screenshotDataUrl})`);
+    if (payload.metadata.elementSelector) {
+      sections.push('');
+      sections.push(
+        `_Selected element is indicated by the rounded highlight border (${getSelectedElementHighlightColor(payload)})._`
+      );
+    }
     sections.push('');
   }
 
@@ -608,6 +615,12 @@ function formatIssueBody(
   sections.push('*Submitted via [BugDrop](https://github.com/mean-weasel/bugdrop)*');
 
   return sections.join('\n');
+}
+
+function getSelectedElementHighlightColor(payload: FeedbackPayload): string {
+  const color = payload.metadata.selectedElementHighlightColor;
+  if (!color || hasControlChars(color)) return resolveAccentColor();
+  return safeInlineCode(color.trim()) || resolveAccentColor();
 }
 
 export default api;

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -553,7 +553,7 @@ function formatIssueBody(
     if (payload.metadata.elementSelector) {
       sections.push('');
       sections.push(
-        `_Selected element is indicated by the rounded highlight border (${getSelectedElementHighlightColor(payload)})._`
+        `_Selected element is indicated by the rounded highlight border (${formatMarkdownInlineCode(getSelectedElementHighlightColor(payload))})._`
       );
     }
     sections.push('');
@@ -626,11 +626,11 @@ function formatIssueBody(
 function getSelectedElementHighlightColor(payload: FeedbackPayload): string {
   const color = payload.metadata.selectedElementHighlightColor;
   if (!color || hasControlChars(color)) return resolveAccentColor();
-  return safeInlineCode(color.trim()) || resolveAccentColor();
+  return normalizeMarkdownValue(color) || resolveAccentColor();
 }
 
 function formatMarkdownTableCode(value: string): string {
-  const tableSafeValue = value.replace(/\|/g, '\\|');
+  const tableSafeValue = normalizeMarkdownValue(value).replace(/\|/g, '\\|');
   if (!tableSafeValue.includes('`')) {
     return `\`${tableSafeValue}\``;
   }
@@ -638,6 +638,38 @@ function formatMarkdownTableCode(value: string): string {
   const longestBacktickRun = Math.max(...tableSafeValue.match(/`+/g)!.map(match => match.length));
   const fence = '`'.repeat(longestBacktickRun + 1);
   return `${fence} ${tableSafeValue} ${fence}`;
+}
+
+function formatMarkdownInlineCode(value: string): string {
+  const inlineSafeValue = normalizeMarkdownValue(value);
+  if (!inlineSafeValue.includes('`')) {
+    return `\`${inlineSafeValue}\``;
+  }
+
+  const longestBacktickRun = Math.max(...inlineSafeValue.match(/`+/g)!.map(match => match.length));
+  const fence = '`'.repeat(longestBacktickRun + 1);
+  return `${fence} ${inlineSafeValue} ${fence}`;
+}
+
+function normalizeMarkdownValue(value: string): string {
+  let normalized = '';
+  let previousWasControl = false;
+
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    const isControl = code < 0x20 || code === 0x7f;
+
+    if (isControl) {
+      if (!previousWasControl) normalized += ' ';
+      previousWasControl = true;
+      continue;
+    }
+
+    normalized += value[i];
+    previousWasControl = false;
+  }
+
+  return normalized.trim();
 }
 
 export default api;

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface FeedbackPayload {
     viewport: { width: number; height: number };
     timestamp: string;
     elementSelector?: string;
+    selectedElementHighlightColor?: string;
     // Parsed system info
     browser?: { name: string; version: string };
     os?: { name: string; version: string };

--- a/src/widget/annotation-flow.ts
+++ b/src/widget/annotation-flow.ts
@@ -5,7 +5,7 @@ export function showAnnotationStep(
   root: HTMLElement,
   screenshot: string,
   redactionCount = 0,
-  opts?: { redactionUnavailable?: boolean }
+  opts?: { redactionUnavailable?: boolean; selectedElementCapture?: boolean }
 ): Promise<string | 'retake' | 'cancel'> {
   return new Promise(resolve => {
     let redactionNote = '';
@@ -18,6 +18,13 @@ export function showAnnotationStep(
         `${redactionCount} private ${redactionCount === 1 ? 'item was' : 'items were'} marked for redaction in this screenshot. Review before sending.`
       );
     }
+    const selectedElementNote = opts?.selectedElementCapture
+      ? `
+        <p class="bd-selected-element-note" style="margin: -4px 0 12px; color: var(--bd-text-secondary); font-size: 13px;">
+          Need more surrounding context? Adjust <a href="https://bugdrop.dev/docs/configuration#select-element-screenshots" target="_blank" rel="noopener noreferrer">data-element-context-max-area</a> on the BugDrop script tag.
+        </p>
+      `
+      : '';
     const modal = createModal(
       root,
       'Review Screenshot',
@@ -26,6 +33,7 @@ export function showAnnotationStep(
         <p style="margin: 0 0 12px; color: var(--bd-text-secondary); font-size: 13px;">
           Check that no sensitive information is visible before sending. Cover sensitive areas before submitting. Redactions are baked into the uploaded image.
         </p>
+        ${selectedElementNote}
         <div class="bd-tools">
           <button class="bd-tool active" data-tool="draw">✏️ Draw</button>
           <button class="bd-tool" data-tool="arrow">➡️ Arrow</button>

--- a/src/widget/capture-flow.ts
+++ b/src/widget/capture-flow.ts
@@ -8,10 +8,16 @@ import {
 import { createElementPicker } from './picker';
 import { beginViewportCapture, getRedactionCount, isFullPageDisabled } from './screenshot';
 import { showScreenshotOptions, type ScreenshotChoice } from './screenshot-options';
+import {
+  DEFAULT_SELECTED_ELEMENT_CONTEXT_MIN_PADDING_PX,
+  DEFAULT_SELECTED_ELEMENT_SCREENSHOT_PIXEL_RATIO,
+  resolveSelectedElementContextMaxArea,
+} from '../defaults';
 
 export interface CaptureFlowConfig {
   screenshotMode: 'optional' | 'auto' | 'required';
   screenshotScale?: number;
+  elementContextMaxArea?: number;
   accentColor?: string;
   font?: string;
   radius?: string;
@@ -84,6 +90,7 @@ export async function runScreenshotCaptureFlow(
       result.redactionCount,
       {
         redactionUnavailable: result.redactionUnavailable,
+        ...(result.elementSelector ? { selectedElementCapture: true } : {}),
       }
     );
 
@@ -210,8 +217,20 @@ async function captureFromElementChoice(
   }
 
   const elementSelector = getElementSelector(element);
-  const result = await captureWithLoading(root, element, config.screenshotScale, {
+  const captureTarget = getElementContextCaptureTarget(element, {
+    maxViewportAreaMultiplier: config.elementContextMaxArea,
+  });
+  const result = await captureWithLoading(root, captureTarget, config.screenshotScale, {
     allowSkip: !screenshotRequired,
+    captureOptions: {
+      highlightElement: element,
+      highlightStyle: {
+        accentColor: config.accentColor,
+        radius: config.radius,
+        borderWidth: config.borderWidth,
+      },
+      pixelRatio: DEFAULT_SELECTED_ELEMENT_SCREENSHOT_PIXEL_RATIO,
+    },
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'skipped') {
@@ -221,7 +240,7 @@ async function captureFromElementChoice(
     kind: 'captured',
     screenshot: result.dataUrl,
     elementSelector,
-    redactionCount: getRedactionCount(element),
+    redactionCount: getRedactionCount(captureTarget),
     redactionUnavailable: false,
   };
 }
@@ -311,4 +330,48 @@ function getElementSelector(element: Element): string {
   }
 
   return path.join(' > ');
+}
+
+interface ElementContextOptions {
+  maxViewportAreaMultiplier?: number;
+}
+
+function getElementContextCaptureTarget(element: Element, options: ElementContextOptions): Element {
+  const selectedRect = element.getBoundingClientRect();
+  if (!isUsableRect(selectedRect)) return element;
+
+  const viewportArea = Math.max(1, window.innerWidth * window.innerHeight);
+  const maxContextArea =
+    viewportArea * resolveSelectedElementContextMaxArea(options.maxViewportAreaMultiplier);
+
+  let best: Element = element;
+  let current = element.parentElement;
+
+  while (current && current !== document.body && current !== document.documentElement) {
+    const rect = current.getBoundingClientRect();
+    const area = rect.width * rect.height;
+
+    if (isUsableRect(rect) && area <= maxContextArea && hasUsefulContext(rect, selectedRect)) {
+      best = current;
+    }
+
+    current = current.parentElement;
+  }
+
+  return best;
+}
+
+function isUsableRect(rect: DOMRect): boolean {
+  return rect.width > 0 && rect.height > 0;
+}
+
+function hasUsefulContext(candidate: DOMRect, selected: DOMRect): boolean {
+  const horizontalContext =
+    candidate.width >= selected.width + DEFAULT_SELECTED_ELEMENT_CONTEXT_MIN_PADDING_PX * 2;
+  const verticalContext =
+    candidate.height >= selected.height + DEFAULT_SELECTED_ELEMENT_CONTEXT_MIN_PADDING_PX * 2;
+  const selectedArea = selected.width * selected.height;
+  const candidateArea = candidate.width * candidate.height;
+
+  return horizontalContext || verticalContext || candidateArea >= selectedArea * 4;
 }

--- a/src/widget/capture-flow.ts
+++ b/src/widget/capture-flow.ts
@@ -342,7 +342,12 @@ function getElementContextCaptureTarget(element: Element, options: ElementContex
     const rect = current.getBoundingClientRect();
     const area = rect.width * rect.height;
 
-    if (isUsableRect(rect) && area <= maxContextArea && hasUsefulContext(rect, selectedRect)) {
+    if (
+      isUsableRect(rect) &&
+      area <= maxContextArea &&
+      containsRect(rect, selectedRect) &&
+      hasUsefulContext(rect, selectedRect)
+    ) {
       best = current;
     }
 
@@ -354,6 +359,15 @@ function getElementContextCaptureTarget(element: Element, options: ElementContex
 
 function isUsableRect(rect: DOMRect): boolean {
   return rect.width > 0 && rect.height > 0;
+}
+
+function containsRect(candidate: DOMRect, selected: DOMRect): boolean {
+  return (
+    candidate.left <= selected.left &&
+    candidate.top <= selected.top &&
+    candidate.right >= selected.right &&
+    candidate.bottom >= selected.bottom
+  );
 }
 
 function hasUsefulContext(candidate: DOMRect, selected: DOMRect): boolean {

--- a/src/widget/capture-loading.ts
+++ b/src/widget/capture-loading.ts
@@ -1,5 +1,9 @@
 import { MaskApplicationError } from './mask';
-import { captureAreaScreenshot, captureScreenshot } from './screenshot';
+import {
+  captureAreaScreenshot,
+  captureScreenshot,
+  type CaptureScreenshotOptions,
+} from './screenshot';
 import { createModal } from './ui';
 
 export type CaptureWithLoadingResult =
@@ -11,12 +15,12 @@ export async function captureWithLoading(
   root: HTMLElement,
   element?: Element,
   screenshotScale?: number,
-  opts?: { allowSkip?: boolean }
+  opts?: { allowSkip?: boolean; captureOptions?: CaptureScreenshotOptions }
 ): Promise<CaptureWithLoadingResult> {
   return capturePromiseWithLoading(
     root,
-    captureScreenshot(element, screenshotScale),
-    () => captureScreenshot(element, screenshotScale),
+    captureScreenshot(element, screenshotScale, opts?.captureOptions),
+    () => captureScreenshot(element, screenshotScale, opts?.captureOptions),
     opts
   );
 }
@@ -25,12 +29,12 @@ export async function captureAreaWithLoading(
   root: HTMLElement,
   rect: DOMRect,
   screenshotScale?: number,
-  opts?: { allowSkip?: boolean }
+  opts?: { allowSkip?: boolean; captureOptions?: CaptureScreenshotOptions }
 ): Promise<CaptureWithLoadingResult> {
   return capturePromiseWithLoading(
     root,
-    captureAreaScreenshot(rect, screenshotScale),
-    () => captureAreaScreenshot(rect, screenshotScale),
+    captureAreaScreenshot(rect, screenshotScale, opts?.captureOptions),
+    () => captureAreaScreenshot(rect, screenshotScale, opts?.captureOptions),
     opts
   );
 }

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -19,6 +19,7 @@ import {
   sanitizeShadowPreset,
   sanitizeUrl,
 } from './sanitize';
+import { resolveAccentColor } from '../defaults';
 
 type FeedbackCategory = 'bug' | 'feature' | 'question';
 type CategoryLabelConfig = Partial<Record<FeedbackCategory, string | string[]>>;
@@ -61,6 +62,7 @@ interface WidgetConfig {
   // Screenshot configuration
   screenshotMode: 'optional' | 'auto' | 'required';
   screenshotScale?: number; // Minimum pixel ratio for captures (default: 2)
+  elementContextMaxArea?: number; // Max ancestor capture area as a viewport multiplier
   issueLinkVisibility: IssueLinkVisibility;
 }
 
@@ -88,6 +90,7 @@ interface FeedbackData {
   category: FeedbackCategory;
   screenshot: string | null;
   elementSelector: string | null;
+  selectedElementHighlightColor: string | null;
   name?: string;
   email?: string;
 }
@@ -353,6 +356,11 @@ const screenshotScale = sanitizeNonNegativeNumber(rawScreenshotScale);
 if (rawScreenshotScale && screenshotScale === undefined) {
   console.warn('[BugDrop] Invalid data-screenshot-scale. Expected a non-negative number.');
 }
+const rawElementContextMaxArea = script?.dataset.elementContextMaxArea;
+const elementContextMaxArea = sanitizeNonNegativeNumber(rawElementContextMaxArea);
+if (rawElementContextMaxArea && elementContextMaxArea === undefined) {
+  console.warn('[BugDrop] Invalid data-element-context-max-area. Expected a non-negative number.');
+}
 const rawShadow = script?.dataset.shadow;
 const shadow = sanitizeShadowPreset(rawShadow);
 if (rawShadow && !shadow) {
@@ -418,6 +426,7 @@ const config: WidgetConfig = {
     return 'optional' as const;
   })(),
   screenshotScale,
+  elementContextMaxArea,
   issueLinkVisibility,
 };
 
@@ -821,6 +830,9 @@ async function openFeedbackFlow(
       email: formResult.email,
       screenshot: screenshotResult.screenshot,
       elementSelector: screenshotResult.elementSelector,
+      selectedElementHighlightColor: screenshotResult.elementSelector
+        ? resolveAccentColor(config.accentColor)
+        : null,
     });
     break;
   }
@@ -1157,6 +1169,7 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
           },
           timestamp: new Date().toISOString(),
           elementSelector: data.elementSelector,
+          selectedElementHighlightColor: data.selectedElementHighlightColor || undefined,
           domNodeCount,
           fullPageDisabled: isFullPageDisabled(),
           // Parsed system info

--- a/src/widget/picker.ts
+++ b/src/widget/picker.ts
@@ -1,4 +1,5 @@
 import { sanitizeCssColor, sanitizeCssFontFamily, sanitizeNonNegativePixelValue } from './sanitize';
+import { resolveAccentColor } from '../defaults';
 
 export interface PickerStyle {
   accentColor?: string;
@@ -28,7 +29,7 @@ export function resolvePickerStyle(style?: PickerStyle): ResolvedPickerStyle {
   const fontFamily = sanitizeCssFontFamily(style?.font);
 
   return {
-    accent: sanitizeCssColor(style?.accentColor) || '#14b8a6',
+    accent: resolveAccentColor(sanitizeCssColor(style?.accentColor)),
     fontFamily:
       style?.font === 'inherit'
         ? 'system-ui, sans-serif'
@@ -59,12 +60,13 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
   highlight.id = 'bugdrop-element-picker-highlight';
   highlight.style.cssText = `
     position: fixed;
+    box-sizing: content-box;
     pointer-events: none;
     border: ${bw}px solid ${accent};
-    background: color-mix(in srgb, ${accent} 15%, transparent);
+    background: transparent;
     z-index: 2147483646;
     transition: all 0.05s ease-out;
-    box-shadow: 0 0 0 4px color-mix(in srgb, ${accent} 30%, transparent);
+    box-shadow: none;
     border-radius: ${radius};
   `;
   document.body.appendChild(highlight);
@@ -93,18 +95,21 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
 
   let currentElement: Element | null = null;
 
-  function onMouseMove(e: MouseEvent) {
-    // Get the element under the cursor, ignoring our picker elements
-    const elementsAtPoint = document.elementsFromPoint(e.clientX, e.clientY);
+  function getSelectableElementAtPoint(x: number, y: number): Element | undefined {
+    const elementsAtPoint = document.elementsFromPoint(x, y);
 
-    // Find the first element that's not our picker UI
-    const target = elementsAtPoint.find(el => {
+    return elementsAtPoint.find(el => {
       if (el === highlight || el === tooltip) return false;
       if (el.id === 'bugdrop-element-picker-highlight') return false;
       if (el.id === 'bugdrop-element-picker-tooltip') return false;
       if (el.closest('#bugdrop-host')) return false;
       return true;
     });
+  }
+
+  function onMouseMove(e: MouseEvent) {
+    // Get the element under the cursor, ignoring our picker elements
+    const target = getSelectableElementAtPoint(e.clientX, e.clientY);
 
     if (!target) return;
 
@@ -122,6 +127,7 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
   function onClick(e: MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
+    currentElement = getSelectableElementAtPoint(e.clientX, e.clientY) ?? currentElement;
     cleanup();
     resolve(currentElement);
   }

--- a/src/widget/screenshot.ts
+++ b/src/widget/screenshot.ts
@@ -331,27 +331,38 @@ async function applyHighlightToImage(
   if (rect.w <= 0 || rect.h <= 0) return dataUrl;
 
   const img = await loadImage(dataUrl);
+  const imageWidth = img.naturalWidth || img.width;
+  const imageHeight = img.naturalHeight || img.height;
+  const scaleX = imageWidth / Math.max(1, targetRect.w);
+  const scaleY = imageHeight / Math.max(1, targetRect.h);
+  const averageScale = Math.max(1, (scaleX + scaleY) / 2);
+  const borderWidth = getHighlightBorderWidth(style.borderWidth, averageScale);
+  const innerGap = 2 * averageScale;
+  const padding = innerGap + borderWidth / 2;
+  const rawX = (rect.x - targetRect.x) * scaleX - padding;
+  const rawY = (rect.y - targetRect.y) * scaleY - padding;
+  const rawW = rect.w * scaleX + padding * 2;
+  const rawH = rect.h * scaleY + padding * 2;
+  const overflowLeft = Math.max(0, Math.ceil(-rawX));
+  const overflowTop = Math.max(0, Math.ceil(-rawY));
+  const overflowRight = Math.max(0, Math.ceil(rawX + rawW - imageWidth));
+  const overflowBottom = Math.max(0, Math.ceil(rawY + rawH - imageHeight));
+
   const canvas = document.createElement('canvas');
-  canvas.width = img.naturalWidth || img.width;
-  canvas.height = img.naturalHeight || img.height;
+  canvas.width = imageWidth + overflowLeft + overflowRight;
+  canvas.height = imageHeight + overflowTop + overflowBottom;
 
   const ctx = canvas.getContext('2d');
   if (!ctx) {
     throw new Error('Failed to get canvas context for selected element highlight');
   }
 
-  ctx.drawImage(img, 0, 0);
+  ctx.drawImage(img, overflowLeft, overflowTop);
 
-  const scaleX = canvas.width / Math.max(1, targetRect.w);
-  const scaleY = canvas.height / Math.max(1, targetRect.h);
-  const averageScale = Math.max(1, (scaleX + scaleY) / 2);
-  const borderWidth = getHighlightBorderWidth(style.borderWidth, averageScale);
-  const innerGap = 2 * averageScale;
-  const padding = innerGap + borderWidth / 2;
-  const x = Math.max(0, Math.round((rect.x - targetRect.x) * scaleX - padding));
-  const y = Math.max(0, Math.round((rect.y - targetRect.y) * scaleY - padding));
-  const w = Math.min(canvas.width - x, Math.round(rect.w * scaleX + padding * 2));
-  const h = Math.min(canvas.height - y, Math.round(rect.h * scaleY + padding * 2));
+  const x = Math.round(rawX + overflowLeft);
+  const y = Math.round(rawY + overflowTop);
+  const w = Math.round(rawW);
+  const h = Math.round(rawH);
   const radius = getHighlightRadius(style.radius, averageScale);
   const accent = resolveAccentColor(style.accentColor);
 

--- a/src/widget/screenshot.ts
+++ b/src/widget/screenshot.ts
@@ -1,6 +1,7 @@
 import * as htmlToImage from 'html-to-image';
 import type { Options as HtmlToImageOptions } from 'html-to-image/lib/types';
 import { applyMaskToImage, countMaskRects, createRedactionPlan } from './mask';
+import { resolveAccentColor } from '../defaults';
 
 declare const __BUGDROP_ENABLE_TEST_HOOKS__: boolean;
 
@@ -10,6 +11,16 @@ const TRANSPARENT_IMAGE_PLACEHOLDER =
   'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 export const FULL_PAGE_DISABLE_THRESHOLD = 10_000;
 export const SAFARI_FULL_PAGE_DISABLE_THRESHOLD = DOM_COMPLEXITY_THRESHOLD;
+
+export interface CaptureScreenshotOptions {
+  highlightElement?: Element;
+  highlightStyle?: {
+    accentColor?: string;
+    radius?: string;
+    borderWidth?: string;
+  };
+  pixelRatio?: number;
+}
 
 type DisplayMediaOptionsWithCurrentTab = DisplayMediaStreamOptions & {
   preferCurrentTab?: boolean;
@@ -201,12 +212,18 @@ function withCaptureTimeout<T>(capturePromise: Promise<T>): Promise<T> {
 
 export async function captureScreenshot(
   element?: Element,
-  screenshotScale?: number
+  screenshotScale?: number,
+  captureOptions: CaptureScreenshotOptions = {}
 ): Promise<string> {
   const target = element || document.body;
   const isFullPage = !element;
+  const targetRect = element ? getDocumentRect(element) : getDocumentRect(document.body);
+  const highlightRect =
+    captureOptions.highlightElement && target.contains(captureOptions.highlightElement)
+      ? getDocumentRect(captureOptions.highlightElement)
+      : null;
 
-  const pixelRatio = getPixelRatio(isFullPage, screenshotScale);
+  const pixelRatio = captureOptions.pixelRatio ?? getPixelRatio(isFullPage, screenshotScale);
 
   const toPng = getToPng();
   const opts: HtmlToImageOptions = {
@@ -217,27 +234,40 @@ export async function captureScreenshot(
   };
 
   const redactionPlan = createRedactionPlan(target);
-  let originOffset = { x: 0, y: 0 };
-  if (element) {
-    const r = element.getBoundingClientRect();
-    originOffset = { x: r.left + window.scrollX, y: r.top + window.scrollY };
-  }
+  const originOffset = element ? { x: targetRect.x, y: targetRect.y } : { x: 0, y: 0 };
 
   const capturePromise = toPng(target as HTMLElement, opts);
   const dataUrl = await withCaptureTimeout(capturePromise);
-  return applyMaskToImage(
+  const maskedDataUrl = await applyMaskToImage(
     dataUrl,
     redactionPlan.targets.map(target => target.rect),
     pixelRatio,
     originOffset
   );
+
+  if (!highlightRect) {
+    return maskedDataUrl;
+  }
+
+  return applyHighlightToImage(
+    maskedDataUrl,
+    highlightRect,
+    targetRect,
+    captureOptions.highlightStyle
+  );
 }
 
 export async function captureAreaScreenshot(
   rect: DOMRect,
-  screenshotScale?: number
+  screenshotScale?: number,
+  captureOptions: CaptureScreenshotOptions = {}
 ): Promise<string> {
-  const pixelRatio = getPixelRatio(true, screenshotScale);
+  const pixelRatio = captureOptions.pixelRatio ?? getPixelRatio(true, screenshotScale);
+  const targetRect = { x: rect.x, y: rect.y, w: rect.width, h: rect.height };
+  const highlightRect =
+    captureOptions.highlightElement && document.body.contains(captureOptions.highlightElement)
+      ? getDocumentRect(captureOptions.highlightElement)
+      : null;
   const toPng = getToPng();
   const opts: HtmlToImageOptions = {
     cacheBust: false,
@@ -256,7 +286,7 @@ export async function captureAreaScreenshot(
 
   const dataUrl = await withCaptureTimeout(toPng(document.body, opts));
   const redactionPlan = createRedactionPlan(document.body);
-  return applyMaskToImage(
+  const maskedDataUrl = await applyMaskToImage(
     dataUrl,
     redactionPlan.targets.map(target => target.rect),
     pixelRatio,
@@ -264,6 +294,17 @@ export async function captureAreaScreenshot(
       x: rect.x,
       y: rect.y,
     }
+  );
+
+  if (!highlightRect) {
+    return maskedDataUrl;
+  }
+
+  return applyHighlightToImage(
+    maskedDataUrl,
+    highlightRect,
+    targetRect,
+    captureOptions.highlightStyle
   );
 }
 
@@ -279,6 +320,98 @@ function getToPng(): typeof htmlToImage.toPng {
     return window.__bugdropMockToPng;
   }
   return htmlToImage.toPng;
+}
+
+async function applyHighlightToImage(
+  dataUrl: string,
+  rect: { x: number; y: number; w: number; h: number },
+  targetRect: { x: number; y: number; w: number; h: number },
+  style: CaptureScreenshotOptions['highlightStyle'] = {}
+): Promise<string> {
+  if (rect.w <= 0 || rect.h <= 0) return dataUrl;
+
+  const img = await loadImage(dataUrl);
+  const canvas = document.createElement('canvas');
+  canvas.width = img.naturalWidth || img.width;
+  canvas.height = img.naturalHeight || img.height;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Failed to get canvas context for selected element highlight');
+  }
+
+  ctx.drawImage(img, 0, 0);
+
+  const scaleX = canvas.width / Math.max(1, targetRect.w);
+  const scaleY = canvas.height / Math.max(1, targetRect.h);
+  const averageScale = Math.max(1, (scaleX + scaleY) / 2);
+  const borderWidth = getHighlightBorderWidth(style.borderWidth, averageScale);
+  const innerGap = 2 * averageScale;
+  const padding = innerGap + borderWidth / 2;
+  const x = Math.max(0, Math.round((rect.x - targetRect.x) * scaleX - padding));
+  const y = Math.max(0, Math.round((rect.y - targetRect.y) * scaleY - padding));
+  const w = Math.min(canvas.width - x, Math.round(rect.w * scaleX + padding * 2));
+  const h = Math.min(canvas.height - y, Math.round(rect.h * scaleY + padding * 2));
+  const radius = getHighlightRadius(style.radius, averageScale);
+  const accent = resolveAccentColor(style.accentColor);
+
+  drawRoundedRect(ctx, x, y, w, h, radius);
+  ctx.lineWidth = borderWidth;
+  ctx.strokeStyle = accent;
+  ctx.stroke();
+
+  return canvas.toDataURL('image/png');
+}
+
+function drawRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  radius: number
+): void {
+  const r = Math.max(0, Math.min(radius, w / 2, h / 2));
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function getHighlightBorderWidth(borderWidth: string | undefined, pixelRatio: number): number {
+  const parsed = Number.parseFloat(borderWidth || '3');
+  return Math.max(1, Math.round((Number.isFinite(parsed) ? parsed : 3) * pixelRatio));
+}
+
+function getHighlightRadius(radius: string | undefined, pixelRatio: number): number {
+  const parsed = Number.parseFloat(radius || '6');
+  return Math.max(0, Math.round((Number.isFinite(parsed) ? parsed : 6) * pixelRatio));
+}
+
+function getDocumentRect(element: Element): { x: number; y: number; w: number; h: number } {
+  const rect = element.getBoundingClientRect();
+  return {
+    x: rect.left + window.scrollX,
+    y: rect.top + window.scrollY,
+    w: rect.width,
+    h: rect.height,
+  };
+}
+
+function loadImage(dataUrl: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to load image for selected element highlight'));
+    img.src = dataUrl;
+  });
 }
 
 export async function cropScreenshot(

--- a/src/widget/theme.ts
+++ b/src/widget/theme.ts
@@ -1,4 +1,5 @@
 import { sanitizeCssColor, sanitizeNonNegativePixelValue, sanitizeShadowPreset } from './sanitize';
+import { getAccentHoverColor } from '../defaults';
 
 // src/widget/theme.ts
 
@@ -51,7 +52,7 @@ export function applyCustomStyles(
   if (accentColor) {
     const color = accentColor;
     root.style.setProperty('--bd-primary', color);
-    root.style.setProperty('--bd-primary-hover', `color-mix(in srgb, ${color} 85%, black)`);
+    root.style.setProperty('--bd-primary-hover', getAccentHoverColor(color));
     root.style.setProperty('--bd-border-focus', color);
   }
 

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -5,6 +5,7 @@ import {
   sanitizeNonNegativePixelValue,
   sanitizeUrl,
 } from './sanitize';
+import { DEFAULT_ACCENT_COLOR, getAccentHoverColor } from '../defaults';
 
 declare const __BUGDROP_VERSION__: string;
 
@@ -97,9 +98,9 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       --bd-text-secondary: #57534e;
       --bd-text-muted: #a8a29e;
       --bd-border: #e7e5e4;
-      --bd-border-focus: #14b8a6;
-      --bd-primary: #14b8a6;
-      --bd-primary-hover: #0d9488;
+      --bd-border-focus: ${DEFAULT_ACCENT_COLOR};
+      --bd-primary: ${DEFAULT_ACCENT_COLOR};
+      --bd-primary-hover: ${getAccentHoverColor(DEFAULT_ACCENT_COLOR)};
       --bd-primary-text: #ffffff;
       --bd-overlay-bg: rgba(0, 0, 0, 0.4);
       --bd-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
@@ -398,6 +399,10 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       padding: 20px;
       overflow-y: auto;
       flex: 1;
+    }
+
+    .bd-modal--annotator .bd-body {
+      padding-top: 0;
     }
 
     .bd-body > *:nth-child(1) { animation: bd-fadeIn 0.2s ease 0.1s both; }

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1067,6 +1067,40 @@ describe('API Routes', () => {
       );
     });
 
+    it('should add a selected-element screenshot caption when an element was chosen', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      const uploadedUrl =
+        'https://raw.githubusercontent.com/testowner/testrepo/main/.feedback/screenshots/selected.png';
+      mockUploadScreenshotAsAsset.mockResolvedValue(uploadedUrl);
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const payloadWithSelectedElement = {
+        ...validPayload,
+        screenshot: validPngDataUrl,
+        metadata: {
+          ...validPayload.metadata,
+          elementSelector: '#book-now',
+          selectedElementHighlightColor: '#2563eb',
+        },
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payloadWithSelectedElement),
+      });
+      await app.fetch(req, mockEnv);
+
+      const issueBody = mockCreateIssue.mock.calls[0][4];
+      expect(issueBody).toContain(`![Screenshot](${uploadedUrl})`);
+      expect(issueBody).toContain(
+        '_Selected element is indicated by the rounded highlight border (#2563eb)._'
+      );
+    });
+
     it('should use screenshot when provided (annotations handled client-side)', async () => {
       mockGetInstallationToken.mockResolvedValue('test-token');
       const uploadedUrl =

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1097,7 +1097,40 @@ describe('API Routes', () => {
       const issueBody = mockCreateIssue.mock.calls[0][4];
       expect(issueBody).toContain(`![Screenshot](${uploadedUrl})`);
       expect(issueBody).toContain(
-        '_Selected element is indicated by the rounded highlight border (#2563eb)._'
+        '_Selected element is indicated by the rounded highlight border (`#2563eb`)._'
+      );
+    });
+
+    it('should render markdown-sensitive selected-element highlight metadata as inline code', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      const uploadedUrl =
+        'https://raw.githubusercontent.com/testowner/testrepo/main/.feedback/screenshots/selected.png';
+      mockUploadScreenshotAsAsset.mockResolvedValue(uploadedUrl);
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const payloadWithMarkdownHighlight = {
+        ...validPayload,
+        screenshot: validPngDataUrl,
+        metadata: {
+          ...validPayload.metadata,
+          elementSelector: '#book-now',
+          selectedElementHighlightColor: '](https://example.com) ![x](y)',
+        },
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payloadWithMarkdownHighlight),
+      });
+      await app.fetch(req, mockEnv);
+
+      const issueBody = mockCreateIssue.mock.calls[0][4];
+      expect(issueBody).toContain(
+        '_Selected element is indicated by the rounded highlight border (`](https://example.com) ![x](y)`)._'
       );
     });
 
@@ -1403,6 +1436,12 @@ describe('API Routes', () => {
         'html > body > button#save\\```now.action\\|primary',
         '| **Element** | ``` button#save\\``now ``` |',
         '| **Full CSS path** | ```` html > body > button#save\\```now.action\\\\|primary ```` |',
+      ],
+      [
+        'button#save\n| **Injected** | yes |',
+        'html > body\r\n## injected',
+        '| **Element** | `button#save \\| **Injected** \\| yes \\|` |',
+        '| **Full CSS path** | `html > body ## injected` |',
       ],
     ])(
       'should format selector metadata safely in markdown tables for %s',

--- a/test/captureFlow.test.ts
+++ b/test/captureFlow.test.ts
@@ -3,6 +3,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { EmptyCaptureReason } from '../src/widget/capture-flow';
 import type { ScreenshotChoice } from '../src/widget/screenshot-options';
 import type { CaptureWithLoadingResult } from '../src/widget/capture-loading';
+import {
+  DEFAULT_SELECTED_ELEMENT_CONTEXT_MAX_VIEWPORT_AREA_MULTIPLIER,
+  DEFAULT_SELECTED_ELEMENT_SCREENSHOT_PIXEL_RATIO,
+} from '../src/defaults';
 
 const baseConfig = {
   screenshotMode: 'optional' as const,
@@ -16,6 +20,12 @@ async function loadCaptureFlowWithMocks(opts: {
   annotationResult?: string | 'retake' | 'cancel';
 }) {
   vi.resetModules();
+  const captureWithLoadingMock = vi
+    .fn()
+    .mockResolvedValue(opts.captureResult ?? { kind: 'skipped' });
+  const captureAreaWithLoadingMock = vi
+    .fn()
+    .mockResolvedValue(opts.captureResult ?? { kind: 'skipped' });
   vi.doMock('../src/widget/screenshot-options', () => ({
     showScreenshotOptions: vi.fn().mockResolvedValue(opts.screenshotChoice),
   }));
@@ -26,8 +36,8 @@ async function loadCaptureFlowWithMocks(opts: {
     createAreaPicker: vi.fn(),
   }));
   vi.doMock('../src/widget/capture-loading', () => ({
-    captureWithLoading: vi.fn().mockResolvedValue(opts.captureResult ?? { kind: 'skipped' }),
-    captureAreaWithLoading: vi.fn(),
+    captureWithLoading: captureWithLoadingMock,
+    captureAreaWithLoading: captureAreaWithLoadingMock,
     capturePromiseWithLoading: vi.fn().mockResolvedValue(opts.captureResult ?? { kind: 'skipped' }),
   }));
   vi.doMock('../src/widget/annotation-flow', () => ({
@@ -39,7 +49,11 @@ async function loadCaptureFlowWithMocks(opts: {
     isFullPageDisabled: vi.fn().mockReturnValue(false),
   }));
 
-  return import('../src/widget/capture-flow');
+  return {
+    ...(await import('../src/widget/capture-flow')),
+    captureWithLoadingMock,
+    captureAreaWithLoadingMock,
+  };
 }
 
 afterEach(() => {
@@ -125,6 +139,275 @@ describe('capture flow state decisions', () => {
       returnToForm: false,
     });
     expect(onComplexScreenshotSkipped).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures a surrounding container and highlights the selected element', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1200, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true });
+
+    const outerContext = document.createElement('article');
+    outerContext.className = 'listing-card';
+    outerContext.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 900,
+        bottom: 900,
+        width: 900,
+        height: 900,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const context = document.createElement('section');
+    context.className = 'field-group';
+    context.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 500,
+        bottom: 300,
+        width: 500,
+        height: 300,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const target = document.createElement('button');
+    target.id = 'book-now';
+    target.getBoundingClientRect = () =>
+      ({
+        x: 100,
+        y: 100,
+        top: 100,
+        left: 100,
+        right: 180,
+        bottom: 140,
+        width: 80,
+        height: 40,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+    context.appendChild(target);
+    outerContext.appendChild(context);
+    document.body.appendChild(outerContext);
+
+    const { runScreenshotCaptureFlow, captureWithLoadingMock } = await loadCaptureFlowWithMocks({
+      screenshotChoice: { kind: 'element' },
+      pickedElement: target,
+      captureResult: { kind: 'skipped' },
+    });
+    const root = document.createElement('div');
+
+    await runScreenshotCaptureFlow(
+      root,
+      {
+        ...baseConfig,
+        elementContextMaxArea: 1.5,
+      },
+      true,
+      vi.fn()
+    );
+
+    expect(captureWithLoadingMock).toHaveBeenCalledWith(root, outerContext, undefined, {
+      allowSkip: true,
+      captureOptions: {
+        highlightElement: target,
+        highlightStyle: {
+          accentColor: undefined,
+          borderWidth: undefined,
+          radius: undefined,
+        },
+        pixelRatio: DEFAULT_SELECTED_ELEMENT_SCREENSHOT_PIXEL_RATIO,
+      },
+    });
+  });
+
+  it('uses the default selected element context settings when no overrides are provided', async () => {
+    expect(DEFAULT_SELECTED_ELEMENT_CONTEXT_MAX_VIEWPORT_AREA_MULTIPLIER).toBe(0);
+  });
+
+  it('limits selected element context by configured viewport area multiplier', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1200, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true });
+
+    const outerContext = document.createElement('article');
+    outerContext.className = 'listing-card';
+    outerContext.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 900,
+        bottom: 900,
+        width: 900,
+        height: 900,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const context = document.createElement('section');
+    context.className = 'field-group';
+    context.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 500,
+        bottom: 300,
+        width: 500,
+        height: 300,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const target = document.createElement('button');
+    target.id = 'book-now';
+    target.getBoundingClientRect = () =>
+      ({
+        x: 100,
+        y: 100,
+        top: 100,
+        left: 100,
+        right: 180,
+        bottom: 140,
+        width: 80,
+        height: 40,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+    context.appendChild(target);
+    outerContext.appendChild(context);
+    document.body.appendChild(outerContext);
+
+    const { runScreenshotCaptureFlow, captureWithLoadingMock } = await loadCaptureFlowWithMocks({
+      screenshotChoice: { kind: 'element' },
+      pickedElement: target,
+      captureResult: { kind: 'skipped' },
+    });
+    const root = document.createElement('div');
+
+    await runScreenshotCaptureFlow(
+      root,
+      {
+        ...baseConfig,
+        elementContextMaxArea: 0.2,
+      },
+      true,
+      vi.fn()
+    );
+
+    expect(captureWithLoadingMock.mock.calls[0]?.[1]).toBe(context);
+  });
+
+  it('keeps selected element captures tight by default', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1200, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true });
+
+    const context = document.createElement('section');
+    context.className = 'field-group';
+    context.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 500,
+        bottom: 300,
+        width: 500,
+        height: 300,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const target = document.createElement('button');
+    target.id = 'book-now';
+    target.getBoundingClientRect = () =>
+      ({
+        x: 100,
+        y: 100,
+        top: 100,
+        left: 100,
+        right: 180,
+        bottom: 140,
+        width: 80,
+        height: 40,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+    context.appendChild(target);
+    document.body.appendChild(context);
+
+    const { runScreenshotCaptureFlow, captureWithLoadingMock } = await loadCaptureFlowWithMocks({
+      screenshotChoice: { kind: 'element' },
+      pickedElement: target,
+      captureResult: { kind: 'skipped' },
+    });
+    const root = document.createElement('div');
+
+    await runScreenshotCaptureFlow(root, baseConfig, true, vi.fn());
+
+    expect(captureWithLoadingMock.mock.calls[0]?.[1]).toBe(target);
+  });
+
+  it('passes the selected element when no larger fallback container is useful', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1200, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true });
+
+    const target = document.createElement('button');
+    target.id = 'book-now';
+    target.getBoundingClientRect = () =>
+      ({
+        x: 100,
+        y: 100,
+        top: 100,
+        left: 100,
+        right: 180,
+        bottom: 140,
+        width: 80,
+        height: 40,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    document.body.appendChild(target);
+
+    const { runScreenshotCaptureFlow, captureWithLoadingMock } = await loadCaptureFlowWithMocks({
+      screenshotChoice: { kind: 'element' },
+      pickedElement: target,
+      captureResult: { kind: 'skipped' },
+    });
+    const root = document.createElement('div');
+
+    await runScreenshotCaptureFlow(root, baseConfig, true, vi.fn());
+
+    expect(captureWithLoadingMock).toHaveBeenCalledWith(root, target, undefined, {
+      allowSkip: true,
+      captureOptions: {
+        highlightElement: target,
+        highlightStyle: {
+          accentColor: undefined,
+          borderWidth: undefined,
+          radius: undefined,
+        },
+        pixelRatio: DEFAULT_SELECTED_ELEMENT_SCREENSHOT_PIXEL_RATIO,
+      },
+    });
   });
 
   it('returns to form when the user dismisses the screenshot options modal', async () => {

--- a/test/captureFlow.test.ts
+++ b/test/captureFlow.test.ts
@@ -263,6 +263,39 @@ describe('capture flow state decisions', () => {
     });
   });
 
+  it('does not choose a context ancestor that does not visually contain the selected element', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1200, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true });
+
+    const overflowParent = document.createElement('section');
+    overflowParent.className = 'overflow-parent';
+    overflowParent.getBoundingClientRect = () => rect(200, 200, 0, 0);
+
+    const target = document.createElement('button');
+    target.id = 'overflowed-target';
+    target.getBoundingClientRect = () => rect(80, 40, 300, 300);
+    overflowParent.appendChild(target);
+    document.body.appendChild(overflowParent);
+
+    const { runScreenshotCaptureFlow, captureWithLoadingMock } = await loadCaptureFlowWithMocks({
+      screenshotChoice: { kind: 'element' },
+      pickedElement: target,
+      captureResult: { kind: 'skipped' },
+    });
+
+    await runScreenshotCaptureFlow(
+      document.createElement('div'),
+      {
+        ...baseConfig,
+        elementContextMaxArea: 1.5,
+      },
+      true,
+      vi.fn()
+    );
+
+    expect(captureWithLoadingMock.mock.calls[0]?.[1]).toBe(target);
+  });
+
   it('uses the default selected element context settings when no overrides are provided', () => {
     expect(DEFAULT_SELECTED_ELEMENT_CONTEXT_MAX_VIEWPORT_AREA_MULTIPLIER).toBe(0);
   });

--- a/test/cropScreenshot.test.ts
+++ b/test/cropScreenshot.test.ts
@@ -401,4 +401,60 @@ describe('captureScreenshot integrates with mask pipeline', () => {
     expect(stroke).toHaveBeenCalledTimes(1);
     expect(strokeRect).not.toHaveBeenCalled();
   });
+
+  it('pads default selected-element captures so the highlight is not clipped', async () => {
+    const selected = document.createElement('button');
+    selected.getBoundingClientRect = () =>
+      ({
+        x: 20,
+        y: 30,
+        width: 200,
+        height: 150,
+        top: 30,
+        left: 20,
+        bottom: 180,
+        right: 220,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+    document.body.appendChild(selected);
+
+    const STUB =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+    const toPng = vi.fn(() => Promise.resolve(STUB));
+    (window as unknown as { __bugdropMockToPng: typeof toPng }).__bugdropMockToPng = toPng;
+
+    const drawImage = vi.fn();
+    const stroke = vi.fn();
+    vi.mocked(HTMLCanvasElement.prototype.getContext).mockReturnValue({
+      beginPath: vi.fn(),
+      closePath: vi.fn(),
+      drawImage,
+      fillRect: vi.fn(),
+      fill: vi.fn(),
+      lineTo: vi.fn(),
+      moveTo: vi.fn(),
+      quadraticCurveTo: vi.fn(),
+      stroke,
+      strokeRect: vi.fn(),
+      fillStyle: '',
+      lineWidth: 0,
+      strokeStyle: '',
+    } as unknown as CanvasRenderingContext2D);
+
+    await expect(
+      captureScreenshot(selected, undefined, { highlightElement: selected })
+    ).resolves.toBe('data:image/png;base64,masked');
+
+    expect(toPng).toHaveBeenCalledWith(selected, expect.any(Object));
+    expect(drawImage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(Number),
+      expect.any(Number)
+    );
+    expect(drawImage.mock.calls[0][1]).toBeGreaterThan(0);
+    expect(drawImage.mock.calls[0][2]).toBeGreaterThan(0);
+    expect(stroke).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/cropScreenshot.test.ts
+++ b/test/cropScreenshot.test.ts
@@ -239,10 +239,10 @@ describe('captureScreenshot integrates with mask pipeline', () => {
     (window as unknown as { Image: unknown }).Image = class FakeImage {
       onload: (() => void) | null = null;
       onerror: (() => void) | null = null;
-      naturalWidth = 1;
-      naturalHeight = 1;
-      width = 1;
-      height = 1;
+      naturalWidth = 800;
+      naturalHeight = 600;
+      width = 800;
+      height = 600;
       set src(_: string) {
         // Fire onload asynchronously so callers can set it first.
         Promise.resolve().then(() => this.onload?.());
@@ -251,9 +251,19 @@ describe('captureScreenshot integrates with mask pipeline', () => {
 
     // jsdom does not implement canvas 2D context; stub it to avoid "Failed to get canvas context".
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      beginPath: vi.fn(),
+      closePath: vi.fn(),
       drawImage: vi.fn(),
       fillRect: vi.fn(),
+      fill: vi.fn(),
+      lineTo: vi.fn(),
+      moveTo: vi.fn(),
+      quadraticCurveTo: vi.fn(),
+      stroke: vi.fn(),
+      strokeRect: vi.fn(),
       fillStyle: '',
+      lineWidth: 0,
+      strokeStyle: '',
     } as unknown as CanvasRenderingContext2D);
     vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(
       'data:image/png;base64,masked'
@@ -320,5 +330,75 @@ describe('captureScreenshot integrates with mask pipeline', () => {
 
     // applyMaskToImage must have run: only it produces the masked sentinel.
     await expect(captureScreenshot(target)).resolves.toBe('data:image/png;base64,masked');
+  });
+
+  it('captures a context element and draws a selected descendant highlight', async () => {
+    const context = document.createElement('section');
+    context.getBoundingClientRect = () =>
+      ({
+        x: 20,
+        y: 30,
+        width: 400,
+        height: 300,
+        top: 30,
+        left: 20,
+        bottom: 330,
+        right: 420,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const selected = document.createElement('button');
+    selected.getBoundingClientRect = () =>
+      ({
+        x: 120,
+        y: 90,
+        width: 80,
+        height: 40,
+        top: 90,
+        left: 120,
+        bottom: 130,
+        right: 200,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    context.appendChild(selected);
+    document.body.appendChild(context);
+
+    const STUB =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+    const toPng = vi.fn(() => Promise.resolve(STUB));
+    (window as unknown as { __bugdropMockToPng: typeof toPng }).__bugdropMockToPng = toPng;
+
+    const fill = vi.fn();
+    const stroke = vi.fn();
+    const strokeRect = vi.fn();
+    vi.mocked(HTMLCanvasElement.prototype.getContext).mockReturnValue({
+      beginPath: vi.fn(),
+      closePath: vi.fn(),
+      drawImage: vi.fn(),
+      fillRect: vi.fn(),
+      fill,
+      lineTo: vi.fn(),
+      moveTo: vi.fn(),
+      quadraticCurveTo: vi.fn(),
+      stroke,
+      strokeRect,
+      fillStyle: '',
+      lineWidth: 0,
+      strokeStyle: '',
+    } as unknown as CanvasRenderingContext2D);
+
+    await expect(
+      captureScreenshot(context, undefined, { highlightElement: selected })
+    ).resolves.toBe('data:image/png;base64,masked');
+
+    expect(toPng).toHaveBeenCalledWith(context, expect.any(Object));
+    expect(fill).not.toHaveBeenCalled();
+    expect(stroke).toHaveBeenCalledTimes(1);
+    expect(strokeRect).not.toHaveBeenCalled();
   });
 });

--- a/test/pickerStyle.test.ts
+++ b/test/pickerStyle.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { resolvePickerStyle } from '../src/widget/picker';
+import { DEFAULT_ACCENT_COLOR } from '../src/defaults';
 
 describe('resolvePickerStyle', () => {
   it('passes through valid style values', () => {
@@ -36,7 +37,7 @@ describe('resolvePickerStyle', () => {
         borderColor: '#000; color: red',
       })
     ).toEqual({
-      accent: '#14b8a6',
+      accent: DEFAULT_ACCENT_COLOR,
       fontFamily: "'Space Grotesk', system-ui, sans-serif",
       radius: '6px',
       bw: '3',


### PR DESCRIPTION
Refs #172

## What changed
Select Element screenshots now have an optional surrounding-context mode that can capture a nearby container and draw a border-only rounded highlight around the selected element. The default remains the original tight element crop, and teams opt into more context with `data-element-context-max-area`.

The review screen and docs now point people to that setting, and GitHub issues explain the highlight using the exact resolved color. The local check config also now recognizes the existing semantic-release workflow usage so the pre-PR check suite passes.

## Why this shape (and not the obvious alternative)
The useful triage behavior is the larger contextual screenshot, but making that the default would change the existing Select Element behavior for every install and could make captures larger or slower. Keeping the default at the selected element, then letting teams expand context explicitly, preserves the current behavior while still supporting AI-assisted review workflows.

The highlight is a border using the widget accent color instead of an overlay. An overlay can obscure the actual element styling, which is exactly the detail the screenshot is meant to preserve.

This branch is built directly on current `main` and does not include the full CSS-path metadata work or the private fixture cleanup work from the other open PRs.

## Out of scope
This does not add a new selector metadata format. It only improves the visual evidence captured by Select Element screenshots.

---

## Test plan
- `git diff --check` passed.
- `npm run format:check` passed.
- `make check` passed. ESLint still reports the existing file-size warnings for `src/widget/capture-flow.ts` and `src/widget/screenshot.ts`; the critical audit gate passed with moderate-only audit output.
- `NODE_OPTIONS=--no-experimental-webstorage make test` passed: 13 files, 236 tests. Plain `make test` hit this machine's experimental Node `localStorage` behavior before the rerun.
- `make build-all` passed.
- `CI=true make test-e2e-shard SHARD=1/2` passed: 89 tests.
- `CI=true make test-e2e-shard SHARD=2/2` passed: 89 tests.
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run test/api.test.ts` passed after the final caption wording change.

---
