### PR TITLE
fix: preserve fractional widget borders

### DIFF
--- a/src/widget/theme.ts
+++ b/src/widget/theme.ts
@@ -87,8 +87,9 @@ export function applyCustomStyles(
   if (borderW !== null || borderC !== null) {
     const bw = borderW !== null ? `${borderW}px` : '1px';
     const bc = borderC || 'var(--bd-border)';
+    root.style.setProperty('--bd-border-width', bw);
     root.style.setProperty('--bd-border', bc);
-    root.style.setProperty('--bd-border-style', `${bw} solid ${bc}`);
+    root.style.setProperty('--bd-border-style', `var(--bd-border-width) solid ${bc}`);
   }
 
   // Apply shadow preset if provided
@@ -100,7 +101,7 @@ export function applyCustomStyles(
     root.style.setProperty('--bd-shadow-glow', 'none');
   } else if (shadowPreset === 'hard') {
     const shadowColor = borderC || (isDark ? '#000' : '#1a1a1a');
-    const offset = borderW !== null ? `${borderW + 2}px` : '6px';
+    const offset = borderW !== null ? `calc(var(--bd-border-width) + 2px)` : '6px';
     root.style.setProperty('--bd-shadow-sm', `${shadowColor} 2px 2px 0 0`);
     root.style.setProperty('--bd-shadow-md', `${shadowColor} ${offset} ${offset} 0 0`);
     root.style.setProperty('--bd-shadow-lg', `${shadowColor} ${offset} ${offset} 0 0`);

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -82,7 +82,8 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       --bd-radius-lg: ${radiusLg};
 
       /* Border */
-      --bd-border-style: ${borderW !== null ? `${borderW}px` : '1px'} solid var(--bd-border);
+      --bd-border-width: ${borderW !== null ? `${borderW}px` : '1px'};
+      --bd-border-style: var(--bd-border-width) solid var(--bd-border);
 
       /* Transitions */
       --bd-transition: 0.15s ease;

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -255,14 +255,30 @@ describe('applyCustomStyles', () => {
     it('sets --bd-border and --bd-border-style when borderWidth is provided', () => {
       const root = makeRoot();
       applyCustomStyles(root, { borderWidth: '4' }, 'light');
-      expect(root.style.getPropertyValue('--bd-border-style')).toBe('4px solid var(--bd-border)');
+      expect(root.style.getPropertyValue('--bd-border-width')).toBe('4px');
+      expect(root.style.getPropertyValue('--bd-border-style')).toBe(
+        'var(--bd-border-width) solid var(--bd-border)'
+      );
+    });
+
+    it('preserves fractional border widths in a dedicated variable', () => {
+      const root = makeRoot();
+      applyCustomStyles(root, { borderWidth: '1.5', borderColor: '#64748b' }, 'light');
+      expect(root.style.getPropertyValue('--bd-border-width')).toBe('1.5px');
+      expect(root.style.getPropertyValue('--bd-border')).toBe('#64748b');
+      expect(root.style.getPropertyValue('--bd-border-style')).toBe(
+        'var(--bd-border-width) solid #64748b'
+      );
     });
 
     it('uses explicit borderColor when provided', () => {
       const root = makeRoot();
       applyCustomStyles(root, { borderWidth: '2', borderColor: '#000' }, 'light');
+      expect(root.style.getPropertyValue('--bd-border-width')).toBe('2px');
       expect(root.style.getPropertyValue('--bd-border')).toBe('#000');
-      expect(root.style.getPropertyValue('--bd-border-style')).toBe('2px solid #000');
+      expect(root.style.getPropertyValue('--bd-border-style')).toBe(
+        'var(--bd-border-width) solid #000'
+      );
     });
 
     it('ignores invalid border width and border color values', () => {


### PR DESCRIPTION
## Summary\n- add a dedicated CSS variable for widget border width\n- keep fractional data-border-width values intact when composing border styles\n- cover the 1.5px border case in theme tests\n\n## Verification\n- npm test -- --run test/theme.test.ts\n- npm run typecheck\n- npx eslint src/widget/theme.ts src/widget/ui.ts test/theme.test.ts\n- npm run build:widget\n- deployed worker version 2fbb7765-8467-4c06-863f-1b8c32107c18