### PR TITLE
Add draggable feedback edge label

### DIFF
--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -53,8 +53,12 @@ The `data-theme` attribute controls the overall color scheme of the widget:
 
 The `data-position` attribute controls where the floating button appears:
 
-- **`bottom-right`** (default) -- Fixed to the bottom-right corner
-- **`bottom-left`** -- Fixed to the bottom-left corner
+- **`bottom-right`** (default) -- Anchored to the right edge
+- **`bottom-left`** -- Anchored to the left edge
+
+The button is shown as an edge label with a small drag handle. Users can drag it vertically
+when it covers page content, and BugDrop remembers that position in the browser for the same
+repository and side.
 
 ## Issue Link Visibility
 

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -117,18 +117,18 @@ Allow users to dismiss the floating button so it does not obstruct their view. T
 | Attribute | Default | Description |
 |-----------|---------|-------------|
 | `data-button-dismissible` | `"false"` | Allow users to dismiss (hide) the floating button |
-| `data-dismiss-duration` | `"session"` | How long the button stays dismissed: `"session"` (until tab close) or a number in minutes (e.g., `"60"`) |
+| `data-dismiss-duration` | Forever | How long the button stays dismissed: omit for forever, or provide a number of days (e.g., `"7"`) |
 | `data-show-restore` | `"true"` | Show a small restore link after dismissing |
 
 ### Dismissible Button Example
 
 ```html
-<!-- Dismissible button that stays hidden for 60 minutes -->
+<!-- Dismissible button that stays hidden for 7 days -->
 <script
   src="https://bugdrop.neonwatty.workers.dev/widget.js"
   data-repo="owner/repo"
   data-button-dismissible="true"
-  data-dismiss-duration="60"
+  data-dismiss-duration="7"
   data-show-restore="true"
 ></script>
 ```
@@ -138,7 +138,7 @@ When a user dismisses the button:
 1. The floating button hides
 2. If `data-show-restore` is `"true"`, a small "Restore feedback button" link appears in the corner
 3. The button stays hidden for the duration specified by `data-dismiss-duration`
-4. After the duration expires (or the session ends), the button reappears automatically
+4. After the duration expires, the button reappears automatically
 
 ## Feedback Categories
 
@@ -393,13 +393,13 @@ Here is a script tag using many configuration options together:
   data-show-email="true"
   data-require-email="true"
   data-button-dismissible="true"
