### PR TITLE
fix: use text/javascript MIME type for local-config.js endpoint

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -223,12 +223,11 @@ test.describe('Widget Loading', () => {
     expect(savedAfterResize).toBe(savedTop);
   });
 
-  test('missing local test config returns an empty script', async ({ page }) => {
+  test('missing local test config returns a javascript file', async ({ page }) => {
     const response = await page.request.get('/test/local-config.js');
 
     expect(response.status()).toBe(200);
-    expect(response.headers()['content-type']).toContain('application/javascript');
-    expect(await response.text()).toBe('');
+    expect(response.headers()['content-type']).toBe('text/javascript; charset=utf-8');
   });
 
   test('test pages use upstream repo when no local override is present', async ({ page }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ app.get('/test/local-config.js', async c => {
   }
   return new Response('', {
     headers: {
-      'content-type': 'application/javascript; charset=utf-8',
+      'content-type': 'text/javascript; charset=utf-8',
     },
   });
 });

--- a/test/localConfigRoute.test.ts
+++ b/test/localConfigRoute.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import app from '../src/index';
+import type { Env } from '../src/types';
+
+function createEnv(assetResponse: Response): Env {
+  return {
+    GITHUB_APP_ID: 'test-app-id',
+    GITHUB_PRIVATE_KEY: 'test-private-key',
+    ENVIRONMENT: 'test',
+    ALLOWED_ORIGINS: 'http://localhost:8787',
+    GITHUB_APP_NAME: 'test-app',
+    MAX_SCREENSHOT_SIZE_MB: '5',
+    ASSETS: {
+      fetch: async () => assetResponse,
+    } as Fetcher,
+  };
+}
+
+describe('GET /test/local-config.js', () => {
+  it('returns an empty JavaScript response when the local config asset is missing', async () => {
+    const response = await app.fetch(
+      new Request('http://localhost/test/local-config.js'),
+      createEnv(new Response('Not found', { status: 404 }))
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('text/javascript; charset=utf-8');
+    expect(await response.text()).toBe('');
+  });
+
+  it('passes through an existing local config asset', async () => {
+    const source = 'window.BugDropTestConfig = { repo: "local-owner/local-repo" };';
+    const response = await app.fetch(
+      new Request('http://localhost/test/local-config.js'),
+      createEnv(
+        new Response(source, {
+          headers: { 'content-type': 'text/javascript; charset=utf-8' },
+        })
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('text/javascript; charset=utf-8');
+    expect(await response.text()).toBe(source);
+  });
+});


### PR DESCRIPTION
** Description of problem

After following the self-hosting setup steps, one of the E2E tests fails.
The issue is caused by this command:

cp public/test/local-config.example.js public/test/local-config.js

Screenshot of failed test:
<img width="1258" height="621" alt="image" src="https://github.com/user-attachments/assets/01bd4639-7098-411e-87b6-349fbf2bf0ea" />


The failure happens because MIME type of js file is 'text/javascript' the test needs 'application/javascript'
When test is run again if fails because the copied file contains text, but the test expects the file to be empty (line 65)

** Fix

- If there is no file, worker now responds with an empty file with 'text/javascript'
- The test now expects 'text/javascript' instead of 'application/javascript'
- The test no longer require the file to be empty anymore, allowing it to pass whether the file exist or not. The original intention of emiting missing-resource console errors is preservered.

All tests pass
No documentation update is needed
