### PR TITLE
feat: polish board demo UX

### DIFF
--- a/docs/goals/bugdrop-board-demo-ux-polish/goal.md
+++ b/docs/goals/bugdrop-board-demo-ux-polish/goal.md
@@ -1,0 +1,115 @@
+# BugDrop Board Demo UX Polish
+
+## Objective
+
+Make the live BugDrop Board demo feel obvious, organic, and easy to use for a first-time
+closed-beta viewer.
+
+## Original Request
+
+> great - use goalbuddy prep board to do all
+
+## Intake Summary
+
+- Input shape: `specific`
+- Audience: closed-beta evaluators and prospective self-hosters seeing BugDrop Board for the
+  first time
+- Authority: `requested`
+- Proof type: `demo`
+- Completion proof: live/local demo walkthroughs show a simple, user-facing embedded feedback board
+  with clear create and upvote affordances, realistic content, reduced clutter, and responsive
+  behavior.
+- Goal oracle: a Chrome/Playwright review of the demo must disprove the prior critique by showing
+  that a new viewer can understand the board purpose, add/request flow, vote counts, and status
+  grouping without debug language or metadata noise.
+- Likely misfire: polishing colors while leaving dogfood/debug content, exposed GitHub metadata,
+  an oversized form, and empty kanban lanes that still make the board feel cluttered.
+- Blind spots considered: the fix spans the widget package and the BugDrop host page; live production
+  deploys and package publishing are separate authority boundaries; realistic demo data may require
+  either non-mutating fixtures or carefully-scoped dogfood issue/status setup.
+- Existing plan facts: independent UX reviewers identified issues with dogfood framing, missing
+  purpose copy, unclear `Prioritize` voting language, empty kanban lanes, noisy sample data, form
+  dominance, embedded-app fit, mobile lane behavior, and customization proof.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`A desktop and mobile browser walkthrough of the BugDrop Board demo proves the experience reads as
+a simple embeddable feature board, with user-facing copy, obvious upvote counts, realistic demo
+items, non-noisy cards, adaptive lanes, and no layout overlap or broken states.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, a passing tiny slice,
+or a prettier screenshot is not enough. The goal finishes only when a final Judge/PM audit maps
+receipts and verification back to this oracle and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`specific`
+
+## Current Tranche
+
+Complete successive safe verified slices until the demo no longer feels like an internal dogfood
+artifact. The first tranche should discover the exact implementation surface, then ship the largest
+safe useful UX package across widget/demo code with focused tests and visual proof.
+
+## Non-Negotiable Constraints
+
+- Preserve the current GitHub-backed, signed-token, upvote-only product model.
+- Do not add hosted control plane, billing, realtime, comments, downvotes, or GitHub Projects.
+- Do not publish npm packages, bump package versions, deploy Cloudflare production, rotate secrets,
+  or mutate production credentials without explicit approval.
+- Do not perform destructive dogfood cleanup without explicit approval.
+- Keep changes scoped to demo UX, widget ergonomics needed by the demo, docs/examples needed to prove
+  customization, and tests for those changes.
+- Use existing repo stacks and validation gates.
+
+## Stop Rule
+
+Stop only when a final audit proves the full original outcome is complete.
+
+Do not stop after planning, discovery, or Judge selection if a safe Worker task can be activated.
+
+Do not stop after a single verified Worker package when the broader owner outcome still has safe
+local follow-up work. Advance the board to the next highest-leverage safe Worker package and
+continue unless a phase, risk, rejected-verification, ambiguity, or final-completion review is due.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. It does not mean tiny.
+
+A good task is the largest safe useful slice: a working demo screen, a working widget behavior
+improvement, a verified responsive flow, or a coherent documentation/example package.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/bugdrop-board-demo-ux-polish/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task,
+receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/bugdrop-board-demo-ux-polish/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter.
+2. Read `state.yaml`.
+3. Run the bundled GoalBuddy update checker when available and mention a newer version without
+   blocking.
+4. Re-check the intake, constraints, likely misfire, and UX critique evidence.
+5. Work only on the active board task.
+6. Assign Scout, Judge, Worker, or PM according to the task.
+7. Write a compact task receipt.
+8. Update the board.
+9. If safe local work remains, choose the next largest reversible Worker package and continue unless
+   blocked.
+10. Finish only with a Judge/PM audit receipt that maps receipts and verification back to the
+    original user outcome and records `full_outcome_complete: true`.

--- a/docs/goals/bugdrop-board-demo-ux-polish/state.yaml
+++ b/docs/goals/bugdrop-board-demo-ux-polish/state.yaml
@@ -1,0 +1,323 @@
+version: 2
+
+goal:
+  title: "BugDrop Board Demo UX Polish"
+  slug: "bugdrop-board-demo-ux-polish"
+  kind: specific
+  tranche: "Make the live/demo BugDrop Board experience obvious, organic, and easy for closed-beta review."
+  status: done
+  oracle:
+    signal: "Desktop and mobile browser walkthroughs prove the board reads as a simple embeddable feature board rather than an internal dogfood artifact."
+    cadence: "after scout, after each UX implementation package, after browser proof, and at final audit"
+    final_proof: "Screenshots, DOM/visual assertions, tests, and direct critique checks prove clear purpose, easy add flow, visible upvotes, realistic content, adaptive lanes, and no debug/noisy metadata."
+  intake:
+    original_request: "great - use goalbuddy prep board to do all"
+    interpreted_outcome: "Create and execute a GoalBuddy conveyor that fixes the current BugDrop Board demo UX critique end to end."
+    input_shape: specific
+    audience: "Closed-beta evaluators and prospective self-hosters"
+    authority: requested
+    proof_type: demo
+    completion_proof: "A reviewer can open the demo on desktop and mobile and immediately understand what the board is for, how to add an idea, how voting works, and how it fits inside an app."
+    likely_misfire: "Only changing colors or screenshots while preserving dogfood language, noisy metadata, form dominance, empty lanes, and unclear voting language."
+    blind_spots_considered:
+      - "Some issues may belong in the widget package, while others belong in the BugDrop host/demo page."
+      - "Production deploy, package publish, version bump, secret changes, and destructive dogfood cleanup require explicit approval and are excluded from this board."
+      - "Realistic data may require a safe fixture/demo mode if production dogfood data should not be destructively cleaned."
+      - "A kanban layout may not be the right default when only one lane has items; adaptive behavior must be verified."
+    existing_plan_facts:
+      - "Use user-facing copy instead of Dogfood/debug copy."
+      - "Make add request less dominant, likely via a compact button or collapsible composer."
+      - "Use Upvote/Voted/votes language instead of Prioritize."
+      - "Hide or de-emphasize GitHub links in default card UI."
+      - "Use realistic product request examples instead of timestamped dogfood items."
+      - "Collapse/adapt empty kanban lanes or seed representative statuses."
+      - "Prove the demo feels embedded inside a realistic host app."
+      - "Show beta-critical states and customization proof where safe."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/bugdrop-board-demo-ux-polish/"
+    command: "npx goalbuddy board docs/goals/bugdrop-board-demo-ux-polish"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: default
+    objective: "Map the exact UX implementation surface across bugdrop-board and bugdrop before editing."
+    inputs:
+      - "/Users/neonwatty/Desktop/bugdrop-board/src/widget"
+      - "/Users/neonwatty/Desktop/bugdrop-board/test"
+      - "/Users/neonwatty/Desktop/bugdrop/src/lib/boardDogfood.ts"
+      - "/Users/neonwatty/Desktop/bugdrop/public/board/index.html"
+      - "Live critique screenshot: /Users/neonwatty/Desktop/bugdrop/test-results/ux-review/board-dogfood-current.png"
+      - "Sub-agent critique receipts from the thread"
+    constraints:
+      - "Read-only."
+      - "Do not edit implementation files."
+      - "Prefer concrete file-path evidence and current behavior over assumptions."
+    expected_output:
+      - "Files and functions that control board layout, copy, metadata, form behavior, card rendering, and demo host shell."
+      - "Verification commands for each repo."
+      - "Which issues are widget-level versus host/demo-level."
+      - "Largest safe first Worker package with allowed_files, verification, and stop conditions."
+    receipt:
+      result: done
+      summary: "Mapped the UX surface. Widget rendering lives in bugdrop-board src/widget/dom.ts/theme.ts/config.ts/types.ts and tests in test/widget-dom.test.ts. Host framing lives in bugdrop src/lib/boardDogfood.ts and test/boardDogfood.test.ts, but this branch is behind origin/main and must be updated before editing. Landing page overclaims status filters/search."
+      evidence:
+        - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/dom.ts renders header, always-visible form, kanban lanes, upvote button text, status, and GitHub issue links."
+        - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/theme.ts controls kanban grid, lane/card density, form, metadata, and upvote styling."
+        - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/config.ts supports copy/theme/density/layout only; no composer, issue-link visibility, metadata, or adaptive-lane config exists."
+        - "/Users/neonwatty/Desktop/bugdrop/src/lib/boardDogfood.ts on origin/main contains the live kanban dogfood config with Dogfood title, signed-in viewer copy, Prioritize labels, and GitHub issue prefix."
+        - "/Users/neonwatty/Desktop/bugdrop/public/board/index.html claims status filters and search at lines 470-471, but the live widget exposes fixed lanes/create/upvote/GitHub links."
+        - "curl https://bugdrop.dev/board-dogfood confirmed Dogfood/Signed in/Prioritize/GitHub config is live."
+      commands:
+        - "git fetch origin --prune in both repos"
+        - "git show origin/main:src/lib/boardDogfood.ts"
+        - "sed -n '1,320p' /Users/neonwatty/Desktop/bugdrop-board/src/widget/dom.ts"
+        - "sed -n '1,320p' /Users/neonwatty/Desktop/bugdrop-board/src/widget/theme.ts"
+        - "curl -fsSL https://bugdrop.dev/board-dogfood | rg -n 'Dogfood|Signed in|Prioritize|GitHub'"
+      facts:
+        - "bugdrop branch codex/bugdrop-board-demo-ux-polish was created from local main at v1.41.0; origin/main is v1.42.0 and has the current kanban dogfood source."
+        - "bugdrop-board main is current with origin/main at 1726f35."
+        - "Verification commands: bugdrop-board npm run validate, npm run knip, npm run audit, npm run build:widget; bugdrop npx vitest run test/boardDogfood.test.ts test/boardLanding.test.ts, npm run validate, optional npx knip, and browser/Playwright desktop-mobile walkthroughs."
+        - "Widget-level issues: always-visible full form, visual vote copy lacks 'votes', GitHub links are always shown when present, kanban always renders empty full lanes, card metadata competes with titles."
+        - "Host-level issues: dogfood/debug page framing, internal viewer copy, Prioritize language, operational sample content from live data, and not-yet-embedded host shell."
+      contradictions:
+        - "Local bugdrop source initially showed older panel/compact config, while live and origin/main show dark kanban config."
+      ambiguity_requiring_judge:
+        - "Whether realistic demo content should be non-mutating fixtures or production dogfood issue/status cleanup; destructive cleanup remains excluded."
+        - "Whether the first Worker should span both repos or land widget support first and host demo second."
+      note_needed: false
+
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Choose the largest safe UX implementation package that directly attacks the critique without over-scoping."
+    inputs:
+      - "T001 receipt"
+      - "Goal oracle and non-negotiable constraints"
+    constraints:
+      - "Do not implement."
+      - "Reject any package requiring npm publish, Cloudflare deploy, secret changes, destructive dogfood cleanup, hosted control plane, billing, realtime, comments, downvotes, or GitHub Projects."
+      - "Prefer one coherent vertical UX package over tiny cosmetic tasks."
+    expected_output:
+      - "Decision"
+      - "Exact Worker objective"
+      - "allowed_files"
+      - "verify"
+      - "stop_if"
+      - "Deferred tasks or blockers"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "Approve one coherent vertical UX package across bugdrop-board and bugdrop. The package should add backwards-compatible widget customization for a collapsed composer, hidden issue links, clearer vote-count text, and adaptive empty kanban lanes, then update the demo host to use user-facing embedded-app framing. It does not require publishing, deploying, secrets, destructive cleanup, or new product domains."
+      evidence:
+        - "T001 showed all core clutter controls live in bugdrop-board src/widget/dom.ts/theme.ts/config.ts/types.ts."
+        - "T001 showed demo framing lives in bugdrop src/lib/boardDogfood.ts and tests."
+        - "T001 showed bugdrop public/board/index.html overclaims status filters/search and can be tightened as part of honest demo positioning."
+      blocked_tasks: []
+      missing_evidence: []
+      required_board_updates:
+        - "T003 allowed_files and verify commands filled for both repos."
+        - "T004 narrowed to post-implementation visual state/customization proof if still needed."
+        - "T005 may be marked done by T003 if landing claim cleanup is included."
+
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Implement the approved vertical UX package: backwards-compatible widget ergonomics plus a user-facing embedded BugDrop demo shell."
+    allowed_files:
+      - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/config.ts"
+      - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/dom.ts"
+      - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/index.ts"
+      - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/theme.ts"
+      - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/types.ts"
+      - "/Users/neonwatty/Desktop/bugdrop-board/test/widget-dom.test.ts"
+      - "/Users/neonwatty/Desktop/bugdrop/src/lib/boardDogfood.ts"
+      - "/Users/neonwatty/Desktop/bugdrop/test/boardDogfood.test.ts"
+      - "/Users/neonwatty/Desktop/bugdrop/public/board/index.html"
+      - "/Users/neonwatty/Desktop/bugdrop/docs/goals/bugdrop-board-demo-ux-polish/**"
+    verify:
+      - "cd /Users/neonwatty/Desktop/bugdrop-board && npm run build:widget"
+      - "cd /Users/neonwatty/Desktop/bugdrop-board && npx vitest run test/widget-dom.test.ts"
+      - "cd /Users/neonwatty/Desktop/bugdrop-board && npm run validate"
+      - "cd /Users/neonwatty/Desktop/bugdrop && npx vitest run test/boardDogfood.test.ts test/boardLanding.test.ts"
+      - "cd /Users/neonwatty/Desktop/bugdrop && npm run validate"
+      - "Desktop and mobile browser/Playwright proof against the local demo using the updated local board widget."
+    stop_if:
+      - "Need files outside allowed_files."
+      - "A change would require publishing, production deploy, credentials, destructive cleanup, or product behavior outside the approved UX scope."
+      - "Verification fails twice."
+      - "The implementation cannot be proven visually on desktop and mobile."
+    receipt:
+      result: done
+      changed_files:
+        - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/config.ts"
+        - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/dom.ts"
+        - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/index.ts"
+        - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/theme.ts"
+        - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/types.ts"
+        - "/Users/neonwatty/Desktop/bugdrop-board/test/widget-dom.test.ts"
+        - "/Users/neonwatty/Desktop/bugdrop/src/lib/boardDogfood.ts"
+        - "/Users/neonwatty/Desktop/bugdrop/test/boardDogfood.test.ts"
+        - "/Users/neonwatty/Desktop/bugdrop/public/board/index.html"
+      summary: "Implemented a vertical UX cleanup: widget supports collapsed composer, hidden issue links, hidden/compact empty kanban lanes, clearer vote-count text, and less repetitive kanban card metadata. The BugDrop demo now renders as a realistic Launch Console workspace with user-facing feature-request copy and opt-in cleaner widget settings. Landing copy no longer claims search/status filters."
+      commands:
+        - command: "cd /Users/neonwatty/Desktop/bugdrop-board && npx vitest run test/widget-dom.test.ts"
+          status: pass
+          evidence: "10 widget DOM/config tests passed."
+        - command: "cd /Users/neonwatty/Desktop/bugdrop-board && npm run build:widget && npm run validate"
+          status: pass
+          evidence: "lint, format:check, typecheck, package/deploy workflow checks, and 11 Vitest files / 76 tests passed."
+        - command: "cd /Users/neonwatty/Desktop/bugdrop && npx vitest run test/boardDogfood.test.ts test/boardLanding.test.ts"
+          status: pass
+          evidence: "2 files / 8 focused host and landing tests passed."
+        - command: "cd /Users/neonwatty/Desktop/bugdrop && npm run validate"
+          status: pass
+          evidence: "lint, format:check, typecheck, and 20 Vitest files / 299 tests passed."
+        - command: "Playwright local proof with rebuilt /Users/neonwatty/Desktop/bugdrop-board/public/board.js"
+          status: pass
+          evidence: "Desktop and mobile assertions passed: no Dogfood/Signed in/Prioritize/GitHub copy, collapsed composer, no default-visible form, one active Open lane, no empty lane text, zero GitHub links, visible Upvote/Voted vote counts, no horizontal overflow."
+      evidence:
+        - "/Users/neonwatty/Desktop/bugdrop-board/test-results/board-demo-ux-polish/desktop.png"
+        - "/Users/neonwatty/Desktop/bugdrop-board/test-results/board-demo-ux-polish/mobile.png"
+
+  - id: T004
+    type: pm
+    assignee: PM
+    status: done
+    reasoning_hint: default
+    objective: "Add or update realistic demo/customization examples and state proof after the main UX package is in place."
+    allowed_files: []
+    verify: []
+    stop_if:
+      - "The required data must be mutated destructively in production."
+      - "The work duplicates T003 instead of adding missing proof."
+      - "Verification cannot prove the customization/state story."
+    receipt:
+      result: done
+      summary: "Covered by T003 visual proof. The proof harness used realistic feature-request examples and verified the cleaned state behavior without destructive production dogfood cleanup."
+      evidence:
+        - "Mock proof items: Slack alerts for new ideas; Export feedback to CSV."
+        - "/Users/neonwatty/Desktop/bugdrop-board/test-results/board-demo-ux-polish/desktop.png"
+        - "/Users/neonwatty/Desktop/bugdrop-board/test-results/board-demo-ux-polish/mobile.png"
+
+  - id: T005
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Tighten docs or marketing claims so the demo and landing page do not overpromise unavailable controls."
+    allowed_files:
+      - "/Users/neonwatty/Desktop/bugdrop/public/board/index.html"
+      - "/Users/neonwatty/Desktop/bugdrop/docs/goals/bugdrop-board-demo-ux-polish/**"
+    verify:
+      - "cd /Users/neonwatty/Desktop/bugdrop && npx vitest run test/boardLanding.test.ts"
+    stop_if:
+      - "Requires a product feature rather than honest copy/docs."
+      - "Would conflict with the closed-beta product positioning."
+    receipt:
+      result: done
+      summary: "Tightened the BugDrop Board landing page gallery copy to remove the unavailable status filters/search claim, replacing it with current request-list/status-lane/roadmap grouping language."
+      changed_files:
+        - "/Users/neonwatty/Desktop/bugdrop/public/board/index.html"
+      commands:
+        - command: "cd /Users/neonwatty/Desktop/bugdrop && npx vitest run test/boardDogfood.test.ts test/boardLanding.test.ts"
+          status: pass
+
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Final audit against the UX oracle and burden-of-proof requirement."
+    inputs:
+      - "All done task receipts"
+      - "Desktop/mobile screenshots or Chrome proof"
+      - "Current diff and repo status"
+      - "Relevant validation commands"
+    constraints:
+      - "Do not implement."
+      - "Reject completion if the demo still reads as dogfood/debug/admin tooling."
+      - "Reject completion if any required Worker task is still queued or active."
+      - "Reject completion if visual proof does not test mobile and desktop."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "strongest failure mode checked"
+      - "missing evidence"
+      - "next task if not complete"
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      summary: "Final audit passed. The cleaned demo UX now has user-facing app framing, collapsed add flow, visible Upvote/Voted vote counts, hidden GitHub issue links, hidden empty lanes, no repeated kanban status metadata, honest landing copy, and desktop/mobile visual proof with no overflow."
+      strongest_failure_mode_checked: "The realistic failure mode was that the work merely changed colors while the demo still looked like dogfood/debug tooling. Grep plus browser proof disproved that for visible product surfaces: no Dogfood/Signed in/Prioritize/GitHub issue copy appears in the rendered proof, and grep finds old terms only in internal function/test names or negative assertions."
+      evidence:
+        - "/Users/neonwatty/Desktop/bugdrop-board/test-results/board-demo-ux-polish/desktop.png"
+        - "/Users/neonwatty/Desktop/bugdrop-board/test-results/board-demo-ux-polish/mobile.png"
+        - "Playwright proof metrics: no dogfood copy, collapsed composer, default form not visible, one active Open lane, no empty lane text, zero GitHub links, Upvote 12 votes, Voted 7 votes, no horizontal overflow on desktop/mobile."
+        - "rg old-copy check found old terms only in internal Dogfood function/test names or negative assertions, not visible demo copy."
+      commands:
+        - command: "cd /Users/neonwatty/Desktop/bugdrop-board && npm run build:widget && npm run validate"
+          status: pass
+        - command: "cd /Users/neonwatty/Desktop/bugdrop-board && npm run knip && npm run audit"
+          status: pass
+        - command: "cd /Users/neonwatty/Desktop/bugdrop && npm run validate"
+          status: pass
+        - command: "cd /Users/neonwatty/Desktop/bugdrop && npx knip"
+          status: pass
+          evidence: "Exited 0 with existing knip.json configuration hints only."
+        - command: "git diff --check in both repos"
+          status: pass
+      residual_risk:
+        - "Changes are local branches only until pushed, reviewed, merged, and deployed/published through the normal release paths."
+        - "Production dogfood data was not destructively cleaned; local proof uses realistic mock data and the widget now hides empty lanes/metadata for noisy all-open data."
+
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: pass
+    task: T999
+    commands:
+      - "cd /Users/neonwatty/Desktop/bugdrop-board && npm run build:widget && npm run validate"
+      - "cd /Users/neonwatty/Desktop/bugdrop-board && npm run knip && npm run audit"
+      - "cd /Users/neonwatty/Desktop/bugdrop && npm run validate"
+      - "cd /Users/neonwatty/Desktop/bugdrop && npx knip"
+      - "Playwright local desktop/mobile proof with rebuilt board.js"

--- a/public/board/index.html
+++ b/public/board/index.html
@@ -467,9 +467,9 @@
           <div class="section-header">
             <h2 id="gallery-title">A board that does not look bolted on.</h2>
             <p>
-              These representative examples show the board itself: vote counts, status filters,
-              search, request lists, and roadmap-style groupings, with themes tuned for different
-              host-product aesthetics.
+              These representative examples show the board itself: vote counts, request lists,
+              status lanes, and roadmap-style groupings, with themes tuned for different host-product
+              aesthetics.
             </p>
           </div>
           <div class="gallery-grid">

--- a/src/lib/boardDogfood.ts
+++ b/src/lib/boardDogfood.ts
@@ -24,49 +24,52 @@ interface BoardTokenClaims {
 }
 
 const boardCustomization = {
+  composer: 'collapsed',
   layout: 'kanban',
   density: 'comfortable',
+  emptyLaneDisplay: 'hidden',
+  issueLinks: 'hidden',
   copy: {
-    heading: 'BugDrop launch board',
-    titleLabel: 'Request',
-    titlePlaceholder: 'Short launch request',
+    heading: 'Ideas from users',
+    titleLabel: 'Idea',
+    titlePlaceholder: 'A short product idea',
     descriptionLabel: 'Context',
-    descriptionPlaceholder: 'Who needs this and what would it unblock?',
-    submitLabel: 'Add request',
+    descriptionPlaceholder: 'Who needs this, and what would it unlock?',
+    submitLabel: 'Add idea',
     submittingLabel: 'Adding...',
-    loadingLabel: 'Loading launch requests...',
-    emptyLabel: 'No launch requests yet. Add the first one for review.',
-    errorTitle: "We couldn't load the launch board.",
+    loadingLabel: 'Loading feature requests...',
+    emptyLabel: 'No ideas yet. Add the first one for the team to review.',
+    errorTitle: "We couldn't load feature requests.",
     retryLabel: 'Try again',
     issuePrefix: 'GitHub #',
-    upvoteLabel: 'Prioritize',
-    upvotedLabel: 'Prioritized',
+    upvoteLabel: 'Upvote',
+    upvotedLabel: 'Voted',
   },
   theme: {
-    accent: '#8b5cf6',
-    accentSoft: '#261b42',
-    background: '#0b1020',
-    border: '#2b3656',
-    buttonBackground: '#8b5cf6',
-    buttonRadius: '12px',
+    accent: '#2563eb',
+    accentSoft: '#dbeafe',
+    background: '#f8fafc',
+    border: '#d7dee8',
+    buttonBackground: '#2563eb',
+    buttonRadius: '8px',
     buttonText: '#ffffff',
-    fieldBackground: '#11172a',
-    fieldRadius: '12px',
-    fieldText: '#f8fbff',
-    focus: '#c4b5fd',
+    fieldBackground: '#ffffff',
+    fieldRadius: '8px',
+    fieldText: '#172026',
+    focus: '#1d4ed8',
     fontSize: '14px',
-    headingSize: '24px',
-    itemRadius: '16px',
-    maxWidth: '1120px',
-    muted: '#9aa8c7',
-    radius: '18px',
-    shadow: '0 24px 70px rgba(3, 7, 18, 0.32)',
-    surface: '#11172a',
-    surfaceAlt: '#171f36',
-    text: '#f8fbff',
-    upvoteBackground: '#171f36',
-    upvoteBorder: '#2b3656',
-    upvoteText: '#f8fbff',
+    headingSize: '22px',
+    itemRadius: '10px',
+    maxWidth: '100%',
+    muted: '#64748b',
+    radius: '12px',
+    shadow: 'none',
+    surface: '#ffffff',
+    surfaceAlt: '#f1f5f9',
+    text: '#172026',
+    upvoteBackground: '#eff6ff',
+    upvoteBorder: '#bfdbfe',
+    upvoteText: '#1d4ed8',
   },
 };
 
@@ -79,34 +82,122 @@ export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): stri
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>BugDrop Board Dogfood</title>
+    <title>BugDrop Feature Board Demo</title>
     <style>
+      * {
+        box-sizing: border-box;
+      }
       body {
-        background: radial-gradient(circle at top left, #261b42, transparent 34%), #080b18;
-        color: #f8fbff;
+        background: #eef2f7;
+        color: #172026;
         font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         margin: 0;
       }
       main {
-        margin: 0 auto;
-        max-width: 1180px;
-        padding: 40px 20px;
+        min-height: 100vh;
       }
       h1 {
-        font-size: 32px;
+        font-size: 28px;
         line-height: 1.2;
-        margin: 0 0 12px;
+        margin: 0;
       }
       p {
-        color: #9aa8c7;
+        color: #64748b;
+        margin: 0;
+      }
+      .demo-app {
+        display: grid;
+        grid-template-columns: 220px minmax(0, 1fr);
+        min-height: 100vh;
+      }
+      .sidebar {
+        background: #0f172a;
+        color: #e2e8f0;
+        padding: 24px;
+      }
+      .brand {
+        font-size: 18px;
+        font-weight: 800;
+        margin-bottom: 28px;
+      }
+      .nav-item {
+        border-radius: 8px;
+        color: #cbd5e1;
+        display: block;
+        font-size: 14px;
+        font-weight: 650;
+        padding: 10px 12px;
+      }
+      .nav-item.active {
+        background: #1e293b;
+        color: #ffffff;
+      }
+      .workspace {
+        padding: 28px;
+      }
+      .topbar {
+        align-items: center;
+        display: flex;
+        gap: 16px;
+        justify-content: space-between;
+        margin: 0 0 24px;
+      }
+      .viewer {
+        background: #ffffff;
+        border: 1px solid #d7dee8;
+        border-radius: 999px;
+        color: #475569;
+        font-size: 13px;
+        font-weight: 650;
+        padding: 8px 12px;
+      }
+      .intro {
+        display: grid;
+        gap: 6px;
+        margin-bottom: 18px;
+        max-width: 720px;
+      }
+      .board-surface {
+        max-width: 1120px;
+      }
+      @media (max-width: 760px) {
+        .demo-app {
+          grid-template-columns: 1fr;
+        }
+        .sidebar {
+          display: none;
+        }
+        .workspace {
+          padding: 18px;
+        }
+        .topbar {
+          align-items: flex-start;
+          flex-direction: column;
+        }
       }
     </style>
   </head>
   <body>
     <main>
-      <h1>BugDrop Board Dogfood</h1>
-      <p>Signed in as dogfood viewer ${viewer.toUpperCase()}.</p>
-      <section id="bugdrop-board-dogfood"></section>
+      <div class="demo-app">
+        <aside class="sidebar" aria-label="Demo app navigation">
+          <div class="brand">Launch Console</div>
+          <span class="nav-item">Overview</span>
+          <span class="nav-item active">Feature requests</span>
+          <span class="nav-item">Customers</span>
+          <span class="nav-item">Settings</span>
+        </aside>
+        <section class="workspace" aria-label="Demo app workspace">
+          <div class="topbar">
+            <div class="intro">
+              <h1>Feature requests</h1>
+              <p>Add ideas, vote once on what matters, and watch requests move through the roadmap.</p>
+            </div>
+            <span class="viewer">Demo viewer ${viewer.toUpperCase()}</span>
+          </div>
+          <section class="board-surface" id="bugdrop-board-dogfood"></section>
+        </section>
+      </div>
     </main>
     <script type="application/json" id="${BOARD_CONFIG_SCRIPT_ID}">${escapeScriptJson(
       boardCustomization
@@ -117,7 +208,7 @@ export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): stri
       data-api-url="${escapeAttribute(config.workerOrigin)}"
       data-token-endpoint="/api/bugdrop-board-token?viewer=${viewer}"
       data-poll-interval="750"
-      data-color="#8b5cf6"
+      data-color="#2563eb"
       data-mount-selector="#bugdrop-board-dogfood"
       data-config-selector="#${BOARD_CONFIG_SCRIPT_ID}"
     ></script>
@@ -136,7 +227,7 @@ export async function createBoardDogfoodToken(env: Env, rawViewer: string | null
   const claims: BoardTokenClaims = {
     boardId: config.boardId,
     externalUserId: `bugdrop-dev-dogfood-${viewer}`,
-    displayName: `BugDrop Dogfood ${viewer.toUpperCase()}`,
+    displayName: `BugDrop Demo ${viewer.toUpperCase()}`,
     exp: Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS,
     aud: config.tokenAudience,
     iss: config.tokenIssuer,

--- a/test/boardDogfood.test.ts
+++ b/test/boardDogfood.test.ts
@@ -31,13 +31,13 @@ describe('BugDrop Board dogfood host', () => {
     expect(html).toContain(`data-api-url="${workerOrigin}"`);
     expect(html).toContain(`data-board-id="${boardId}"`);
     expect(html).toContain('data-token-endpoint="/api/bugdrop-board-token?viewer=a"');
-    expect(html).toContain('<section id="bugdrop-board-dogfood"></section>');
+    expect(html).toContain('<section class="board-surface" id="bugdrop-board-dogfood"></section>');
     expect(html).toContain('data-mount-selector="#bugdrop-board-dogfood"');
     expect(html).toContain('data-config-selector="#bugdrop-board-dogfood-config"');
     expect(html).not.toContain(boardSecret);
   });
 
-  it('renders a kanban launch-board customization config for the dogfood board', async () => {
+  it('renders a clean embedded feature-board customization config for the demo board', async () => {
     const response = await app.fetch(
       new Request('https://bugdrop.dev/board-dogfood?viewer=a'),
       env
@@ -46,25 +46,44 @@ describe('BugDrop Board dogfood host', () => {
     const config = extractDogfoodConfig(html);
 
     expect(config).toMatchObject({
+      composer: 'collapsed',
       layout: 'kanban',
       density: 'comfortable',
+      emptyLaneDisplay: 'hidden',
+      issueLinks: 'hidden',
       copy: {
-        heading: 'BugDrop launch board',
-        submitLabel: 'Add request',
-        upvoteLabel: 'Prioritize',
-        upvotedLabel: 'Prioritized',
+        heading: 'Ideas from users',
+        submitLabel: 'Add idea',
+        upvoteLabel: 'Upvote',
+        upvotedLabel: 'Voted',
       },
       theme: {
-        accent: '#8b5cf6',
-        background: '#0b1020',
-        buttonRadius: '12px',
-        itemRadius: '16px',
-        maxWidth: '1120px',
-        surface: '#11172a',
-        surfaceAlt: '#171f36',
+        accent: '#2563eb',
+        background: '#f8fafc',
+        buttonRadius: '8px',
+        itemRadius: '10px',
+        maxWidth: '100%',
+        surface: '#ffffff',
+        surfaceAlt: '#f1f5f9',
       },
     });
     expect(JSON.stringify(config)).not.toContain(boardSecret);
+  });
+
+  it('frames the board as an embedded demo app instead of internal dogfood tooling', async () => {
+    const response = await app.fetch(
+      new Request('https://bugdrop.dev/board-dogfood?viewer=a'),
+      env
+    );
+    const html = await response.text();
+
+    expect(html).toContain('<title>BugDrop Feature Board Demo</title>');
+    expect(html).toContain('<div class="brand">Launch Console</div>');
+    expect(html).toContain('<h1>Feature requests</h1>');
+    expect(html).toContain('Add ideas, vote once on what matters');
+    expect(html).toContain('Demo viewer A');
+    expect(html).not.toContain('BugDrop Board Dogfood');
+    expect(html).not.toContain('Signed in as dogfood viewer');
   });
 
   it('signs a short-lived board token for viewer b without exposing the secret', async () => {
@@ -81,7 +100,7 @@ describe('BugDrop Board dogfood host', () => {
     expect(claims).toMatchObject({
       boardId,
       externalUserId: 'bugdrop-dev-dogfood-b',
-      displayName: 'BugDrop Dogfood B',
+      displayName: 'BugDrop Demo B',
       aud: 'bugdrop-board',
       iss: 'bugdrop-board-production-host',
     });


### PR DESCRIPTION
## Summary
- Reframe `/board-dogfood` as a realistic embedded Launch Console feature-request surface instead of an internal dogfood page.
- Opt the demo config into the cleaner board UX settings from mean-weasel/bugdrop-board#62.
- Tighten the `/board` landing page gallery copy so it does not claim search/status filters that are not currently shipped.
- Add/refresh GoalBuddy receipts for the UX polish conveyor.

## Test Plan
- `npx vitest run test/boardDogfood.test.ts test/boardLanding.test.ts`
- `npm run validate`
- `npx knip` (exits 0 with existing knip.json configuration hints only)
- GoalBuddy checker: `check-goal-state docs/goals/bugdrop-board-demo-ux-polish/state.yaml`

## Dependency
- Depends on mean-weasel/bugdrop-board#62 for the new `composer`, `emptyLaneDisplay`, and `issueLinks` widget settings to affect production. Existing deployed board.js ignores unknown settings safely.

## Notes
No Cloudflare deploy, npm publish, package version bump, secret change, or production dogfood cleanup is included.