### PR TITLE
Support selected-area capture on mobile touch screens

### DIFF
--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -571,8 +571,8 @@ test.describe('Screenshot Capture (Live)', () => {
 
     const tooltip = page.locator('#bugdrop-area-picker-tooltip');
     await expect(tooltip).toBeVisible({ timeout: 5_000 });
-    await expect(tooltip).toHaveText('Draw a selection around the area to capture (ESC to cancel)');
-    await expect(tooltip).not.toContainText('Drag');
+    await expect(tooltip).toHaveText('Draw a selection around the area to capture');
+    await expect(page.locator('#bugdrop-area-picker-cancel')).toHaveText('Cancel');
 
     await page.keyboard.press('Escape');
     await expect(page.locator('#bugdrop-area-picker-overlay')).not.toBeVisible({ timeout: 3_000 });

--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -571,8 +571,8 @@ test.describe('Screenshot Capture (Live)', () => {
 
     const tooltip = page.locator('#bugdrop-area-picker-tooltip');
     await expect(tooltip).toBeVisible({ timeout: 5_000 });
-    await expect(tooltip).toHaveText('Draw a selection around the area to capture');
-    await expect(page.locator('#bugdrop-area-picker-cancel')).toHaveText('Cancel');
+    await expect(tooltip).toHaveText('Draw a selection around the area to capture (ESC to cancel)');
+    await expect(page.locator('#bugdrop-area-picker-cancel')).not.toBeAttached();
 
     await page.keyboard.press('Escape');
     await expect(page.locator('#bugdrop-area-picker-overlay')).not.toBeVisible({ timeout: 3_000 });

--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -578,6 +578,61 @@ test.describe('Screenshot Capture (Live)', () => {
     await expect(page.locator('#bugdrop-area-picker-overlay')).not.toBeVisible({ timeout: 3_000 });
   });
 
+  test('selected-area capture works with touch input on deployed preview widget', async ({
+    browser,
+    browserName,
+  }) => {
+    test.skip(!process.env.LIVE_TARGET, 'Requires a deployed live widget target');
+    test.skip(browserName !== 'chromium', 'CDP touch dispatch is Chromium-only');
+
+    const context = await browser.newContext({
+      hasTouch: true,
+      isMobile: true,
+      viewport: { width: 390, height: 844 },
+    });
+    if (bypassSecret) {
+      await context.route('**/*.vercel.app/**', async route => {
+        const headers = {
+          ...route.request().headers(),
+          'x-vercel-protection-bypass': bypassSecret,
+        };
+        await route.continue({ headers });
+      });
+    }
+    const page = await context.newPage();
+
+    try {
+      const host = await openScreenshotOptions(page, 'Live mobile area capture');
+      const areaBtn = host.locator('css=[data-action="area"]');
+      await expect(areaBtn).toBeVisible({ timeout: 5_000 });
+      await areaBtn.click();
+
+      const overlay = page.locator('#bugdrop-area-picker-overlay');
+      await expect(overlay).toBeVisible({ timeout: 5_000 });
+      await expect(page.locator('#bugdrop-area-picker-cancel')).toHaveText('Cancel');
+
+      const client = await context.newCDPSession(page);
+      await client.send('Input.dispatchTouchEvent', {
+        type: 'touchStart',
+        touchPoints: [{ x: 40, y: 170, radiusX: 1, radiusY: 1, id: 1 }],
+      });
+      await client.send('Input.dispatchTouchEvent', {
+        type: 'touchMove',
+        touchPoints: [{ x: 280, y: 430, radiusX: 1, radiusY: 1, id: 1 }],
+      });
+      await client.send('Input.dispatchTouchEvent', {
+        type: 'touchEnd',
+        touchPoints: [],
+      });
+      await client.detach();
+
+      await expect(overlay).not.toBeVisible({ timeout: 5_000 });
+      await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 30_000 });
+    } finally {
+      await context.close();
+    }
+  });
+
   test('full-page capture reaches annotation with a third-party no-CORS image', async ({
     page,
   }) => {

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -802,15 +802,93 @@ test.describe('Widget Interaction', () => {
       await expect
         .poll(() => tooltip.evaluate(el => (el as HTMLElement).style.top))
         .toContain('safe-area-inset-top');
+      await expect(cancelLink).toHaveCSS('display', 'inline-flex');
+      const tooltipBox = await tooltip.boundingBox();
       const cancelBox = await cancelLink.boundingBox();
+      expect(tooltipBox).not.toBeNull();
       expect(cancelBox).not.toBeNull();
       expect(cancelBox!.width).toBeGreaterThanOrEqual(44);
       expect(cancelBox!.height).toBeGreaterThanOrEqual(44);
+      expect(cancelBox!.width).toBeLessThan(Math.min(140, tooltipBox!.width));
 
       await cancelLink.click();
       await expect(page.locator('#bugdrop-area-picker-overlay')).not.toBeVisible({
         timeout: 3000,
       });
+      await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0].screenshot).toBeNull();
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('area picker shows mobile cancel on hybrid touch devices', async ({ browser }) => {
+    const context = await browser.newContext({
+      hasTouch: true,
+      viewport: { width: 900, height: 700 },
+    });
+    await context.addInitScript(() => {
+      const nativeMatchMedia = window.matchMedia.bind(window);
+      Object.defineProperty(navigator, 'maxTouchPoints', {
+        configurable: true,
+        value: 1,
+      });
+      window.matchMedia = query => {
+        if (query.includes('any-pointer: coarse')) {
+          return {
+            matches: true,
+            media: query,
+            onchange: null,
+            addEventListener: () => undefined,
+            removeEventListener: () => undefined,
+            addListener: () => undefined,
+            removeListener: () => undefined,
+            dispatchEvent: () => false,
+          };
+        }
+        if (query.includes('hover: none') || query.includes('pointer: coarse')) {
+          return {
+            matches: false,
+            media: query,
+            onchange: null,
+            addEventListener: () => undefined,
+            removeEventListener: () => undefined,
+            addListener: () => undefined,
+            removeListener: () => undefined,
+            dispatchEvent: () => false,
+          };
+        }
+        return nativeMatchMedia(query);
+      };
+    });
+    const page = await context.newPage();
+
+    try {
+      const payloads = await trackFeedbackPayloads(page);
+      await page.route('**/api/check/**', async route => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ installed: true }),
+        });
+      });
+
+      await page.goto('/test/');
+
+      const host = page.locator('#bugdrop-host');
+      await host.locator('css=.bd-trigger').click();
+      await host.locator('css=[data-action="continue"]').click();
+      await host.locator('css=#title').fill('Hybrid touch area test');
+      await host.locator('css=#include-screenshot').check();
+      await host.locator('css=#submit-btn').click();
+      await host.locator('css=[data-action="area"]').click();
+
+      await expect(page.locator('#bugdrop-area-picker-tooltip')).not.toContainText('ESC');
+      const cancelButton = page.locator('#bugdrop-area-picker-cancel');
+      await expect(cancelButton).toHaveText('Cancel');
+
+      await cancelButton.click();
       await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
       expect(payloads).toHaveLength(1);
       expect(payloads[0].screenshot).toBeNull();

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -730,13 +730,146 @@ test.describe('Widget Interaction', () => {
     // Tooltip should be visible
     const tooltip = page.locator('#bugdrop-area-picker-tooltip');
     await expect(tooltip).toBeVisible();
-    await expect(tooltip).toHaveText('Draw a selection around the area to capture');
-    await expect(page.locator('#bugdrop-area-picker-cancel')).toHaveText('Cancel');
+    await expect(tooltip).toHaveText('Draw a selection around the area to capture (ESC to cancel)');
+    await expect(page.locator('#bugdrop-area-picker-cancel')).not.toBeAttached();
 
-    await page.locator('#bugdrop-area-picker-cancel').click();
+    await page.keyboard.press('Escape');
 
     // Overlay should be removed
     await expect(overlay).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test('area picker prompt clears mobile safe areas and uses an inline cancel link', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      hasTouch: true,
+      isMobile: true,
+      viewport: { width: 390, height: 844 },
+    });
+    const page = await context.newPage();
+
+    try {
+      await page.route('**/api/check/**', async route => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ installed: true }),
+        });
+      });
+
+      await page.goto('/test/');
+      await page.addStyleTag({
+        content: `
+          button {
+            display: block;
+            width: 100%;
+          }
+        `,
+      });
+
+      const host = page.locator('#bugdrop-host');
+      await host.locator('css=.bd-trigger').click();
+      await host.locator('css=[data-action="continue"]').click();
+      await host.locator('css=#title').fill('Mobile safe area test');
+      await host.locator('css=#include-screenshot').check();
+      await host.locator('css=#submit-btn').click();
+      await host.locator('css=[data-action="area"]').click();
+
+      const tooltip = page.locator('#bugdrop-area-picker-tooltip');
+      const cancelLink = page.locator('#bugdrop-area-picker-cancel');
+      await expect(tooltip).toBeVisible({ timeout: 5000 });
+      await expect(tooltip).not.toContainText('ESC');
+      await expect(cancelLink).toHaveText('Cancel');
+
+      await expect
+        .poll(() => tooltip.evaluate(el => (el as HTMLElement).style.top))
+        .toContain('safe-area-inset-top');
+      const cancelBox = await cancelLink.boundingBox();
+      expect(cancelBox).not.toBeNull();
+      expect(cancelBox!.width).toBeLessThan(80);
+
+      await cancelLink.click();
+      await expect(page.locator('#bugdrop-area-picker-overlay')).not.toBeVisible({
+        timeout: 3000,
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('area picker touch drags pass through non-link prompt text', async ({ browser }) => {
+    const context = await browser.newContext({
+      hasTouch: true,
+      isMobile: true,
+      viewport: { width: 390, height: 844 },
+    });
+    const page = await context.newPage();
+
+    try {
+      await page.route('**/api/check/**', async route => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ installed: true }),
+        });
+      });
+
+      await page.goto('/test/');
+
+      const host = page.locator('#bugdrop-host');
+      await host.locator('css=.bd-trigger').click();
+      await host.locator('css=[data-action="continue"]').click();
+      await host.locator('css=#title').fill('Prompt pass-through test');
+      await host.locator('css=#include-screenshot').check();
+      await host.locator('css=#submit-btn').click();
+      await host.locator('css=[data-action="area"]').click();
+
+      const tooltip = page.locator('#bugdrop-area-picker-tooltip');
+      await expect(tooltip).toBeVisible({ timeout: 5000 });
+
+      const tooltipBox = await tooltip.boundingBox();
+      expect(tooltipBox).not.toBeNull();
+      const startX = Math.round(tooltipBox!.x + tooltipBox!.width / 2);
+      const startY = Math.round(tooltipBox!.y + 8);
+
+      await page.evaluate(
+        ({ x, y }) => {
+          const startTarget = document.elementFromPoint(x, y);
+          if (!startTarget) throw new Error('no start target for prompt drag');
+
+          startTarget.dispatchEvent(
+            new PointerEvent('pointerdown', {
+              bubbles: true,
+              cancelable: true,
+              clientX: x,
+              clientY: y,
+              pointerId: 2,
+              pointerType: 'touch',
+              isPrimary: true,
+              buttons: 1,
+            })
+          );
+          document.dispatchEvent(
+            new PointerEvent('pointermove', {
+              bubbles: true,
+              cancelable: true,
+              clientX: x,
+              clientY: y + 180,
+              pointerId: 2,
+              pointerType: 'touch',
+              isPrimary: true,
+              buttons: 1,
+            })
+          );
+        },
+        { x: startX, y: startY }
+      );
+
+      await expect(page.locator('#bugdrop-area-picker-selection')).toBeVisible();
+    } finally {
+      await context.close();
+    }
   });
 
   test('area picker accepts touch drag selection on mobile', async ({ browser }) => {

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -327,6 +327,19 @@ test.describe('Widget Loading', () => {
 });
 
 test.describe('Widget Interaction', () => {
+  async function trackFeedbackPayloads(page: Page) {
+    const payloads: Array<Record<string, unknown>> = [];
+    await page.route('**/feedback', async route => {
+      payloads.push(route.request().postDataJSON());
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, issueNumber: 1, issueUrl: '#', isPublic: false }),
+      });
+    });
+    return payloads;
+  }
+
   test('clicking feedback button triggers modal', async ({ page }) => {
     await page.goto('/test/');
 
@@ -684,6 +697,7 @@ test.describe('Widget Interaction', () => {
   });
 
   test('select area button appears and launches area picker overlay', async ({ page }) => {
+    const payloads = await trackFeedbackPayloads(page);
     await page.route('**/api/check/**', async route => {
       await route.fulfill({
         status: 200,
@@ -736,6 +750,9 @@ test.describe('Widget Interaction', () => {
 
     // Overlay should be removed
     await expect(overlay).not.toBeVisible({ timeout: 3000 });
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].screenshot).toBeNull();
   });
 
   test('area picker prompt clears mobile safe areas and uses an inline cancel link', async ({
@@ -749,6 +766,7 @@ test.describe('Widget Interaction', () => {
     const page = await context.newPage();
 
     try {
+      const payloads = await trackFeedbackPayloads(page);
       await page.route('**/api/check/**', async route => {
         await route.fulfill({
           status: 200,
@@ -786,12 +804,16 @@ test.describe('Widget Interaction', () => {
         .toContain('safe-area-inset-top');
       const cancelBox = await cancelLink.boundingBox();
       expect(cancelBox).not.toBeNull();
-      expect(cancelBox!.width).toBeLessThan(80);
+      expect(cancelBox!.width).toBeGreaterThanOrEqual(44);
+      expect(cancelBox!.height).toBeGreaterThanOrEqual(44);
 
       await cancelLink.click();
       await expect(page.locator('#bugdrop-area-picker-overlay')).not.toBeVisible({
         timeout: 3000,
       });
+      await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0].screenshot).toBeNull();
     } finally {
       await context.close();
     }
@@ -901,46 +923,20 @@ test.describe('Widget Interaction', () => {
       const overlay = page.locator('#bugdrop-area-picker-overlay');
       await expect(overlay).toBeVisible({ timeout: 5000 });
 
-      await page.evaluate(() => {
-        const pickerOverlay = document.querySelector('#bugdrop-area-picker-overlay');
-        if (!pickerOverlay) throw new Error('area picker overlay was not found');
-
-        pickerOverlay.dispatchEvent(
-          new PointerEvent('pointerdown', {
-            bubbles: true,
-            cancelable: true,
-            clientX: 40,
-            clientY: 160,
-            pointerId: 1,
-            pointerType: 'touch',
-            isPrimary: true,
-            buttons: 1,
-          })
-        );
-        document.dispatchEvent(
-          new PointerEvent('pointermove', {
-            bubbles: true,
-            cancelable: true,
-            clientX: 280,
-            clientY: 420,
-            pointerId: 1,
-            pointerType: 'touch',
-            isPrimary: true,
-            buttons: 1,
-          })
-        );
-        document.dispatchEvent(
-          new PointerEvent('pointerup', {
-            bubbles: true,
-            cancelable: true,
-            clientX: 280,
-            clientY: 420,
-            pointerId: 1,
-            pointerType: 'touch',
-            isPrimary: true,
-          })
-        );
+      const client = await context.newCDPSession(page);
+      await client.send('Input.dispatchTouchEvent', {
+        type: 'touchStart',
+        touchPoints: [{ x: 40, y: 160, radiusX: 1, radiusY: 1, id: 1 }],
       });
+      await client.send('Input.dispatchTouchEvent', {
+        type: 'touchMove',
+        touchPoints: [{ x: 280, y: 420, radiusX: 1, radiusY: 1, id: 1 }],
+      });
+      await client.send('Input.dispatchTouchEvent', {
+        type: 'touchEnd',
+        touchPoints: [],
+      });
+      await client.detach();
 
       await expect(overlay).not.toBeVisible({ timeout: 5000 });
       await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 30000 });

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -730,14 +730,91 @@ test.describe('Widget Interaction', () => {
     // Tooltip should be visible
     const tooltip = page.locator('#bugdrop-area-picker-tooltip');
     await expect(tooltip).toBeVisible();
-    await expect(tooltip).toHaveText('Draw a selection around the area to capture (ESC to cancel)');
-    await expect(tooltip).not.toContainText('Drag');
+    await expect(tooltip).toHaveText('Draw a selection around the area to capture');
+    await expect(page.locator('#bugdrop-area-picker-cancel')).toHaveText('Cancel');
 
-    // Press ESC to cancel
-    await page.keyboard.press('Escape');
+    await page.locator('#bugdrop-area-picker-cancel').click();
 
     // Overlay should be removed
     await expect(overlay).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test('area picker accepts touch drag selection on mobile', async ({ browser }) => {
+    const context = await browser.newContext({
+      hasTouch: true,
+      isMobile: true,
+      viewport: { width: 390, height: 844 },
+    });
+    const page = await context.newPage();
+
+    try {
+      await page.route('**/api/check/**', async route => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ installed: true }),
+        });
+      });
+
+      await page.goto('/test/');
+
+      const host = page.locator('#bugdrop-host');
+      await host.locator('css=.bd-trigger').click();
+      await host.locator('css=[data-action="continue"]').click();
+      await host.locator('css=#title').fill('Mobile area test');
+      await host.locator('css=#include-screenshot').check();
+      await host.locator('css=#submit-btn').click();
+      await host.locator('css=[data-action="area"]').click();
+
+      const overlay = page.locator('#bugdrop-area-picker-overlay');
+      await expect(overlay).toBeVisible({ timeout: 5000 });
+
+      await page.evaluate(() => {
+        const pickerOverlay = document.querySelector('#bugdrop-area-picker-overlay');
+        if (!pickerOverlay) throw new Error('area picker overlay was not found');
+
+        pickerOverlay.dispatchEvent(
+          new PointerEvent('pointerdown', {
+            bubbles: true,
+            cancelable: true,
+            clientX: 40,
+            clientY: 160,
+            pointerId: 1,
+            pointerType: 'touch',
+            isPrimary: true,
+            buttons: 1,
+          })
+        );
+        document.dispatchEvent(
+          new PointerEvent('pointermove', {
+            bubbles: true,
+            cancelable: true,
+            clientX: 280,
+            clientY: 420,
+            pointerId: 1,
+            pointerType: 'touch',
+            isPrimary: true,
+            buttons: 1,
+          })
+        );
+        document.dispatchEvent(
+          new PointerEvent('pointerup', {
+            bubbles: true,
+            cancelable: true,
+            clientX: 280,
+            clientY: 420,
+            pointerId: 1,
+            pointerType: 'touch',
+            isPrimary: true,
+          })
+        );
+      });
+
+      await expect(overlay).not.toBeVisible({ timeout: 5000 });
+      await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 30000 });
+    } finally {
+      await context.close();
+    }
   });
 
   test('screenshot options prioritize capture actions before skip', async ({ page }) => {

--- a/src/widget/area-picker.ts
+++ b/src/widget/area-picker.ts
@@ -5,6 +5,7 @@ const MIN_SELECTION_SIZE = 10;
 const AREA_PICKER_INSTRUCTION = 'Draw a selection around the area to capture';
 const AREA_PICKER_REDACTION_INSTRUCTION =
   'Draw a selection around the area to capture. Marked private fields may be masked if included.';
+const AREA_PICKER_DESKTOP_CANCEL_INSTRUCTION = 'ESC to cancel';
 type ResolvedAreaPickerStyle = ReturnType<typeof resolvePickerStyle>;
 
 export function createAreaPicker(
@@ -35,22 +36,14 @@ function startAreaPicker(
   const instruction = opts?.redactionsAvailable
     ? AREA_PICKER_REDACTION_INSTRUCTION
     : AREA_PICKER_INSTRUCTION;
+  const showInlineCancel = usesTouchInput();
   const tooltip = createTooltip(
-    { fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder },
-    instruction
+    { accent, fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder },
+    instruction,
+    showInlineCancel
   );
   document.body.appendChild(tooltip);
-
-  const cancelButton = createCancelButton({
-    fontFamily,
-    radius,
-    bw,
-    tooltipBg,
-    tooltipText,
-    tooltipBorder,
-  });
-  document.body.appendChild(cancelButton);
-  positionCancelButton();
+  const cancelLink = tooltip.querySelector<HTMLAnchorElement>('#bugdrop-area-picker-cancel');
 
   let startX = 0;
   let startY = 0;
@@ -134,13 +127,10 @@ function startAreaPicker(
     }
   }
 
-  function onCancelClick() {
+  function onCancelClick(e: Event) {
+    e.preventDefault();
     cleanup();
     resolve(null);
-  }
-
-  function positionCancelButton() {
-    positionBelow(tooltip, cancelButton, 12);
   }
 
   function cleanup() {
@@ -149,12 +139,10 @@ function startAreaPicker(
     document.removeEventListener('pointerup', onPointerUp);
     document.removeEventListener('pointercancel', onPointerCancel);
     document.removeEventListener('keydown', onKeyDown);
-    window.removeEventListener('resize', positionCancelButton);
-    cancelButton.removeEventListener('click', onCancelClick);
+    cancelLink?.removeEventListener('click', onCancelClick);
     overlay.remove();
     selectionBorder.remove();
     tooltip.remove();
-    cancelButton.remove();
   }
 
   overlay.addEventListener('pointerdown', onPointerDown);
@@ -162,8 +150,7 @@ function startAreaPicker(
   document.addEventListener('pointerup', onPointerUp);
   document.addEventListener('pointercancel', onPointerCancel);
   document.addEventListener('keydown', onKeyDown);
-  window.addEventListener('resize', positionCancelButton);
-  cancelButton.addEventListener('click', onCancelClick);
+  cancelLink?.addEventListener('click', onCancelClick);
 }
 
 function createOverlay(): HTMLDivElement {
@@ -204,15 +191,16 @@ function createSelectionBorder(
 function createTooltip(
   style: Pick<
     ResolvedAreaPickerStyle,
-    'fontFamily' | 'radius' | 'bw' | 'tooltipBg' | 'tooltipText' | 'tooltipBorder'
+    'accent' | 'fontFamily' | 'radius' | 'bw' | 'tooltipBg' | 'tooltipText' | 'tooltipBorder'
   >,
-  text: string
+  text: string,
+  showInlineCancel: boolean
 ): HTMLDivElement {
   const tooltip = document.createElement('div');
   tooltip.id = 'bugdrop-area-picker-tooltip';
   tooltip.style.cssText = `
     position: fixed;
-    top: 20px;
+    top: calc(env(safe-area-inset-top, 0px) + 20px);
     left: 50%;
     transform: translateX(-50%);
     background: ${style.tooltipBg};
@@ -231,42 +219,31 @@ function createTooltip(
     border: ${style.bw}px solid ${style.tooltipBorder};
     pointer-events: none;
   `;
-  tooltip.textContent = text;
+  if (showInlineCancel) {
+    const cancelLink = document.createElement('a');
+    cancelLink.id = 'bugdrop-area-picker-cancel';
+    cancelLink.href = '#';
+    cancelLink.textContent = 'Cancel';
+    cancelLink.style.cssText = `
+      color: ${style.accent};
+      cursor: pointer;
+      display: inline;
+      font: inherit;
+      font-weight: 700;
+      pointer-events: auto;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+      white-space: nowrap;
+    `;
+    tooltip.append(text, ' (', cancelLink, ')');
+  } else {
+    tooltip.textContent = `${text} (${AREA_PICKER_DESKTOP_CANCEL_INSTRUCTION})`;
+  }
   return tooltip;
 }
 
-function createCancelButton(
-  style: Pick<
-    ResolvedAreaPickerStyle,
-    'fontFamily' | 'radius' | 'bw' | 'tooltipBg' | 'tooltipText' | 'tooltipBorder'
-  >
-): HTMLButtonElement {
-  const cancelButton = document.createElement('button');
-  cancelButton.id = 'bugdrop-area-picker-cancel';
-  cancelButton.type = 'button';
-  cancelButton.textContent = 'Cancel';
-  cancelButton.style.cssText = `
-    position: fixed;
-    top: 84px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: ${style.tooltipBg};
-    color: ${style.tooltipText};
-    padding: 10px 18px;
-    border-radius: ${style.radius};
-    font-family: ${style.fontFamily};
-    font-size: 14px;
-    font-weight: 600;
-    z-index: 2147483647;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.24);
-    border: ${style.bw}px solid ${style.tooltipBorder};
-    cursor: pointer;
-    touch-action: manipulation;
-  `;
-  return cancelButton;
-}
-
-function positionBelow(anchor: HTMLElement, element: HTMLElement, gap: number) {
-  const anchorRect = anchor.getBoundingClientRect();
-  element.style.top = `${anchorRect.bottom + gap}px`;
+function usesTouchInput(): boolean {
+  return (
+    window.matchMedia?.('(hover: none), (pointer: coarse)').matches || navigator.maxTouchPoints > 0
+  );
 }

--- a/src/widget/area-picker.ts
+++ b/src/widget/area-picker.ts
@@ -243,6 +243,7 @@ function createTooltip(
       text-underline-offset: 2px;
       touch-action: manipulation;
       white-space: nowrap;
+      width: auto;
     `;
     tooltip.append(text, ' (', cancelButton, ')');
   } else {
@@ -252,8 +253,11 @@ function createTooltip(
 }
 
 function usesCoarsePointer(): boolean {
-  if (window.matchMedia) {
-    return window.matchMedia('(hover: none), (pointer: coarse)').matches;
-  }
-  return navigator.maxTouchPoints > 0;
+  const hasTouchPoints = navigator.maxTouchPoints > 0;
+  if (!window.matchMedia) return hasTouchPoints;
+
+  return (
+    window.matchMedia('(hover: none), (pointer: coarse), (any-pointer: coarse)').matches ||
+    hasTouchPoints
+  );
 }

--- a/src/widget/area-picker.ts
+++ b/src/widget/area-picker.ts
@@ -36,14 +36,14 @@ function startAreaPicker(
   const instruction = opts?.redactionsAvailable
     ? AREA_PICKER_REDACTION_INSTRUCTION
     : AREA_PICKER_INSTRUCTION;
-  const showInlineCancel = usesTouchInput();
+  const showInlineCancel = usesCoarsePointer();
   const tooltip = createTooltip(
     { accent, fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder },
     instruction,
     showInlineCancel
   );
   document.body.appendChild(tooltip);
-  const cancelLink = tooltip.querySelector<HTMLAnchorElement>('#bugdrop-area-picker-cancel');
+  const cancelButton = tooltip.querySelector<HTMLButtonElement>('#bugdrop-area-picker-cancel');
 
   let startX = 0;
   let startY = 0;
@@ -127,8 +127,7 @@ function startAreaPicker(
     }
   }
 
-  function onCancelClick(e: Event) {
-    e.preventDefault();
+  function onCancelClick() {
     cleanup();
     resolve(null);
   }
@@ -139,7 +138,7 @@ function startAreaPicker(
     document.removeEventListener('pointerup', onPointerUp);
     document.removeEventListener('pointercancel', onPointerCancel);
     document.removeEventListener('keydown', onKeyDown);
-    cancelLink?.removeEventListener('click', onCancelClick);
+    cancelButton?.removeEventListener('click', onCancelClick);
     overlay.remove();
     selectionBorder.remove();
     tooltip.remove();
@@ -150,7 +149,7 @@ function startAreaPicker(
   document.addEventListener('pointerup', onPointerUp);
   document.addEventListener('pointercancel', onPointerCancel);
   document.addEventListener('keydown', onKeyDown);
-  cancelLink?.addEventListener('click', onCancelClick);
+  cancelButton?.addEventListener('click', onCancelClick);
 }
 
 function createOverlay(): HTMLDivElement {
@@ -220,30 +219,41 @@ function createTooltip(
     pointer-events: none;
   `;
   if (showInlineCancel) {
-    const cancelLink = document.createElement('a');
-    cancelLink.id = 'bugdrop-area-picker-cancel';
-    cancelLink.href = '#';
-    cancelLink.textContent = 'Cancel';
-    cancelLink.style.cssText = `
+    const cancelButton = document.createElement('button');
+    cancelButton.id = 'bugdrop-area-picker-cancel';
+    cancelButton.type = 'button';
+    cancelButton.textContent = 'Cancel';
+    cancelButton.style.cssText = `
+      align-items: center;
+      appearance: none;
+      background: transparent;
+      border: 0;
       color: ${style.accent};
       cursor: pointer;
-      display: inline;
+      display: inline-flex;
       font: inherit;
       font-weight: 700;
+      justify-content: center;
+      margin: -10px -12px;
+      min-height: 44px;
+      min-width: 44px;
+      padding: 10px 12px;
       pointer-events: auto;
       text-decoration: underline;
       text-underline-offset: 2px;
+      touch-action: manipulation;
       white-space: nowrap;
     `;
-    tooltip.append(text, ' (', cancelLink, ')');
+    tooltip.append(text, ' (', cancelButton, ')');
   } else {
     tooltip.textContent = `${text} (${AREA_PICKER_DESKTOP_CANCEL_INSTRUCTION})`;
   }
   return tooltip;
 }
 
-function usesTouchInput(): boolean {
-  return (
-    window.matchMedia?.('(hover: none), (pointer: coarse)').matches || navigator.maxTouchPoints > 0
-  );
+function usesCoarsePointer(): boolean {
+  if (window.matchMedia) {
+    return window.matchMedia('(hover: none), (pointer: coarse)').matches;
+  }
+  return navigator.maxTouchPoints > 0;
 }

--- a/src/widget/area-picker.ts
+++ b/src/widget/area-picker.ts
@@ -2,9 +2,10 @@ import type { PickerStyle } from './picker';
 import { resolvePickerStyle } from './picker';
 
 const MIN_SELECTION_SIZE = 10;
-const AREA_PICKER_INSTRUCTION = 'Draw a selection around the area to capture (ESC to cancel)';
+const AREA_PICKER_INSTRUCTION = 'Draw a selection around the area to capture';
 const AREA_PICKER_REDACTION_INSTRUCTION =
-  'Draw a selection around the area to capture. Marked private fields may be masked if included. (ESC to cancel)';
+  'Draw a selection around the area to capture. Marked private fields may be masked if included.';
+type ResolvedAreaPickerStyle = ReturnType<typeof resolvePickerStyle>;
 
 export function createAreaPicker(
   style?: PickerStyle,
@@ -25,63 +26,36 @@ function startAreaPicker(
   const { accent, fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder } =
     resolvePickerStyle(style);
 
-  // Full-screen dimming overlay
-  const overlay = document.createElement('div');
-  overlay.id = 'bugdrop-area-picker-overlay';
-  overlay.style.cssText = `
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.4);
-    z-index: 2147483646;
-    cursor: crosshair;
-  `;
+  const overlay = createOverlay();
   document.body.appendChild(overlay);
 
-  // Selection border element (hidden until drag starts)
-  const selectionBorder = document.createElement('div');
-  selectionBorder.id = 'bugdrop-area-picker-selection';
-  selectionBorder.style.cssText = `
-    position: fixed;
-    border: ${bw}px solid ${accent};
-    box-shadow: 0 0 0 4px color-mix(in srgb, ${accent} 30%, transparent);
-    border-radius: ${radius};
-    z-index: 2147483647;
-    pointer-events: none;
-    display: none;
-  `;
+  const selectionBorder = createSelectionBorder({ accent, bw, radius });
   document.body.appendChild(selectionBorder);
 
-  // Tooltip
-  const tooltip = document.createElement('div');
-  tooltip.id = 'bugdrop-area-picker-tooltip';
-  tooltip.style.cssText = `
-    position: fixed;
-    top: 20px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: ${tooltipBg};
-    color: ${tooltipText};
-    padding: 14px 28px;
-    border-radius: ${radius};
-    font-family: ${fontFamily};
-    font-size: 14px;
-    font-weight: 500;
-    z-index: 2147483647;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-    border: ${bw}px solid ${tooltipBorder};
-    pointer-events: none;
-  `;
-  tooltip.textContent = opts?.redactionsAvailable
+  const instruction = opts?.redactionsAvailable
     ? AREA_PICKER_REDACTION_INSTRUCTION
     : AREA_PICKER_INSTRUCTION;
+  const tooltip = createTooltip(
+    { fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder },
+    instruction
+  );
   document.body.appendChild(tooltip);
+
+  const cancelButton = createCancelButton({
+    fontFamily,
+    radius,
+    bw,
+    tooltipBg,
+    tooltipText,
+    tooltipBorder,
+  });
+  document.body.appendChild(cancelButton);
+  positionCancelButton();
 
   let startX = 0;
   let startY = 0;
   let isDragging = false;
+  let activePointerId: number | null = null;
 
   function updateSelection(x1: number, y1: number, x2: number, y2: number) {
     const left = Math.min(x1, x2);
@@ -105,20 +79,28 @@ function startAreaPicker(
     )`;
   }
 
-  function onMouseDown(e: MouseEvent) {
+  function onPointerDown(e: PointerEvent) {
+    if (activePointerId !== null || !e.isPrimary) return;
+    e.preventDefault();
     startX = e.clientX;
     startY = e.clientY;
     isDragging = true;
+    activePointerId = e.pointerId;
+    overlay.setPointerCapture?.(e.pointerId);
   }
 
-  function onMouseMove(e: MouseEvent) {
-    if (!isDragging) return;
+  function onPointerMove(e: PointerEvent) {
+    if (!isDragging || e.pointerId !== activePointerId) return;
+    e.preventDefault();
     updateSelection(startX, startY, e.clientX, e.clientY);
   }
 
-  function onMouseUp(e: MouseEvent) {
-    if (!isDragging) return;
+  function onPointerUp(e: PointerEvent) {
+    if (!isDragging || e.pointerId !== activePointerId) return;
+    e.preventDefault();
     isDragging = false;
+    activePointerId = null;
+    overlay.releasePointerCapture?.(e.pointerId);
 
     const width = Math.abs(e.clientX - startX);
     const height = Math.abs(e.clientY - startY);
@@ -137,6 +119,14 @@ function startAreaPicker(
     resolve(new DOMRect(left, top, width, height));
   }
 
+  function onPointerCancel(e: PointerEvent) {
+    if (e.pointerId !== activePointerId) return;
+    isDragging = false;
+    activePointerId = null;
+    selectionBorder.style.display = 'none';
+    overlay.style.clipPath = '';
+  }
+
   function onKeyDown(e: KeyboardEvent) {
     if (e.key === 'Escape') {
       cleanup();
@@ -144,18 +134,139 @@ function startAreaPicker(
     }
   }
 
+  function onCancelClick() {
+    cleanup();
+    resolve(null);
+  }
+
+  function positionCancelButton() {
+    positionBelow(tooltip, cancelButton, 12);
+  }
+
   function cleanup() {
-    overlay.removeEventListener('mousedown', onMouseDown);
-    document.removeEventListener('mousemove', onMouseMove);
-    document.removeEventListener('mouseup', onMouseUp);
+    overlay.removeEventListener('pointerdown', onPointerDown);
+    document.removeEventListener('pointermove', onPointerMove);
+    document.removeEventListener('pointerup', onPointerUp);
+    document.removeEventListener('pointercancel', onPointerCancel);
     document.removeEventListener('keydown', onKeyDown);
+    window.removeEventListener('resize', positionCancelButton);
+    cancelButton.removeEventListener('click', onCancelClick);
     overlay.remove();
     selectionBorder.remove();
     tooltip.remove();
+    cancelButton.remove();
   }
 
-  overlay.addEventListener('mousedown', onMouseDown);
-  document.addEventListener('mousemove', onMouseMove);
-  document.addEventListener('mouseup', onMouseUp);
+  overlay.addEventListener('pointerdown', onPointerDown);
+  document.addEventListener('pointermove', onPointerMove);
+  document.addEventListener('pointerup', onPointerUp);
+  document.addEventListener('pointercancel', onPointerCancel);
   document.addEventListener('keydown', onKeyDown);
+  window.addEventListener('resize', positionCancelButton);
+  cancelButton.addEventListener('click', onCancelClick);
+}
+
+function createOverlay(): HTMLDivElement {
+  const overlay = document.createElement('div');
+  overlay.id = 'bugdrop-area-picker-overlay';
+  overlay.style.cssText = `
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 2147483646;
+    cursor: crosshair;
+    touch-action: none;
+    user-select: none;
+  `;
+  return overlay;
+}
+
+function createSelectionBorder(
+  style: Pick<ResolvedAreaPickerStyle, 'accent' | 'bw' | 'radius'>
+): HTMLDivElement {
+  const selectionBorder = document.createElement('div');
+  selectionBorder.id = 'bugdrop-area-picker-selection';
+  selectionBorder.style.cssText = `
+    position: fixed;
+    border: ${style.bw}px solid ${style.accent};
+    box-shadow: 0 0 0 4px color-mix(in srgb, ${style.accent} 30%, transparent);
+    border-radius: ${style.radius};
+    z-index: 2147483647;
+    pointer-events: none;
+    display: none;
+  `;
+  return selectionBorder;
+}
+
+function createTooltip(
+  style: Pick<
+    ResolvedAreaPickerStyle,
+    'fontFamily' | 'radius' | 'bw' | 'tooltipBg' | 'tooltipText' | 'tooltipBorder'
+  >,
+  text: string
+): HTMLDivElement {
+  const tooltip = document.createElement('div');
+  tooltip.id = 'bugdrop-area-picker-tooltip';
+  tooltip.style.cssText = `
+    position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: ${style.tooltipBg};
+    color: ${style.tooltipText};
+    padding: 14px 28px;
+    border-radius: ${style.radius};
+    font-family: ${style.fontFamily};
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.5;
+    max-width: min(420px, calc(100vw - 40px));
+    box-sizing: border-box;
+    text-align: center;
+    z-index: 2147483647;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border: ${style.bw}px solid ${style.tooltipBorder};
+    pointer-events: none;
+  `;
+  tooltip.textContent = text;
+  return tooltip;
+}
+
+function createCancelButton(
+  style: Pick<
+    ResolvedAreaPickerStyle,
+    'fontFamily' | 'radius' | 'bw' | 'tooltipBg' | 'tooltipText' | 'tooltipBorder'
+  >
+): HTMLButtonElement {
+  const cancelButton = document.createElement('button');
+  cancelButton.id = 'bugdrop-area-picker-cancel';
+  cancelButton.type = 'button';
+  cancelButton.textContent = 'Cancel';
+  cancelButton.style.cssText = `
+    position: fixed;
+    top: 84px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: ${style.tooltipBg};
+    color: ${style.tooltipText};
+    padding: 10px 18px;
+    border-radius: ${style.radius};
+    font-family: ${style.fontFamily};
+    font-size: 14px;
+    font-weight: 600;
+    z-index: 2147483647;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.24);
+    border: ${style.bw}px solid ${style.tooltipBorder};
+    cursor: pointer;
+    touch-action: manipulation;
+  `;
+  return cancelButton;
+}
+
+function positionBelow(anchor: HTMLElement, element: HTMLElement, gap: number) {
+  const anchorRect = anchor.getBoundingClientRect();
+  element.style.top = `${anchorRect.bottom + gap}px`;
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -36,5 +36,6 @@ beforeEach(() => {
       ? globalThis.localStorage
       : createMemoryLocalStorage();
 
+  storage.clear();
   Object.defineProperty(globalThis, 'localStorage', { value: storage, configurable: true });
 });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,6 +1,40 @@
-import { beforeAll } from 'vitest';
+import { beforeAll, beforeEach } from 'vitest';
+
+function createMemoryLocalStorage(): Storage {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+}
 
 beforeAll(() => {
   // Setup global test environment
   process.env.NODE_ENV = 'test';
+});
+
+beforeEach(() => {
+  const storage =
+    typeof globalThis.localStorage?.clear === 'function'
+      ? globalThis.localStorage
+      : createMemoryLocalStorage();
+
+  Object.defineProperty(globalThis, 'localStorage', { value: storage, configurable: true });
 });


### PR DESCRIPTION
Closes #179

## What changed

This makes selected-area capture usable on touch screens by letting finger drags draw the selection rectangle, while preserving the existing desktop mouse and Escape-key behavior.

On mobile, the area-picker prompt now stays below the phone safe area and uses an inline Cancel link instead of desktop-only Escape instructions.

## Why this shape

The important constraint is that the prompt must not intercept selection gestures. Making the whole prompt tappable would make the new mobile Cancel control easy to wire up, but it would also block drags that start over the prompt text. This keeps the prompt itself pass-through and only lets the inline Cancel link receive taps.

The drag handling uses pointer events instead of adding a separate touch-only path. That keeps mouse, pen, and touch input on the same behavior path and avoids maintaining two versions of the same selection logic.

## Test plan

- [x] `npx prettier --check src/widget/area-picker.ts e2e/widget.spec.ts e2e/widget.live.spec.ts test/setup.ts`
- [x] `LIVE_TARGET=local PLAYWRIGHT_BASE_URL=http://localhost:8788 CI=true npx playwright test --project=chromium --shard=1/2`
- [x] `LIVE_TARGET=local PLAYWRIGHT_BASE_URL=http://localhost:8788 CI=true npx playwright test --project=chromium --shard=2/2`
- [x] `make check`
- [x] `make test`
- [x] `make build-all`
