### PR TITLE
Fix default widget borders not rendering

### DIFF
--- a/e2e/widget-border.spec.ts
+++ b/e2e/widget-border.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+const DEFAULT_BORDER_COLOR = 'rgb(231, 229, 228)';
+
+type BorderSnapshot = {
+  color: string;
+  style: string;
+  width: string;
+};
+
+type FormBorderSnapshot = {
+  input: BorderSnapshot;
+  modal: BorderSnapshot;
+};
+
+function escapeAttribute(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}
+
+async function mountWidget(
+  page: Page,
+  baseURL: string | undefined,
+  dataset: Record<string, string> = {}
+): Promise<void> {
+  await page.route('**/api/check/**', async route => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ installed: true }),
+    });
+  });
+
+  const widgetUrl = new URL('/widget.js', baseURL ?? 'http://localhost:8787').toString();
+  const dataAttributes = Object.entries(dataset)
+    .map(([key, value]) => `data-${key}="${escapeAttribute(value)}"`)
+    .join(' ');
+
+  await page.setContent(`
+    <!doctype html>
+    <html>
+      <body>
+        <script
+          id="bugdrop-script"
+          src="${widgetUrl}"
+          data-repo="mean-weasel/bugdrop-widget-test"
+          data-theme="light"
+          data-welcome="never"
+          ${dataAttributes}
+        ></script>
+      </body>
+    </html>
+  `);
+
+  await page.locator('#bugdrop-host').locator('css=.bd-trigger').waitFor({ state: 'visible' });
+}
+
+async function readBorder(locator: Locator): Promise<BorderSnapshot> {
+  return locator.evaluate(element => {
+    const styles = getComputedStyle(element);
+    return {
+      color: styles.borderTopColor,
+      style: styles.borderTopStyle,
+      width: styles.borderTopWidth,
+    };
+  });
+}
+
+async function openFormAndReadBorders(page: Page): Promise<FormBorderSnapshot> {
+  const host = page.locator('#bugdrop-host');
+  await host.locator('css=.bd-trigger').click();
+
+  const modal = host.locator('css=.bd-modal');
+  const titleInput = host.locator('css=#title');
+  await expect(modal).toBeVisible();
+  await expect(titleInput).toBeVisible();
+
+  return {
+    input: await readBorder(titleInput),
+    modal: await readBorder(modal),
+  };
+}
+
+test.describe('widget border styles', () => {
+  test('renders default form borders from theme variables', async ({ page, baseURL }) => {
+    await mountWidget(page, baseURL);
+
+    const expectedBorder = {
+      color: DEFAULT_BORDER_COLOR,
+      style: 'solid',
+      width: '1px',
+    };
+
+    await expect(openFormAndReadBorders(page)).resolves.toEqual({
+      input: expectedBorder,
+      modal: expectedBorder,
+    });
+  });
+
+  test('keeps the theme border color when only border width is customized', async ({
+    page,
+    baseURL,
+  }) => {
+    await mountWidget(page, baseURL, { 'border-width': '4' });
+
+    const expectedBorder = {
+      color: DEFAULT_BORDER_COLOR,
+      style: 'solid',
+      width: '4px',
+    };
+
+    await expect(openFormAndReadBorders(page)).resolves.toEqual({
+      input: expectedBorder,
+      modal: expectedBorder,
+    });
+  });
+
+  test('uses explicit custom border color with custom border width', async ({ page, baseURL }) => {
+    await mountWidget(page, baseURL, {
+      'border-color': '#64748b',
+      'border-width': '2',
+    });
+
+    const expectedBorder = {
+      color: 'rgb(100, 116, 139)',
+      style: 'solid',
+      width: '2px',
+    };
+
+    await expect(openFormAndReadBorders(page)).resolves.toEqual({
+      input: expectedBorder,
+      modal: expectedBorder,
+    });
+  });
+});

