### PR TITLE
Harden mobile element picker selection

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -1050,6 +1050,19 @@ test.describe('Widget Interaction', () => {
           body: JSON.stringify({ installed: true }),
         });
       });
+      await page.addInitScript(`
+        window.__bugdropMockToPng = function(el) {
+          var rect = el.getBoundingClientRect();
+          window.__captureTargetInfo = {
+            tagName: el.tagName,
+            id: el.id || '',
+            className: typeof el.className === 'string' ? el.className : '',
+            width: rect.width,
+            height: rect.height
+          };
+          return Promise.resolve('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==');
+        };
+      `);
 
       await page.goto('/test/');
       await page.evaluate(() => {
@@ -1067,8 +1080,12 @@ test.describe('Widget Interaction', () => {
         target.addEventListener('pointerup', () => {
           document.body.dataset.mobileTapAction = 'fired';
         });
+        target.addEventListener('click', () => {
+          document.body.dataset.mobileClickAction = 'fired';
+        });
         document.body.appendChild(target);
         document.body.dataset.mobileTapAction = 'idle';
+        document.body.dataset.mobileClickAction = 'idle';
       });
 
       const host = page.locator('#bugdrop-host');
@@ -1080,6 +1097,16 @@ test.describe('Widget Interaction', () => {
       await host.locator('css=[data-action="element"]').click();
 
       await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
+      await page.evaluate(() => {
+        window.addEventListener(
+          'pointerup',
+          () => {
+            document.body.dataset.mobileCapturePointerAction = 'fired';
+          },
+          true
+        );
+        document.body.dataset.mobileCapturePointerAction = 'idle';
+      });
 
       const targetBox = await page.locator('#mobile-select-action-target').boundingBox();
       expect(targetBox).not.toBeNull();
@@ -1101,6 +1128,74 @@ test.describe('Widget Interaction', () => {
       await expect
         .poll(() => page.evaluate(() => document.body.dataset.mobileTapAction))
         .toBe('idle');
+      await expect
+        .poll(() => page.evaluate(() => document.body.dataset.mobileClickAction))
+        .toBe('idle');
+      await expect
+        .poll(() => page.evaluate(() => document.body.dataset.mobileCapturePointerAction))
+        .toBe('idle');
+
+      const targetInfo = await page.evaluate(() => window.__captureTargetInfo);
+      expect(targetInfo).toBeDefined();
+      if (!targetInfo) throw new Error('Missing capture target info');
+      expect(targetInfo.tagName).toBe('BUTTON');
+      expect(targetInfo.id).toBe('mobile-select-action-target');
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('element picker exposes a mobile cancel affordance', async ({ browser }) => {
+    const context = await browser.newContext({
+      hasTouch: true,
+      isMobile: true,
+      viewport: { width: 390, height: 844 },
+    });
+    const page = await context.newPage();
+    const submissions: unknown[] = [];
+
+    try {
+      await page.route('**/api/check**', async route => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ installed: true }),
+        });
+      });
+      await page.route('**/feedback', async route => {
+        submissions.push(route.request().postDataJSON());
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, issueNumber: 1, issueUrl: '#', isPublic: false }),
+        });
+      });
+
+      await page.goto('/test/');
+      const host = page.locator('#bugdrop-host');
+      await host.locator('css=.bd-trigger').click();
+      await host.locator('css=[data-action="continue"]').click();
+      await host.locator('css=#title').fill('Mobile element cancel test');
+      await host.locator('css=#include-screenshot').check();
+      await host.locator('css=#submit-btn').click();
+      await host.locator('css=[data-action="element"]').click();
+
+      const cancelButton = page.locator('#bugdrop-element-picker-cancel');
+      await expect(cancelButton).toBeVisible({ timeout: 5000 });
+      await cancelButton.click();
+
+      await expect(page.locator('#bugdrop-element-picker-tooltip')).not.toBeVisible({
+        timeout: 5000,
+      });
+      await expect(host.locator('css=.bd-trigger')).toBeVisible({ timeout: 5000 });
+      expect(submissions).toHaveLength(1);
+      const payload = submissions[0] as {
+        screenshot: string | null;
+        metadata: { elementSelector?: string | null; fullElementSelector?: string | null };
+      };
+      expect(payload.screenshot).toBeNull();
+      expect(payload.metadata.elementSelector).toBeNull();
+      expect(payload.metadata.fullElementSelector).toBeNull();
     } finally {
       await context.close();
     }
@@ -3773,6 +3868,90 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     expect(targetInfo.tagName).toBe('DIV');
     expect(targetInfo.id).toBe('role-token-control');
     expect(targetInfo.width).toBeGreaterThan(selectedBox!.width);