-  data-dismiss-duration="120"
+  data-dismiss-duration="7"
   data-show-restore="true"
   data-label="Feedback"
 ></script>
 ```
 
-This configuration creates a dark-themed widget in the bottom-left corner with an indigo accent color, collects the submitter's name and email (email required), and shows a "Feedback" label on the button. The button is dismissible for 2 hours with a restore link.
+This configuration creates a dark-themed widget in the bottom-left corner with an indigo accent color, collects the submitter's name and email (email required), and shows a "Feedback" label on the button. The button is dismissible for 7 days with a restore link.
 
 ## Next Steps
 

--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -106,6 +106,31 @@ async function trackLiveFeedbackPayloads(page: Page) {
   return payloads;
 }
 
+async function clearTriggerPositionStorage(page: Page) {
+  await page.evaluate(() => {
+    Object.keys(localStorage)
+      .filter(key => key.startsWith('bugdrop_trigger_position_'))
+      .forEach(key => localStorage.removeItem(key));
+  });
+}
+
+async function dragTriggerHandle(page: Page, deltaY: number) {
+  const handle = page.locator('#bugdrop-host').locator('css=.bd-trigger-drag-handle');
+  await expect(handle).toBeVisible({ timeout: 10_000 });
+
+  const handleBox = await handle.boundingBox();
+  expect(handleBox).not.toBeNull();
+
+  await page.mouse.move(handleBox!.x + handleBox!.width / 2, handleBox!.y + handleBox!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(
+    handleBox!.x + handleBox!.width / 2,
+    handleBox!.y + handleBox!.height / 2 + deltaY,
+    { steps: 8 }
+  );
+  await page.mouse.up();
+}
+
 async function countRedPixelsInRegion(
   canvas: Locator,
   region: { left: number; top: number; right: number; bottom: number }
@@ -323,6 +348,33 @@ test.describe('Feedback Button (Live)', () => {
 
     const modal = page.locator('#bugdrop-host').locator('css=.bd-modal');
     await expect(modal).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('feedback button drag position persists on deployed preview widget', async ({ page }) => {
+    await page.goto(venuePath);
+    await clearTriggerPositionStorage(page);
+    await page.reload();
+
+    const host = page.locator('#bugdrop-host');
+    const trigger = host.locator('css=.bd-trigger');
+    await expect(trigger).toBeVisible({ timeout: 10_000 });
+
+    await dragTriggerHandle(page, -140);
+
+    const draggedTop = await trigger.evaluate(el => el.getBoundingClientRect().top);
+    const storedPosition = await page.evaluate(() => {
+      const key = Object.keys(localStorage).find(k => k.startsWith('bugdrop_trigger_position_'));
+      return key ? localStorage.getItem(key) : null;
+    });
+
+    expect(storedPosition).not.toBeNull();
+    await expect(host.locator('css=.bd-modal')).not.toBeVisible();
+
+    await page.reload();
+    await expect(trigger).toBeVisible({ timeout: 10_000 });
+
+    const restoredTop = await trigger.evaluate(el => el.getBoundingClientRect().top);
+    expect(Math.abs(restoredTop - draggedTop)).toBeLessThanOrEqual(2);
   });
 });
 

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -57,6 +57,73 @@ test.describe('Widget Loading', () => {
     await expect(button).toBeVisible();
   });
 
+  test('feedback button is an edge label with a drag handle', async ({ page }) => {
+    await page.goto('/test/');
+    const host = page.locator('#bugdrop-host');
+    const trigger = host.locator('css=.bd-trigger');
+    await expect(trigger).toBeVisible({ timeout: 5000 });
+    await trigger.evaluate(async el => {
+      await Promise.all(el.getAnimations().map(animation => animation.finished));
+    });
+
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+
+    const triggerBox = await trigger.boundingBox();
+    expect(triggerBox).not.toBeNull();
+    expect(Math.round(triggerBox!.x + triggerBox!.width)).toBe(viewport!.width);
+
+    await expect(trigger).toHaveCSS('border-top-right-radius', '0px');
+    await expect(trigger).toHaveCSS('border-bottom-right-radius', '0px');
+    await expect(host.locator('css=.bd-trigger-drag-handle')).toBeVisible();
+    await expect(host.locator('css=.bd-trigger-drag-handle')).toHaveCSS('cursor', 'grab');
+  });
+
+  test('dragging the feedback button persists after reload', async ({ page }) => {
+    await page.goto('/test/');
+    await page.evaluate(() => {
+      Object.keys(localStorage)
+        .filter(key => key.startsWith('bugdrop_trigger_position_'))
+        .forEach(key => localStorage.removeItem(key));
+    });
+    await page.reload();
+
+    const host = page.locator('#bugdrop-host');
+    const trigger = host.locator('css=.bd-trigger');
+    const handle = host.locator('css=.bd-trigger-drag-handle');
+    await expect(trigger).toBeVisible({ timeout: 5000 });
+    await expect(handle).toBeVisible();
+
+    const handleBox = await handle.boundingBox();
+    expect(handleBox).not.toBeNull();
+
+    await page.mouse.move(
+      handleBox!.x + handleBox!.width / 2,
+      handleBox!.y + handleBox!.height / 2
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      handleBox!.x + handleBox!.width / 2,
+      handleBox!.y + handleBox!.height / 2 - 160,
+      { steps: 8 }
+    );
+    await page.mouse.up();
+
+    const draggedTop = await trigger.evaluate(el => el.getBoundingClientRect().top);
+    const storedPosition = await page.evaluate(() => {
+      const key = Object.keys(localStorage).find(k => k.startsWith('bugdrop_trigger_position_'));
+      return key ? localStorage.getItem(key) : null;
+    });
+    expect(storedPosition).not.toBeNull();
+
+    await expect(host.locator('css=.bd-modal')).not.toBeVisible();
+    await page.reload();
+    await expect(trigger).toBeVisible({ timeout: 5000 });
+
+    const restoredTop = await trigger.evaluate(el => el.getBoundingClientRect().top);
+    expect(Math.abs(restoredTop - draggedTop)).toBeLessThanOrEqual(2);
+  });
+
   test('missing local test config returns an empty script', async ({ page }) => {
     const response = await page.request.get('/test/local-config.js');
 

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -30,6 +30,37 @@ declare global {
  * Tests run against wrangler dev server at http://localhost:8787
  */
 
+async function clearTriggerPositionStorage(page: Page) {
+  await page.evaluate(() => {
+    Object.keys(localStorage)
+      .filter(key => key.startsWith('bugdrop_trigger_position_'))
+      .forEach(key => localStorage.removeItem(key));
+  });
+}
+
+async function dragTriggerHandle(page: Page, deltaY: number) {
+  const handle = page.locator('#bugdrop-host').locator('css=.bd-trigger-drag-handle');
+  await expect(handle).toBeVisible();
+
+  const handleBox = await handle.boundingBox();
+  expect(handleBox).not.toBeNull();
+
+  await page.mouse.move(handleBox!.x + handleBox!.width / 2, handleBox!.y + handleBox!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(
+    handleBox!.x + handleBox!.width / 2,
+    handleBox!.y + handleBox!.height / 2 + deltaY,
+    { steps: 8 }
+  );
+  await page.mouse.up();
+}
+
+async function getWidgetRepo(page: Page) {
+  return page.locator('script[src="/widget.js"]').evaluate(script => {
+    return (script as HTMLScriptElement).dataset.repo;
+  });
+}
+
 test.describe('Widget Loading', () => {
   test('page loads without console errors', async ({ page }) => {
     const errors: string[] = [];
@@ -89,39 +120,21 @@ test.describe('Widget Loading', () => {
 
   test('dragging the feedback button persists after reload', async ({ page }) => {
     await page.goto('/test/');
-    await page.evaluate(() => {
-      Object.keys(localStorage)
-        .filter(key => key.startsWith('bugdrop_trigger_position_'))
-        .forEach(key => localStorage.removeItem(key));
-    });
+    await clearTriggerPositionStorage(page);
     await page.reload();
 
     const host = page.locator('#bugdrop-host');
     const trigger = host.locator('css=.bd-trigger');
-    const handle = host.locator('css=.bd-trigger-drag-handle');
     await expect(trigger).toBeVisible({ timeout: 5000 });
-    await expect(handle).toBeVisible();
 
-    const handleBox = await handle.boundingBox();
-    expect(handleBox).not.toBeNull();
-
-    await page.mouse.move(
-      handleBox!.x + handleBox!.width / 2,
-      handleBox!.y + handleBox!.height / 2
-    );
-    await page.mouse.down();
-    await page.mouse.move(
-      handleBox!.x + handleBox!.width / 2,
-      handleBox!.y + handleBox!.height / 2 - 160,
-      { steps: 8 }
-    );
-    await page.mouse.up();
+    await dragTriggerHandle(page, -160);
 
     const draggedTop = await trigger.evaluate(el => el.getBoundingClientRect().top);
-    const storedPosition = await page.evaluate(() => {
-      const key = Object.keys(localStorage).find(k => k.startsWith('bugdrop_trigger_position_'));
-      return key ? localStorage.getItem(key) : null;
-    });
+    const repo = await getWidgetRepo(page);
+    const storedPosition = await page.evaluate(
+      key => localStorage.getItem(key),
+      `bugdrop_trigger_position_${repo}_bottom-right`
+    );
     expect(storedPosition).not.toBeNull();
 
     await expect(host.locator('css=.bd-modal')).not.toBeVisible();
@@ -130,6 +143,84 @@ test.describe('Widget Loading', () => {
 
     const restoredTop = await trigger.evaluate(el => el.getBoundingClientRect().top);
     expect(Math.abs(restoredTop - draggedTop)).toBeLessThanOrEqual(2);
+  });
+
+  test('feedback button position reclamps when the viewport is resized', async ({ page }) => {
+    await page.setViewportSize({ width: 900, height: 900 });
+    await page.goto('/test/');
+    await clearTriggerPositionStorage(page);
+    await page.reload();
+
+    const trigger = page.locator('#bugdrop-host').locator('css=.bd-trigger');
+    await expect(trigger).toBeVisible({ timeout: 5000 });
+
+    await dragTriggerHandle(page, 500);
+    await page.setViewportSize({ width: 900, height: 360 });
+
+    await expect
+      .poll(async () => {
+        return trigger.evaluate(el => {
+          const rect = el.getBoundingClientRect();
+          return window.innerHeight - rect.bottom;
+        });
+      })
+      .toBeGreaterThanOrEqual(7);
+  });
+
+  test('hidden feedback button keeps saved position across viewport resize', async ({ page }) => {
+    await page.setViewportSize({ width: 900, height: 700 });
+    await page.goto('/test/');
+    await clearTriggerPositionStorage(page);
+    await page.reload();
+
+    const trigger = page.locator('#bugdrop-host').locator('css=.bd-trigger');
+    await expect(trigger).toBeVisible({ timeout: 5000 });
+
+    await dragTriggerHandle(page, -140);
+
+    await page.evaluate(() => {
+      (window as Window & { BugDrop?: { hide: () => void } }).BugDrop?.hide();
+    });
+    await page.setViewportSize({ width: 900, height: 500 });
+    await page.evaluate(() => {
+      (window as Window & { BugDrop?: { show: () => void } }).BugDrop?.show();
+    });
+    await page.mouse.move(10, 10);
+
+    await expect
+      .poll(async () => {
+        return trigger.evaluate(el => {
+          const rect = el.getBoundingClientRect();
+          return window.innerHeight - rect.bottom;
+        });
+      })
+      .toBeGreaterThanOrEqual(0);
+
+    const shownTop = await trigger.evaluate(el => el.getBoundingClientRect().top);
+    expect(shownTop).toBeGreaterThan(100);
+  });
+
+  test('hovered feedback button does not drift saved position during resize', async ({ page }) => {
+    await page.setViewportSize({ width: 900, height: 900 });
+    await page.goto('/test/');
+    await clearTriggerPositionStorage(page);
+    await page.reload();
+
+    const trigger = page.locator('#bugdrop-host').locator('css=.bd-trigger');
+    await expect(trigger).toBeVisible({ timeout: 5000 });
+
+    await dragTriggerHandle(page, -160);
+    const repo = await getWidgetRepo(page);
+    const storageKey = `bugdrop_trigger_position_${repo}_bottom-right`;
+    const savedTop = await page.evaluate(key => localStorage.getItem(key), storageKey);
+    expect(savedTop).not.toBeNull();
+
+    await trigger.hover();
+    await page.setViewportSize({ width: 900, height: 860 });
+    await page.setViewportSize({ width: 900, height: 900 });
+
+    const savedAfterResize = await page.evaluate(key => localStorage.getItem(key), storageKey);
+    expect(savedAfterResize).toBe(savedTop);
   });
 
   test('missing local test config returns an empty script', async ({ page }) => {
@@ -962,8 +1053,10 @@ test.describe('Dismissible Button', () => {
   test('dismissible button works with bottom-left position', async ({ page }) => {
     await page.goto('/test/dismissible-left.html');
     await page.evaluate(() => localStorage.removeItem('bugdrop_dismissed'));
+    await clearTriggerPositionStorage(page);
     await page.reload();
 
+    const host = page.locator('#bugdrop-host');
     const trigger = page.locator('#bugdrop-host').locator('css=.bd-trigger');
     await expect(trigger).toBeVisible({ timeout: 5000 });
 
@@ -976,8 +1069,27 @@ test.describe('Dismissible Button', () => {
       expect(buttonBox.x).toBeLessThan(viewportWidth / 2);
     }
 
+    await expect(trigger).toHaveCSS('border-top-left-radius', '0px');
+    await expect(trigger).toHaveCSS('border-bottom-left-radius', '0px');
+
+    const firstChildClass = await trigger.evaluate(el => el.firstElementChild?.className);
+    expect(firstChildClass).toContain('bd-trigger-drag-handle');
+
+    await dragTriggerHandle(page, -120);
+    const repo = await getWidgetRepo(page);
+    const leftPosition = await page.evaluate(
+      key => localStorage.getItem(key),
+      `bugdrop_trigger_position_${repo}_bottom-left`
+    );
+    const rightPosition = await page.evaluate(
+      key => localStorage.getItem(key),
+      `bugdrop_trigger_position_${repo}_bottom-right`
+    );
+    expect(leftPosition).not.toBeNull();
+    expect(rightPosition).toBeNull();
+
     // Close button should exist and work
-    const closeBtn = page.locator('#bugdrop-host').locator('css=.bd-trigger-close');
+    const closeBtn = host.locator('css=.bd-trigger-close');
     await expect(closeBtn).toBeAttached();
 
     // Hover and dismiss
@@ -985,6 +1097,30 @@ test.describe('Dismissible Button', () => {
     await expect(closeBtn).toHaveCSS('opacity', '1', { timeout: 2000 });
     await closeBtn.click();
     await expect(trigger).not.toBeAttached();
+  });
+
+  test('drag handle top area does not dismiss the feedback button', async ({ page }) => {
+    await page.goto('/test/dismissible.html');
+    await page.evaluate(() => localStorage.removeItem('bugdrop_dismissed'));
+    await clearTriggerPositionStorage(page);
+    await page.reload();
+
+    const host = page.locator('#bugdrop-host');
+    const trigger = host.locator('css=.bd-trigger');
+    const handle = host.locator('css=.bd-trigger-drag-handle');
+    await expect(trigger).toBeVisible({ timeout: 5000 });
+
+    const handleBox = await handle.boundingBox();
+    expect(handleBox).not.toBeNull();
+
+    await page.mouse.move(handleBox!.x + handleBox!.width / 2, handleBox!.y + 4);
+    await page.mouse.down();
+    await page.mouse.move(handleBox!.x + handleBox!.width / 2, handleBox!.y - 100, { steps: 8 });
+    await page.mouse.up();
+
+    await expect(trigger).toBeVisible();
+    await expect(host.locator('css=.bd-pull-tab')).not.toBeAttached();
+    expect(await page.evaluate(() => localStorage.getItem('bugdrop_dismissed'))).toBeNull();
   });
 
   test('close icon is always visible on touch devices', async ({ browser }) => {

--- a/knip.json
+++ b/knip.json
@@ -3,5 +3,6 @@
   "entry": ["src/index.ts", "src/widget/index.ts", "scripts/build-widget.js"],
   "project": ["src/**/*.ts", "scripts/**/*.js"],
   "ignore": [],
-  "ignoreDependencies": ["esbuild"]
+  "ignoreBinaries": ["semantic-release"],
+  "ignoreDependencies": ["esbuild", "semantic-release"]
 }

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -103,6 +103,7 @@ const BUGDROP_WELCOMED_PREFIX = 'bugdrop_welcomed_';
 const BUGDROP_COMPLEX_SCREENSHOT_SKIPPED_PREFIX = 'bugdrop_complex_screenshot_skipped_';
 const COMPLEX_SCREENSHOT_SKIP_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const TRIGGER_VIEWPORT_MARGIN_PX = 8;
+const TRIGGER_KEYBOARD_MOVE_PX = 16;
 
 // Parse user agent to extract browser info
 function parseBrowser(ua: string): { name: string; version: string } {
@@ -550,9 +551,11 @@ function clampTriggerTop(trigger: HTMLElement, top: number): number {
   return Math.min(Math.max(top, TRIGGER_VIEWPORT_MARGIN_PX), maxTop);
 }
 
-function setTriggerTop(trigger: HTMLElement, top: number): void {
-  trigger.style.top = `${clampTriggerTop(trigger, top)}px`;
+function setTriggerTop(trigger: HTMLElement, top: number): number {
+  const clampedTop = clampTriggerTop(trigger, top);
+  trigger.style.top = `${clampedTop}px`;
   trigger.style.bottom = 'auto';
+  return clampedTop;
 }
 
 function applyStoredTriggerPosition(trigger: HTMLElement, config: WidgetConfig): void {
@@ -560,6 +563,37 @@ function applyStoredTriggerPosition(trigger: HTMLElement, config: WidgetConfig):
   if (top === null) return;
   trigger.classList.add('bd-trigger--positioned');
   setTriggerTop(trigger, top);
+}
+
+function reclampVisibleTriggerPosition(trigger: HTMLElement, config: WidgetConfig): void {
+  if (!trigger.style.top) return;
+
+  const rect = trigger.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) return;
+
+  const currentTop = parseFloat(trigger.style.top);
+  if (!Number.isFinite(currentTop)) return;
+
+  const clampedTop = setTriggerTop(trigger, currentTop);
+  saveTriggerTop(config, clampedTop);
+}
+
+function attachTriggerViewportClamp(trigger: HTMLElement, config: WidgetConfig): void {
+  const reclamp = () => {
+    if (!trigger.isConnected) {
+      cleanup();
+      return;
+    }
+    reclampVisibleTriggerPosition(trigger, config);
+  };
+
+  const cleanup = () => {
+    window.removeEventListener('resize', reclamp);
+    window.visualViewport?.removeEventListener('resize', reclamp);
+  };
+
+  window.addEventListener('resize', reclamp);
+  window.visualViewport?.addEventListener('resize', reclamp);
 }
 
 function attachTriggerDragBehavior(trigger: HTMLElement, config: WidgetConfig): void {
@@ -627,6 +661,30 @@ function attachTriggerDragBehavior(trigger: HTMLElement, config: WidgetConfig): 
   handle.addEventListener('click', e => {
     e.preventDefault();
     e.stopPropagation();
+  });
+}
+
+function attachTriggerKeyboardMove(trigger: HTMLElement, config: WidgetConfig): void {
+  trigger.addEventListener('keydown', e => {
+    if (e.target !== trigger) return;
+    if (!['ArrowUp', 'ArrowDown', 'Home', 'End'].includes(e.key)) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    const rect = trigger.getBoundingClientRect();
+    const maxTop = window.innerHeight - rect.height - TRIGGER_VIEWPORT_MARGIN_PX;
+    const nextTop =
+      e.key === 'ArrowUp'
+        ? rect.top - TRIGGER_KEYBOARD_MOVE_PX
+        : e.key === 'ArrowDown'
+          ? rect.top + TRIGGER_KEYBOARD_MOVE_PX
+          : e.key === 'Home'
+            ? TRIGGER_VIEWPORT_MARGIN_PX
+            : maxTop;
+
+    trigger.classList.add('bd-trigger--positioned');
+    saveTriggerTop(config, setTriggerTop(trigger, nextTop));
   });
 }
 
@@ -753,7 +811,9 @@ function initWidget(config: WidgetConfig) {
     root.appendChild(trigger);
     _triggerButton = trigger;
     applyStoredTriggerPosition(trigger, config);
+    attachTriggerViewportClamp(trigger, config);
     attachTriggerDragBehavior(trigger, config);
+    attachTriggerKeyboardMove(trigger, config);
 
     // Handle trigger click
     trigger.addEventListener('click', () => {
@@ -831,6 +891,10 @@ function exposeBugDropAPI(root: HTMLElement, config: WidgetConfig) {
 
       if (_triggerButton) {
         _triggerButton.style.display = '';
+        reclampVisibleTriggerPosition(_triggerButton, config);
+        window.requestAnimationFrame(() => {
+          if (_triggerButton) reclampVisibleTriggerPosition(_triggerButton, config);
+        });
       } else if (config.showButton) {
         // Recreate button if it was removed
         createTriggerButton(root, config);
@@ -919,7 +983,9 @@ function createTriggerButton(root: HTMLElement, config: WidgetConfig, isRestorin
   root.appendChild(trigger);
   _triggerButton = trigger;
   applyStoredTriggerPosition(trigger, config);
+  attachTriggerViewportClamp(trigger, config);
   attachTriggerDragBehavior(trigger, config);
+  attachTriggerKeyboardMove(trigger, config);
 
   trigger.addEventListener('click', () => {
     if (_triggerDragMoved) {

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -94,9 +94,11 @@ interface FeedbackData {
 
 // localStorage key for dismissed state
 const BUGDROP_DISMISSED_KEY = 'bugdrop_dismissed';
+const BUGDROP_TRIGGER_POSITION_PREFIX = 'bugdrop_trigger_position_';
 const BUGDROP_WELCOMED_PREFIX = 'bugdrop_welcomed_';
 const BUGDROP_COMPLEX_SCREENSHOT_SKIPPED_PREFIX = 'bugdrop_complex_screenshot_skipped_';
 const COMPLEX_SCREENSHOT_SKIP_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const TRIGGER_VIEWPORT_MARGIN_PX = 8;
 
 // Parse user agent to extract browser info
 function parseBrowser(ua: string): { name: string; version: string } {
@@ -181,6 +183,7 @@ let _triggerButton: HTMLElement | null = null;
 let _pullTab: HTMLElement | null = null;
 let _isModalOpen = false;
 let _widgetConfig: WidgetConfig | null = null;
+let _triggerDragMoved = false;
 
 // Helper to check if button was dismissed
 function isButtonDismissed(dismissDuration?: number): boolean {
@@ -438,6 +441,10 @@ function getTriggerLabel(config: WidgetConfig): string {
 }
 
 function appendTriggerContent(trigger: HTMLElement, config: WidgetConfig): void {
+  if (config.position === 'bottom-left') {
+    trigger.appendChild(createTriggerDragHandle());
+  }
+
   if (config.iconUrl !== 'none') {
     const icon = document.createElement('span');
     icon.className = 'bd-trigger-icon';
@@ -465,6 +472,152 @@ function appendTriggerContent(trigger: HTMLElement, config: WidgetConfig): void 
   label.className = 'bd-trigger-label';
   label.textContent = getTriggerLabel(config);
   trigger.appendChild(label);
+
+  if (config.position !== 'bottom-left') {
+    trigger.appendChild(createTriggerDragHandle());
+  }
+}
+
+function createTriggerDragHandle(): HTMLElement {
+  const handle = document.createElement('span');
+  handle.className = 'bd-trigger-drag-handle';
+  handle.setAttribute('aria-hidden', 'true');
+  handle.title = 'Drag feedback button';
+  handle.innerHTML = `
+    <svg viewBox="0 0 12 24" aria-hidden="true" focusable="false">
+      <circle cx="4" cy="5" r="1.5" fill="currentColor"></circle>
+      <circle cx="8" cy="5" r="1.5" fill="currentColor"></circle>
+      <circle cx="4" cy="9.5" r="1.5" fill="currentColor"></circle>
+      <circle cx="8" cy="9.5" r="1.5" fill="currentColor"></circle>
+      <circle cx="4" cy="14" r="1.5" fill="currentColor"></circle>
+      <circle cx="8" cy="14" r="1.5" fill="currentColor"></circle>
+      <circle cx="4" cy="18.5" r="1.5" fill="currentColor"></circle>
+      <circle cx="8" cy="18.5" r="1.5" fill="currentColor"></circle>
+    </svg>
+  `;
+  return handle;
+}
+
+function getTriggerClassName(config: WidgetConfig, isRestoring = false): string {
+  const classes = [
+    'bd-trigger',
+    `bd-trigger--${config.position === 'bottom-left' ? 'left' : 'right'}`,
+  ];
+  if (isRestoring) classes.push('bd-trigger--restoring');
+  return classes.join(' ');
+}
+
+function getTriggerPositionKey(config: WidgetConfig): string {
+  return `${BUGDROP_TRIGGER_POSITION_PREFIX}${config.repo}_${config.position}`;
+}
+
+function getStoredTriggerTop(config: WidgetConfig): number | null {
+  try {
+    const raw = localStorage.getItem(getTriggerPositionKey(config));
+    if (!raw) return null;
+
+    const top = Number(raw);
+    return Number.isFinite(top) ? top : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveTriggerTop(config: WidgetConfig, top: number): void {
+  try {
+    localStorage.setItem(getTriggerPositionKey(config), String(Math.round(top)));
+  } catch {
+    // localStorage may be blocked
+  }
+}
+
+function clampTriggerTop(trigger: HTMLElement, top: number): number {
+  const rect = trigger.getBoundingClientRect();
+  const maxTop = Math.max(
+    TRIGGER_VIEWPORT_MARGIN_PX,
+    window.innerHeight - rect.height - TRIGGER_VIEWPORT_MARGIN_PX
+  );
+  return Math.min(Math.max(top, TRIGGER_VIEWPORT_MARGIN_PX), maxTop);
+}
+
+function setTriggerTop(trigger: HTMLElement, top: number): void {
+  trigger.style.top = `${clampTriggerTop(trigger, top)}px`;
+  trigger.style.bottom = 'auto';
+}
+
+function applyStoredTriggerPosition(trigger: HTMLElement, config: WidgetConfig): void {
+  const top = getStoredTriggerTop(config);
+  if (top === null) return;
+  trigger.classList.add('bd-trigger--positioned');
+  setTriggerTop(trigger, top);
+}
+
+function attachTriggerDragBehavior(trigger: HTMLElement, config: WidgetConfig): void {
+  const handle = trigger.querySelector<HTMLElement>('.bd-trigger-drag-handle');
+  if (!handle) return;
+
+  let pointerId: number | null = null;
+  let startPointerY = 0;
+  let startTop = 0;
+  let moved = false;
+
+  const endDrag = () => {
+    if (pointerId === null) return;
+    pointerId = null;
+    trigger.classList.remove('bd-trigger--dragging');
+    window.removeEventListener('pointermove', handlePointerMove);
+    window.removeEventListener('pointerup', handlePointerUp);
+    window.removeEventListener('pointercancel', handlePointerCancel);
+
+    if (moved) {
+      saveTriggerTop(config, trigger.getBoundingClientRect().top);
+      window.setTimeout(() => {
+        _triggerDragMoved = false;
+      }, 0);
+    }
+  };
+
+  function handlePointerMove(e: PointerEvent): void {
+    if (pointerId !== e.pointerId) return;
+    const nextTop = startTop + e.clientY - startPointerY;
+    if (Math.abs(e.clientY - startPointerY) > 3) {
+      moved = true;
+      _triggerDragMoved = true;
+    }
+    setTriggerTop(trigger, nextTop);
+  }
+
+  function handlePointerUp(e: PointerEvent): void {
+    if (pointerId !== e.pointerId) return;
+    endDrag();
+  }
+
+  function handlePointerCancel(e: PointerEvent): void {
+    if (pointerId !== e.pointerId) return;
+    endDrag();
+  }
+
+  handle.addEventListener('pointerdown', e => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const rect = trigger.getBoundingClientRect();
+    pointerId = e.pointerId;
+    startPointerY = e.clientY;
+    startTop = rect.top;
+    moved = false;
+    trigger.classList.add('bd-trigger--dragging');
+    handle.setPointerCapture(e.pointerId);
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointercancel', handlePointerCancel);
+  });
+
+  handle.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+  });
 }
 
 // Create the pull tab shown after dismissing the button
@@ -547,7 +700,7 @@ function initWidget(config: WidgetConfig) {
 
   if (shouldShowButton) {
     const trigger = document.createElement('button');
-    trigger.className = 'bd-trigger';
+    trigger.className = getTriggerClassName(config);
     appendTriggerContent(trigger, config);
     trigger.setAttribute('aria-label', 'Report a bug or send feedback');
 
@@ -589,9 +742,17 @@ function initWidget(config: WidgetConfig) {
 
     root.appendChild(trigger);
     _triggerButton = trigger;
+    applyStoredTriggerPosition(trigger, config);
+    attachTriggerDragBehavior(trigger, config);
 
     // Handle trigger click
-    trigger.addEventListener('click', () => openFeedbackFlow(root, config));
+    trigger.addEventListener('click', () => {
+      if (_triggerDragMoved) {
+        _triggerDragMoved = false;
+        return;
+      }
+      openFeedbackFlow(root, config);
+    });
   } else if (
     config.showButton &&
     config.buttonDismissible &&
@@ -707,7 +868,7 @@ function exposeBugDropAPI(root: HTMLElement, config: WidgetConfig) {
 // Helper to create the trigger button (used by show() API and pull tab restore)
 function createTriggerButton(root: HTMLElement, config: WidgetConfig, isRestoring = false) {
   const trigger = document.createElement('button');
-  trigger.className = isRestoring ? 'bd-trigger bd-trigger--restoring' : 'bd-trigger';
+  trigger.className = getTriggerClassName(config, isRestoring);
   appendTriggerContent(trigger, config);
   trigger.setAttribute('aria-label', 'Report a bug or send feedback');
 
@@ -747,8 +908,16 @@ function createTriggerButton(root: HTMLElement, config: WidgetConfig, isRestorin
 
   root.appendChild(trigger);
   _triggerButton = trigger;
+  applyStoredTriggerPosition(trigger, config);
+  attachTriggerDragBehavior(trigger, config);
 
-  trigger.addEventListener('click', () => openFeedbackFlow(root, config));
+  trigger.addEventListener('click', () => {
+    if (_triggerDragMoved) {
+      _triggerDragMoved = false;
+      return;
+    }
+    openFeedbackFlow(root, config);
+  });
 }
 
 async function openFeedbackFlow(

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -360,6 +360,7 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       line-height: 1;
       cursor: pointer;
       opacity: 0;
+      pointer-events: none;
       transform: scale(0.8);
       transition: opacity var(--bd-transition), transform var(--bd-transition);
       display: flex;
@@ -371,11 +372,17 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
 
     .bd-trigger--left .bd-trigger-close {
       right: auto;
-      left: 4px;
+      left: 36px;
     }
 
-    .bd-trigger:hover .bd-trigger-close {
+    .bd-trigger--right .bd-trigger-close {
+      right: 36px;
+    }
+
+    .bd-trigger:hover .bd-trigger-close,
+    .bd-trigger-close:focus-visible {
       opacity: 1;
+      pointer-events: auto;
       transform: scale(1);
     }
 
@@ -1109,6 +1116,7 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       /* Always show close button on touch devices */
       .bd-trigger-close {
         opacity: 1;
+        pointer-events: auto;
         transform: scale(1);
       }
 

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -41,7 +41,7 @@ export function shouldRenderIssueLink(
 }
 
 export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
-  const pos = config.position === 'bottom-left' ? 'left: 20px' : 'right: 20px';
+  const pos = config.position === 'bottom-left' ? 'left: 0' : 'right: 0';
   const resolved = resolveTheme(config.theme);
 
   // Determine font settings
@@ -143,14 +143,15 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       font-family: inherit;
     }
 
-    /* Trigger Button (Pill) */
+    /* Trigger Button (edge label) */
     .bd-trigger {
       position: fixed;
       bottom: 20px;
       ${pos};
       height: 44px;
-      padding: 0 16px;
-      border-radius: ${radiusPx !== null ? `${radiusPx * 2}px` : '22px'};
+      min-width: 0;
+      padding: 0 0 0 16px;
+      border-radius: ${radiusPx !== null ? `${radiusPx * 2}px 0 0 ${radiusPx * 2}px` : '22px 0 0 22px'};
       border: ${borderW !== null ? 'var(--bd-border-style)' : 'none'};
       background: var(--bd-primary);
       color: var(--bd-primary-text);
@@ -163,7 +164,20 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       display: flex;
       align-items: center;
       gap: 8px;
+      overflow: visible;
       animation: bd-triggerSlideIn 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+      touch-action: none;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
+    .bd-trigger--left {
+      padding: 0 16px 0 0;
+      border-radius: ${radiusPx !== null ? `0 ${radiusPx * 2}px ${radiusPx * 2}px 0` : '0 22px 22px 0'};
+    }
+
+    .bd-trigger--positioned {
+      animation: none;
     }
 
     .bd-trigger:hover {
@@ -192,7 +206,51 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
     .bd-trigger-label {
       font-size: 14px;
       font-weight: 600;
-      letter-spacing: -0.01em;
+      letter-spacing: 0;
+      white-space: nowrap;
+    }
+
+    .bd-trigger-drag-handle {
+      align-self: center;
+      width: 30px;
+      height: calc(100% - 8px);
+      margin: 4px;
+      border-radius: 7px;
+      background: transparent;
+      cursor: grab;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--bd-primary-text);
+      opacity: 0.95;
+      touch-action: none;
+    }
+
+    .bd-trigger--left .bd-trigger-drag-handle {
+      order: -1;
+    }
+
+    .bd-trigger-drag-handle:hover,
+    .bd-trigger-drag-handle:active,
+    .bd-trigger--dragging .bd-trigger-drag-handle {
+      background: color-mix(in srgb, var(--bd-primary-text) 18%, transparent);
+      opacity: 1;
+    }
+
+    .bd-trigger-drag-handle:hover {
+      cursor: grab;
+    }
+
+    .bd-trigger-drag-handle:active,
+    .bd-trigger--dragging .bd-trigger-drag-handle {
+      cursor: grabbing;
+    }
+
+    .bd-trigger-drag-handle svg {
+      display: block;
+      width: 14px;
+      height: 22px;
+      pointer-events: none;
     }
 
     @keyframes bd-triggerSlideIn {
@@ -289,7 +347,7 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
     .bd-trigger-close {
       position: absolute;
       top: -4px;
-      right: -4px;
+      right: 4px;
       width: 20px;
       height: 20px;
       border-radius: 50%;
@@ -308,6 +366,11 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       justify-content: center;
       padding: 0;
       box-shadow: var(--bd-shadow-sm);
+    }
+
+    .bd-trigger--left .bd-trigger-close {
+      right: auto;
+      left: 4px;
     }
 
     .bd-trigger:hover .bd-trigger-close {
@@ -891,9 +954,17 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
     @media (max-width: 640px) {
       .bd-trigger {
         height: 40px;
-        padding: 0 14px;
+        padding: 0 0 0 14px;
         bottom: 16px;
         gap: 6px;
+      }
+
+      .bd-trigger--left {
+        padding: 0 14px 0 0;
+      }
+
+      .bd-trigger-drag-handle {
+        width: 28px;
       }
 
       .bd-trigger-icon {


### PR DESCRIPTION
Closes #176

## What changed
The feedback button now renders as an edge label that sits flush against the configured side of the viewport. It includes a small dotted drag handle so users can move it vertically when it covers page content, and the moved position is remembered for the same repository and side after refresh.

The normal button click still opens BugDrop. Dragging the handle does not open the modal.

This PR also teaches Knip about the existing `semantic-release` workflow usage so the branch can pass the repo's current check suite independently.

## Why
On mobile and desktop, the floating feedback button can cover the exact element a user is trying to inspect, click, or select for a report. Dismissing the button removes the entry point entirely, so moving it out of the way is a better fit for triage.

## Test plan
- `make check`
- `NODE_OPTIONS=--no-experimental-webstorage make test`
- `make build-all`
- `CI=true make test-e2e-shard SHARD=1/2`
- `CI=true make test-e2e-shard SHARD=2/2`


## Example
<img width="412" height="236" alt="CleanShot 2026-05-19 at 00 05 18" src="https://github.com/user-attachments/assets/60d0b72a-2b2c-4921-a233-9df9b7b50f77" />