--- a/src/widget/theme.ts
+++ b/src/widget/theme.ts
@@ -88,7 +88,9 @@ export function applyCustomStyles(
     const bw = borderW !== null ? `${borderW}px` : '1px';
     const bc = borderC || 'var(--bd-border)';
     root.style.setProperty('--bd-border-width', bw);
-    root.style.setProperty('--bd-border', bc);
+    if (borderC) {
+      root.style.setProperty('--bd-border', bc);
+    }
     root.style.setProperty('--bd-border-style', `var(--bd-border-width) solid ${bc}`);
   }
 

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -83,7 +83,6 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
 
       /* Border */
       --bd-border-width: ${borderW !== null ? `${borderW}px` : '1px'};
-      --bd-border-style: var(--bd-border-width) solid var(--bd-border);
 
       /* Transitions */
       --bd-transition: 0.15s ease;
@@ -99,6 +98,7 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       --bd-text-secondary: #57534e;
       --bd-text-muted: #a8a29e;
       --bd-border: #e7e5e4;
+      --bd-border-style: var(--bd-border-width) solid var(--bd-border);
       --bd-border-focus: ${DEFAULT_ACCENT_COLOR};
       --bd-primary: ${DEFAULT_ACCENT_COLOR};
       --bd-primary-hover: ${getAccentHoverColor(DEFAULT_ACCENT_COLOR)};

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -252,10 +252,11 @@ describe('applyCustomStyles', () => {
   });
 
   describe('border', () => {
-    it('sets --bd-border and --bd-border-style when borderWidth is provided', () => {
+    it('sets border width without self-referencing the inherited border color', () => {
       const root = makeRoot();
       applyCustomStyles(root, { borderWidth: '4' }, 'light');
       expect(root.style.getPropertyValue('--bd-border-width')).toBe('4px');
+      expect(root.style.getPropertyValue('--bd-border')).toBe('');
       expect(root.style.getPropertyValue('--bd-border-style')).toBe(
         'var(--bd-border-width) solid var(--bd-border)'
       );

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { injectStyles } from '../src/widget/ui';
+
+describe('widget UI styles', () => {
+  it('defines the default border style where the border color is available', () => {
+    const host = document.createElement('div');
+    const shadow = host.attachShadow({ mode: 'open' });
+
+    injectStyles(shadow, {
+      position: 'bottom-right',
+      theme: 'light',
+    });
+
+    const styleText = shadow.querySelector('style')?.textContent ?? '';
+    const hostBlock = styleText.match(/:host\s*\{[\s\S]*?\n {4}\}/)?.[0] ?? '';
+    const rootBlock = styleText.match(/\.bd-root\s*\{[\s\S]*?\n {4}\}/)?.[0] ?? '';
+
+    expect(hostBlock).toContain('--bd-border-width: 1px;');
+    expect(hostBlock).not.toContain('--bd-border-style:');
+    expect(rootBlock).toContain('--bd-border: #e7e5e4;');
+    expect(rootBlock).toContain(
+      '--bd-border-style: var(--bd-border-width) solid var(--bd-border);'
+    );
+  });
+});


### PR DESCRIPTION
Closes #192

## What changed
The widget now defines its reusable default border style on `.bd-root`, where the default border color is also defined. Custom border widths still flow through the dedicated `--bd-border-width` variable, and custom border colors are only written when an explicit color is provided.

## Why this shape
The broken path was not the individual `border` declarations on inputs, textareas, category options, or modal surfaces. Those declarations were all reading the same shared border value. Keeping the fix at the shared CSS variable preserves the existing styling API and avoids patching every bordered element separately.

The custom-width path also needed to stop writing `--bd-border: var(--bd-border)`. That self-reference can erase the inherited theme color, so width-only customization now changes only the width and leaves the active theme color in place.

## Test plan
- `npx vitest run test/ui.test.ts test/theme.test.ts` passed: 2 files, 47 tests.
- `npm run validate` passed: lint, formatting, typecheck, and 291 unit tests.
- Pre-push hook passed TypeScript checks.
