### PR TITLE
Harden screenshot redaction architecture

### DIFF
--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -297,9 +297,28 @@ Supported attributes:
 - `data-bugdrop-redacted`
 - `data-bugdrop-mask`
 
-This is best-effort visual masking, not a data-loss-prevention or security boundary. BugDrop can only mask content it can measure in the page DOM. Unmarked sensitive information can still appear, and browser rendering limits can apply to canvas, image, video, iframe, SVG, shadow DOM, pseudo-element, and highly custom control content.
+This is visual masking, not a data-loss-prevention or security boundary.
+BugDrop can only mask content it can measure in the page DOM. Unmarked
+sensitive information can still appear, and browser rendering limits can apply
+to canvas, image, video, iframe, SVG, shadow DOM, pseudo-element, and highly
+custom control content.
 
-Selected-area screenshots are rendered to the selected dimensions and masks are translated into that crop, but the capture still runs client-side against the page DOM. Avoid screenshots entirely for pages where client-side screenshot rendering is unacceptable.
+Masking works in full-page, selected-element, selected-area, and automatic
+screenshot modes when BugDrop renders the page through its DOM screenshot path.
+For selected-area captures, mask rectangles are translated into the selected
+crop. For selected-element captures with surrounding context enabled, masks are
+computed relative to the captured context element.
+
+| Capture path | Automatic DOM masks | User preview | Manual redact tool | Limitation warning | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Full page | Yes | Yes | Yes | Yes | Uses DOM screenshot rendering unless the page is too complex |
+| Selected element | Yes | Yes | Yes | Yes | Masks are relative to the captured element or surrounding context |
+| Selected area | Yes | Yes | Yes | Yes, scoped to the crop | Masks outside the selected crop are ignored |
+| Automatic screenshot | Yes | No | No | No in the current UI | Use only when marked sensitive regions are stable and supported |
+| Native viewport fallback | No | Yes | Yes | Existing unavailable-mask warning | Used for very complex pages; users must review manually |
+
+Disable screenshots or use `data-screenshot="optional"` on pages where sensitive
+pixels cannot be reliably enclosed by DOM boxes.
 
 ```html
 <!-- Automatically attach a full-page screenshot -->

--- a/docs/website/security.mdx
+++ b/docs/website/security.mdx
@@ -78,7 +78,9 @@ BugDrop is built with a privacy-first approach:
 
 ### Screenshot masking
 
-You can mark sensitive elements so BugDrop visually covers them in supported screenshot modes. Add `data-bugdrop-redact` or `data-bugdrop-mask` to any element you want covered:
+BugDrop supports developer-configured visual masking for screenshots. Add
+`data-bugdrop-redact` or `data-bugdrop-mask` to any DOM element that should be
+covered:
 
 ```html
 <input type="email" data-bugdrop-redact />
@@ -92,16 +94,14 @@ You can mark sensitive elements so BugDrop visually covers them in supported scr
 Supported explicit attributes are `data-bugdrop-redact`, `data-bd-redact`,
 `data-bugdrop-redacted`, and `data-bugdrop-mask`.
 
-When a user submits feedback, BugDrop plans redactions from matching DOM
-elements, then paints an opaque rectangle over each target's measured bounding
-box on supported captured PNGs. In manual screenshot flows, the masked image is
-shown in the annotator preview so the user can audit it before submitting. In
-automatic screenshot mode, BugDrop applies supported masks but submits without
-showing the preview step.
+When capture starts, BugDrop records the geometry of matching DOM elements,
+renders the screenshot, then paints opaque rectangles over those measured boxes
+in the PNG. The submitted image contains the black rectangles. The original page
+DOM is not mutated.
 
-Masking is best-effort visual coverage, not a data-loss-prevention or security
-boundary. Users should still review screenshots before submitting when the manual
-screenshot flow is enabled.
+Masking is visual coverage, not data-loss prevention. BugDrop does not inspect
+text or pixels to discover secrets. Developers must mark the sensitive regions
+they control, and users should review manual screenshots before submitting.
 
 **Inheritance.** When an ancestor has `data-bugdrop-mask`, the entire ancestor box is
 masked as a single rectangle. Descendants do not get individual rectangles — this
@@ -112,26 +112,25 @@ prevents gaps from CSS `gap` or non-masked siblings inside a masked container.
 - `input[type="password"]`
 - Any input with `autocomplete="cc-number"`, `cc-csc`, or `cc-exp`
 
-**Known limitations:**
+| Surface | Behavior | Recommended control |
+| --- | --- | --- |
+| Regular DOM elements | Marked element box is covered | Mark the smallest stable container that fully encloses the sensitive content |
+| Password and credit-card inputs | Covered automatically | No extra attribute required, but explicit marks are fine |
+| Open Shadow DOM | Traversed when the browser exposes `shadowRoot` | Mark inner controls or the host |
+| Closed Shadow DOM | Not traversed | Mark the host custom element |
+| Iframes | Iframe internals are not traversed | Mark the iframe element if the whole embedded frame is sensitive |
+| Canvas, image, SVG, video | Internal pixels are not inspected | Mark the element or a containing wrapper |
+| Pseudo-elements and highly custom controls | Generated pixels are not inspected separately | Mark a stable wrapper around the whole control |
+| Native viewport capture fallback | Element masks cannot be applied | Avoid viewport fallback on pages that require masking |
 
