### PR TITLE
feat: add board dogfood host

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -3,6 +3,26 @@
   "entry": ["src/index.ts", "src/widget/index.ts", "scripts/build-widget.js"],
   "project": ["src/**/*.ts", "scripts/**/*.js"],
   "ignore": [],
-  "ignoreBinaries": ["semantic-release"],
-  "ignoreDependencies": ["esbuild", "semantic-release"]
+  "ignoreBinaries": [
+    "commitlint",
+    "eslint",
+    "husky",
+    "lint-staged",
+    "playwright",
+    "prettier",
+    "semantic-release",
+    "tsc",
+    "vitest",
+    "wrangler"
+  ],
+  "ignoreDependencies": [
+    "@commitlint/cli",
+    "esbuild",
+    "eslint",
+    "husky",
+    "lint-staged",
+    "prettier",
+    "semantic-release",
+    "wrangler"
+  ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { logger } from 'hono/logger';
 import type { Env } from './types';
 import api from './routes/api';
+import { createBoardDogfoodToken, renderBoardDogfoodPage } from './lib/boardDogfood';
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -65,6 +66,28 @@ export function resolveRootRedirectUrl(rawUrl?: string): string {
 // Redirect to landing page on Vercel
 app.get('/', c => {
   return c.redirect(resolveRootRedirectUrl(c.env.ROOT_REDIRECT_URL), 301);
+});
+
+app.get('/board-dogfood', c => {
+  const viewer = c.req.query('viewer') ?? null;
+  return c.html(renderBoardDogfoodPage(c.env, viewer));
+});
+
+app.get('/api/bugdrop-board-token', async c => {
+  try {
+    const token = await createBoardDogfoodToken(c.env, c.req.query('viewer') ?? null);
+    return c.json({ token }, 200, {
+      'Cache-Control': 'no-store',
+    });
+  } catch (error) {
+    return c.json(
+      { error: error instanceof Error ? error.message : 'BugDrop Board dogfood token failed' },
+      503,
+      {
+        'Cache-Control': 'no-store',
+      }
+    );
+  }
 });
 
 // Serve widget.js from static assets

--- a/src/lib/boardDogfood.ts
+++ b/src/lib/boardDogfood.ts
@@ -1,0 +1,144 @@
+import type { Env } from '../types';
+
+const DEFAULT_BOARD_ID = 'board_mean_weasel_bugdrop_board_production_dogfood';
+const DEFAULT_WORKER_ORIGIN = 'https://board.bugdrop.dev';
+const DEFAULT_TOKEN_AUDIENCE = 'bugdrop-board';
+const DEFAULT_TOKEN_ISSUER = 'bugdrop-board-production-host';
+const TOKEN_TTL_SECONDS = 300;
+
+interface BoardDogfoodConfig {
+  boardId: string;
+  workerOrigin: string;
+  tokenAudience: string;
+  tokenIssuer: string;
+}
+
+interface BoardTokenClaims {
+  boardId: string;
+  externalUserId: string;
+  displayName: string;
+  exp: number;
+  aud: string;
+  iss: string;
+}
+
+export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): string {
+  const viewer = normalizeViewer(rawViewer);
+  const config = dogfoodConfig(env);
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>BugDrop Board Dogfood</title>
+    <style>
+      body {
+        background: #f8fafc;
+        color: #172026;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+      }
+      main {
+        margin: 0 auto;
+        max-width: 880px;
+        padding: 32px 20px;
+      }
+      h1 {
+        font-size: 28px;
+        line-height: 1.2;
+        margin: 0 0 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>BugDrop Board Dogfood</h1>
+      <p>Signed in as dogfood viewer ${viewer.toUpperCase()}.</p>
+    </main>
+    <script
+      src="${escapeAttribute(config.workerOrigin)}/board.js"
+      data-board-id="${escapeAttribute(config.boardId)}"
+      data-api-url="${escapeAttribute(config.workerOrigin)}"
+      data-token-endpoint="/api/bugdrop-board-token?viewer=${viewer}"
+      data-poll-interval="750"
+      data-color="#1f883d"
+    ></script>
+  </body>
+</html>`;
+}
+
+export async function createBoardDogfoodToken(env: Env, rawViewer: string | null): Promise<string> {
+  const secret = envValue(env.BUGDROP_BOARD_TOKEN_SECRET);
+  if (!secret) {
+    throw new Error('BugDrop Board dogfood token signing is not configured');
+  }
+
+  const viewer = normalizeViewer(rawViewer);
+  const config = dogfoodConfig(env);
+  const claims: BoardTokenClaims = {
+    boardId: config.boardId,
+    externalUserId: `bugdrop-dev-dogfood-${viewer}`,
+    displayName: `BugDrop Dogfood ${viewer.toUpperCase()}`,
+    exp: Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS,
+    aud: config.tokenAudience,
+    iss: config.tokenIssuer,
+  };
+  const payload = base64UrlEncodeString(JSON.stringify(claims));
+  const signature = await sign(payload, secret);
+  return `${payload}.${signature}`;
+}
+
+function dogfoodConfig(env: Env): BoardDogfoodConfig {
+  return {
+    boardId: envValue(env.BUGDROP_BOARD_ID) ?? DEFAULT_BOARD_ID,
+    workerOrigin: stripTrailingSlash(
+      envValue(env.BUGDROP_BOARD_WORKER_ORIGIN) ?? DEFAULT_WORKER_ORIGIN
+    ),
+    tokenAudience: envValue(env.BUGDROP_BOARD_TOKEN_AUDIENCE) ?? DEFAULT_TOKEN_AUDIENCE,
+    tokenIssuer: envValue(env.BUGDROP_BOARD_TOKEN_ISSUER) ?? DEFAULT_TOKEN_ISSUER,
+  };
+}
+
+function normalizeViewer(value: string | null): 'a' | 'b' {
+  return value === 'b' ? 'b' : 'a';
+}
+
+function envValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+async function sign(payload: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload));
+  return base64UrlEncodeBytes(new Uint8Array(signature));
+}
+
+function base64UrlEncodeString(value: string): string {
+  return base64UrlEncodeBytes(new TextEncoder().encode(value));
+}
+
+function base64UrlEncodeBytes(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,11 @@ export interface Env {
   AUTH_TOKEN_AUDIENCE?: string; // Optional expected token audience claim
   AUTH_TOKEN_ISSUER?: string; // Optional expected token issuer claim
   AUTH_TOKEN_REQUIRED_FOR_CHECK?: string; // Optional gate for /check installation lookups
+  BUGDROP_BOARD_TOKEN_SECRET?: string; // Optional signer secret for /board-dogfood tokens
+  BUGDROP_BOARD_ID?: string; // Optional override for the dogfood board id
+  BUGDROP_BOARD_WORKER_ORIGIN?: string; // Optional override for the board Worker origin
+  BUGDROP_BOARD_TOKEN_AUDIENCE?: string; // Optional override for board token audience
+  BUGDROP_BOARD_TOKEN_ISSUER?: string; // Optional override for board token issuer
 
   // Bindings
   ASSETS: Fetcher;

--- a/test/boardDogfood.test.ts
+++ b/test/boardDogfood.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import app from '../src/index';
+import type { Env } from '../src/types';
+
+const boardSecret = 'board-dogfood-secret-with-at-least-32-bytes';
+const boardId = 'board_mean_weasel_bugdrop_board_production_dogfood';
+const workerOrigin = 'https://board.bugdrop.dev';
+
+const env = {
+  GITHUB_APP_ID: 'test-app-id',
+  GITHUB_PRIVATE_KEY: 'test-private-key',
+  ENVIRONMENT: 'test',
+  ALLOWED_ORIGINS: '*',
+  GITHUB_APP_NAME: 'test-bugdrop-app',
+  MAX_SCREENSHOT_SIZE_MB: '5',
+  ASSETS: { fetch: () => new Response('not found', { status: 404 }) } as Fetcher,
+  BUGDROP_BOARD_TOKEN_SECRET: boardSecret,
+} satisfies Env;
+
+describe('BugDrop Board dogfood host', () => {
+  it('renders the board dogfood page with production board embed config', async () => {
+    const response = await app.fetch(
+      new Request('https://bugdrop.dev/board-dogfood?viewer=a'),
+      env
+    );
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(html).toContain(`src="${workerOrigin}/board.js"`);
+    expect(html).toContain(`data-api-url="${workerOrigin}"`);
+    expect(html).toContain(`data-board-id="${boardId}"`);
+    expect(html).toContain('data-token-endpoint="/api/bugdrop-board-token?viewer=a"');
+    expect(html).not.toContain(boardSecret);
+  });
+
+  it('signs a short-lived board token for viewer b without exposing the secret', async () => {
+    const response = await app.fetch(
+      new Request('https://bugdrop.dev/api/bugdrop-board-token?viewer=b'),
+      env
+    );
+    const body = (await response.json()) as { token: string };
+    const claims = await verifyBoardToken(body.token, boardSecret);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(JSON.stringify(body)).not.toContain(boardSecret);
+    expect(claims).toMatchObject({
+      boardId,
+      externalUserId: 'bugdrop-dev-dogfood-b',
+      displayName: 'BugDrop Dogfood B',
+      aud: 'bugdrop-board',
+      iss: 'bugdrop-board-production-host',
+    });
+    expect(claims.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    expect(claims.exp).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + 300);
+  });
+
+  it('rejects token requests when the board signing secret is missing', async () => {
+    const response = await app.fetch(
+      new Request('https://bugdrop.dev/api/bugdrop-board-token?viewer=a'),
+      { ...env, BUGDROP_BOARD_TOKEN_SECRET: '' }
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: 'BugDrop Board dogfood token signing is not configured',
+    });
+  });
+});
+
+interface BoardTokenClaims {
+  boardId: string;
+  externalUserId: string;
+  displayName: string;
+  exp: number;
+  aud: string;
+  iss: string;
+}
+
+async function verifyBoardToken(token: string, secret: string): Promise<BoardTokenClaims> {
+  const [payload, signature, extra] = token.split('.');
+  expect(payload).toBeTruthy();
+  expect(signature).toBeTruthy();
+  expect(extra).toBeUndefined();
+
+  const expectedSignature = await sign(payload ?? '', secret);
+  expect(signature).toBe(expectedSignature);
+
+  return JSON.parse(base64UrlDecode(payload ?? '')) as BoardTokenClaims;
+}
+
+async function sign(payload: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload));
+  return base64UrlEncodeBytes(new Uint8Array(signature));
+}
+
+function base64UrlEncodeBytes(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function base64UrlDecode(value: string): string {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new TextDecoder().decode(bytes);
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -29,6 +29,7 @@ preview_id = "ff8f3809037d4403befd09369a9f7e36"
 # GITHUB_APP_ID
 # GITHUB_PRIVATE_KEY
 # AUTH_TOKEN_SECRET  # Optional: set to require signed host-app auth tokens for /feedback
+# BUGDROP_BOARD_TOKEN_SECRET  # Optional: enables /board-dogfood board token signing
 
 # Preview environment for live E2E tests (deployed in merge queue)
 [env.preview]


### PR DESCRIPTION
## Summary
- add /board-dogfood host page that embeds https://board.bugdrop.dev/board.js with the production dogfood board id
- add /api/bugdrop-board-token endpoint that server-signs short-lived BugDrop Board tokens for deterministic viewer A/B identities
- add focused route/token tests covering embed config, token claims/signature, no secret exposure, and missing-secret failure
- adjust Knip config so make check recognizes intentional dev-tool binaries/deps used by Make, Husky, package scripts, and Actions

## Verification
- RED first: npm run test -- test/boardDogfood.test.ts failed with 404s before implementation
- npm run test -- test/boardDogfood.test.ts
- npm run test
- npm run build
- make check
- deployable-file secret scan for GitHub/npm/Cloudflare/private-key/board-secret value shapes
- diff scope scan for secret values and excluded product/deploy/publish behavior
- git diff --cached --check before commit
- wc -l touched source/test files stayed below repo limits

## Notes
- make check passes; npm audit --audit-level=critical still prints existing moderate advisories, but exits successfully with no critical advisory.
- Repo-requested pr-review-toolkit agents were not available in this Codex session via tool discovery, so local gates plus CI are the available review proof.

## Boundaries
No board Worker deploy, no npm publish, no secret creation/rotation/inspection, no hosted control plane, billing, realtime, comments, downvotes, GitHub Projects, or unrelated product behavior.