### PR TITLE
Add self-hosted auth token gate

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -42,5 +42,12 @@ YOUR_PRIVATE_KEY_CONTENT_HERE
 # Optional: where "/" redirects for self-hosted deployments.
 # ROOT_REDIRECT_URL=https://example.com
 
+# Optional: require short-lived host-app auth tokens before creating issues.
+# Use this for self-hosted widgets that should only accept feedback from authenticated users.
+# AUTH_TOKEN_SECRET=replace-with-a-long-random-secret-at-least-32-bytes
+# AUTH_TOKEN_AUDIENCE=bugdrop.your-subdomain.workers.dev
+# AUTH_TOKEN_ISSUER=app.yourdomain.com
+# AUTH_TOKEN_REQUIRED_FOR_CHECK=true
+
 # RATE_LIMIT is intentionally not configured here.
 # Local development runs with ENVIRONMENT=development and can work without a KV namespace.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,12 @@ jobs:
           key: pw-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
 
       - name: Install Playwright browsers
+        timeout-minutes: 5
         if: steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Install Playwright system deps
+        timeout-minutes: 5
         if: steps.pw-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
 
@@ -135,6 +137,7 @@ jobs:
   live-preview-tests:
     name: Live Preview Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [deploy-preview]
     if: github.event_name == 'merge_group'
     env:
@@ -165,10 +168,12 @@ jobs:
           key: pw-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
 
       - name: Install Playwright browsers
+        timeout-minutes: 5
         if: steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Install Playwright system deps
+        timeout-minutes: 5
         if: steps.pw-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
 
