### PR TITLE
[codex] Document auth secret hygiene

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -245,6 +245,19 @@ Set a long random secret on the BugDrop worker:
 wrangler secret put AUTH_TOKEN_SECRET
 ```
 
+Use the exact same secret bytes in the host app that mints BugDrop tokens. The worker and
+host-app signing secret must be byte-for-byte identical, including whitespace. Prefer a long
+random no-newline value, and avoid shell or file flows that append a trailing newline. For
+example, when setting a known value with Wrangler:
+
+```bash
+printf '%s' "$secret" | wrangler secret put AUTH_TOKEN_SECRET
+```
+
+Use an equivalent no-newline secret-setting flow for your host app platform. If your host app
+successfully returns a `bd1` token but the worker logs `Invalid token signature`, check for a
+secret mismatch, trailing newline, or quoting difference before debugging token claims.
+
 Then set optional claim checks in your worker vars:
 
 ```toml

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -229,7 +229,7 @@ Then reference that function on the BugDrop script tag:
 
 The provider may return either a raw token or a value already prefixed with `Bearer `. BugDrop calls it before installation checks and feedback submissions, then sends the token in the `Authorization` header.
 
-This attribute only adds the client-side header. Your self-hosted worker must also set `AUTH_TOKEN_SECRET` to enforce the token gate. See the [Self-Hosting guide](https://github.com/mean-weasel/bugdrop/blob/main/SELF_HOSTING.md) for the worker environment variables and token claim format.
+This attribute only adds the client-side header. Your self-hosted worker must also set `AUTH_TOKEN_SECRET` to enforce the token gate. The worker secret and the host app's token-signing secret must be byte-for-byte identical; if a valid-looking `bd1` token is rejected, check for trailing newlines or quoting differences. See the [Self-Hosting guide](https://github.com/mean-weasel/bugdrop/blob/main/SELF_HOSTING.md) for the worker environment variables, secret hygiene notes, and token claim format.
 
 ### Rules and behavior
 


### PR DESCRIPTION
## Summary
- document that AUTH_TOKEN_SECRET and the host-app signing secret must match byte-for-byte
- add no-newline Wrangler secret guidance and Invalid token signature troubleshooting
- point configuration docs to the secret hygiene note

## Validation
- npx prettier --check SELF_HOSTING.md docs/website/configuration.mdx
- git diff --check

Closes #189