+  });
+
+  test('element picker uses the first recognized ARIA role token', async ({ page }) => {
+    await mockHtmlToImage(page, targetSpyToPng());
+    await page.goto('/test/?elementContextMaxArea=0');
+    await page.evaluate(() => {
+      const heading = document.createElement('div');
+      heading.id = 'ordered-role-heading';
+      heading.setAttribute('role', 'heading button');
+      heading.innerHTML = '<span class="ordered-role-name">Notifications</span>';
+      heading.style.cssText = `
+        display: block;
+        margin: 24px;
+        padding: 16px 20px;
+        width: 360px;
+        background: #1f2937;
+        color: white;
+      `;
+      document.body.prepend(heading);
+    });
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="element"]').click();
+    await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
+
+    const selected = page.locator('#ordered-role-heading .ordered-role-name');
+    await expect(selected).toBeVisible();
+    const selectedBox = await selected.boundingBox();
+    expect(selectedBox).toBeTruthy();
+
+    await page.mouse.click(
+      selectedBox!.x + selectedBox!.width / 2,
+      selectedBox!.y + selectedBox!.height / 2
+    );
+
+    await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+
+    const targetInfo = await page.evaluate(() => window.__captureTargetInfo);
+    expect(targetInfo).toBeDefined();
+    if (!targetInfo) throw new Error('Missing capture target info');
+    expect(targetInfo.tagName).toBe('SPAN');
+    expect(targetInfo.className).toContain('ordered-role-name');
+  });
+
+  test('element picker honors non-clickable ARIA fallback roles', async ({ page }) => {
+    await mockHtmlToImage(page, targetSpyToPng());
+    await page.goto('/test/?elementContextMaxArea=0');
+    await page.evaluate(() => {
+      const group = document.createElement('div');
+      group.id = 'ordered-role-group';
+      group.setAttribute('role', 'group button');
+      group.innerHTML = '<span class="ordered-group-name">Messages</span>';
+      group.style.cssText = `
+        display: block;
+        margin: 24px;
+        padding: 16px 20px;
+        width: 360px;
+        background: #1f2937;
+        color: white;
+      `;
+      document.body.prepend(group);
+    });
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="element"]').click();
+    await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
+
+    const groupSelected = page.locator('#ordered-role-group .ordered-group-name');
+    await expect(groupSelected).toBeVisible();
+    const groupSelectedBox = await groupSelected.boundingBox();
+    expect(groupSelectedBox).toBeTruthy();
+
+    await page.mouse.click(
+      groupSelectedBox!.x + groupSelectedBox!.width / 2,
+      groupSelectedBox!.y + groupSelectedBox!.height / 2
+    );
+
+    await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+
+    const groupTargetInfo = await page.evaluate(() => window.__captureTargetInfo);
+    expect(groupTargetInfo).toBeDefined();
+    if (!groupTargetInfo) throw new Error('Missing capture target info');
+    expect(groupTargetInfo.tagName).toBe('SPAN');
+    expect(groupTargetInfo.className).toContain('ordered-group-name');
   });
 
   test('shows error modal when capture times out', async ({ page }) => {

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -416,7 +416,10 @@ test.describe('Widget Interaction', () => {
     // Click on the SVG element - this previously caused className.split error
     const svgElement = page.locator('#test-svg');
     await expect(svgElement).toBeVisible();
-    await svgElement.click();
+    await svgElement.scrollIntoViewIfNeeded();
+    const svgBox = await svgElement.boundingBox();
+    expect(svgBox).not.toBeNull();
+    await page.mouse.click(svgBox!.x + svgBox!.width / 2, svgBox!.y + svgBox!.height / 2);
 
     // Check for the className.split error that was previously occurring
     const classNameErrors = errors.filter(
@@ -493,7 +496,13 @@ test.describe('Widget Interaction', () => {
     // This tests that getElementSelector handles SVG elements when walking up the tree
     const svgText = page.locator('#test-svg text');
     await expect(svgText).toBeVisible();
-    await svgText.click();
+    await svgText.scrollIntoViewIfNeeded();
+    const svgTextBox = await svgText.boundingBox();
+    expect(svgTextBox).not.toBeNull();
+    await page.mouse.click(
+      svgTextBox!.x + svgTextBox!.width / 2,
+      svgTextBox!.y + svgTextBox!.height / 2
+    );
 
     // Check for the className.split error
     const classNameErrors = errors.filter(
@@ -1018,6 +1027,80 @@ test.describe('Widget Interaction', () => {
 
       await expect(overlay).not.toBeVisible({ timeout: 5000 });
       await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 30000 });
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('element picker prevents selected mobile tap from reaching the page', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      hasTouch: true,
+      isMobile: true,
+      viewport: { width: 390, height: 844 },
+    });
+    const page = await context.newPage();
+
+    try {
+      await page.route('**/api/check**', async route => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ installed: true }),
+        });
+      });
+
+      await page.goto('/test/');
+      await page.evaluate(() => {
+        const target = document.createElement('button');
+        target.id = 'mobile-select-action-target';
+        target.textContent = 'Continue';
+        target.style.cssText = `
+          position: fixed;
+          left: 40px;
+          top: 180px;
+          width: 220px;
+          height: 64px;
+          z-index: 1;
+        `;
+        target.addEventListener('pointerup', () => {
+          document.body.dataset.mobileTapAction = 'fired';
+        });
+        document.body.appendChild(target);
+        document.body.dataset.mobileTapAction = 'idle';
+      });
+
+      const host = page.locator('#bugdrop-host');
+      await host.locator('css=.bd-trigger').click();
+      await host.locator('css=[data-action="continue"]').click();
+      await host.locator('css=#title').fill('Mobile element tap test');
+      await host.locator('css=#include-screenshot').check();
+      await host.locator('css=#submit-btn').click();
+      await host.locator('css=[data-action="element"]').click();
+
+      await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
+
+      const targetBox = await page.locator('#mobile-select-action-target').boundingBox();
+      expect(targetBox).not.toBeNull();
+      const tapX = Math.round(targetBox!.x + targetBox!.width / 2);
+      const tapY = Math.round(targetBox!.y + targetBox!.height / 2);
+
+      const client = await context.newCDPSession(page);
+      await client.send('Input.dispatchTouchEvent', {
+        type: 'touchStart',
+        touchPoints: [{ x: tapX, y: tapY, radiusX: 1, radiusY: 1, id: 1 }],
+      });
+      await client.send('Input.dispatchTouchEvent', {
+        type: 'touchEnd',
+        touchPoints: [],
+      });
+      await client.detach();
+
+      await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 30000 });
+      await expect
+        .poll(() => page.evaluate(() => document.body.dataset.mobileTapAction))
+        .toBe('idle');
     } finally {
       await context.close();
     }
@@ -3581,6 +3664,117 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     expect(targetInfo.height).toBeLessThanOrEqual(selectedBox!.height + 1);
   });
 