@@ -239,6 +244,7 @@ jobs:
   live-preview-cross-browser-tests:
     name: Live Preview Cross-Browser (${{ matrix.browser }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [deploy-preview]
     if: github.event_name == 'merge_group'
     strategy:
@@ -273,10 +279,12 @@ jobs:
           key: pw-${{ runner.os }}-${{ matrix.browser }}-${{ steps.pw-version.outputs.version }}
 
       - name: Install Playwright browser
+        timeout-minutes: 5
         if: steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps ${{ matrix.browser }}
 
       - name: Install Playwright system deps
+        timeout-minutes: 5
         if: steps.pw-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps ${{ matrix.browser }}
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -129,6 +129,8 @@ To customize limits, edit `src/middleware/rateLimit.ts` and the middleware confi
 # Set production secrets
 wrangler secret put GITHUB_APP_ID
 wrangler secret put GITHUB_PRIVATE_KEY
+# Optional: require signed host-app auth tokens before accepting feedback
+wrangler secret put AUTH_TOKEN_SECRET
 
 # Deploy
 make deploy
@@ -166,18 +168,22 @@ The release tag (e.g., `v1.2.0`) becomes the version number for the widget files
 
 ### Environment Variables
 
-| Variable                       | Required | Description                                                           |
-| ------------------------------ | -------- | --------------------------------------------------------------------- |
-| `GITHUB_APP_ID`                | Yes      | Your GitHub App's numeric ID                                          |
-| `GITHUB_PRIVATE_KEY`           | Yes      | Private key from GitHub App settings                                  |
-| `ENVIRONMENT`                  | No       | `development` disables rate limiting; `production` enables all checks |
-| `ALLOWED_ORIGINS`              | No       | Comma-separated allowed domains (default: `*`)                        |
-| `GITHUB_APP_NAME`              | No       | Your app's URL slug for install links                                 |
-| `MAX_SCREENSHOT_SIZE_MB`       | No       | Max screenshot size in MB (default: `5`)                              |
-| `CATEGORY_LABELS`              | No       | JSON mapping from repos/categories to GitHub labels                   |
-| `ALLOW_CLIENT_CATEGORY_LABELS` | No       | Set to `true` to trust `data-category-labels` from your own pages     |
-| `ROOT_REDIRECT_URL`            | No       | Landing page URL for `/` redirects (default: `https://bugdrop.dev`)   |
-| `RATE_LIMIT`                   | No       | KV namespace binding for rate limiting (see section 5)                |
+| Variable                        | Required | Description                                                           |
+| ------------------------------- | -------- | --------------------------------------------------------------------- |
+| `GITHUB_APP_ID`                 | Yes      | Your GitHub App's numeric ID                                          |
+| `GITHUB_PRIVATE_KEY`            | Yes      | Private key from GitHub App settings                                  |
+| `ENVIRONMENT`                   | No       | `development` disables rate limiting; `production` enables all checks |
+| `ALLOWED_ORIGINS`               | No       | Comma-separated allowed domains (default: `*`)                        |
+| `GITHUB_APP_NAME`               | No       | Your app's URL slug for install links                                 |
+| `MAX_SCREENSHOT_SIZE_MB`        | No       | Max screenshot size in MB (default: `5`)                              |
+| `CATEGORY_LABELS`               | No       | JSON mapping from repos/categories to GitHub labels                   |
+| `ALLOW_CLIENT_CATEGORY_LABELS`  | No       | Set to `true` to trust `data-category-labels` from your own pages     |
+| `ROOT_REDIRECT_URL`             | No       | Landing page URL for `/` redirects (default: `https://bugdrop.dev`)   |
+| `AUTH_TOKEN_SECRET`             | No       | HMAC secret that requires signed host-app tokens for `/feedback`      |
+| `AUTH_TOKEN_AUDIENCE`           | No       | Expected token `aud` claim, usually your BugDrop worker hostname      |
+| `AUTH_TOKEN_ISSUER`             | No       | Expected token `iss` claim, usually your app hostname                 |
+| `AUTH_TOKEN_REQUIRED_FOR_CHECK` | No       | Set to `true` to require auth tokens for `/check/:owner/:repo` too    |
+| `RATE_LIMIT`                    | No       | KV namespace binding for rate limiting (see section 5)                |
 
 ### Custom Category Labels
 
@@ -228,6 +234,64 @@ GITHUB_APP_NAME = "my-bugdrop-app"
 Only list the exact origins (scheme + host) of sites where you embed the BugDrop widget. The worker validates the `Origin` header on incoming requests and rejects any not in this list.
 
 > **Note:** `ALLOWED_ORIGINS` is a CORS-level check — it only blocks browser-based cross-origin requests. Direct API calls (curl, scripts) don't send an `Origin` header and bypass CORS entirely. Rate limiting (section 5) is your primary defense against non-browser abuse.
+
+### Requiring Host-App Auth Tokens (Recommended for Private Apps)
+
+For self-hosted deployments embedded in authenticated apps, add a short-lived signed token so the worker only accepts feedback from users your app has already authorized. This is stronger than CORS alone because direct API callers must also produce a valid token.
+
+Set a long random secret on the BugDrop worker:
+
+```bash
+wrangler secret put AUTH_TOKEN_SECRET
+```
+
+Then set optional claim checks in your worker vars:
+
+```toml
+[vars]
+AUTH_TOKEN_AUDIENCE = "bugdrop.your-subdomain.workers.dev"
+AUTH_TOKEN_ISSUER = "app.yourdomain.com"
+AUTH_TOKEN_REQUIRED_FOR_CHECK = "true"
+```
+
+When `AUTH_TOKEN_SECRET` is set, `/feedback` requires an `Authorization: Bearer <token>` header. `/check/:owner/:repo` remains public by default for backwards compatibility; set `AUTH_TOKEN_REQUIRED_FOR_CHECK = "true"` if even installation status should be visible only to authenticated users.
+
+Your application should expose a same-origin endpoint that returns a token only after checking its own session:
+
+```js
+window.getBugDropToken = async function getBugDropToken() {
+  const response = await fetch('/api/bugdrop-token', { credentials: 'include' });
+  if (!response.ok) throw new Error('Unable to create BugDrop token');
+  const { token } = await response.json();
+  return token;
+};
+```
+
+Then point the widget at that global function:
+
+```html
+<script
+  src="https://bugdrop.your-subdomain.workers.dev/widget.js"
+  data-repo="owner/repo"
+  data-auth-token-provider="getBugDropToken"
+></script>
+```
+
+Tokens use a compact HMAC-SHA256 format with a `bd1` prefix. The payload is JSON with these claims:
+
+```json
+{
+  "iss": "app.yourdomain.com",
+  "aud": "bugdrop.your-subdomain.workers.dev",
+  "sub": "user_123",
+  "repo": "owner/repo",
+  "iat": 1779700000,
+  "exp": 1779700300,
+  "jti": "unique-token-id"
+}
+```
+
+Use short expirations, usually 5 minutes or less. The `repo` claim must exactly match the widget's `data-repo` value. `sub` and `jti` are not persisted by BugDrop today, but including them gives you useful audit material in your own token issuer logs.
 
 ### Root URL Redirect
 

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -16,6 +16,7 @@ These attributes control the fundamental behavior of the widget.
 | `data-label` | `"Feedback"` | Text label displayed next to the button icon |
 | `data-category-labels` | built-in labels | Self-hosted JSON mapping from built-in categories to GitHub labels |
 | `data-button` | `"true"` | Show the floating button: `"true"` or `"false"` |
+| `data-auth-token-provider` | none | Name of a global function that returns a self-hosted auth token |
 | `data-welcome` | `"Report a bug or request a feature"` | Welcome message displayed at the top of the form |
 | `data-show-issue-link` | `"public"` | Show the GitHub issue link after submission: `"public"`, `"always"`, or `"never"` |
 
@@ -198,6 +199,37 @@ Self-hosted deployments can also let pages set labels via the `data-category-lab
 ```
 
 Only enable this when your worker's `ALLOWED_ORIGINS` is locked down to trusted domains.
+
+## Auth Token Provider
+
+Self-hosted deployments can require short-lived host-app auth tokens before BugDrop accepts feedback. This is useful when the widget is only meant for authenticated users in your product.
+
+First, define a global function that fetches a token from your own backend:
+
+```html
+<script>
+  window.getBugDropToken = async function getBugDropToken() {
+    const response = await fetch('/api/bugdrop-token', { credentials: 'include' });
+    if (!response.ok) throw new Error('Unable to create BugDrop token');
+    const { token } = await response.json();
+    return token;
+  };
+</script>
+```
+
+Then reference that function on the BugDrop script tag:
+
+```html
+<script
+  src="https://bugdrop.yourcompany.com/widget.js"
+  data-repo="owner/repo"
+  data-auth-token-provider="getBugDropToken"
+></script>
+```
+
+The provider may return either a raw token or a value already prefixed with `Bearer `. BugDrop calls it before installation checks and feedback submissions, then sends the token in the `Authorization` header.
+
+This attribute only adds the client-side header. Your self-hosted worker must also set `AUTH_TOKEN_SECRET` to enforce the token gate. See the [Self-Hosting guide](https://github.com/mean-weasel/bugdrop/blob/main/SELF_HOSTING.md) for the worker environment variables and token claim format.
 
 ### Rules and behavior
 

--- a/docs/website/security.mdx
+++ b/docs/website/security.mdx
@@ -215,7 +215,16 @@ If you run your own instance of BugDrop:
 3. **Monitor your Cloudflare Worker logs** for unusual activity
 4. **Add edge protections** such as WAF rules, CAPTCHA, bot detection, and allowlists as needed
 5. **Define retention/cleanup** for the `bugdrop-screenshots` branch
-6. **Keep your instance updated** with the latest version
+6. **Use host-app auth tokens** when the widget should only be available to authenticated users
+7. **Keep your instance updated** with the latest version
+
+### Host-App Auth Tokens
+
+For private or authenticated applications, self-hosted workers can require a signed token on feedback submissions. Set `AUTH_TOKEN_SECRET` on the BugDrop worker, mint short-lived tokens from your own backend after checking the user's session, and configure the widget with `data-auth-token-provider`.
+
+This protects the feedback endpoint from direct API calls that bypass browser CORS. CORS still matters for browser isolation, but it is not an authentication boundary. The token should include the exact target repository and expire quickly, usually within 5 minutes.
+
+If installation status is also sensitive, set `AUTH_TOKEN_REQUIRED_FOR_CHECK = "true"` so the widget's `/check/:owner/:repo` request requires the same token.
 
 ## Reporting Security Issues
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,11 @@ app.use('*', async (c, next) => {
     if (c.env.ALLOWED_ORIGINS === '*' && c.env.ENVIRONMENT !== 'development') {
       console.warn('WARNING: ALLOWED_ORIGINS is set to "*" in non-development environment');
     }
+    if (isWeakAuthTokenSecret(c.env.AUTH_TOKEN_SECRET)) {
+      console.warn(
+        '[BugDrop] AUTH_TOKEN_SECRET should be a long random value of at least 32 characters.'
+      );
+    }
 
     envChecked = true;
   }
@@ -34,6 +39,10 @@ app.use('*', logger());
 
 // Mount API routes
 app.route('/api', api);
+
+export function isWeakAuthTokenSecret(secret?: string): boolean {
+  return typeof secret === 'string' && secret.length > 0 && secret.length < 32;
+}
 
 export function resolveRootRedirectUrl(rawUrl?: string): string {
   if (!rawUrl) {

--- a/src/lib/authToken.ts
+++ b/src/lib/authToken.ts
@@ -1,4 +1,4 @@
-export interface BugDropAuthTokenPayload {
+interface BugDropAuthTokenPayload {
   iss?: string;
   aud?: string;
   sub: string;
@@ -10,7 +10,7 @@ export interface BugDropAuthTokenPayload {
   jti: string;
 }
 
-export interface VerifyBugDropAuthTokenOptions {
+interface VerifyBugDropAuthTokenOptions {
   secret: string;
   repo: string;
   audience?: string;

--- a/src/lib/authToken.ts
+++ b/src/lib/authToken.ts
@@ -1,0 +1,143 @@
+export interface BugDropAuthTokenPayload {
+  iss?: string;
+  aud?: string;
+  sub: string;
+  repo: string;
+  origin?: string;
+  iat: number;
+  nbf?: number;
+  exp: number;
+  jti: string;
+}
+
+export interface VerifyBugDropAuthTokenOptions {
+  secret: string;
+  repo: string;
+  audience?: string;
+  issuer?: string;
+  now?: number;
+}
+
+const TOKEN_PREFIX = 'bd1';
+const CLOCK_SKEW_SECONDS = 30;
+
+export async function verifyBugDropAuthToken(
+  token: string | undefined,
+  options: VerifyBugDropAuthTokenOptions
+): Promise<BugDropAuthTokenPayload> {
+  if (!token) throw new Error('Missing BugDrop auth token');
+
+  const parts = token.split('.');
+  if (parts.length !== 3 || parts[0] !== TOKEN_PREFIX) {
+    throw new Error('Invalid BugDrop auth token format');
+  }
+
+  const signedValue = `${parts[0]}.${parts[1]}`;
+  const expectedSignature = await signBase64Url(signedValue, options.secret);
+  if (!timingSafeEqual(parts[2] ?? '', expectedSignature)) {
+    throw new Error('Invalid token signature');
+  }
+
+  const payload = parsePayload(parts[1] ?? '');
+  const now = options.now ?? Math.floor(Date.now() / 1000);
+
+  if (payload.nbf !== undefined && payload.nbf > now + CLOCK_SKEW_SECONDS) {
+    throw new Error('Token not active yet');
+  }
+  if (payload.exp < now - CLOCK_SKEW_SECONDS) {
+    throw new Error('Token expired');
+  }
+  if (payload.repo !== options.repo) {
+    throw new Error('Token repo does not match request repo');
+  }
+  if (options.audience && payload.aud !== options.audience) {
+    throw new Error('Token audience does not match worker');
+  }
+  if (options.issuer && payload.iss !== options.issuer) {
+    throw new Error('Token issuer does not match configuration');
+  }
+
+  return payload;
+}
+
+export async function createBugDropAuthTokenForTest(
+  payload: BugDropAuthTokenPayload,
+  secret: string
+): Promise<string> {
+  const encodedPayload = base64UrlEncodeString(JSON.stringify(payload));
+  const signedValue = `${TOKEN_PREFIX}.${encodedPayload}`;
+  const signature = await signBase64Url(signedValue, secret);
+  return `${signedValue}.${signature}`;
+}
+
+async function signBase64Url(value: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(value));
+  return base64UrlEncodeBytes(new Uint8Array(signature));
+}
+
+function parsePayload(encoded: string): BugDropAuthTokenPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(base64UrlDecodeToString(encoded));
+  } catch {
+    throw new Error('Invalid token payload');
+  }
+
+  if (!isPayload(parsed)) throw new Error('Invalid token payload');
+  return parsed;
+}
+
+function isPayload(value: unknown): value is BugDropAuthTokenPayload {
+  if (!value || typeof value !== 'object') return false;
+  const payload = value as Record<string, unknown>;
+  return (
+    typeof payload.sub === 'string' &&
+    typeof payload.repo === 'string' &&
+    typeof payload.iat === 'number' &&
+    typeof payload.exp === 'number' &&
+    typeof payload.jti === 'string' &&
+    (payload.iss === undefined || typeof payload.iss === 'string') &&
+    (payload.aud === undefined || typeof payload.aud === 'string') &&
+    (payload.origin === undefined || typeof payload.origin === 'string') &&
+    (payload.nbf === undefined || typeof payload.nbf === 'number')
+  );
+}
+
+function timingSafeEqual(left: string, right: string): boolean {
+  const leftBytes = new TextEncoder().encode(left);
+  const rightBytes = new TextEncoder().encode(right);
+  let diff = leftBytes.length ^ rightBytes.length;
+  const max = Math.max(leftBytes.length, rightBytes.length);
+  for (let index = 0; index < max; index++) {
+    diff |= (leftBytes[index] ?? 0) ^ (rightBytes[index] ?? 0);
+  }
+  return diff === 0;
+}
+
+function base64UrlEncodeString(value: string): string {
+  return base64UrlEncodeBytes(new TextEncoder().encode(value));
+}
+
+function base64UrlEncodeBytes(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function base64UrlDecodeToString(value: string): string {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new TextDecoder().decode(bytes);
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -12,7 +12,12 @@ import { rateLimit, rateLimitByRepo } from '../middleware/rateLimit';
 import { resolveAccentColor } from '../defaults';
 import { verifyBugDropAuthToken } from '../lib/authToken';
 
-const api = new Hono<{ Bindings: Env }>();
+type ApiVariables = {
+  feedbackPayload?: FeedbackPayload;
+};
+type ApiEnv = { Bindings: Env; Variables: ApiVariables };
+
+const api = new Hono<ApiEnv>();
 
 const DEFAULT_CATEGORY_LABELS: Record<FeedbackCategory, string[]> = {
   bug: ['bug'],
@@ -111,7 +116,7 @@ api.post('/feedback', async c => {
   // Parse payload
   let payload: FeedbackPayload;
   try {
-    payload = await c.req.json();
+    payload = c.get('feedbackPayload') ?? (await c.req.json());
   } catch {
     return c.json({ error: 'Invalid JSON' }, 400);
   }
@@ -247,16 +252,17 @@ api.post('/feedback', async c => {
 });
 
 async function requireBugDropFeedbackAuthToken(
-  c: Context<{ Bindings: Env }>,
+  c: Context<ApiEnv>,
   next: Next
 ): Promise<Response | void> {
   if (!c.env.AUTH_TOKEN_SECRET || c.req.method !== 'POST') return next();
 
   try {
-    const body = (await c.req.raw.clone().json()) as { repo?: unknown };
-    if (typeof body.repo !== 'string') return next();
+    const payload = (await c.req.raw.clone().json()) as FeedbackPayload;
+    c.set('feedbackPayload', payload);
+    if (typeof payload.repo !== 'string') return next();
 
-    const authError = await requireBugDropAuthToken(c, body.repo);
+    const authError = await requireBugDropAuthToken(c, payload.repo);
     if (authError) return authError;
   } catch {
     // Let the route handler return the existing invalid JSON response.
@@ -269,10 +275,7 @@ function getBearerToken(value: string | undefined): string | undefined {
   return value?.match(/^Bearer\s+(.+)$/i)?.[1];
 }
 
-async function requireBugDropAuthToken(
-  c: Context<{ Bindings: Env }>,
-  repo: string
-): Promise<Response | null> {
+async function requireBugDropAuthToken(c: Context<ApiEnv>, repo: string): Promise<Response | null> {
   if (!c.env.AUTH_TOKEN_SECRET) return null;
 
   try {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,4 +1,4 @@
-import { Hono, type Context } from 'hono';
+import { Hono, type Context, type Next } from 'hono';
 import { cors } from 'hono/cors';
 import type { Env, FeedbackCategory, FeedbackPayload } from '../types';
 import {
@@ -65,6 +65,9 @@ api.use(
     keyPrefix: 'ip',
   })
 );
+
+// Authenticate protected submissions before shared repo quota accounting.
+api.use('/feedback', requireBugDropFeedbackAuthToken);
 
 // Rate limit: 50 requests per hour per repo
 api.use(
@@ -242,6 +245,25 @@ api.post('/feedback', async c => {
     );
   }
 });
+
+async function requireBugDropFeedbackAuthToken(
+  c: Context<{ Bindings: Env }>,
+  next: Next
+): Promise<Response | void> {
+  if (!c.env.AUTH_TOKEN_SECRET || c.req.method !== 'POST') return next();
+
+  try {
+    const body = (await c.req.raw.clone().json()) as { repo?: unknown };
+    if (typeof body.repo !== 'string') return next();
+
+    const authError = await requireBugDropAuthToken(c, body.repo);
+    if (authError) return authError;
+  } catch {
+    // Let the route handler return the existing invalid JSON response.
+  }
+
+  return next();
+}
 
 function getBearerToken(value: string | undefined): string | undefined {
   return value?.match(/^Bearer\s+(.+)$/i)?.[1];

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { cors } from 'hono/cors';
 import type { Env, FeedbackCategory, FeedbackPayload } from '../types';
 import {
@@ -10,6 +10,7 @@ import {
 } from '../lib/github';
 import { rateLimit, rateLimitByRepo } from '../middleware/rateLimit';
 import { resolveAccentColor } from '../defaults';
+import { verifyBugDropAuthToken } from '../lib/authToken';
 
 const api = new Hono<{ Bindings: Env }>();
 
@@ -49,7 +50,7 @@ api.use('*', async (c, next) => {
       return originList.includes(origin) ? origin : null;
     },
     allowMethods: ['GET', 'POST', 'OPTIONS'],
-    allowHeaders: ['Content-Type'],
+    allowHeaders: ['Content-Type', 'Authorization'],
   });
 
   return corsMiddleware(c, next);
@@ -86,12 +87,18 @@ api.get('/health', c => {
 // Check if app is installed on repo
 api.get('/check/:owner/:repo', async c => {
   const { owner, repo } = c.req.param();
+  const fullRepo = `${owner}/${repo}`;
+
+  if (c.env.AUTH_TOKEN_REQUIRED_FOR_CHECK === 'true') {
+    const authError = await requireBugDropAuthToken(c, fullRepo);
+    if (authError) return authError;
+  }
 
   const token = await getInstallationToken(c.env, owner, repo);
 
   return c.json({
     installed: !!token,
-    repo: `${owner}/${repo}`,
+    repo: fullRepo,
     appName: c.env.GITHUB_APP_NAME || undefined,
   });
 });
@@ -136,6 +143,9 @@ api.post('/feedback', async c => {
       400
     );
   }
+
+  const authError = await requireBugDropAuthToken(c, payload.repo);
+  if (authError) return authError;
 
   try {
     // Get installation token
@@ -232,6 +242,33 @@ api.post('/feedback', async c => {
     );
   }
 });
+
+function getBearerToken(value: string | undefined): string | undefined {
+  return value?.match(/^Bearer\s+(.+)$/i)?.[1];
+}
+
+async function requireBugDropAuthToken(
+  c: Context<{ Bindings: Env }>,
+  repo: string
+): Promise<Response | null> {
+  if (!c.env.AUTH_TOKEN_SECRET) return null;
+
+  try {
+    await verifyBugDropAuthToken(getBearerToken(c.req.header('Authorization')), {
+      secret: c.env.AUTH_TOKEN_SECRET,
+      repo,
+      audience: c.env.AUTH_TOKEN_AUDIENCE,
+      issuer: c.env.AUTH_TOKEN_ISSUER,
+    });
+    return null;
+  } catch (error) {
+    console.warn('[BugDrop] rejected auth token', {
+      repo,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    return c.json({ error: 'BugDrop auth token required' }, 401);
+  }
+}
 
 type ScreenshotValidationResult = { valid: true } | { valid: false; error: string };
 type LabelResolution = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,10 @@ export interface Env {
   CATEGORY_LABELS?: string; // Optional JSON category-label mapping keyed by repo or "*"
   ALLOW_CLIENT_CATEGORY_LABELS?: string; // Self-host escape hatch for script-tag mappings
   ROOT_REDIRECT_URL?: string; // Optional landing page for self-hosted deployments
+  AUTH_TOKEN_SECRET?: string; // Optional HMAC secret for host-app submission tokens
+  AUTH_TOKEN_AUDIENCE?: string; // Optional expected token audience claim
+  AUTH_TOKEN_ISSUER?: string; // Optional expected token issuer claim
+  AUTH_TOKEN_REQUIRED_FOR_CHECK?: string; // Optional gate for /check installation lookups
 
   // Bindings
   ASSETS: Fetcher;

--- a/src/widget/auth-token.ts
+++ b/src/widget/auth-token.ts
@@ -1,0 +1,31 @@
+export type BugDropAuthTokenProvider = () => string | Promise<string> | null | undefined;
+
+type GlobalWithTokenProviders = Window & Record<string, unknown>;
+
+export function resolveAuthTokenProvider(
+  providerName: string | undefined,
+  globalObject: GlobalWithTokenProviders = window as unknown as GlobalWithTokenProviders
+): BugDropAuthTokenProvider | undefined {
+  if (!providerName) return undefined;
+
+  const provider = globalObject[providerName];
+  if (typeof provider !== 'function') {
+    console.warn(`[BugDrop] data-auth-token-provider "${providerName}" must reference a function.`);
+    return undefined;
+  }
+
+  return provider as BugDropAuthTokenProvider;
+}
+
+export async function getAuthHeaders(
+  tokenProvider: BugDropAuthTokenProvider | undefined
+): Promise<Record<string, string>> {
+  if (!tokenProvider) return {};
+
+  const token = await tokenProvider();
+  if (!token) return {};
+
+  return {
+    Authorization: token.startsWith('Bearer ') ? token : `Bearer ${token}`,
+  };
+}

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -19,6 +19,11 @@ import {
   sanitizeShadowPreset,
   sanitizeUrl,
 } from './sanitize';
+import {
+  getAuthHeaders,
+  resolveAuthTokenProvider,
+  type BugDropAuthTokenProvider,
+} from './auth-token';
 import { resolveAccentColor } from '../defaults';
 
 type FeedbackCategory = 'bug' | 'feature' | 'question';
@@ -27,6 +32,7 @@ type CategoryLabelConfig = Partial<Record<FeedbackCategory, string | string[]>>;
 interface WidgetConfig {
   repo: string;
   apiUrl: string;
+  authTokenProvider?: BugDropAuthTokenProvider;
   position: 'bottom-right' | 'bottom-left';
   theme: 'light' | 'dark' | 'auto';
   // Name/email field configuration
@@ -382,6 +388,7 @@ if (rawShowIssueLink && rawShowIssueLink !== 'public' && rawShowIssueLink !== is
 const config: WidgetConfig = {
   repo: script?.dataset.repo || '',
   apiUrl: script?.src.replace(/\/widget(?:\.v[\d.]+)?\.js$/, '/api') || '',
+  authTokenProvider: resolveAuthTokenProvider(script?.dataset.authTokenProvider),
   position: rawPosition === 'bottom-left' ? 'bottom-left' : 'bottom-right',
   theme: isValidTheme(rawTheme) ? rawTheme : 'auto', // Default to auto-detection
   // Name/email field configuration (all default to false for backwards compatibility)
@@ -1082,7 +1089,9 @@ async function checkInstallation(
   config: WidgetConfig
 ): Promise<{ status: 'installed' | 'not_installed' | 'unreachable'; appName?: string }> {
   try {
-    const response = await fetch(`${config.apiUrl}/check/${config.repo}`);
+    const response = await fetch(`${config.apiUrl}/check/${config.repo}`, {
+      headers: await getAuthHeaders(config.authTokenProvider),
+    });
     if (!response.ok) return { status: 'unreachable' };
     const data = await response.json();
     return {
@@ -1388,7 +1397,10 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
 
     const response = await fetch(`${config.apiUrl}/feedback`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(await getAuthHeaders(config.authTokenProvider)),
+      },
       body: JSON.stringify({
         repo: config.repo,
         title: data.title,

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -242,6 +242,41 @@ describe('API Routes', () => {
       expect(mockCreateIssue).not.toHaveBeenCalled();
     });
 
+    it('should reject tokenless feedback before consuming repository rate limits', async () => {
+      const rateLimit = {
+        get: vi.fn().mockResolvedValue('0'),
+        put: vi.fn().mockResolvedValue(undefined),
+      };
+      const env = {
+        ...mockEnv,
+        ENVIRONMENT: 'production',
+        AUTH_TOKEN_SECRET: 'test-secret-with-at-least-32-bytes-for-hmac',
+        RATE_LIMIT: rateLimit as unknown as KVNamespace,
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'cf-connecting-ip': '203.0.113.10',
+        },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(401);
+      expect(rateLimit.put).toHaveBeenCalledWith(
+        expect.stringMatching(/^ip:203\.0\.113\.10:/),
+        '1',
+        expect.any(Object)
+      );
+      expect(rateLimit.put).not.toHaveBeenCalledWith(
+        expect.stringMatching(/^repo:testowner\/testrepo:/),
+        expect.any(String),
+        expect.any(Object)
+      );
+    });
+
     it('should create issue with a valid bearer token when token auth is configured', async () => {
       const env = {
         ...mockEnv,

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -277,6 +277,42 @@ describe('API Routes', () => {
       );
     });
 
+    it('should parse protected feedback payload only once for successful requests', async () => {
+      const env = {
+        ...mockEnv,
+        AUTH_TOKEN_SECRET: 'test-secret-with-at-least-32-bytes-for-hmac',
+        AUTH_TOKEN_AUDIENCE: 'bugdrop.example.workers.dev',
+        AUTH_TOKEN_ISSUER: 'app.example.com',
+      };
+      const now = Math.floor(Date.now() / 1000);
+      const token = await createBugDropAuthTokenForTest(
+        {
+          iss: 'app.example.com',
+          aud: 'bugdrop.example.workers.dev',
+          sub: 'user-123',
+          repo: 'testowner/testrepo',
+          iat: now,
+          exp: now + 300,
+          jti: 'jti-123',
+        },
+        env.AUTH_TOKEN_SECRET
+      );
+      const request = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(validPayload),
+      });
+      const jsonSpy = vi.spyOn(request, 'json');
+
+      const res = await app.fetch(request, env);
+
+      expect(res.status).toBe(200);
+      expect(jsonSpy).not.toHaveBeenCalled();
+    });
+
     it('should create issue with a valid bearer token when token auth is configured', async () => {
       const env = {
         ...mockEnv,

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import type { Env, FeedbackPayload } from '../src/types';
+import { createBugDropAuthTokenForTest } from '../src/lib/authToken';
 
 // Mock GitHub API functions
 const mockGetInstallationToken = vi.fn();
@@ -148,6 +149,21 @@ describe('API Routes', () => {
       expect(res.headers.get('access-control-allow-origin')).toBe('*');
     });
 
+    it('should reject tokenless check requests when check auth is required', async () => {
+      const env = {
+        ...mockEnv,
+        AUTH_TOKEN_SECRET: 'test-secret-with-at-least-32-bytes-for-hmac',
+        AUTH_TOKEN_REQUIRED_FOR_CHECK: 'true',
+      };
+      const req = new Request('http://localhost/check/testowner/testrepo');
+      const res = await app.fetch(req, env);
+      const data = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(data).toEqual({ error: 'BugDrop auth token required' });
+      expect(mockGetInstallationToken).not.toHaveBeenCalled();
+    });
+
     it('should handle special characters in repo names', async () => {
       mockGetInstallationToken.mockResolvedValue('test-token');
 
@@ -202,6 +218,69 @@ describe('API Routes', () => {
         expect.stringContaining('This is a test feedback'),
         ['bug', 'bugdrop']
       );
+    });
+
+    it('should reject feedback without a bearer token when token auth is configured', async () => {
+      const env = {
+        ...mockEnv,
+        AUTH_TOKEN_SECRET: 'test-secret-with-at-least-32-bytes-for-hmac',
+        AUTH_TOKEN_AUDIENCE: 'bugdrop.example.workers.dev',
+        AUTH_TOKEN_ISSUER: 'app.example.com',
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Origin: 'https://app.example.com' },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, env);
+      const data = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(data).toEqual({ error: 'BugDrop auth token required' });
+      expect(mockGetInstallationToken).not.toHaveBeenCalled();
+      expect(mockCreateIssue).not.toHaveBeenCalled();
+    });
+
+    it('should create issue with a valid bearer token when token auth is configured', async () => {
+      const env = {
+        ...mockEnv,
+        AUTH_TOKEN_SECRET: 'test-secret-with-at-least-32-bytes-for-hmac',
+        AUTH_TOKEN_AUDIENCE: 'bugdrop.example.workers.dev',
+        AUTH_TOKEN_ISSUER: 'app.example.com',
+      };
+      const now = Math.floor(Date.now() / 1000);
+      const token = await createBugDropAuthTokenForTest(
+        {
+          iss: 'app.example.com',
+          aud: 'bugdrop.example.workers.dev',
+          sub: 'user-123',
+          repo: 'testowner/testrepo',
+          iat: now,
+          exp: now + 300,
+          jti: 'jti-123',
+        },
+        env.AUTH_TOKEN_SECRET
+      );
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+          Origin: 'https://app.example.com',
+        },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, env);
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data).toMatchObject({
+        success: true,
+        issueNumber: 42,
+      });
+      expect(mockCreateIssue).toHaveBeenCalledOnce();
     });
 
     it('should ignore client-provided category labels unless explicitly enabled', async () => {

--- a/test/authToken.test.ts
+++ b/test/authToken.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { createBugDropAuthTokenForTest, verifyBugDropAuthToken } from '../src/lib/authToken';
+
+const secret = 'test-secret-with-at-least-32-bytes-for-hmac';
+const now = 1_779_710_400;
+
+const payload = {
+  iss: 'app.example.com',
+  aud: 'bugdrop.example.workers.dev',
+  sub: 'user-123',
+  repo: 'owner/repo',
+  origin: 'https://app.example.com',
+  iat: now,
+  nbf: now - 10,
+  exp: now + 300,
+  jti: 'jti-123',
+};
+
+describe('BugDrop auth token verification', () => {
+  it('accepts a valid token scoped to the requested repo', async () => {
+    const token = await createBugDropAuthTokenForTest(payload, secret);
+
+    await expect(
+      verifyBugDropAuthToken(token, {
+        secret,
+        repo: 'owner/repo',
+        audience: 'bugdrop.example.workers.dev',
+        issuer: 'app.example.com',
+        now,
+      })
+    ).resolves.toMatchObject({ sub: 'user-123', repo: 'owner/repo' });
+  });
+
+  it('rejects a token scoped to another repo', async () => {
+    const token = await createBugDropAuthTokenForTest(payload, secret);
+
+    await expect(
+      verifyBugDropAuthToken(token, {
+        secret,
+        repo: 'owner/other',
+        audience: 'bugdrop.example.workers.dev',
+        issuer: 'app.example.com',
+        now,
+      })
+    ).rejects.toThrow('Token repo does not match request repo');
+  });
+
+  it('rejects expired tokens', async () => {
+    const token = await createBugDropAuthTokenForTest({ ...payload, exp: now - 60 }, secret);
+
+    await expect(
+      verifyBugDropAuthToken(token, {
+        secret,
+        repo: 'owner/repo',
+        audience: 'bugdrop.example.workers.dev',
+        issuer: 'app.example.com',
+        now,
+      })
+    ).rejects.toThrow('Token expired');
+  });
+
+  it('rejects tampered signatures', async () => {
+    const token = await createBugDropAuthTokenForTest(payload, secret);
+    const parts = token.split('.');
+    const tampered = `${parts[0]}.${parts[1]}.bad${parts[2]}`;
+
+    await expect(
+      verifyBugDropAuthToken(tampered, {
+        secret,
+        repo: 'owner/repo',
+        audience: 'bugdrop.example.workers.dev',
+        issuer: 'app.example.com',
+        now,
+      })
+    ).rejects.toThrow('Invalid token signature');
+  });
+});

--- a/test/rootRedirect.test.ts
+++ b/test/rootRedirect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { resolveRootRedirectUrl } from '../src/index';
+import { isWeakAuthTokenSecret, resolveRootRedirectUrl } from '../src/index';
 
 describe('resolveRootRedirectUrl', () => {
   it('uses the hosted site by default', () => {
@@ -19,5 +19,21 @@ describe('resolveRootRedirectUrl', () => {
     expect(warnSpy).toHaveBeenCalledTimes(2);
 
     warnSpy.mockRestore();
+  });
+});
+
+describe('isWeakAuthTokenSecret', () => {
+  it('does not warn when auth token enforcement is unset', () => {
+    expect(isWeakAuthTokenSecret()).toBe(false);
+    expect(isWeakAuthTokenSecret('')).toBe(false);
+  });
+
+  it('flags configured secrets shorter than 32 characters', () => {
+    expect(isWeakAuthTokenSecret('too-short')).toBe(true);
+    expect(isWeakAuthTokenSecret('x'.repeat(31))).toBe(true);
+  });
+
+  it('accepts secrets with at least 32 characters', () => {
+    expect(isWeakAuthTokenSecret('x'.repeat(32))).toBe(false);
   });
 });

--- a/test/widgetAuthToken.test.ts
+++ b/test/widgetAuthToken.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getAuthHeaders, resolveAuthTokenProvider } from '../src/widget/auth-token';
+
+describe('widget auth token helpers', () => {
+  it('resolves a named global provider function', async () => {
+    const tokenProvider = vi.fn(() => 'test-token');
+    const provider = resolveAuthTokenProvider('getBugDropToken', {
+      getBugDropToken: tokenProvider,
+    } as unknown as Window & Record<string, unknown>);
+
+    expect(await provider?.()).toBe('test-token');
+  });
+
+  it('returns undefined and warns when the named global is not a function', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    expect(
+      resolveAuthTokenProvider('getBugDropToken', {
+        getBugDropToken: 'not-a-function',
+      } as unknown as Window & Record<string, unknown>)
+    ).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      '[BugDrop] data-auth-token-provider "getBugDropToken" must reference a function.'
+    );
+
+    warn.mockRestore();
+  });
+
+  it('omits auth headers when no provider exists', async () => {
+    await expect(getAuthHeaders(undefined)).resolves.toEqual({});
+  });
+
+  it('adds a bearer prefix to raw tokens', async () => {
+    await expect(getAuthHeaders(() => 'raw-token')).resolves.toEqual({
+      Authorization: 'Bearer raw-token',
+    });
+  });
+
+  it('preserves an existing bearer prefix', async () => {
+    await expect(getAuthHeaders(() => 'Bearer existing-token')).resolves.toEqual({
+      Authorization: 'Bearer existing-token',
+    });
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -28,6 +28,7 @@ preview_id = "ff8f3809037d4403befd09369a9f7e36"
 # Secrets (set with: wrangler secret put GITHUB_APP_ID)
 # GITHUB_APP_ID
 # GITHUB_PRIVATE_KEY
+# AUTH_TOKEN_SECRET  # Optional: set to require signed host-app auth tokens for /feedback
 
 # Preview environment for live E2E tests (deployed in merge queue)
 [env.preview]


### PR DESCRIPTION
## Summary
- Adds optional HMAC-signed BugDrop auth tokens for self-hosted workers.
- Gates `/feedback` when `AUTH_TOKEN_SECRET` is configured, with optional `/check/:owner/:repo` gating via `AUTH_TOKEN_REQUIRED_FOR_CHECK`.
- Adds `data-auth-token-provider` so host apps can provide short-lived tokens from their own authenticated backend.
- Documents the setup in self-hosting, configuration, security, `.dev.vars.example`, and `wrangler.toml`.

Closes #187

## Verification
- `npm test -- test/authToken.test.ts`
- `npm test -- test/api.test.ts test/authToken.test.ts`
- `npm test -- test/widgetAuthToken.test.ts test/api.test.ts test/authToken.test.ts`
- `npm run validate`
- `npm run build:widget`
- `git push` pre-push typecheck passed

## E2E note
- `npm run test:e2e` completed with 217 passed, 2 skipped, 10 failed. The failures appear unrelated to this token gate: missing local Firefox/WebKit Playwright browser installs, live/deployed preview timing/screenshot assertions, and one existing 1px saved-position assertion in `e2e/widget.spec.ts`.
