### PR TITLE
test: mount board dogfood inline

### DIFF
--- a/src/lib/boardDogfood.ts
+++ b/src/lib/boardDogfood.ts
@@ -55,6 +55,7 @@ export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): stri
     <main>
       <h1>BugDrop Board Dogfood</h1>
       <p>Signed in as dogfood viewer ${viewer.toUpperCase()}.</p>
+      <section id="bugdrop-board-dogfood"></section>
     </main>
     <script
       src="${escapeAttribute(config.workerOrigin)}/board.js"
@@ -63,6 +64,7 @@ export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): stri
       data-token-endpoint="/api/bugdrop-board-token?viewer=${viewer}"
       data-poll-interval="750"
       data-color="#1f883d"
+      data-mount-selector="#bugdrop-board-dogfood"
     ></script>
   </body>
 </html>`;

--- a/test/boardDogfood.test.ts
+++ b/test/boardDogfood.test.ts
@@ -31,6 +31,8 @@ describe('BugDrop Board dogfood host', () => {
     expect(html).toContain(`data-api-url="${workerOrigin}"`);
     expect(html).toContain(`data-board-id="${boardId}"`);
     expect(html).toContain('data-token-endpoint="/api/bugdrop-board-token?viewer=a"');
+    expect(html).toContain('<section id="bugdrop-board-dogfood"></section>');
+    expect(html).toContain('data-mount-selector="#bugdrop-board-dogfood"');
     expect(html).not.toContain(boardSecret);
   });
 


### PR DESCRIPTION
## Summary
- add an inline `#bugdrop-board-dogfood` mount target to the board dogfood route
- pass `data-mount-selector="#bugdrop-board-dogfood"` to the embedded BugDrop Board script
- extend the dogfood route test so the real host page exercises the board package's inline mount path

## Proof
- RED: `npm run test -- test/boardDogfood.test.ts` failed until the inline target and `data-mount-selector` were added
- `npm run test -- test/boardDogfood.test.ts`
- `npm run build`
- `npm run validate` passed: 19 test files, 294 tests
- `git diff --check`

## Scope
Dogfood route only. No auth, token signing, feedback widget, GitHub app, billing, realtime, comments, downvotes, or production secret changes.