+  test('element picker selects nearest clickable ancestor from nested content', async ({
+    page,
+  }) => {
+    await mockHtmlToImage(page, targetSpyToPng());
+    await page.goto('/test/?elementContextMaxArea=0');
+    await page.evaluate(() => {
+      const row = document.createElement('div');
+      row.id = 'clickable-row-fixture';
+      row.innerHTML = `
+        <a id="chat-row-link" class="item-link" href="/chats/12078/">
+          <div class="item-content">
+            <div class="item-inner">
+              <div class="item-title">
+                <div class="conversation-title">
+                  <div class="conversation-name">Eugene</div>
+                  <div class="conversation-preview-line">test for eugene</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </a>
+      `;
+      row.style.cssText = `
+        margin: 24px;
+        width: 420px;
+      `;
+      const link = row.querySelector<HTMLAnchorElement>('#chat-row-link');
+      if (link) {
+        link.style.cssText = `
+          display: block;
+          padding: 16px 20px;
+          background: #1f2937;
+          color: white;
+          text-decoration: none;
+        `;
+      }
+      document.body.prepend(row);
+    });
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="element"]').click();
+    await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
+
+    const selected = page.locator('#clickable-row-fixture .conversation-name');
+    await expect(selected).toBeVisible();
+    const selectedBox = await selected.boundingBox();
+    expect(selectedBox).toBeTruthy();
+
+    await page.mouse.click(
+      selectedBox!.x + selectedBox!.width / 2,
+      selectedBox!.y + selectedBox!.height / 2
+    );
+
+    await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+
+    const targetInfo = await page.evaluate(() => window.__captureTargetInfo);
+    expect(targetInfo).toBeDefined();
+    if (!targetInfo) throw new Error('Missing capture target info');
+    expect(targetInfo.tagName).toBe('A');
+    expect(targetInfo.id).toBe('chat-row-link');
+    expect(targetInfo.className).toContain('item-link');
+    expect(targetInfo.width).toBeGreaterThan(selectedBox!.width);
+  });
+
+  test('element picker recognizes mixed-case clickable fallback role tokens', async ({ page }) => {
+    await mockHtmlToImage(page, targetSpyToPng());
+    await page.goto('/test/?elementContextMaxArea=0');
+    await page.evaluate(() => {
+      const control = document.createElement('div');
+      control.id = 'role-token-control';
+      control.setAttribute('role', 'Switch Button');
+      control.innerHTML = `
+        <span class="role-token-label">
+          <span class="role-token-name">Notifications</span>
+        </span>
+      `;
+      control.style.cssText = `
+        display: block;
+        margin: 24px;
+        padding: 16px 20px;
+        width: 360px;
+        background: #1f2937;
+        color: white;
+      `;
+      document.body.prepend(control);
+    });
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="element"]').click();
+    await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
+
+    const selected = page.locator('#role-token-control .role-token-name');
+    await expect(selected).toBeVisible();
+    const selectedBox = await selected.boundingBox();
+    expect(selectedBox).toBeTruthy();
+
+    await page.mouse.click(
+      selectedBox!.x + selectedBox!.width / 2,
+      selectedBox!.y + selectedBox!.height / 2
+    );
+
+    await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+
+    const targetInfo = await page.evaluate(() => window.__captureTargetInfo);
+    expect(targetInfo).toBeDefined();
+    if (!targetInfo) throw new Error('Missing capture target info');
+    expect(targetInfo.tagName).toBe('DIV');
+    expect(targetInfo.id).toBe('role-token-control');
+    expect(targetInfo.width).toBeGreaterThan(selectedBox!.width);
+  });
+
   test('shows error modal when capture times out', async ({ page }) => {
     await mockHtmlToImage(page, 'function() { return new Promise(function() {}); }');
     await page.goto('/test/');
@@ -5583,9 +5777,9 @@ test.describe('Screenshot Masking', () => {
 
   // Walk the element-picker flow and capture the chosen element.
   //
-  // `selector` identifies the element to click in the picker.  Because the picker
-  // resolves the DEEPEST element at the click point (via elementsFromPoint), pass
-  // `clickOffset` to land on the element's own padding rather than a child.
+  // `selector` identifies the element to click in the picker.  The picker prefers
+  // the nearest clickable ancestor and otherwise falls back to the deepest element
+  // at the click point, so pass `clickOffset` when a fixture needs a precise target.
   // Defaults to the element's center.
   //
   // Returns the screenshot data URL and the image's natural pixel dimensions.
@@ -5639,10 +5833,9 @@ test.describe('Screenshot Masking', () => {
     // Wait for the element picker tooltip to confirm picker mode is active.
     await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
 
-    // Click the target element using mouse coordinates.  The picker intercepts
-    // pointer events at document level via elementsFromPoint, which returns the
-    // DEEPEST element at the cursor — use clickOffset to land on the element's
-    // own padding when you need to select the element rather than a child.
+    // Click the target element using mouse coordinates. The picker intercepts
+    // pointer events through its overlay, then resolves the page element under
+    // that point.
     const target = page.locator(selector);
     await expect(target).toBeVisible({ timeout: 5000 });
     const targetBox = await target.boundingBox();
@@ -5745,7 +5938,7 @@ test.describe('Screenshot Masking', () => {
 
   test('element-scoped capture masks descendant inside picked element', async ({ page }) => {
     // Click inside the top padding of #unmasked-parent (above the first <p> child)
-    // so the picker's elementsFromPoint resolves the parent, not a child element.
+    // so the picker resolves the parent, not a child element.
     // The 16px top padding gives ~8px of safe click area before the first child.
     const { screenshot, imageSize, metadata } = await submitFeedbackWithElementCapture(
       page,

--- a/src/widget/picker-style.ts
+++ b/src/widget/picker-style.ts
@@ -1,0 +1,43 @@
+import { resolveAccentColor } from '../defaults';
+import { sanitizeCssColor, sanitizeCssFontFamily, sanitizeNonNegativePixelValue } from './sanitize';
+
+export interface PickerStyle {
+  accentColor?: string;
+  font?: string;
+  radius?: string;
+  borderWidth?: string;
+  bgColor?: string;
+  textColor?: string;
+  borderColor?: string;
+  theme?: string;
+}
+
+export interface ResolvedPickerStyle {
+  accent: string;
+  fontFamily: string;
+  radius: string;
+  bw: string;
+  tooltipBg: string;
+  tooltipText: string;
+  tooltipBorder: string;
+}
+
+export function resolvePickerStyle(style?: PickerStyle): ResolvedPickerStyle {
+  const isDark = style?.theme === 'dark';
+  const radius = sanitizeNonNegativePixelValue(style?.radius);
+  const borderWidth = sanitizeNonNegativePixelValue(style?.borderWidth);
+  const fontFamily = sanitizeCssFontFamily(style?.font);
+
+  return {
+    accent: resolveAccentColor(sanitizeCssColor(style?.accentColor)),
+    fontFamily:
+      style?.font === 'inherit'
+        ? 'system-ui, sans-serif'
+        : fontFamily || "'Space Grotesk', system-ui, sans-serif",
+    radius: radius !== undefined ? `${radius}px` : '6px',
+    bw: borderWidth !== undefined ? String(borderWidth) : '3',
+    tooltipBg: sanitizeCssColor(style?.bgColor) || (isDark ? '#0f172a' : '#1a1a1a'),
+    tooltipText: sanitizeCssColor(style?.textColor) || '#f1f5f9',
+    tooltipBorder: sanitizeCssColor(style?.borderColor) || (isDark ? '#334155' : '#333'),
+  };
+}

--- a/src/widget/picker-target.ts
+++ b/src/widget/picker-target.ts
@@ -1,0 +1,132 @@
+const KNOWN_ROLES = new Set([
+  'alert',
+  'alertdialog',
+  'application',
+  'article',
+  'banner',
+  'button',
+  'cell',
+  'checkbox',
+  'columnheader',
+  'combobox',
+  'complementary',
+  'contentinfo',
+  'definition',
+  'dialog',
+  'directory',
+  'document',
+  'feed',
+  'figure',
+  'form',
+  'grid',
+  'gridcell',
+  'group',
+  'heading',
+  'img',
+  'link',
+  'list',
+  'listbox',
+  'listitem',
+  'log',
+  'main',
+  'marquee',
+  'math',
+  'menu',
+  'menubar',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'meter',
+  'navigation',
+  'none',
+  'note',
+  'option',
+  'presentation',
+  'progressbar',
+  'radio',
+  'radiogroup',
+  'region',
+  'row',
+  'rowgroup',
+  'rowheader',
+  'scrollbar',
+  'search',
+  'searchbox',
+  'separator',
+  'slider',
+  'spinbutton',
+  'status',
+  'switch',
+  'tab',
+  'table',
+  'tablist',
+  'tabpanel',
+  'term',
+  'textbox',
+  'timer',
+  'toolbar',
+  'tooltip',
+  'tree',
+  'treegrid',
+  'treeitem',
+]);
+const CLICKABLE_ROLES = new Set([
+  'button',
+  'checkbox',
+  'link',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'radio',
+  'searchbox',
+  'switch',
+  'tab',
+  'textbox',
+]);
+const CLICKABLE_FORM_TAGS = new Set(['button', 'input', 'select', 'textarea']);
+
+export function getSelectionTarget(element: Element): Element {
+  return getNearestClickableAncestor(element) ?? element;
+}
+
+function getNearestClickableAncestor(element: Element): Element | null {
+  const { body, documentElement } = element.ownerDocument;
+  let current: Element | null = element;
+
+  while (current && current !== body && current !== documentElement) {
+    if (isClickableElement(current)) return current;
+    current = current.parentElement;
+  }
+
+  return null;
+}
+
+function isClickableElement(element: Element): boolean {
+  if (element.getAttribute('aria-disabled') === 'true') return false;
+
+  const tagName = element.tagName.toLowerCase();
+  if (tagName === 'a') return element.hasAttribute('href');
+  if (CLICKABLE_FORM_TAGS.has(tagName)) {
+    return !('disabled' in element && (element as HTMLButtonElement).disabled);
+  }
+  if (tagName === 'summary') return true;
+
+  const role = getFirstRecognizedRole(element);
+  if (role && CLICKABLE_ROLES.has(role)) return true;
+
+  const tabIndex = element.getAttribute('tabindex');
+  return tabIndex !== null && Number.parseInt(tabIndex, 10) >= 0;
+}
+
+function getFirstRecognizedRole(element: Element): string | null {
+  const role = element.getAttribute('role');
+  if (!role) return null;
+
+  for (const roleToken of role.split(/\s+/)) {
+    const normalizedRole = roleToken.toLowerCase();
+    if (KNOWN_ROLES.has(normalizedRole)) return normalizedRole;
+  }
+
+  return null;
+}

--- a/src/widget/picker.ts
+++ b/src/widget/picker.ts
@@ -2,7 +2,7 @@
 import { resolvePickerStyle, type PickerStyle, type ResolvedPickerStyle } from './picker-style';
 import { getSelectionTarget } from './picker-target';
 
-export { resolvePickerStyle, type PickerStyle, type ResolvedPickerStyle };
+export { resolvePickerStyle, type PickerStyle };
 
 const PICKER_CHROME_IDS = new Set([
   'bugdrop-element-picker-overlay',

--- a/src/widget/picker.ts
+++ b/src/widget/picker.ts
@@ -235,14 +235,18 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
   }
 
   function onClick(e: MouseEvent) {
+    if (resolved) {
+      document.removeEventListener('click', onClick, true);
+      if (e.target instanceof Element && e.target.closest('#bugdrop-host')) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      return;
+    }
+
     e.preventDefault();
     e.stopImmediatePropagation();
     if (e.target instanceof Element && e.target.id === 'bugdrop-element-picker-cancel') {
       finish(null);
-      return;
-    }
-    if (resolved) {
-      document.removeEventListener('click', onClick, true);
       return;
     }
     selectElementAtPoint(e.clientX, e.clientY);

--- a/src/widget/picker.ts
+++ b/src/widget/picker.ts
@@ -1,83 +1,125 @@
-import { sanitizeCssColor, sanitizeCssFontFamily, sanitizeNonNegativePixelValue } from './sanitize';
-import { resolveAccentColor } from '../defaults';
+/* eslint-disable max-lines, max-lines-per-function */
+import { resolvePickerStyle, type PickerStyle, type ResolvedPickerStyle } from './picker-style';
+import { getSelectionTarget } from './picker-target';
 
-export interface PickerStyle {
-  accentColor?: string;
-  font?: string;
-  radius?: string;
-  borderWidth?: string;
-  bgColor?: string;
-  textColor?: string;
-  borderColor?: string;
-  theme?: string;
+export { resolvePickerStyle, type PickerStyle, type ResolvedPickerStyle };
+
+const PICKER_CHROME_IDS = new Set([
+  'bugdrop-element-picker-overlay',
+  'bugdrop-element-picker-highlight',
+  'bugdrop-element-picker-tooltip',
+  'bugdrop-element-picker-cancel',
+]);
+
+function usesCoarsePointer(): boolean {
+  const hasTouchPoints = navigator.maxTouchPoints > 0;
+  if (!window.matchMedia) return hasTouchPoints;
+
+  return (
+    window.matchMedia('(hover: none), (pointer: coarse), (any-pointer: coarse)').matches ||
+    hasTouchPoints
+  );
 }
 
-interface ResolvedPickerStyle {
-  accent: string;
-  fontFamily: string;
-  radius: string;
-  bw: string;
-  tooltipBg: string;
-  tooltipText: string;
-  tooltipBorder: string;
+function createOverlay(): HTMLDivElement {
+  const overlay = document.createElement('div');
+  overlay.id = 'bugdrop-element-picker-overlay';
+  overlay.style.cssText = `
+    position: fixed;
+    inset: 0;
+    z-index: 2147483647;
+    cursor: crosshair;
+    touch-action: none;
+    user-select: none;
+    background: transparent;
+  `;
+  return overlay;
 }
 
-const CLICKABLE_ROLES = new Set(['button', 'link', 'menuitem', 'tab', 'option']);
-const CLICKABLE_FORM_TAGS = new Set(['button', 'input', 'select', 'textarea']);
-
-function getSelectionTarget(element: Element): Element {
-  return getNearestClickableAncestor(element) ?? element;
+function createHighlight(
+  style: Pick<ResolvedPickerStyle, 'accent' | 'bw' | 'radius'>
+): HTMLDivElement {
+  const highlight = document.createElement('div');
+  highlight.id = 'bugdrop-element-picker-highlight';
+  highlight.style.cssText = `
+    position: fixed;
+    box-sizing: content-box;
+    pointer-events: none;
+    border: ${style.bw}px solid ${style.accent};
+    background: transparent;
+    z-index: 2147483645;
+    transition: all 0.05s ease-out;
+    box-shadow: none;
+    border-radius: ${style.radius};
+  `;
+  return highlight;
 }
 
-function getNearestClickableAncestor(element: Element): Element | null {
-  const { body, documentElement } = element.ownerDocument;
-  let current: Element | null = element;
+function createTooltip(
+  style: ResolvedPickerStyle,
+  showInlineCancel: boolean
+): { tooltip: HTMLDivElement; cancelButton: HTMLButtonElement | null } {
+  const tooltip = document.createElement('div');
+  tooltip.id = 'bugdrop-element-picker-tooltip';
+  tooltip.style.cssText = `
+    position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: ${style.tooltipBg};
+    color: ${style.tooltipText};
+    padding: 14px 28px;
+    border-radius: ${style.radius};
+    font-family: ${style.fontFamily};
+    font-size: 14px;
+    font-weight: 500;
+    z-index: 2147483647;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border: ${style.bw}px solid ${style.tooltipBorder};
+  `;
 
-  while (current && current !== body && current !== documentElement) {
-    if (isClickableElement(current)) return current;
-    current = current.parentElement;
+  if (!showInlineCancel) {
+    tooltip.textContent = 'Click any element to capture it (ESC to cancel)';
+    return { tooltip, cancelButton: null };
   }
 
-  return null;
+  const cancelButton = createCancelButton(style.accent);
+  tooltip.append('Tap any element to capture it (', cancelButton, ')');
+  return { tooltip, cancelButton };
 }
 
-function isClickableElement(element: Element): boolean {
-  if (element.getAttribute('aria-disabled') === 'true') return false;
-
-  const tagName = element.tagName.toLowerCase();
-  if (tagName === 'a') return element.hasAttribute('href');
-  if (CLICKABLE_FORM_TAGS.has(tagName)) {
-    return !('disabled' in element && (element as HTMLButtonElement).disabled);
-  }
-  if (tagName === 'summary') return true;
-
-  const role = element.getAttribute('role');
-  if (role && role.split(/\s+/).some(roleToken => CLICKABLE_ROLES.has(roleToken.toLowerCase()))) {
-    return true;
-  }
-
-  const tabIndex = element.getAttribute('tabindex');
-  return tabIndex !== null && Number.parseInt(tabIndex, 10) >= 0;
+function updateHighlight(highlight: HTMLDivElement, element: Element): void {
+  const rect = element.getBoundingClientRect();
+  highlight.style.top = `${rect.top - 2}px`;
+  highlight.style.left = `${rect.left - 2}px`;
+  highlight.style.width = `${rect.width + 4}px`;
+  highlight.style.height = `${rect.height + 4}px`;
+  highlight.style.display = 'block';
 }
 
-export function resolvePickerStyle(style?: PickerStyle): ResolvedPickerStyle {
-  const isDark = style?.theme === 'dark';
-  const radius = sanitizeNonNegativePixelValue(style?.radius);
-  const borderWidth = sanitizeNonNegativePixelValue(style?.borderWidth);
-  const fontFamily = sanitizeCssFontFamily(style?.font);
+interface PickerListeners {
+  overlay: HTMLDivElement;
+  onPointerDown: (e: PointerEvent) => void;
+  onPointerMove: (e: PointerEvent) => void;
+  onPointerUp: (e: PointerEvent) => void;
+  onPointerCancel: (e: PointerEvent) => void;
+  onMouseMove: (e: MouseEvent) => void;
+}
 
-  return {
-    accent: resolveAccentColor(sanitizeCssColor(style?.accentColor)),
-    fontFamily:
-      style?.font === 'inherit'
-        ? 'system-ui, sans-serif'
-        : fontFamily || "'Space Grotesk', system-ui, sans-serif",
-    radius: radius !== undefined ? `${radius}px` : '6px',
-    bw: borderWidth !== undefined ? String(borderWidth) : '3',
-    tooltipBg: sanitizeCssColor(style?.bgColor) || (isDark ? '#0f172a' : '#1a1a1a'),
-    tooltipText: sanitizeCssColor(style?.textColor) || '#f1f5f9',
-    tooltipBorder: sanitizeCssColor(style?.borderColor) || (isDark ? '#334155' : '#333'),
-  };
+function addPickerListeners(listeners: PickerListeners): void {
+  listeners.overlay.addEventListener('pointerdown', listeners.onPointerDown);
+  listeners.overlay.addEventListener('pointermove', listeners.onPointerMove);
+  listeners.overlay.addEventListener('pointerup', listeners.onPointerUp);
+  listeners.overlay.addEventListener('pointercancel', listeners.onPointerCancel);
+  document.addEventListener('mousemove', listeners.onMouseMove, true);
+}
+
+function removePickerListeners(listeners: PickerListeners): void {
+  listeners.overlay.removeEventListener('pointerdown', listeners.onPointerDown);
+  listeners.overlay.removeEventListener('pointermove', listeners.onPointerMove);
+  listeners.overlay.removeEventListener('pointerup', listeners.onPointerUp);
+  listeners.overlay.removeEventListener('pointercancel', listeners.onPointerCancel);
+  document.removeEventListener('mousemove', listeners.onMouseMove, true);
 }
 
 export function createElementPicker(style?: PickerStyle): Promise<Element | null> {
@@ -93,59 +135,31 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
   const { accent, fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder } =
     resolvePickerStyle(style);
 
-  const overlay = document.createElement('div');
-  overlay.id = 'bugdrop-element-picker-overlay';
-  overlay.style.cssText = `
-    position: fixed;
-    inset: 0;
-    z-index: 2147483645;
-    cursor: crosshair;
-    touch-action: none;
-    user-select: none;
-    background: transparent;
-  `;
+  const overlay = createOverlay();
   document.body.appendChild(overlay);
 
-  // Create highlight overlay with higher z-index than modal (1000000)
-  const highlight = document.createElement('div');
-  highlight.id = 'bugdrop-element-picker-highlight';
-  highlight.style.cssText = `
-    position: fixed;
-    box-sizing: content-box;
-    pointer-events: none;
-    border: ${bw}px solid ${accent};
-    background: transparent;
-    z-index: 2147483646;
-    transition: all 0.05s ease-out;
-    box-shadow: none;
-    border-radius: ${radius};
-  `;
+  const highlight = createHighlight({ accent, bw, radius });
   document.body.appendChild(highlight);
 
-  // Instruction tooltip with higher z-index
-  const tooltip = document.createElement('div');
-  tooltip.id = 'bugdrop-element-picker-tooltip';
-  tooltip.style.cssText = `
-    position: fixed;
-    top: 20px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: ${tooltipBg};
-    color: ${tooltipText};
-    padding: 14px 28px;
-    border-radius: ${radius};
-    font-family: ${fontFamily};
-    font-size: 14px;
-    font-weight: 500;
-    z-index: 2147483647;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-    border: ${bw}px solid ${tooltipBorder};
-  `;
-  tooltip.textContent = 'Click or tap any element to capture it (ESC to cancel)';
+  const { tooltip, cancelButton } = createTooltip(
+    { accent, fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder },
+    usesCoarsePointer()
+  );
   document.body.appendChild(tooltip);
 
   let currentElement: Element | null = null;
   let activePointerId: number | null = null;
+  let resolved = false;
+  let clickBlockerRemovalTimer: number | undefined;
+
+  function isPickerChrome(element: Element): boolean {
+    return (
+      element === overlay ||
+      element === highlight ||
+      element === tooltip ||
+      PICKER_CHROME_IDS.has(element.id)
+    );
+  }
 
   function getSelectableElementAtPoint(x: number, y: number): Element | undefined {
     const previousPointerEvents = overlay.style.pointerEvents;
@@ -159,38 +173,34 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
     })();
 
     return elementsAtPoint.find(el => {
-      if (el === overlay) return false;
-      if (el === highlight || el === tooltip) return false;
-      if (el.id === 'bugdrop-element-picker-overlay') return false;
-      if (el.id === 'bugdrop-element-picker-highlight') return false;
-      if (el.id === 'bugdrop-element-picker-tooltip') return false;
+      if (isPickerChrome(el)) return false;
       if (el.closest('#bugdrop-host')) return false;
       return true;
     });
   }
 
-  function onMouseMove(e: MouseEvent) {
-    // Get the element under the cursor, ignoring our picker elements
-    const target = getSelectableElementAtPoint(e.clientX, e.clientY);
-
-    if (!target) return;
-
-    currentElement = getSelectionTarget(target);
-    const rect = currentElement.getBoundingClientRect();
-
-    // Update highlight position with slight padding
-    highlight.style.top = `${rect.top - 2}px`;
-    highlight.style.left = `${rect.left - 2}px`;
-    highlight.style.width = `${rect.width + 4}px`;
-    highlight.style.height = `${rect.height + 4}px`;
-    highlight.style.display = 'block';
+  function resolveSelectionAtPoint(x: number, y: number, fallback: Element | null) {
+    const target = getSelectableElementAtPoint(x, y);
+    return target ? getSelectionTarget(target) : fallback;
   }
 
-  function selectElementAtPoint(x: number, y: number) {
-    const target = getSelectableElementAtPoint(x, y);
-    currentElement = target ? getSelectionTarget(target) : currentElement;
-    cleanup();
-    resolve(currentElement);
+  function onMouseMove(e: MouseEvent) {
+    // Get the element under the cursor, ignoring our picker elements
+    currentElement = resolveSelectionAtPoint(e.clientX, e.clientY, currentElement);
+    if (!currentElement) return;
+    updateHighlight(highlight, currentElement);
+  }
+
+  function selectElementAtPoint(x: number, y: number, keepClickBlocker = false) {
+    currentElement = resolveSelectionAtPoint(x, y, currentElement);
+    finish(currentElement, keepClickBlocker);
+  }
+
+  function finish(element: Element | null, keepClickBlocker = false) {
+    if (resolved) return;
+    resolved = true;
+    cleanup(keepClickBlocker);
+    resolve(element);
   }
 
   function onPointerDown(e: PointerEvent) {
@@ -199,8 +209,7 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
     e.stopPropagation();
     activePointerId = e.pointerId;
     overlay.setPointerCapture?.(e.pointerId);
-    const target = getSelectableElementAtPoint(e.clientX, e.clientY);
-    currentElement = target ? getSelectionTarget(target) : currentElement;
+    currentElement = resolveSelectionAtPoint(e.clientX, e.clientY, currentElement);
   }
 
   function onPointerMove(e: PointerEvent) {
@@ -216,7 +225,7 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
     e.stopPropagation();
     activePointerId = null;
     overlay.releasePointerCapture?.(e.pointerId);
-    selectElementAtPoint(e.clientX, e.clientY);
+    selectElementAtPoint(e.clientX, e.clientY, true);
   }
 
   function onPointerCancel(e: PointerEvent) {
@@ -227,38 +236,128 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
 
   function onClick(e: MouseEvent) {
     e.preventDefault();
-    e.stopPropagation();
+    e.stopImmediatePropagation();
+    if (e.target instanceof Element && e.target.id === 'bugdrop-element-picker-cancel') {
+      finish(null);
+      return;
+    }
+    if (resolved) {
+      document.removeEventListener('click', onClick, true);
+      return;
+    }
     selectElementAtPoint(e.clientX, e.clientY);
+  }
+
+  function blockPagePointerEvent(e: PointerEvent) {
+    if (e.target instanceof Element && e.target.id === 'bugdrop-element-picker-cancel') return;
+
+    if (e.type === 'pointerdown') onPointerDown(e);
+    if (e.type === 'pointermove') onPointerMove(e);
+    if (e.type === 'pointerup') onPointerUp(e);
+    if (e.type === 'pointercancel') onPointerCancel(e);
+
+    e.preventDefault();
+    e.stopImmediatePropagation();
   }
 
   function onKeyDown(e: KeyboardEvent) {
     if (e.key === 'Escape') {
-      cleanup();
-      resolve(null);
+      finish(null);
     }
   }
 
-  function cleanup() {
-    overlay.removeEventListener('pointerdown', onPointerDown);
-    overlay.removeEventListener('pointermove', onPointerMove);
-    overlay.removeEventListener('pointerup', onPointerUp);
-    overlay.removeEventListener('pointercancel', onPointerCancel);
-    document.removeEventListener('mousemove', onMouseMove, true);
-    document.removeEventListener('click', onClick, true);
+  function onCancelClick(e: MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    finish(null);
+  }
+
+  function cleanup(keepClickBlocker = false) {
+    if (clickBlockerRemovalTimer !== undefined) {
+      window.clearTimeout(clickBlockerRemovalTimer);
+      clickBlockerRemovalTimer = undefined;
+    }
+    removePickerListeners({
+      overlay,
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel,
+      onMouseMove,
+    });
+    if (keepClickBlocker) {
+      clickBlockerRemovalTimer = window.setTimeout(() => {
+        document.removeEventListener('click', onClick, true);
+        clickBlockerRemovalTimer = undefined;
+      }, 1000);
+    } else {
+      document.removeEventListener('click', onClick, true);
+    }
     document.removeEventListener('keydown', onKeyDown);
+    removePagePointerBlockers();
+    cancelButton?.removeEventListener('click', onCancelClick);
     overlay.remove();
     highlight.remove();
     tooltip.remove();
     document.body.style.cursor = '';
   }
 
+  function addPagePointerBlockers() {
+    window.addEventListener('pointerdown', blockPagePointerEvent, true);
+    window.addEventListener('pointermove', blockPagePointerEvent, true);
+    window.addEventListener('pointerup', blockPagePointerEvent, true);
+    window.addEventListener('pointercancel', blockPagePointerEvent, true);
+  }
+
+  function removePagePointerBlockers() {
+    window.removeEventListener('pointerdown', blockPagePointerEvent, true);
+    window.removeEventListener('pointermove', blockPagePointerEvent, true);
+    window.removeEventListener('pointerup', blockPagePointerEvent, true);
+    window.removeEventListener('pointercancel', blockPagePointerEvent, true);
+  }
+
   // Set cursor and start listening
   document.body.style.cursor = 'crosshair';
-  overlay.addEventListener('pointerdown', onPointerDown);
-  overlay.addEventListener('pointermove', onPointerMove);
-  overlay.addEventListener('pointerup', onPointerUp);
-  overlay.addEventListener('pointercancel', onPointerCancel);
-  document.addEventListener('mousemove', onMouseMove, true);
+  addPagePointerBlockers();
+  addPickerListeners({
+    overlay,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+    onMouseMove,
+  });
   document.addEventListener('click', onClick, true);
   document.addEventListener('keydown', onKeyDown);
+  cancelButton?.addEventListener('click', onCancelClick);
+}
+
+function createCancelButton(accent: string): HTMLButtonElement {
+  const cancelButton = document.createElement('button');
+  cancelButton.id = 'bugdrop-element-picker-cancel';
+  cancelButton.type = 'button';
+  cancelButton.textContent = 'Cancel';
+  cancelButton.style.cssText = `
+    align-items: center;
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: ${accent};
+    cursor: pointer;
+    display: inline-flex;
+    font: inherit;
+    font-weight: 700;
+    justify-content: center;
+    margin: -10px -12px;
+    min-height: 44px;
+    min-width: 44px;
+    padding: 10px 12px;
+    pointer-events: auto;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    touch-action: manipulation;
+    white-space: nowrap;
+    width: auto;
+  `;
+  return cancelButton;
 }

--- a/src/widget/picker.ts
+++ b/src/widget/picker.ts
@@ -22,6 +22,44 @@ interface ResolvedPickerStyle {
   tooltipBorder: string;
 }
 
+const CLICKABLE_ROLES = new Set(['button', 'link', 'menuitem', 'tab', 'option']);
+const CLICKABLE_FORM_TAGS = new Set(['button', 'input', 'select', 'textarea']);
+
+function getSelectionTarget(element: Element): Element {
+  return getNearestClickableAncestor(element) ?? element;
+}
+
+function getNearestClickableAncestor(element: Element): Element | null {
+  const { body, documentElement } = element.ownerDocument;
+  let current: Element | null = element;
+
+  while (current && current !== body && current !== documentElement) {
+    if (isClickableElement(current)) return current;
+    current = current.parentElement;
+  }
+
+  return null;
+}
+
+function isClickableElement(element: Element): boolean {
+  if (element.getAttribute('aria-disabled') === 'true') return false;
+
+  const tagName = element.tagName.toLowerCase();
+  if (tagName === 'a') return element.hasAttribute('href');
+  if (CLICKABLE_FORM_TAGS.has(tagName)) {
+    return !('disabled' in element && (element as HTMLButtonElement).disabled);
+  }
+  if (tagName === 'summary') return true;
+
+  const role = element.getAttribute('role');
+  if (role && role.split(/\s+/).some(roleToken => CLICKABLE_ROLES.has(roleToken.toLowerCase()))) {
+    return true;
+  }
+
+  const tabIndex = element.getAttribute('tabindex');
+  return tabIndex !== null && Number.parseInt(tabIndex, 10) >= 0;
+}
+
 export function resolvePickerStyle(style?: PickerStyle): ResolvedPickerStyle {
   const isDark = style?.theme === 'dark';
   const radius = sanitizeNonNegativePixelValue(style?.radius);
@@ -54,6 +92,19 @@ export function createElementPicker(style?: PickerStyle): Promise<Element | null
 function startPicker(resolve: (element: Element | null) => void, style?: PickerStyle): void {
   const { accent, fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder } =
     resolvePickerStyle(style);
+
+  const overlay = document.createElement('div');
+  overlay.id = 'bugdrop-element-picker-overlay';
+  overlay.style.cssText = `
+    position: fixed;
+    inset: 0;
+    z-index: 2147483645;
+    cursor: crosshair;
+    touch-action: none;
+    user-select: none;
+    background: transparent;
+  `;
+  document.body.appendChild(overlay);
 
   // Create highlight overlay with higher z-index than modal (1000000)
   const highlight = document.createElement('div');
@@ -90,16 +141,27 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
     border: ${bw}px solid ${tooltipBorder};
   `;
-  tooltip.textContent = 'Click on any element to capture it (ESC to cancel)';
+  tooltip.textContent = 'Click or tap any element to capture it (ESC to cancel)';
   document.body.appendChild(tooltip);
 
   let currentElement: Element | null = null;
+  let activePointerId: number | null = null;
 
   function getSelectableElementAtPoint(x: number, y: number): Element | undefined {
-    const elementsAtPoint = document.elementsFromPoint(x, y);
+    const previousPointerEvents = overlay.style.pointerEvents;
+    overlay.style.pointerEvents = 'none';
+    const elementsAtPoint = (() => {
+      try {
+        return document.elementsFromPoint(x, y);
+      } finally {
+        overlay.style.pointerEvents = previousPointerEvents;
+      }
+    })();
 
     return elementsAtPoint.find(el => {
+      if (el === overlay) return false;
       if (el === highlight || el === tooltip) return false;
+      if (el.id === 'bugdrop-element-picker-overlay') return false;
       if (el.id === 'bugdrop-element-picker-highlight') return false;
       if (el.id === 'bugdrop-element-picker-tooltip') return false;
       if (el.closest('#bugdrop-host')) return false;
@@ -113,8 +175,8 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
 
     if (!target) return;
 
-    currentElement = target;
-    const rect = target.getBoundingClientRect();
+    currentElement = getSelectionTarget(target);
+    const rect = currentElement.getBoundingClientRect();
 
     // Update highlight position with slight padding
     highlight.style.top = `${rect.top - 2}px`;
@@ -124,12 +186,49 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
     highlight.style.display = 'block';
   }
 
+  function selectElementAtPoint(x: number, y: number) {
+    const target = getSelectableElementAtPoint(x, y);
+    currentElement = target ? getSelectionTarget(target) : currentElement;
+    cleanup();
+    resolve(currentElement);
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (activePointerId !== null || !e.isPrimary) return;
+    e.preventDefault();
+    e.stopPropagation();
+    activePointerId = e.pointerId;
+    overlay.setPointerCapture?.(e.pointerId);
+    const target = getSelectableElementAtPoint(e.clientX, e.clientY);
+    currentElement = target ? getSelectionTarget(target) : currentElement;
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (activePointerId !== null && e.pointerId !== activePointerId) return;
+    e.preventDefault();
+    e.stopPropagation();
+    onMouseMove(e);
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (activePointerId !== null && e.pointerId !== activePointerId) return;
+    e.preventDefault();
+    e.stopPropagation();
+    activePointerId = null;
+    overlay.releasePointerCapture?.(e.pointerId);
+    selectElementAtPoint(e.clientX, e.clientY);
+  }
+
+  function onPointerCancel(e: PointerEvent) {
+    if (e.pointerId !== activePointerId) return;
+    activePointerId = null;
+    overlay.releasePointerCapture?.(e.pointerId);
+  }
+
   function onClick(e: MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
-    currentElement = getSelectableElementAtPoint(e.clientX, e.clientY) ?? currentElement;
-    cleanup();
-    resolve(currentElement);
+    selectElementAtPoint(e.clientX, e.clientY);
   }
 
   function onKeyDown(e: KeyboardEvent) {
@@ -140,9 +239,14 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
   }
 
   function cleanup() {
+    overlay.removeEventListener('pointerdown', onPointerDown);
+    overlay.removeEventListener('pointermove', onPointerMove);
+    overlay.removeEventListener('pointerup', onPointerUp);
+    overlay.removeEventListener('pointercancel', onPointerCancel);
     document.removeEventListener('mousemove', onMouseMove, true);
     document.removeEventListener('click', onClick, true);
     document.removeEventListener('keydown', onKeyDown);
+    overlay.remove();
     highlight.remove();
     tooltip.remove();
     document.body.style.cursor = '';
@@ -150,6 +254,10 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
 
   // Set cursor and start listening
   document.body.style.cursor = 'crosshair';
+  overlay.addEventListener('pointerdown', onPointerDown);
+  overlay.addEventListener('pointermove', onPointerMove);
+  overlay.addEventListener('pointerup', onPointerUp);
+  overlay.addEventListener('pointercancel', onPointerCancel);
   document.addEventListener('mousemove', onMouseMove, true);
   document.addEventListener('click', onClick, true);
   document.addEventListener('keydown', onKeyDown);


### PR DESCRIPTION
Closes #185

## What changed

Select Element mode now owns pointer input while the picker is active, so a mobile tap chooses the screenshot target without also firing the host page's tap behavior. When the tap lands inside an interactive control, the picker resolves the selected target to the nearest clickable ancestor instead of the deepest child at that point.

## Why this shape

The tempting fix for the mobile issue is to keep listening at the document level and cancel more events there. That still leaves the browser free to target the underlying page first on touch devices. A transparent picker overlay gives the flow one clear input owner during selection, while temporarily ignoring that overlay only for hit-testing the real page element underneath.

For target selection, choosing the outermost element in the tap area can over-capture broad layout containers. Choosing the nearest clickable ancestor keeps the user's likely intent for rows, links, buttons, and ARIA controls, while preserving the old deepest-element behavior for non-interactive content.

## Test plan

- `npm run build:widget` passed
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run test -- captureFlow.test.ts pickerStyle.test.ts selectorMetadata.test.ts` passed, 34 tests
- `npx playwright test e2e/widget.spec.ts -g "element picker selects nearest clickable ancestor from nested content|element picker recognizes mixed-case clickable fallback role tokens|element picker prevents selected mobile tap from reaching the page|element capture uses a surrounding context target|element context max-area setting can keep captures tightly scoped|element picker handles SVG elements|element picker handles nested SVG child elements" --project=chromium` passed, 7 tests
- Pre-push typecheck passed
