### PR TITLE
Add adversarial proof instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent Instructions
+
+Follow `CLAUDE.md` for repo-level agent guidance.
+
+## Burden Of Proof
+
+Before declaring work complete, try to disprove the change. Identify the
+strongest realistic failure mode, verify it with a command, test, trace,
+screenshot, audit record, diff, or direct inspection, and include that evidence
+in the final handoff.
+
+Treat `done`, `tests passed`, worker claims, passing happy-path tests, generated
+summaries, and optimistic UI as claims, not proof. Treat unverified assumptions
+as blockers or explicit follow-ups.
+
+Keep this section synchronized with `CLAUDE.md` whenever either file changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,3 +154,16 @@ installs dependencies, builds the widget, and runs all tests to verify the setup
 - Repo is in the `mean-weasel` org (transferred from `neonwatty` for merge queue support)
 - `html-to-image` library bundled into widget.js via esbuild (static import, not CDN-loaded)
 - Complex DOM pages (>3000 nodes) get reduced pixelRatio; pages with >10k nodes have Full Page and Select Area buttons hidden entirely
+
+## Burden Of Proof
+
+Before declaring work complete, try to disprove the change. Identify the
+strongest realistic failure mode, verify it with a command, test, trace,
+screenshot, audit record, diff, or direct inspection, and include that evidence
+in the final handoff.
+
+Treat `done`, `tests passed`, worker claims, passing happy-path tests, generated
+summaries, and optimistic UI as claims, not proof. Treat unverified assumptions
+as blockers or explicit follow-ups.
+
+Keep this section synchronized with `AGENTS.md` whenever either file changes.


### PR DESCRIPTION
## Summary
- add or update top-level `AGENTS.md` and `CLAUDE.md`
- require agents to try to disprove work before declaring it complete
- keep the proof-gate wording synchronized between both instruction files

Closes #195

## Verification
- `git diff --check -- AGENTS.md CLAUDE.md`
- direct scan confirmed both files include the burden-of-proof wording