-- Elements inside open Shadow DOM are traversed when the browser exposes the
-  shadow root. Closed Shadow DOM cannot be traversed; mark the host element if
-  the whole custom control should be covered.
-- Iframe contents are not traversed. Mark the iframe element itself if the whole
-  embedded frame should be visually covered.
-- BugDrop does not inspect pixels or text inside canvas, image, video, plugin,
-  or iframe content. Mark the containing DOM element if that entire region should
-  be visually covered.
-- Mask rectangles are collected at the start of capture. If the page reflows or reveals
-  sensitive elements between collection and the moment `html-to-image` finishes
-  rendering, the mask may not cover the final pixels. Keep masked content stable during
-  the brief capture window.
-- **Viewport capture fallback (very complex pages):** When the page exceeds the
-  full-page DOM-complexity threshold, BugDrop falls back to a screen-recording
-  capture (via the browser's `getDisplayMedia` API). That path captures the
-  visible viewport directly and does not apply element masks. If you rely on
-  masking, ensure the user is not capturing through this fallback when sensitive
-  elements are visible.
+If a marked region includes embedded, media, or pixel-rendered content, BugDrop
+covers the marked element box and warns the user in manual screenshot review
+flows that it cannot inspect the internal pixels. Automatic screenshot mode
+still applies supported masks, but it submits without showing a review step.
+
+Mask rectangles are measured at capture start. If the page reflows or reveals
+sensitive elements after that measurement but before rendering finishes, a mask
+can become stale. Keep sensitive marked regions stable during capture.
 
 The only network requests BugDrop makes are:
 

--- a/docs/website/security.mdx
+++ b/docs/website/security.mdx
@@ -94,10 +94,11 @@ covered:
 Supported explicit attributes are `data-bugdrop-redact`, `data-bd-redact`,
 `data-bugdrop-redacted`, and `data-bugdrop-mask`.
 
-When capture starts, BugDrop records the geometry of matching DOM elements,
-renders the screenshot, then paints opaque rectangles over those measured boxes
-in the PNG. The submitted image contains the black rectangles. The original page
-DOM is not mutated.
+For supported DOM-rendered captures, when masking succeeds, BugDrop records the
+geometry of matching DOM elements, renders the screenshot, then paints opaque
+rectangles over those measured boxes in the PNG. The submitted image contains
+the black rectangles. If masking fails, BugDrop discards the screenshot instead
+of uploading it. The original page DOM is not mutated.
 
 Masking is visual coverage, not data-loss prevention. BugDrop does not inspect
 text or pixels to discover secrets. Developers must mark the sensitive regions
@@ -107,10 +108,14 @@ they control, and users should review manual screenshots before submitting.
 masked as a single rectangle. Descendants do not get individual rectangles — this
 prevents gaps from CSS `gap` or non-masked siblings inside a masked container.
 
-**Built-in defaults.** These are always masked, with or without an explicit attribute:
+**Built-in defaults.** In supported DOM-rendered screenshot paths, BugDrop
+automatically masks these with or without an explicit attribute:
 
 - `input[type="password"]`
 - Any input with `autocomplete="cc-number"`, `cc-csc`, or `cc-exp`
+
+These defaults do not apply to native viewport capture or skipped/failed
+screenshot paths.
 
 | Surface | Behavior | Recommended control |
 | --- | --- | --- |

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -368,7 +368,7 @@ test.describe('Widget Interaction', () => {
     });
 
     // Mock the installation check to return installed: true
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -444,7 +444,7 @@ test.describe('Widget Interaction', () => {
     });
 
     // Mock the installation check to return installed: true
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -508,7 +508,7 @@ test.describe('Widget Interaction', () => {
   });
 
   test('welcome screen only shows once per repo (default behavior)', async ({ page }) => {
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -552,7 +552,7 @@ test.describe('Widget Interaction', () => {
   });
 
   test('data-welcome="false" skips welcome entirely', async ({ page }) => {
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -577,7 +577,7 @@ test.describe('Widget Interaction', () => {
   });
 
   test('data-welcome="always" shows welcome every time', async ({ page }) => {
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -612,7 +612,7 @@ test.describe('Widget Interaction', () => {
   });
 
   test('BugDrop.open() skips welcome screen', async ({ page }) => {
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -640,7 +640,7 @@ test.describe('Widget Interaction', () => {
   });
 
   test('screenshot checkbox is checked by default', async ({ page }) => {
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -665,7 +665,7 @@ test.describe('Widget Interaction', () => {
   });
 
   test('version number appears on welcome screen but not on form', async ({ page }) => {
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -698,7 +698,7 @@ test.describe('Widget Interaction', () => {
 
   test('select area button appears and launches area picker overlay', async ({ page }) => {
     const payloads = await trackFeedbackPayloads(page);
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -767,7 +767,7 @@ test.describe('Widget Interaction', () => {
 
     try {
       const payloads = await trackFeedbackPayloads(page);
-      await page.route('**/api/check/**', async route => {
+      await page.route('**/api/check**', async route => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
@@ -866,7 +866,7 @@ test.describe('Widget Interaction', () => {
 
     try {
       const payloads = await trackFeedbackPayloads(page);
-      await page.route('**/api/check/**', async route => {
+      await page.route('**/api/check**', async route => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
@@ -906,7 +906,7 @@ test.describe('Widget Interaction', () => {
     const page = await context.newPage();
 
     try {
-      await page.route('**/api/check/**', async route => {
+      await page.route('**/api/check**', async route => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
@@ -980,7 +980,7 @@ test.describe('Widget Interaction', () => {
     const page = await context.newPage();
 
     try {
-      await page.route('**/api/check/**', async route => {
+      await page.route('**/api/check**', async route => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
@@ -1024,7 +1024,7 @@ test.describe('Widget Interaction', () => {
   });
 
   test('screenshot options prioritize capture actions before skip', async ({ page }) => {
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1072,7 +1072,7 @@ test.describe('Widget Interaction', () => {
   });
 
   test('retake button on annotation step returns to screenshot options', async ({ page }) => {
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1841,7 +1841,7 @@ test.describe('Dismiss Duration', () => {
 test.describe('Keyboard Event Isolation', () => {
   test('typing in widget inputs does not leak keystrokes to host page', async ({ page }) => {
     // Mock the installation check so the feedback form loads
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1901,7 +1901,7 @@ test.describe('Keyboard Event Isolation', () => {
 test.describe('Install URL from appName', () => {
   test('uses server-provided appName in install link', async ({ page }) => {
     // Mock /check to return installed: false with a custom appName
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1931,7 +1931,7 @@ test.describe('Install URL from appName', () => {
 
   test('falls back to URL-derived appName when server omits it', async ({ page }) => {
     // Mock /check to return installed: false without appName
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -2215,7 +2215,7 @@ test.describe('Custom Accent Color', () => {
 
   test('custom color applies to focus ring on form inputs', async ({ page }) => {
     // Mock the installation check to return installed: true
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -2550,7 +2550,7 @@ test.describe('API-Only Mode (data-button="false")', () => {
 test.describe('Feedback Categories', () => {
   test('category selector is visible on feedback form', async ({ page }) => {
     // Mock installation check
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -2599,7 +2599,7 @@ test.describe('Feedback Categories', () => {
   test('feedback form fields progress from category to details and submitter info', async ({
     page,
   }) => {
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -2662,7 +2662,7 @@ test.describe('Feedback Categories', () => {
 
   test('bug category is selected by default', async ({ page }) => {
     // Mock installation check
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -2693,7 +2693,7 @@ test.describe('Feedback Categories', () => {
 
   test('can select different categories', async ({ page }) => {
     // Mock installation check
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -2974,7 +2974,7 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
   }
 
   test.beforeEach(async ({ page }) => {
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -4759,7 +4759,7 @@ test.describe('Screenshot Mode Configuration', () => {
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 
   async function setupInstalledApp(page: Page) {
-    await page.route('**/api/check/**', async route => {
+    await page.route('**/api/check**', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -4976,13 +4976,56 @@ test.describe('Screenshot Masking', () => {
     }, selector);
   }
 
+  async function imagePixelRatio(page: Page, dataUrl: string): Promise<number> {
+    return page.evaluate(
+      url =>
+        new Promise<number>((resolve, reject) => {
+          const img = new Image();
+          img.onload = () => {
+            const vw = window.innerWidth;
+            resolve(vw > 0 ? img.naturalWidth / vw : 1);
+          };
+          img.onerror = () => reject(new Error('image load failed'));
+          img.src = url;
+        }),
+      dataUrl
+    );
+  }
+
+  function mockHtmlToImage(page: Page, toPngBody: string) {
+    return page.addInitScript(`window.__bugdropMockToPng = ${toPngBody};`);
+  }
+
+  function redactionAwarePng() {
+    return `function(el, opts) {
+      var canvas = document.createElement('canvas');
+      var pixelRatio = opts && opts.pixelRatio ? opts.pixelRatio : 1;
+      canvas.width = Math.max(1, Math.ceil((opts && opts.width ? opts.width : document.documentElement.scrollWidth) * pixelRatio));
+      canvas.height = Math.max(1, Math.ceil((opts && opts.height ? opts.height : document.documentElement.scrollHeight) * pixelRatio));
+      var ctx = canvas.getContext('2d');
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      return Promise.resolve(canvas.toDataURL('image/png'));
+    }`;
+  }
+
+  async function mockInstalledCheck(page: Page): Promise<void> {
+    await page.route('**/api/check**', async route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      })
+    );
+  }
+
   // Walk the standard feedback flow up to a captured screenshot, returning the submitted payload.
   async function submitFeedbackWithFullPageCapture(
     page: Page,
     fixturePath: string
   ): Promise<{ screenshot: string; pixelRatio: number }> {
     let payload: Record<string, unknown> | null = null;
-    await page.route('**/api/check/**', async route =>
+    await page.route('**/api/check**', async route =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -5029,19 +5072,7 @@ test.describe('Screenshot Masking', () => {
     // window.devicePixelRatio, because the widget's getPixelRatio() enforces a
     // minimum scale of 2 regardless of the browser's DPR.
     const screenshotDataUrl = payload.screenshot as string;
-    const pr = await page.evaluate(
-      ({ dataUrl }) =>
-        new Promise<number>((resolve, reject) => {
-          const img = new Image();
-          img.onload = () => {
-            const vw = window.innerWidth;
-            resolve(vw > 0 ? img.naturalWidth / vw : 1);
-          };
-          img.onerror = () => reject(new Error('image load failed'));
-          img.src = dataUrl;
-        }),
-      { dataUrl: screenshotDataUrl }
-    );
+    const pr = await imagePixelRatio(page, screenshotDataUrl);
     return { screenshot: screenshotDataUrl, pixelRatio: pr };
   }
 
@@ -5161,7 +5192,7 @@ test.describe('Screenshot Masking', () => {
     // A scrolled variant of the helper — same flow, but scrolls AFTER goto so the page is
     // captured while the user is offset from the top.
     let payload: Record<string, unknown> | null = null;
-    await page.route('**/api/check/**', async route =>
+    await page.route('**/api/check**', async route =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -5280,6 +5311,245 @@ test.describe('Screenshot Masking', () => {
     expect(await pixelAt(page, screenshot, cx, cy)).toEqual([0, 0, 0, 255]);
   });
 
+  test('masks explicit elements inside open shadow DOM', async ({ page }) => {
+    await mockHtmlToImage(page, redactionAwarePng());
+    const { screenshot, pixelRatio } = await submitFeedbackWithFullPageCapture(
+      page,
+      '/test/masking-edge-surfaces.html'
+    );
+
+    const rect = await page.locator('#open-shadow-host').evaluate(el => {
+      const input = el.shadowRoot?.querySelector('#shadow-secret');
+      if (!input) throw new Error('shadow secret not found');
+      const r = input.getBoundingClientRect();
+      return {
+        x: r.left + window.scrollX,
+        y: r.top + window.scrollY,
+        w: r.width,
+        h: r.height,
+      };
+    });
+
+    expect(
+      await pixelAt(
+        page,
+        screenshot,
+        Math.floor((rect.x + rect.w / 2) * pixelRatio),
+        Math.floor((rect.y + rect.h / 2) * pixelRatio)
+      )
+    ).toEqual([0, 0, 0, 255]);
+  });
+
+  test('masks a closed shadow custom element when the host is marked', async ({ page }) => {
+    await mockHtmlToImage(page, redactionAwarePng());
+    const { screenshot, pixelRatio } = await submitFeedbackWithFullPageCapture(
+      page,
+      '/test/masking-edge-surfaces.html'
+    );
+
+    const rect = await docRectOf(page, '#closed-shadow-host');
+    expect(
+      await pixelAt(
+        page,
+        screenshot,
+        Math.floor((rect.x + rect.w / 2) * pixelRatio),
+        Math.floor((rect.y + rect.h / 2) * pixelRatio)
+      )
+    ).toEqual([0, 0, 0, 255]);
+  });
+
+  test('warns when marked unsupported surfaces are covered by their element boxes', async ({
+    page,
+  }) => {
+    await mockHtmlToImage(page, redactionAwarePng());
+    await mockInstalledCheck(page);
+    await page.goto('/test/masking-edge-surfaces.html');
+    const host = page.locator('#bugdrop-host');
+
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+    await host.locator('css=#title').fill('Surface warning');
+    await host.locator('css=#include-screenshot').check();
+    await host.locator('css=#submit-btn').click();
+    await host.locator('css=[data-action="capture"]').click();
+
+    const note = host.locator('css=.bd-redaction-note');
+    await expect(note).toContainText('private');
+    await expect(note).toContainText('BugDrop covered the marked element boxes');
+  });
+
+  test('warns when a marked wrapper contains unsupported pixel-rendered descendants', async ({
+    page,
+  }) => {
+    await mockHtmlToImage(page, redactionAwarePng());
+    await mockInstalledCheck(page);
+    await page.goto('/test/masking-edge-surfaces.html');
+    const host = page.locator('#bugdrop-host');
+
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+    await host.locator('css=#title').fill('Wrapper warning');
+    await host.locator('css=#include-screenshot').check();
+    await host.locator('css=#submit-btn').click();
+    await host.locator('css=[data-action="capture"]').click();
+
+    await expect(host.locator('css=.bd-redaction-note')).toContainText(
+      'BugDrop covered the marked element boxes',
+      { timeout: 30000 }
+    );
+  });
+
+  test('selected-area capture warns only for unsupported marked surfaces inside the crop', async ({
+    page,
+  }) => {
+    await mockHtmlToImage(page, redactionAwarePng());
+    await mockInstalledCheck(page);
+    await page.goto('/test/masking-edge-surfaces.html');
+    const host = page.locator('#bugdrop-host');
+
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+    await host.locator('css=#title').fill('Area includes unsupported surface');
+    await host.locator('css=#include-screenshot').check();
+    await host.locator('css=#submit-btn').click();
+    await host.locator('css=[data-action="area"]').click();
+    await expect(page.locator('#bugdrop-area-picker-overlay')).toBeVisible();
+
+    const box = await page.locator('#secret-canvas').boundingBox();
+    if (!box) throw new Error('secret canvas not found');
+    await page.mouse.move(box.x - 8, box.y - 8);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width + 8, box.y + box.height + 8);
+    await page.mouse.up();
+
+    await expect(host.locator('css=.bd-redaction-note')).toContainText(
+      'BugDrop covered the marked element boxes',
+      { timeout: 30000 }
+    );
+  });
+
+  test('selected-area capture does not warn for unsupported surfaces outside the crop', async ({
+    page,
+  }) => {
+    await mockHtmlToImage(page, redactionAwarePng());
+    await mockInstalledCheck(page);
+    await page.goto('/test/masking-edge-surfaces.html');
+    const host = page.locator('#bugdrop-host');
+
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+    await host.locator('css=#title').fill('Area excludes unsupported surface');
+    await host.locator('css=#include-screenshot').check();
+    await host.locator('css=#submit-btn').click();
+    await host.locator('css=[data-action="area"]').click();
+    await expect(page.locator('#bugdrop-area-picker-overlay')).toBeVisible();
+
+    const box = await page.locator('#custom-control').boundingBox();
+    if (!box) throw new Error('custom control not found');
+    await page.mouse.move(box.x - 8, box.y - 8);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width + 8, box.y + box.height + 8);
+    await page.mouse.up();
+
+    await expect(host.locator('css=.bd-redaction-note')).not.toContainText(
+      'BugDrop covered the marked element boxes',
+      { timeout: 30000 }
+    );
+  });
+
+  test('auto mode applies developer masks to the submitted screenshot', async ({ page }) => {
+    let payload: Record<string, unknown> | null = null;
+    await page.route('**/api/check**', async route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      })
+    );
+    await page.route('**/feedback', async route => {
+      payload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, issueNumber: 1, issueUrl: '#', isPublic: false }),
+      });
+    });
+
+    await page.goto('/test/redaction.html?screenshot=auto');
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+    await host.locator('css=#title').fill('Auto masked screenshot');
+    await host.locator('css=#submit-btn').click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 30000 });
+
+    if (!payload?.screenshot || typeof payload.screenshot !== 'string') {
+      throw new Error('expected screenshot payload');
+    }
+
+    const rect = await docRectOf(page, '#redacted-test-input');
+    const pixelRatio = await imagePixelRatio(page, payload.screenshot);
+    expect(
+      await pixelAt(
+        page,
+        payload.screenshot,
+        Math.floor((rect.x + rect.w / 2) * pixelRatio),
+        Math.floor((rect.y + rect.h / 2) * pixelRatio)
+      )
+    ).toEqual([0, 0, 0, 255]);
+  });
+
+  test('full-page capture uses capture-start redaction geometry after DOM mutation', async ({
+    page,
+  }) => {
+    await mockHtmlToImage(
+      page,
+      `function(el, opts) {
+        window.__mutationCaptureRect = (function() {
+          var target = document.querySelector('[data-bugdrop-redact]');
+          var rect = target.getBoundingClientRect();
+          return {
+            x: rect.left + window.scrollX,
+            y: rect.top + window.scrollY,
+            w: rect.width,
+            h: rect.height
+          };
+        })();
+        document.querySelector('[data-bugdrop-redact]').remove();
+        var canvas = document.createElement('canvas');
+        var pixelRatio = opts && opts.pixelRatio ? opts.pixelRatio : 1;
+        canvas.width = Math.ceil(document.documentElement.scrollWidth * pixelRatio);
+        canvas.height = Math.ceil(document.documentElement.scrollHeight * pixelRatio);
+        var ctx = canvas.getContext('2d');
+        ctx.fillStyle = '#fff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        return Promise.resolve(canvas.toDataURL('image/png'));
+      }`
+    );
+
+    const { screenshot, pixelRatio } = await submitFeedbackWithFullPageCapture(
+      page,
+      '/test/redaction.html'
+    );
+    const originalRect = await page.evaluate(
+      () =>
+        (
+          window as Window & {
+            __mutationCaptureRect: { x: number; y: number; w: number; h: number };
+          }
+        ).__mutationCaptureRect
+    );
+
+    expect(
+      await pixelAt(
+        page,
+        screenshot,
+        Math.floor((originalRect.x + originalRect.w / 2) * pixelRatio),
+        Math.floor((originalRect.y + originalRect.h / 2) * pixelRatio)
+      )
+    ).toEqual([0, 0, 0, 255]);
+  });
+
   // Walk the element-picker flow and capture the chosen element.
   //
   // `selector` identifies the element to click in the picker.  Because the picker
@@ -5306,7 +5576,7 @@ test.describe('Screenshot Masking', () => {
     };
   }> {
     let payload: Record<string, unknown> | null = null;
-    await page.route('**/api/check/**', async route =>
+    await page.route('**/api/check**', async route =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -5514,7 +5784,7 @@ test.describe('Screenshot Masking', () => {
 
   test('area-cropped capture preserves masks inside the selected region', async ({ page }) => {
     let payload: Record<string, unknown> | null = null;
-    await page.route('**/api/check/**', async route =>
+    await page.route('**/api/check**', async route =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -5609,7 +5879,7 @@ test.describe('Screenshot Masking', () => {
     });
 
     let payload: Record<string, unknown> | null = null;
-    await page.route('**/api/check/**', async route =>
+    await page.route('**/api/check**', async route =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -4976,6 +4976,20 @@ test.describe('Screenshot Masking', () => {
     }, selector);
   }
 
+  async function shadowDocRectOf(page: Page, hostSelector: string, shadowSelector: string) {
+    return page.locator(hostSelector).evaluate((host, selector) => {
+      const el = host.shadowRoot?.querySelector(selector);
+      if (!el) throw new Error(`no shadow element matches ${selector}`);
+      const r = el.getBoundingClientRect();
+      return {
+        x: r.left + window.scrollX,
+        y: r.top + window.scrollY,
+        w: r.width,
+        h: r.height,
+      };
+    }, shadowSelector);
+  }
+
   async function imagePixelRatio(page: Page, dataUrl: string): Promise<number> {
     return page.evaluate(
       url =>
@@ -5318,17 +5332,7 @@ test.describe('Screenshot Masking', () => {
       '/test/masking-edge-surfaces.html'
     );
 
-    const rect = await page.locator('#open-shadow-host').evaluate(el => {
-      const input = el.shadowRoot?.querySelector('#shadow-secret');
-      if (!input) throw new Error('shadow secret not found');
-      const r = input.getBoundingClientRect();
-      return {
-        x: r.left + window.scrollX,
-        y: r.top + window.scrollY,
-        w: r.width,
-        h: r.height,
-      };
-    });
+    const rect = await shadowDocRectOf(page, '#open-shadow-host', '#shadow-secret');
 
     expect(
       await pixelAt(
@@ -5375,7 +5379,20 @@ test.describe('Screenshot Masking', () => {
 
     const note = host.locator('css=.bd-redaction-note');
     await expect(note).toContainText('private');
-    await expect(note).toContainText('BugDrop covered the marked element boxes');
+    await expect(note).toContainText('BugDrop only covered the measured marked boxes');
+
+    const canvasRect = await docRectOf(page, '#secret-canvas');
+    const canvas = host.locator('css=#annotation-canvas canvas');
+    const dataUrl = await canvas.evaluate(el => (el as HTMLCanvasElement).toDataURL('image/png'));
+    const pixelRatio = await imagePixelRatio(page, dataUrl);
+    expect(
+      await pixelAt(
+        page,
+        dataUrl,
+        Math.floor((canvasRect.x + canvasRect.w / 2) * pixelRatio),
+        Math.floor((canvasRect.y + canvasRect.h / 2) * pixelRatio)
+      )
+    ).toEqual([0, 0, 0, 255]);
   });
 
   test('warns when a marked wrapper contains unsupported pixel-rendered descendants', async ({
@@ -5383,7 +5400,7 @@ test.describe('Screenshot Masking', () => {
   }) => {
     await mockHtmlToImage(page, redactionAwarePng());
     await mockInstalledCheck(page);
-    await page.goto('/test/masking-edge-surfaces.html');
+    await page.goto('/test/masking-edge-surfaces.html?fixture=wrapper-only');
     const host = page.locator('#bugdrop-host');
 
     await host.locator('css=.bd-trigger').click();
@@ -5394,9 +5411,22 @@ test.describe('Screenshot Masking', () => {
     await host.locator('css=[data-action="capture"]').click();
 
     await expect(host.locator('css=.bd-redaction-note')).toContainText(
-      'BugDrop covered the marked element boxes',
+      'BugDrop only covered the measured marked boxes',
       { timeout: 30000 }
     );
+
+    const wrappedRect = await docRectOf(page, '#wrapped-secret-canvas');
+    const canvas = host.locator('css=#annotation-canvas canvas');
+    const dataUrl = await canvas.evaluate(el => (el as HTMLCanvasElement).toDataURL('image/png'));
+    const pixelRatio = await imagePixelRatio(page, dataUrl);
+    expect(
+      await pixelAt(
+        page,
+        dataUrl,
+        Math.floor((wrappedRect.x + wrappedRect.w / 2) * pixelRatio),
+        Math.floor((wrappedRect.y + wrappedRect.h / 2) * pixelRatio)
+      )
+    ).toEqual([0, 0, 0, 255]);
   });
 
   test('selected-area capture warns only for unsupported marked surfaces inside the crop', async ({
@@ -5423,7 +5453,7 @@ test.describe('Screenshot Masking', () => {
     await page.mouse.up();
 
     await expect(host.locator('css=.bd-redaction-note')).toContainText(
-      'BugDrop covered the marked element boxes',
+      'BugDrop only covered the measured marked boxes',
       { timeout: 30000 }
     );
   });
@@ -5451,8 +5481,9 @@ test.describe('Screenshot Masking', () => {
     await page.mouse.move(box.x + box.width + 8, box.y + box.height + 8);
     await page.mouse.up();
 
+    await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 30000 });
     await expect(host.locator('css=.bd-redaction-note')).not.toContainText(
-      'BugDrop covered the marked element boxes',
+      'BugDrop only covered the measured marked boxes',
       { timeout: 30000 }
     );
   });

--- a/public/test/masking-edge-surfaces.html
+++ b/public/test/masking-edge-surfaces.html
@@ -93,7 +93,7 @@
         <iframe id="secret-frame" data-bugdrop-mask srcdoc="<p>iframe secret</p>"></iframe>
       </section>
 
-      <section id="wrapper-marked-surface" data-bugdrop-mask>
+      <section id="wrapper-marked-surface" class="wrapper-only-surface" data-bugdrop-mask>
         <p>Wrapper contains an unsupported descendant.</p>
         <canvas id="wrapped-secret-canvas" width="320" height="120"></canvas>
       </section>
@@ -139,6 +139,17 @@
 
       paintCanvas('secret-canvas', 'canvas secret');
       paintCanvas('wrapped-secret-canvas', 'wrapped canvas secret');
+
+      if (new URLSearchParams(window.location.search).get('fixture') === 'wrapper-only') {
+        document
+          .querySelectorAll(
+            '#secret-canvas, #secret-image, #secret-video, #secret-frame, #custom-control, #closed-shadow-host, #offscreen-secret'
+          )
+          .forEach(element => {
+            element.removeAttribute('data-bugdrop-mask');
+            element.removeAttribute('data-bugdrop-redact');
+          });
+      }
     </script>
 
     <script src="/test/load-widget.js"></script>

--- a/public/test/masking-edge-surfaces.html
+++ b/public/test/masking-edge-surfaces.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BugDrop Masking Edge Surfaces</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: system-ui, sans-serif;
+        background: #f8fafc;
+        color: #111827;
+      }
+
+      main {
+        width: 960px;
+        margin: 0 auto;
+        padding: 32px;
+      }
+
+      section {
+        margin-bottom: 28px;
+        padding: 18px;
+        border: 1px solid #cbd5e1;
+        background: white;
+      }
+
+      .offscreen-spacer {
+        height: 1400px;
+      }
+
+      #open-shadow-host,
+      #closed-shadow-host,
+      #custom-control {
+        display: block;
+        width: 360px;
+        min-height: 64px;
+        border: 1px solid #64748b;
+        padding: 12px;
+      }
+
+      canvas,
+      img,
+      video,
+      iframe {
+        display: block;
+        width: 320px;
+        height: 120px;
+        border: 1px solid #334155;
+        background: #fee2e2;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Masking edge surfaces</h1>
+
+      <section>
+        <label>
+          Open shadow secret
+          <open-secret id="open-shadow-host"></open-secret>
+        </label>
+      </section>
+
+      <section>
+        <closed-secret id="closed-shadow-host" data-bugdrop-mask></closed-secret>
+      </section>
+
+      <section>
+        <div id="custom-control" role="textbox" aria-label="Private custom control" data-bugdrop-mask>
+          Account token: custom-control-secret
+        </div>
+      </section>
+
+      <section>
+        <canvas id="secret-canvas" data-bugdrop-mask width="320" height="120"></canvas>
+      </section>
+
+      <section>
+        <img
+          id="secret-image"
+          data-bugdrop-mask
+          alt="secret rendered image"
+          src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='320' height='120'%3E%3Crect width='320' height='120' fill='%23fee2e2'/%3E%3Ctext x='20' y='64' font-size='24'%3Eimage secret%3C/text%3E%3C/svg%3E"
+        />
+      </section>
+
+      <section>
+        <video id="secret-video" data-bugdrop-mask muted playsinline></video>
+      </section>
+
+      <section>
+        <iframe id="secret-frame" data-bugdrop-mask srcdoc="<p>iframe secret</p>"></iframe>
+      </section>
+
+      <section id="wrapper-marked-surface" data-bugdrop-mask>
+        <p>Wrapper contains an unsupported descendant.</p>
+        <canvas id="wrapped-secret-canvas" width="320" height="120"></canvas>
+      </section>
+
+      <div class="offscreen-spacer"></div>
+
+      <section id="offscreen-section">
+        <input id="offscreen-secret" data-bugdrop-mask value="offscreen-secret-value" />
+      </section>
+    </main>
+
+    <script>
+      customElements.define(
+        'open-secret',
+        class extends HTMLElement {
+          connectedCallback() {
+            const root = this.attachShadow({ mode: 'open' });
+            root.innerHTML =
+              '<input id="shadow-secret" data-bugdrop-mask value="open-shadow-secret" />';
+          }
+        }
+      );
+
+      customElements.define(
+        'closed-secret',
+        class extends HTMLElement {
+          connectedCallback() {
+            const root = this.attachShadow({ mode: 'closed' });
+            root.innerHTML = '<input value="closed-shadow-secret" />';
+          }
+        }
+      );
+
+      function paintCanvas(id, label) {
+        const canvas = document.getElementById(id);
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = '#fee2e2';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#111827';
+        ctx.font = '24px sans-serif';
+        ctx.fillText(label, 20, 68);
+      }
+
+      paintCanvas('secret-canvas', 'canvas secret');
+      paintCanvas('wrapped-secret-canvas', 'wrapped canvas secret');
+    </script>
+
+    <script src="/test/load-widget.js"></script>
+    <script>
+      window.loadBugDropTestWidget({
+        dataset: { screenshot: 'optional' },
+      });
+    </script>
+  </body>
+</html>

--- a/src/widget/annotation-flow.ts
+++ b/src/widget/annotation-flow.ts
@@ -25,7 +25,7 @@ export function showAnnotationStep(
       }
       if (opts?.redactionLimitations) {
         redactionMessages.push(
-          'BugDrop covered the marked element boxes. It does not inspect or selectively redact pixels inside iframes, canvas, images, SVGs, or videos, so mark the whole sensitive region and review before sending.'
+          'BugDrop only covered the measured marked boxes. It does not inspect pixels inside embedded or rendered content such as iframes, canvas, images, SVGs, videos, CSS backgrounds, or custom controls. Confirm the black box fully covers the sensitive region before sending, or retake after marking a larger wrapper.'
         );
       }
     }

--- a/src/widget/annotation-flow.ts
+++ b/src/widget/annotation-flow.ts
@@ -5,19 +5,33 @@ export function showAnnotationStep(
   root: HTMLElement,
   screenshot: string,
   redactionCount = 0,
-  opts?: { redactionUnavailable?: boolean; selectedElementCapture?: boolean }
+  opts?: {
+    redactionUnavailable?: boolean;
+    redactionLimitations?: boolean;
+    selectedElementCapture?: boolean;
+  }
 ): Promise<string | 'retake' | 'cancel'> {
   return new Promise(resolve => {
-    let redactionNote = '';
+    const redactionMessages: string[] = [];
     if (opts?.redactionUnavailable) {
-      redactionNote = redactionNoteHtml(
+      redactionMessages.push(
         'This browser viewport capture could not apply automatic private-field masks. Review and cover any sensitive areas before sending.'
       );
-    } else if (redactionCount > 0) {
-      redactionNote = redactionNoteHtml(
-        `${redactionCount} private ${redactionCount === 1 ? 'item was' : 'items were'} marked for redaction in this screenshot. Review before sending.`
-      );
+    } else {
+      if (redactionCount > 0) {
+        redactionMessages.push(
+          `${redactionCount} private ${redactionCount === 1 ? 'item was' : 'items were'} marked for redaction in this screenshot. Review before sending.`
+        );
+      }
+      if (opts?.redactionLimitations) {
+        redactionMessages.push(
+          'BugDrop covered the marked element boxes. It does not inspect or selectively redact pixels inside iframes, canvas, images, SVGs, or videos, so mark the whole sensitive region and review before sending.'
+        );
+      }
     }
+    const redactionNote = redactionMessages.length
+      ? redactionNoteHtml(redactionMessages.join(' '))
+      : '';
     const selectedElementNote = opts?.selectedElementCapture
       ? `
         <p class="bd-selected-element-note" style="margin: -4px 0 12px; color: var(--bd-text-secondary); font-size: 13px;">

--- a/src/widget/capture-flow.ts
+++ b/src/widget/capture-flow.ts
@@ -46,6 +46,7 @@ type ChosenCaptureResult =
       screenshot: string;
       redactionCount: number;
       redactionUnavailable: boolean;
+      redactionLimitations: boolean;
     } & ElementMetadata)
   | { kind: 'returnToForm' }
   | ({
@@ -93,6 +94,7 @@ export async function runScreenshotCaptureFlow(
       result.redactionCount,
       {
         redactionUnavailable: result.redactionUnavailable,
+        ...(result.redactionLimitations ? { redactionLimitations: true } : {}),
         ...(result.elementSelector ? { selectedElementCapture: true } : {}),
       }
     );
@@ -188,6 +190,7 @@ async function captureFromViewportChoice(
     fullElementSelector: null,
     redactionCount: 0,
     redactionUnavailable: true,
+    redactionLimitations: false,
   };
 }
 
@@ -208,8 +211,9 @@ async function captureFromFullPageChoice(
     screenshot: result.dataUrl,
     elementSelector: null,
     fullElementSelector: null,
-    redactionCount: getRedactionCount(),
+    redactionCount: result.redaction?.count ?? 0,
     redactionUnavailable: false,
+    redactionLimitations: result.redaction?.hasLimitations ?? false,
   };
 }
 
@@ -250,8 +254,9 @@ async function captureFromElementChoice(
     kind: 'captured',
     screenshot: result.dataUrl,
     ...elementMetadata,
-    redactionCount: getRedactionCount(captureTarget),
+    redactionCount: result.redaction?.count ?? 0,
     redactionUnavailable: false,
+    redactionLimitations: result.redaction?.hasLimitations ?? false,
   };
 }
 
@@ -279,8 +284,9 @@ async function captureFromAreaChoice(
     screenshot: result.dataUrl,
     elementSelector: null,
     fullElementSelector: null,
-    redactionCount: getRedactionCount(undefined, rect),
+    redactionCount: result.redaction?.count ?? 0,
     redactionUnavailable: false,
+    redactionLimitations: result.redaction?.hasLimitations ?? false,
   };
 }
 

--- a/src/widget/capture-loading.ts
+++ b/src/widget/capture-loading.ts
@@ -2,14 +2,17 @@ import { MaskApplicationError } from './mask';
 import {
   captureAreaScreenshot,
   captureScreenshot,
+  type CapturedScreenshot,
   type CaptureScreenshotOptions,
 } from './screenshot';
 import { createModal } from './ui';
 
 export type CaptureWithLoadingResult =
-  | { kind: 'ok'; dataUrl: string }
+  | { kind: 'ok'; dataUrl: string; redaction?: CapturedScreenshot['redaction'] }
   | { kind: 'skipped' }
   | { kind: 'cancelled' };
+
+type CapturePayload = string | CapturedScreenshot;
 
 export async function captureWithLoading(
   root: HTMLElement,
@@ -41,8 +44,8 @@ export async function captureAreaWithLoading(
 
 export async function capturePromiseWithLoading(
   root: HTMLElement,
-  capturePromise: Promise<string>,
-  retryCapture: () => Promise<string>,
+  capturePromise: Promise<CapturePayload>,
+  retryCapture: () => Promise<CapturePayload>,
   opts?: { allowSkip?: boolean; showLoading?: boolean }
 ): Promise<CaptureWithLoadingResult> {
   const loadingModal =
@@ -62,7 +65,7 @@ export async function capturePromiseWithLoading(
   try {
     const screenshot = await capturePromise;
     loadingModal?.remove();
-    return { kind: 'ok', dataUrl: screenshot };
+    return normalizeCaptureResult(screenshot);
   } catch (error) {
     console.warn('[BugDrop] Screenshot capture failed:', error);
     loadingModal?.remove();
@@ -146,4 +149,16 @@ function showMaskFailureModal(root: HTMLElement): Promise<CaptureWithLoadingResu
       resolve({ kind: 'skipped' });
     });
   });
+}
+
+function normalizeCaptureResult(capture: CapturePayload): CaptureWithLoadingResult {
+  if (typeof capture === 'string') {
+    return { kind: 'ok', dataUrl: capture };
+  }
+
+  return {
+    kind: 'ok',
+    dataUrl: capture.dataUrl,
+    redaction: capture.redaction,
+  };
 }

--- a/src/widget/crop-screenshot.ts
+++ b/src/widget/crop-screenshot.ts
@@ -1,0 +1,38 @@
+export async function cropScreenshot(
+  imageDataUrl: string,
+  rect: DOMRect,
+  pixelRatio: number
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      const cropW = Math.round(rect.width * pixelRatio);
+      const cropH = Math.round(rect.height * pixelRatio);
+      canvas.width = cropW;
+      canvas.height = cropH;
+
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        reject(new Error('Failed to get canvas context'));
+        return;
+      }
+
+      ctx.drawImage(
+        img,
+        Math.round(rect.x * pixelRatio),
+        Math.round(rect.y * pixelRatio),
+        cropW,
+        cropH,
+        0,
+        0,
+        cropW,
+        cropH
+      );
+
+      resolve(canvas.toDataURL('image/png'));
+    };
+    img.onerror = () => reject(new Error('Failed to load image for cropping'));
+    img.src = imageDataUrl;
+  });
+}

--- a/src/widget/mask.ts
+++ b/src/widget/mask.ts
@@ -1,22 +1,22 @@
-export interface MaskRect {
+interface MaskRect {
   x: number;
   y: number;
   w: number;
   h: number;
 }
 
-export type RedactionReason = 'developer-marked' | 'sensitive-input';
-export type RedactionStrategy = 'canvas-mask';
-export type UnsupportedSurfaceReason = 'embedded-document' | 'pixel-content' | 'media-content';
+type RedactionReason = 'developer-marked' | 'sensitive-input';
+type RedactionStrategy = 'canvas-mask';
+type UnsupportedSurfaceReason = 'embedded-document' | 'pixel-content' | 'media-content';
 
-export interface RedactionTarget {
+interface RedactionTarget {
   element: Element;
   rect: MaskRect;
   reason: RedactionReason;
   strategy: RedactionStrategy;
 }
 
-export interface UnsupportedRedactionSurface {
+interface UnsupportedRedactionSurface {
   tagName: string;
   reason: UnsupportedSurfaceReason;
   rect: MaskRect;
@@ -207,9 +207,10 @@ function collectUnsupportedSurface(
 }
 
 function getUnsupportedSurfaceReason(element: Element): UnsupportedSurfaceReason | null {
-  if (element.tagName === 'IFRAME') return 'embedded-document';
-  if (PIXEL_CONTENT_TAGS.has(element.tagName)) return 'pixel-content';
-  if (MEDIA_CONTENT_TAGS.has(element.tagName)) return 'media-content';
+  const tagName = element.tagName.toUpperCase();
+  if (tagName === 'IFRAME') return 'embedded-document';
+  if (PIXEL_CONTENT_TAGS.has(tagName)) return 'pixel-content';
+  if (MEDIA_CONTENT_TAGS.has(tagName)) return 'media-content';
   return null;
 }
 

--- a/src/widget/mask.ts
+++ b/src/widget/mask.ts
@@ -1,22 +1,36 @@
-interface MaskRect {
+export interface MaskRect {
   x: number;
   y: number;
   w: number;
   h: number;
 }
 
-type RedactionReason = 'developer-marked' | 'sensitive-input';
-type RedactionStrategy = 'canvas-mask';
+export type RedactionReason = 'developer-marked' | 'sensitive-input';
+export type RedactionStrategy = 'canvas-mask';
+export type UnsupportedSurfaceReason = 'embedded-document' | 'pixel-content' | 'media-content';
 
-interface RedactionTarget {
+export interface RedactionTarget {
   element: Element;
   rect: MaskRect;
   reason: RedactionReason;
   strategy: RedactionStrategy;
 }
 
-interface RedactionPlan {
+export interface UnsupportedRedactionSurface {
+  tagName: string;
+  reason: UnsupportedSurfaceReason;
+  rect: MaskRect;
+}
+
+export interface RedactionSnapshot {
   targets: RedactionTarget[];
+  unsupportedSurfaces: UnsupportedRedactionSurface[];
+  redactionCount: number;
+}
+
+export interface RedactionSummary {
+  count: number;
+  hasLimitations: boolean;
 }
 
 export class MaskApplicationError extends Error {
@@ -30,6 +44,9 @@ const EXPLICIT_SELECTOR =
   '[data-bugdrop-mask], [data-bugdrop-redact], [data-bd-redact], [data-bugdrop-redacted]';
 const DEFAULT_SELECTOR =
   'input[type="password"], input[autocomplete*="cc-number"], input[autocomplete*="cc-csc"], input[autocomplete*="cc-exp"]';
+const UNSUPPORTED_SURFACE_SELECTOR = 'iframe, canvas, img, svg, video';
+const PIXEL_CONTENT_TAGS = new Set(['CANVAS', 'IMG', 'SVG']);
+const MEDIA_CONTENT_TAGS = new Set(['VIDEO']);
 
 function getRedactionReason(el: Element): RedactionReason | null {
   if (el.matches(EXPLICIT_SELECTOR)) return 'developer-marked';
@@ -53,28 +70,62 @@ function createTarget(el: Element, reason: RedactionReason): RedactionTarget | n
   };
 }
 
-export function createRedactionPlan(root: Element): RedactionPlan {
+export function createRedactionSnapshot(root: Element): RedactionSnapshot {
   const targets: RedactionTarget[] = [];
+  const unsupportedSurfaces: UnsupportedRedactionSurface[] = [];
   const rootReason = getRedactionReason(root);
 
   if (rootReason) {
     const rootTarget = createTarget(root, rootReason);
-    return { targets: rootTarget ? [rootTarget] : [] };
+    if (rootTarget) {
+      targets.push(rootTarget);
+      collectUnsupportedSurfaces(root, unsupportedSurfaces);
+    }
+    return {
+      targets,
+      unsupportedSurfaces,
+      redactionCount: targets.length,
+    };
   }
 
-  walk(root, targets);
-  walkOpenShadowRoot(root, targets);
-  return { targets };
+  walk(root, targets, unsupportedSurfaces);
+  walkOpenShadowRoot(root, targets, unsupportedSurfaces);
+  return {
+    targets,
+    unsupportedSurfaces,
+    redactionCount: targets.length,
+  };
+}
+
+export function createRedactionPlan(root: Element): RedactionSnapshot {
+  return createRedactionSnapshot(root);
 }
 
 export function collectMaskRects(root: Element): MaskRect[] {
-  return createRedactionPlan(root).targets.map(target => target.rect);
+  return createRedactionSnapshot(root).targets.map(target => target.rect);
 }
 
 export function countMaskRects(root: Element = document.body, area?: DOMRect): number {
-  const rects = createRedactionPlan(root).targets.map(target => target.rect);
+  const rects = createRedactionSnapshot(root).targets.map(target => target.rect);
   if (!area) return rects.length;
   return rects.filter(rect => intersects(rect, area)).length;
+}
+
+export function summarizeRedactionSnapshot(
+  snapshot: RedactionSnapshot,
+  area?: DOMRect
+): RedactionSummary {
+  const targets = area
+    ? snapshot.targets.filter(target => intersects(target.rect, area))
+    : snapshot.targets;
+  const unsupportedSurfaces = area
+    ? snapshot.unsupportedSurfaces.filter(surface => intersects(surface.rect, area))
+    : snapshot.unsupportedSurfaces;
+
+  return {
+    count: targets.length,
+    hasLimitations: unsupportedSurfaces.length > 0,
+  };
 }
 
 function intersects(rect: MaskRect, area: DOMRect): boolean {
@@ -86,21 +137,32 @@ function intersects(rect: MaskRect, area: DOMRect): boolean {
   );
 }
 
-function walk(node: Element, targets: RedactionTarget[]): void {
+function walk(
+  node: Element,
+  targets: RedactionTarget[],
+  unsupportedSurfaces: UnsupportedRedactionSurface[]
+): void {
   for (const child of Array.from(node.children)) {
     const reason = getRedactionReason(child);
     if (reason) {
       const target = createTarget(child, reason);
-      if (target) targets.push(target);
+      if (target) {
+        targets.push(target);
+        collectUnsupportedSurfaces(child, unsupportedSurfaces);
+      }
       // Top-most-ancestor rule: do not descend into masked subtrees.
       continue;
     }
-    walk(child, targets);
-    walkOpenShadowRoot(child, targets);
+    walk(child, targets, unsupportedSurfaces);
+    walkOpenShadowRoot(child, targets, unsupportedSurfaces);
   }
 }
 
-function walkOpenShadowRoot(node: Element, targets: RedactionTarget[]): void {
+function walkOpenShadowRoot(
+  node: Element,
+  targets: RedactionTarget[],
+  unsupportedSurfaces: UnsupportedRedactionSurface[]
+): void {
   const shadowRoot = node.shadowRoot;
   if (!shadowRoot) return;
 
@@ -108,11 +170,62 @@ function walkOpenShadowRoot(node: Element, targets: RedactionTarget[]): void {
     const reason = getRedactionReason(child);
     if (reason) {
       const target = createTarget(child, reason);
-      if (target) targets.push(target);
+      if (target) {
+        targets.push(target);
+        collectUnsupportedSurfaces(child, unsupportedSurfaces);
+      }
       continue;
     }
-    walk(child, targets);
-    walkOpenShadowRoot(child, targets);
+    walk(child, targets, unsupportedSurfaces);
+    walkOpenShadowRoot(child, targets, unsupportedSurfaces);
+  }
+}
+
+function collectUnsupportedSurfaces(root: Element, surfaces: UnsupportedRedactionSurface[]): void {
+  collectUnsupportedSurface(root, surfaces);
+  for (const child of Array.from(root.querySelectorAll(UNSUPPORTED_SURFACE_SELECTOR))) {
+    collectUnsupportedSurface(child, surfaces);
+  }
+  walkOpenShadowUnsupportedSurfaces(root, surfaces);
+}
+
+function collectUnsupportedSurface(
+  element: Element,
+  surfaces: UnsupportedRedactionSurface[]
+): void {
+  const reason = getUnsupportedSurfaceReason(element);
+  if (!reason) return;
+
+  const target = createTarget(element, getRedactionReason(element) ?? 'developer-marked');
+  if (!target) return;
+
+  surfaces.push({
+    tagName: element.tagName,
+    reason,
+    rect: target.rect,
+  });
+}
+
+function getUnsupportedSurfaceReason(element: Element): UnsupportedSurfaceReason | null {
+  if (element.tagName === 'IFRAME') return 'embedded-document';
+  if (PIXEL_CONTENT_TAGS.has(element.tagName)) return 'pixel-content';
+  if (MEDIA_CONTENT_TAGS.has(element.tagName)) return 'media-content';
+  return null;
+}
+
+function walkOpenShadowUnsupportedSurfaces(
+  root: Element,
+  surfaces: UnsupportedRedactionSurface[]
+): void {
+  const shadowRoot = root.shadowRoot;
+  if (shadowRoot) {
+    for (const child of Array.from(shadowRoot.querySelectorAll(UNSUPPORTED_SURFACE_SELECTOR))) {
+      collectUnsupportedSurface(child, surfaces);
+    }
+  }
+
+  for (const child of Array.from(root.children)) {
+    walkOpenShadowUnsupportedSurfaces(child, surfaces);
   }
 }
 

--- a/src/widget/screenshot.ts
+++ b/src/widget/screenshot.ts
@@ -1,8 +1,16 @@
 import * as htmlToImage from 'html-to-image';
 import type { Options as HtmlToImageOptions } from 'html-to-image/lib/types';
 import { withCaptureTimeout } from './capture-timeout';
-import { applyMaskToImage, countMaskRects, createRedactionPlan } from './mask';
+import {
+  applyMaskToImage,
+  countMaskRects,
+  createRedactionSnapshot,
+  summarizeRedactionSnapshot,
+  type RedactionSnapshot,
+  type RedactionSummary,
+} from './mask';
 import { resolveAccentColor } from '../defaults';
+export { cropScreenshot } from './crop-screenshot';
 export { beginViewportCapture } from './viewport-capture';
 
 declare const __BUGDROP_ENABLE_TEST_HOOKS__: boolean;
@@ -21,6 +29,11 @@ export interface CaptureScreenshotOptions {
     borderWidth?: string;
   };
   pixelRatio?: number;
+}
+
+export interface CapturedScreenshot {
+  dataUrl: string;
+  redaction: RedactionSummary;
 }
 
 declare global {
@@ -75,7 +88,7 @@ export async function captureScreenshot(
   element?: Element,
   screenshotScale?: number,
   captureOptions: CaptureScreenshotOptions = {}
-): Promise<string> {
+): Promise<CapturedScreenshot> {
   const target = element || document.body;
   const isFullPage = !element;
   const targetRect = element ? getDocumentRect(element) : getDocumentRect(document.body);
@@ -94,27 +107,30 @@ export async function captureScreenshot(
     filter: (node: HTMLElement) => node.id !== 'bugdrop-host',
   };
 
-  const redactionPlan = createRedactionPlan(target);
+  const redactionSnapshot = createRedactionSnapshot(target);
   const originOffset = element ? { x: targetRect.x, y: targetRect.y } : { x: 0, y: 0 };
 
   const capturePromise = toPng(target as HTMLElement, opts);
   const dataUrl = await withCaptureTimeout(capturePromise);
   const maskedDataUrl = await applyMaskToImage(
     dataUrl,
-    redactionPlan.targets.map(target => target.rect),
+    redactionSnapshot.targets.map(target => target.rect),
     pixelRatio,
     originOffset
   );
 
   if (!highlightRect) {
-    return maskedDataUrl;
+    return capturedScreenshot(maskedDataUrl, redactionSnapshot);
   }
 
-  return applyHighlightToImage(
-    maskedDataUrl,
-    highlightRect,
-    targetRect,
-    captureOptions.highlightStyle
+  return capturedScreenshot(
+    await applyHighlightToImage(
+      maskedDataUrl,
+      highlightRect,
+      targetRect,
+      captureOptions.highlightStyle
+    ),
+    redactionSnapshot
   );
 }
 
@@ -122,7 +138,7 @@ export async function captureAreaScreenshot(
   rect: DOMRect,
   screenshotScale?: number,
   captureOptions: CaptureScreenshotOptions = {}
-): Promise<string> {
+): Promise<CapturedScreenshot> {
   const pixelRatio = captureOptions.pixelRatio ?? getPixelRatio(true, screenshotScale);
   const targetRect = { x: rect.x, y: rect.y, w: rect.width, h: rect.height };
   const highlightRect =
@@ -145,11 +161,11 @@ export async function captureAreaScreenshot(
     filter: (node: HTMLElement) => node.id !== 'bugdrop-host',
   };
 
+  const redactionSnapshot = createRedactionSnapshot(document.body);
   const dataUrl = await withCaptureTimeout(toPng(document.body, opts));
-  const redactionPlan = createRedactionPlan(document.body);
   const maskedDataUrl = await applyMaskToImage(
     dataUrl,
-    redactionPlan.targets.map(target => target.rect),
+    redactionSnapshot.targets.map(target => target.rect),
     pixelRatio,
     {
       x: rect.x,
@@ -158,14 +174,18 @@ export async function captureAreaScreenshot(
   );
 
   if (!highlightRect) {
-    return maskedDataUrl;
+    return capturedScreenshot(maskedDataUrl, redactionSnapshot, rect);
   }
 
-  return applyHighlightToImage(
-    maskedDataUrl,
-    highlightRect,
-    targetRect,
-    captureOptions.highlightStyle
+  return capturedScreenshot(
+    await applyHighlightToImage(
+      maskedDataUrl,
+      highlightRect,
+      targetRect,
+      captureOptions.highlightStyle
+    ),
+    redactionSnapshot,
+    rect
   );
 }
 
@@ -181,6 +201,17 @@ function getToPng(): typeof htmlToImage.toPng {
     return window.__bugdropMockToPng;
   }
   return htmlToImage.toPng;
+}
+
+function capturedScreenshot(
+  dataUrl: string,
+  snapshot: RedactionSnapshot,
+  area?: DOMRect
+): CapturedScreenshot {
+  return {
+    dataUrl,
+    redaction: summarizeRedactionSnapshot(snapshot, area),
+  };
 }
 
 async function applyHighlightToImage(
@@ -283,44 +314,5 @@ function loadImage(dataUrl: string): Promise<HTMLImageElement> {
     img.onload = () => resolve(img);
     img.onerror = () => reject(new Error('Failed to load image for selected element highlight'));
     img.src = dataUrl;
-  });
-}
-
-export async function cropScreenshot(
-  imageDataUrl: string,
-  rect: DOMRect,
-  pixelRatio: number
-): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-    img.onload = () => {
-      const canvas = document.createElement('canvas');
-      const cropW = Math.round(rect.width * pixelRatio);
-      const cropH = Math.round(rect.height * pixelRatio);
-      canvas.width = cropW;
-      canvas.height = cropH;
-
-      const ctx = canvas.getContext('2d');
-      if (!ctx) {
-        reject(new Error('Failed to get canvas context'));
-        return;
-      }
-
-      ctx.drawImage(
-        img,
-        Math.round(rect.x * pixelRatio),
-        Math.round(rect.y * pixelRatio),
-        cropW,
-        cropH,
-        0,
-        0,
-        cropW,
-        cropH
-      );
-
-      resolve(canvas.toDataURL('image/png'));
-    };
-    img.onerror = () => reject(new Error('Failed to load image for cropping'));
-    img.src = imageDataUrl;
   });
 }

--- a/test/cropScreenshot.test.ts
+++ b/test/cropScreenshot.test.ts
@@ -285,7 +285,10 @@ describe('captureScreenshot integrates with mask pipeline', () => {
     const result = await captureScreenshot();
 
     // No masks → applyMaskToImage short-circuits and returns the input unchanged.
-    expect(result).toBe(STUB);
+    expect(result).toEqual({
+      dataUrl: STUB,
+      redaction: { count: 0, hasLimitations: false },
+    });
   });
 
   it('completes element-scoped capture when the picked element has a masked descendant', async () => {
@@ -329,7 +332,10 @@ describe('captureScreenshot integrates with mask pipeline', () => {
       Promise.resolve(STUB);
 
     // applyMaskToImage must have run: only it produces the masked sentinel.
-    await expect(captureScreenshot(target)).resolves.toBe('data:image/png;base64,masked');
+    await expect(captureScreenshot(target)).resolves.toEqual({
+      dataUrl: 'data:image/png;base64,masked',
+      redaction: { count: 1, hasLimitations: false },
+    });
   });
 
   it('captures a context element and draws a selected descendant highlight', async () => {
@@ -394,7 +400,10 @@ describe('captureScreenshot integrates with mask pipeline', () => {
 
     await expect(
       captureScreenshot(context, undefined, { highlightElement: selected })
-    ).resolves.toBe('data:image/png;base64,masked');
+    ).resolves.toEqual({
+      dataUrl: 'data:image/png;base64,masked',
+      redaction: { count: 0, hasLimitations: false },
+    });
 
     expect(toPng).toHaveBeenCalledWith(context, expect.any(Object));
     expect(fill).not.toHaveBeenCalled();
@@ -445,7 +454,10 @@ describe('captureScreenshot integrates with mask pipeline', () => {
 
     await expect(
       captureScreenshot(selected, undefined, { highlightElement: selected })
-    ).resolves.toBe('data:image/png;base64,masked');
+    ).resolves.toEqual({
+      dataUrl: 'data:image/png;base64,masked',
+      redaction: { count: 0, hasLimitations: false },
+    });
 
     expect(toPng).toHaveBeenCalledWith(selected, expect.any(Object));
     expect(drawImage).toHaveBeenCalledWith(

--- a/test/mask.test.ts
+++ b/test/mask.test.ts
@@ -4,7 +4,9 @@ import {
   applyMaskToImage,
   collectMaskRects,
   createRedactionPlan,
+  createRedactionSnapshot,
   MaskApplicationError,
+  summarizeRedactionSnapshot,
   translateMaskRect,
 } from '../src/widget/mask';
 
@@ -15,6 +17,10 @@ describe('mask module exports', () => {
 
   it('exports createRedactionPlan', () => {
     expect(typeof createRedactionPlan).toBe('function');
+  });
+
+  it('exports createRedactionSnapshot', () => {
+    expect(typeof createRedactionSnapshot).toBe('function');
   });
 
   it('exports applyMaskToImage', () => {
@@ -250,14 +256,52 @@ describe('collectMaskRects — nesting and scoping', () => {
     document.body.appendChild(iframe);
 
     expect(collectMaskRects(document.body)).toEqual([{ x: 0, y: 0, w: 200, h: 100 }]);
+    expect(createRedactionSnapshot(document.body).unsupportedSurfaces).toMatchObject([
+      {
+        tagName: 'IFRAME',
+        reason: 'embedded-document',
+        rect: { x: 0, y: 0, w: 200, h: 100 },
+      },
+    ]);
   });
 
-  it.each(['canvas', 'img', 'video'] as const)('masks a marked %s container', tagName => {
+  it.each([
+    ['canvas', 'pixel-content'],
+    ['img', 'pixel-content'],
+    ['video', 'media-content'],
+  ] as const)('masks a marked %s container', (tagName, reason) => {
     const media = withRect(document.createElement(tagName), 0, 0, 200, 100);
     media.setAttribute('data-bugdrop-mask', '');
     document.body.appendChild(media);
 
     expect(collectMaskRects(document.body)).toEqual([{ x: 0, y: 0, w: 200, h: 100 }]);
+    expect(createRedactionSnapshot(document.body).unsupportedSurfaces).toMatchObject([
+      {
+        tagName: tagName.toUpperCase(),
+        reason,
+        rect: { x: 0, y: 0, w: 200, h: 100 },
+      },
+    ]);
+  });
+
+  it('reports unsupported descendants inside a marked wrapper without adding child masks', () => {
+    const wrapper = withRect(document.createElement('section'), 0, 0, 300, 160);
+    wrapper.setAttribute('data-bugdrop-mask', '');
+    const canvas = withRect(document.createElement('canvas'), 20, 30, 120, 50);
+    wrapper.appendChild(canvas);
+    document.body.appendChild(wrapper);
+
+    const snapshot = createRedactionSnapshot(document.body);
+
+    expect(snapshot.targets).toHaveLength(1);
+    expect(snapshot.targets[0].rect).toEqual({ x: 0, y: 0, w: 300, h: 160 });
+    expect(snapshot.unsupportedSurfaces).toMatchObject([
+      {
+        tagName: 'CANVAS',
+        reason: 'pixel-content',
+        rect: { x: 20, y: 30, w: 120, h: 50 },
+      },
+    ]);
   });
 
   it.each(['canvas', 'img', 'video'] as const)(
@@ -314,6 +358,43 @@ describe('collectMaskRects — coordinates and visibility', () => {
 
     expect(collectMaskRects(document.body)).toEqual([{ x: 10, y: 20, w: 100, h: 50 }]);
   });
+
+  it('creates an immutable snapshot with target count and unsupported surface metadata', () => {
+    const privateSection = withRect(document.createElement('section'), 0, 0, 100, 40);
+    privateSection.setAttribute('data-bugdrop-mask', '');
+    const canvas = withRect(document.createElement('canvas'), 120, 0, 100, 40);
+    canvas.setAttribute('data-bugdrop-mask', '');
+    const iframe = withRect(document.createElement('iframe'), 240, 0, 100, 40);
+    iframe.setAttribute('data-bugdrop-mask', '');
+    document.body.append(privateSection, canvas, iframe);
+
+    const snapshot = createRedactionSnapshot(document.body);
+
+    expect(snapshot.targets).toHaveLength(3);
+    expect(snapshot.redactionCount).toBe(3);
+    expect(snapshot.unsupportedSurfaces).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ tagName: 'CANVAS', reason: 'pixel-content' }),
+        expect.objectContaining({ tagName: 'IFRAME', reason: 'embedded-document' }),
+      ])
+    );
+
+    privateSection.remove();
+    expect(snapshot.targets).toHaveLength(3);
+  });
+
+  it('keeps offscreen target geometry in document coordinates', () => {
+    const spacer = document.createElement('div');
+    const input = withRect(document.createElement('input'), 12, 2400, 160, 32);
+    input.setAttribute('data-bugdrop-mask', '');
+    document.body.append(spacer, input);
+
+    const rect = input.getBoundingClientRect();
+    const snapshot = createRedactionSnapshot(document.body);
+
+    expect(snapshot.targets[0].rect.y).toBeCloseTo(rect.top + window.scrollY);
+    expect(snapshot.targets[0].rect.h).toBeGreaterThan(0);
+  });
 });
 
 describe('translateMaskRect', () => {
@@ -327,6 +408,12 @@ describe('translateMaskRect', () => {
     expect(
       translateMaskRect({ x: 110, y: 220, w: 100, h: 50 }, 2, { x: 100, y: 200 }, 1000, 1000)
     ).toEqual({ x: 19, y: 39, w: 202, h: 102 });
+  });
+
+  it('translates snapshot rectangles into selected-area image coordinates', () => {
+    expect(
+      translateMaskRect({ x: 120, y: 240, w: 40, h: 20 }, 2, { x: 100, y: 200 }, 300, 200)
+    ).toEqual({ x: 39, y: 79, w: 82, h: 42 });
   });
 
   it('clips a rect that overflows the canvas on the right and bottom', () => {
@@ -348,6 +435,51 @@ describe('translateMaskRect', () => {
     const out = translateMaskRect({ x: 1000, y: 1000, w: 50, h: 50 }, 1, { x: 0, y: 0 }, 100, 100);
     expect(out.w).toBeLessThanOrEqual(0);
     expect(out.h).toBeLessThanOrEqual(0);
+  });
+});
+
+describe('summarizeRedactionSnapshot', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('summarizes count and limitations for the whole snapshot', () => {
+    const input = withRect(document.createElement('input'), 0, 0, 100, 20);
+    input.setAttribute('data-bugdrop-mask', '');
+    const canvas = withRect(document.createElement('canvas'), 0, 40, 100, 40);
+    canvas.setAttribute('data-bugdrop-mask', '');
+    document.body.append(input, canvas);
+
+    expect(summarizeRedactionSnapshot(createRedactionSnapshot(document.body))).toEqual({
+      count: 2,
+      hasLimitations: true,
+    });
+  });
+
+  it('scopes limitation summaries to a selected area', () => {
+    const input = withRect(document.createElement('input'), 0, 0, 100, 20);
+    input.setAttribute('data-bugdrop-mask', '');
+    const canvas = withRect(document.createElement('canvas'), 0, 200, 100, 40);
+    canvas.setAttribute('data-bugdrop-mask', '');
+    document.body.append(input, canvas);
+
+    const snapshot = createRedactionSnapshot(document.body);
+
+    expect(
+      summarizeRedactionSnapshot(snapshot, {
+        x: 0,
+        y: 0,
+        width: 120,
+        height: 40,
+        top: 0,
+        left: 0,
+        right: 120,
+        bottom: 40,
+        toJSON() {
+          return {};
+        },
+      } as DOMRect)
+    ).toEqual({ count: 1, hasLimitations: false });
   });
 });
 

--- a/test/mask.test.ts
+++ b/test/mask.test.ts
@@ -304,6 +304,48 @@ describe('collectMaskRects — nesting and scoping', () => {
     ]);
   });
 
+  it('reports inline SVG unsupported surfaces with lowercase tag names', () => {
+    const svg = withRect(
+      document.createElementNS('http://www.w3.org/2000/svg', 'svg') as unknown as HTMLElement,
+      0,
+      0,
+      200,
+      100
+    );
+    svg.setAttribute('data-bugdrop-mask', '');
+    document.body.appendChild(svg);
+
+    expect(createRedactionSnapshot(document.body).unsupportedSurfaces).toMatchObject([
+      {
+        tagName: 'svg',
+        reason: 'pixel-content',
+        rect: { x: 0, y: 0, w: 200, h: 100 },
+      },
+    ]);
+  });
+
+  it('reports inline SVG descendants inside a marked wrapper', () => {
+    const wrapper = withRect(document.createElement('section'), 0, 0, 300, 160);
+    wrapper.setAttribute('data-bugdrop-mask', '');
+    const svg = withRect(
+      document.createElementNS('http://www.w3.org/2000/svg', 'svg') as unknown as HTMLElement,
+      30,
+      40,
+      120,
+      60
+    );
+    wrapper.appendChild(svg);
+    document.body.appendChild(wrapper);
+
+    expect(createRedactionSnapshot(document.body).unsupportedSurfaces).toMatchObject([
+      {
+        tagName: 'svg',
+        reason: 'pixel-content',
+        rect: { x: 30, y: 40, w: 120, h: 60 },
+      },
+    ]);
+  });
+
   it.each(['canvas', 'img', 'video'] as const)(
     'does not treat unmarked %s pixels as redaction targets',
     tagName => {


### PR DESCRIPTION
Closes #152

## Summary
- Create immutable redaction snapshots at capture start and carry the same redaction metadata through the capture result used by annotation.
- Detect unsupported marked surfaces, including wrapper-marked canvas/image/video/iframe descendants, and warn during manual review without rescanning live DOM.
- Add edge fixture and E2E coverage for open Shadow DOM, closed-shadow host masking, selected-area warning scoping, auto-mode masking, and DOM mutation during capture.
- Clarify screenshot masking guarantees and limitations in developer docs.

## Verification
- npm run validate
- npx playwright test e2e/widget.spec.ts --project=chromium -g "open shadow|closed shadow|marked unsupported surfaces|marked wrapper|selected-area capture warns|selected-area capture does not warn|auto mode applies|capture-start redaction geometry"
- CI=true make test-e2e-shard SHARD=1/2
- CI=true make test-e2e-shard SHARD=2/2