### PR TITLE
fix: persist board dogfood worker routes

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,12 @@
 name = "bugdrop"
 main = "src/index.ts"
 compatibility_date = "2024-01-29"
+workers_dev = true
+
+routes = [
+  { pattern = "bugdrop.dev/board-dogfood*", zone_name = "bugdrop.dev" },
+  { pattern = "bugdrop.dev/api/bugdrop-board-token*", zone_name = "bugdrop.dev" },
+]
 
 # Static assets directory (for widget.js)
 [assets]
@@ -35,6 +41,7 @@ preview_id = "ff8f3809037d4403befd09369a9f7e36"
 [env.preview]
 name = "bugdrop-preview"
 workers_dev = true
+routes = []
 
 [env.preview.vars]
 ENVIRONMENT = "preview"


### PR DESCRIPTION
## Summary
- make the production Worker workers.dev trigger explicit so the hosted widget URL stays live
- persist the two narrow Cloudflare routes needed for the bugdrop.dev board dogfood host page and token endpoint
- keep `env.preview.routes = []` so merge-queue preview deploys do not try to claim production `bugdrop.dev` routes

## Verification
- make check
- npx wrangler deploy --dry-run
- npx wrangler deploy --dry-run --env preview
- npx wrangler deploy
- curl -fsS https://bugdrop.neonwatty.workers.dev/widget.js -> HTTP 200, 108784 bytes
- curl -fsS https://bugdrop.dev/board-dogfood -> HTTP 200 with board.bugdrop.dev embed markers
- curl -fsS https://bugdrop.dev/api/bugdrop-board-token?viewer=a -> HTTP 200 signed token claims for board_mean_weasel_bugdrop_board_production_dogfood

## Notes
This follows up PR #197. A manual `wrangler triggers deploy` initially attached only `bugdrop.dev/board-dogfood*`, which made the dogfood page live but disabled workers.dev because `workers_dev` was implicit. This patch captures the intended trigger state in source control, restores workers.dev, and prevents preview deployments from inheriting production routes.