### PR TITLE
Polish board demo onboarding

### DIFF
--- a/docs/goals/bugdrop-board-guided-demo-polish/goal.md
+++ b/docs/goals/bugdrop-board-guided-demo-polish/goal.md
@@ -1,0 +1,53 @@
+# BugDrop Board Guided Demo Polish
+
+## Objective
+
+Make the production BugDrop Board demo at `/board-dogfood` feel like a smooth,
+obvious embedded feedback board inside a believable customer app.
+
+## Original Request
+
+> Use three independent UX sub-agents to examine this screenshot looking for ways
+> to improve the UX, making a smoother user experience and introduction to the
+> feedback board with any kind of highlighting, elaboration, simplifications
+> necessary. Then I want you to make a goal buddy prep board to make those
+> suggested changes, ship them, and then double check the shipped results in
+> production and show me a new screenshot when you're done.
+
+## Goal Oracle
+
+A desktop and mobile production walkthrough proves that a first-time viewer can
+understand the embedded app context, the purpose of the feedback board, the
+kanban lifecycle, and the upvote action without internal dogfood framing,
+ambiguous vote labels, noisy metadata, broken layout, or hidden primary actions.
+
+## Acceptance Criteria
+
+- Three independent UX critiques are captured and synthesized.
+- The demo host uses believable customer-app framing instead of internal console
+  framing.
+- The board introduction is brief, visible, and explains add/vote/status flow
+  without turning into a tutorial.
+- Kanban lane headers, counts, cards, and voting controls are easier to scan.
+- Upvote counts remain visible and accessible.
+- Existing signed-token, GitHub-backed, upvote-only product behavior is
+  preserved.
+- Focused unit tests and repo validation gates pass for changed code.
+- Pull requests are opened, CI is monitored, and changes are merged when green.
+- Production is checked after deploy with DOM assertions and desktop/mobile
+  screenshots.
+
+## Constraints
+
+- No hosted control plane, billing, realtime, comments, downvotes, GitHub
+  Projects, package publishing, version bump, credential changes, or destructive
+  dogfood cleanup.
+- Keep changes scoped to demo UX, widget presentation ergonomics, tests, and this
+  GoalBuddy record.
+- Use existing repo stacks and release paths.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/bugdrop-board-guided-demo-polish/goal.md.
+```

--- a/docs/goals/bugdrop-board-guided-demo-polish/state.yaml
+++ b/docs/goals/bugdrop-board-guided-demo-polish/state.yaml
@@ -1,0 +1,89 @@
+version: 2
+
+goal:
+  title: "BugDrop Board Guided Demo Polish"
+  slug: "bugdrop-board-guided-demo-polish"
+  kind: specific
+  tranche: "Apply UX critique to the live demo, ship, and prove production."
+  status: active
+  oracle:
+    signal: "Production desktop/mobile walkthrough proves smoother embedded-app intro, clearer kanban scanning, and visible upvote counts."
+    cadence: "after implementation, after CI, after merge/deploy, and at final production proof"
+    final_proof: "Production screenshot plus DOM assertions show accepted UX changes and no layout/browser errors."
+  intake:
+    original_request: "Use three independent UX sub-agents, make a GoalBuddy prep board, ship changes, and show a new production screenshot."
+    interpreted_outcome: "Use independent UX critique to improve the BugDrop Board production demo and prove the shipped result."
+    input_shape: specific
+    audience: "Closed-beta reviewers and prospective self-hosters"
+    authority: requested
+    proof_type: demo
+    completion_proof: "Live production board visibly reads as a polished embedded feedback board with clear intro, kanban lifecycle, and vote affordance."
+    likely_misfire: "Only changing copy or colors while leaving cluttered card hierarchy, ambiguous voting, or internal host framing."
+    blind_spots_considered:
+      - "The screenshot used by sub-agents may be older than current production; stale dogfood/timestamp critiques must be filtered."
+      - "Widget and host changes live in different repositories and deploy independently."
+      - "Production deploys are allowed here only through existing repo release/deploy workflows after green PRs."
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: planned
+    url: "http://goalbuddy.localhost:41737/bugdrop-board-guided-demo-polish/"
+    command: "npx goalbuddy board docs/goals/bugdrop-board-guided-demo-polish"
+
+active_task: T003
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: "UX sub-agents"
+    status: done
+    objective: "Collect three independent critiques of the demo screenshot."
+    receipt:
+      result: done
+      summary: "Agents agreed on clearer first-run framing, less internal language, better lane/card hierarchy, clearer vote action, realistic customer-app context, and balanced kanban lifecycle."
+      evidence:
+        - "Sub-agent 1 prioritized purpose copy, first-run cue, reduced internal language, vote clarity, and balanced statuses."
+        - "Sub-agent 2 prioritized collapsing creation, lane header badges, card hierarchy, compact voting, and more breathing room."
+        - "Sub-agent 3 prioritized customer-app framing, closed-beta context, visible customization, realistic data, and a credibility marker."
+      stale_notes_filtered:
+        - "Dogfood titles and empty status lanes were already addressed by prior production seeding and are not repeated as new work."
+
+  - id: T002
+    type: judge
+    assignee: PM
+    status: done
+    objective: "Choose the largest safe reversible slice."
+    receipt:
+      result: approved
+      summary: "Proceed with one vertical demo UX slice: widget kanban scanability and compact vote text in bugdrop-board, plus host framing/intro/stats copy in bugdrop."
+      allowed_files:
+        - "/Users/neonwatty/Desktop/bugdrop-board/src/widget/**"
+        - "/Users/neonwatty/Desktop/bugdrop-board/test/widget-dom.test.ts"
+        - "/Users/neonwatty/Desktop/bugdrop/src/lib/boardDogfood.ts"
+        - "/Users/neonwatty/Desktop/bugdrop/test/boardDogfood.test.ts"
+        - "/Users/neonwatty/Desktop/bugdrop/docs/goals/bugdrop-board-guided-demo-polish/**"
+      verify:
+        - "bugdrop-board focused widget tests and validate gate"
+        - "bugdrop focused dogfood host tests and validate gate"
+        - "production desktop/mobile Playwright proof after merge/deploy"
+
+  - id: T003
+    type: worker
+    assignee: PM
+    status: active
+    objective: "Implement and ship the guided demo polish with focused tests, PRs, CI, merge, deploy proof, and screenshots."
+    constraints:
+      - "No product behavior changes beyond backwards-compatible presentation/customization."
+      - "No package publish, version bump, credential changes, or destructive data cleanup."
+    acceptance:
+      - "Host copy no longer uses Launch Console."
+      - "Closed beta/lifecycle introduction is visible."
+      - "Kanban cards show compact vote action/counts."
+      - "Lane headers and cards are calmer and more scannable."
+      - "Production screenshot is attached to the final handoff."

--- a/src/lib/boardDogfood.ts
+++ b/src/lib/boardDogfood.ts
@@ -30,48 +30,105 @@ const boardCustomization = {
   emptyLaneDisplay: 'hidden',
   issueLinks: 'hidden',
   copy: {
-    heading: 'Ideas from users',
-    titleLabel: 'Idea',
+    heading: 'Ideas from beta users',
+    description:
+      'Share feedback, vote on what matters, and follow requests as they move from open to shipped.',
+    titleLabel: 'What should we improve?',
     titlePlaceholder: 'A short product idea',
-    descriptionLabel: 'Context',
+    descriptionLabel: 'Why does this matter?',
     descriptionPlaceholder: 'Who needs this, and what would it unlock?',
-    submitLabel: 'Add idea',
-    submittingLabel: 'Adding...',
+    submitLabel: 'Share feedback',
+    submittingLabel: 'Sharing...',
     loadingLabel: 'Loading feature requests...',
     emptyLabel: 'No ideas yet. Add the first one for the team to review.',
     errorTitle: "We couldn't load feature requests.",
     retryLabel: 'Try again',
     issuePrefix: 'GitHub #',
-    upvoteLabel: 'Upvote',
+    upvoteLabel: 'Vote',
     upvotedLabel: 'Voted',
   },
   theme: {
-    accent: '#2563eb',
-    accentSoft: '#dbeafe',
+    accent: '#0f766e',
+    accentSoft: '#ccfbf1',
     background: '#f8fafc',
-    border: '#d7dee8',
-    buttonBackground: '#2563eb',
-    buttonRadius: '8px',
+    border: '#d8e2dc',
+    borderWidth: '0px',
+    buttonBackground: '#0f766e',
+    buttonRadius: '999px',
     buttonText: '#ffffff',
     fieldBackground: '#ffffff',
     fieldRadius: '8px',
     fieldText: '#172026',
-    focus: '#1d4ed8',
+    focus: '#0f766e',
     fontSize: '14px',
     headingSize: '22px',
     itemRadius: '10px',
+    itemShadow: '0 12px 28px rgba(15, 23, 42, 0.06)',
+    padding: '0',
     maxWidth: '100%',
-    muted: '#64748b',
+    muted: '#60736f',
     radius: '12px',
     shadow: 'none',
     surface: '#ffffff',
-    surfaceAlt: '#f1f5f9',
+    surfaceAlt: '#f3f7f4',
     text: '#172026',
-    upvoteBackground: '#eff6ff',
-    upvoteBorder: '#bfdbfe',
-    upvoteText: '#1d4ed8',
+    upvoteBackground: '#ecfdf5',
+    upvoteBorder: '#99f6e4',
+    upvoteText: '#0f766e',
   },
 };
+
+const DOGFOOD_PAGE_STYLE = `
+      * { box-sizing: border-box; }
+      body {
+        background: #f4f7f5; color: #172026;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+      }
+      main { min-height: 100vh; }
+      h1 { font-size: 32px; line-height: 1.2; margin: 0; }
+      p { color: #64748b; margin: 0; }
+      .demo-app { display: grid; grid-template-columns: 232px minmax(0, 1fr); min-height: 100vh; }
+      .sidebar { background: #10201d; color: #dce8e3; padding: 24px; }
+      .brand {
+        align-items: center; display: flex; gap: 10px;
+        font-size: 18px; font-weight: 800; margin-bottom: 28px;
+      }
+      .brand-mark {
+        background: #14b8a6; border-radius: 8px; color: #ffffff;
+        display: inline-grid; font-size: 13px; height: 30px;
+        place-items: center; width: 30px;
+      }
+      .nav-item {
+        border-radius: 8px; color: #bfd0ca; display: block;
+        font-size: 14px; font-weight: 650; padding: 10px 12px;
+      }
+      .nav-item.active { background: #17342f; color: #ffffff; }
+      .workspace { padding: 30px; }
+      .topbar {
+        align-items: center; display: flex; gap: 16px;
+        justify-content: space-between; margin: 0 0 18px;
+      }
+      .viewer, .stat {
+        background: #ffffff; border: 1px solid #d8e2dc; border-radius: 999px;
+        color: #40524e; font-size: 13px; font-weight: 650;
+      }
+      .viewer { padding: 8px 12px; }
+      .kicker {
+        color: #0f766e; font-size: 12px; font-weight: 800;
+        letter-spacing: 0; text-transform: uppercase;
+      }
+      .intro { display: grid; gap: 8px; max-width: 720px; }
+      .stats { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 22px; }
+      .stat { padding: 7px 10px; }
+      .board-surface { max-width: 1180px; }
+      @media (max-width: 760px) {
+        .demo-app { grid-template-columns: 1fr; }
+        .sidebar { display: none; }
+        .workspace { padding: 18px; }
+        .topbar { align-items: flex-start; flex-direction: column; }
+      }
+`;
 
 export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): string {
   const viewer = normalizeViewer(rawViewer);
@@ -83,117 +140,34 @@ export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): stri
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>BugDrop Feature Board Demo</title>
-    <style>
-      * {
-        box-sizing: border-box;
-      }
-      body {
-        background: #eef2f7;
-        color: #172026;
-        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        margin: 0;
-      }
-      main {
-        min-height: 100vh;
-      }
-      h1 {
-        font-size: 28px;
-        line-height: 1.2;
-        margin: 0;
-      }
-      p {
-        color: #64748b;
-        margin: 0;
-      }
-      .demo-app {
-        display: grid;
-        grid-template-columns: 220px minmax(0, 1fr);
-        min-height: 100vh;
-      }
-      .sidebar {
-        background: #0f172a;
-        color: #e2e8f0;
-        padding: 24px;
-      }
-      .brand {
-        font-size: 18px;
-        font-weight: 800;
-        margin-bottom: 28px;
-      }
-      .nav-item {
-        border-radius: 8px;
-        color: #cbd5e1;
-        display: block;
-        font-size: 14px;
-        font-weight: 650;
-        padding: 10px 12px;
-      }
-      .nav-item.active {
-        background: #1e293b;
-        color: #ffffff;
-      }
-      .workspace {
-        padding: 28px;
-      }
-      .topbar {
-        align-items: center;
-        display: flex;
-        gap: 16px;
-        justify-content: space-between;
-        margin: 0 0 24px;
-      }
-      .viewer {
-        background: #ffffff;
-        border: 1px solid #d7dee8;
-        border-radius: 999px;
-        color: #475569;
-        font-size: 13px;
-        font-weight: 650;
-        padding: 8px 12px;
-      }
-      .intro {
-        display: grid;
-        gap: 6px;
-        margin-bottom: 18px;
-        max-width: 720px;
-      }
-      .board-surface {
-        max-width: 1120px;
-      }
-      @media (max-width: 760px) {
-        .demo-app {
-          grid-template-columns: 1fr;
-        }
-        .sidebar {
-          display: none;
-        }
-        .workspace {
-          padding: 18px;
-        }
-        .topbar {
-          align-items: flex-start;
-          flex-direction: column;
-        }
-      }
-    </style>
+    <style>${DOGFOOD_PAGE_STYLE}</style>
   </head>
   <body>
     <main>
       <div class="demo-app">
         <aside class="sidebar" aria-label="Demo app navigation">
-          <div class="brand">Launch Console</div>
+          <div class="brand"><span class="brand-mark">N</span>Northstar</div>
           <span class="nav-item">Overview</span>
-          <span class="nav-item active">Feature requests</span>
+          <span class="nav-item">Accounts</span>
+          <span class="nav-item active">Feedback</span>
+          <span class="nav-item">Roadmap</span>
           <span class="nav-item">Customers</span>
           <span class="nav-item">Settings</span>
         </aside>
         <section class="workspace" aria-label="Demo app workspace">
           <div class="topbar">
             <div class="intro">
-              <h1>Feature requests</h1>
-              <p>Add ideas, vote once on what matters, and watch requests move through the roadmap.</p>
+              <span class="kicker">Closed beta feedback board</span>
+              <h1>Shape the roadmap</h1>
+              <p>Invite beta users to add ideas, vote once on what matters, and see what the team is reviewing, building, and shipping.</p>
             </div>
-            <span class="viewer">Demo viewer ${viewer.toUpperCase()}</span>
+            <span class="viewer">${viewerDisplayName(viewer)}</span>
+          </div>
+          <div class="stats" aria-label="Feedback board summary">
+            <span class="stat">11 requests</span>
+            <span class="stat">18 votes</span>
+            <span class="stat">Private beta workspace</span>
+            <span class="stat">Synced with GitHub Issues</span>
           </div>
           <section class="board-surface" id="bugdrop-board-dogfood"></section>
         </section>
@@ -208,12 +182,16 @@ export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): stri
       data-api-url="${escapeAttribute(config.workerOrigin)}"
       data-token-endpoint="/api/bugdrop-board-token?viewer=${viewer}"
       data-poll-interval="750"
-      data-color="#2563eb"
+      data-color="#0f766e"
       data-mount-selector="#bugdrop-board-dogfood"
       data-config-selector="#${BOARD_CONFIG_SCRIPT_ID}"
     ></script>
   </body>
 </html>`;
+}
+
+function viewerDisplayName(viewer: 'a' | 'b'): string {
+  return viewer === 'b' ? 'Jordan Lee, beta user' : 'Maya Chen, beta user';
 }
 
 export async function createBoardDogfoodToken(env: Env, rawViewer: string | null): Promise<string> {

--- a/test/boardDogfood.test.ts
+++ b/test/boardDogfood.test.ts
@@ -52,19 +52,22 @@ describe('BugDrop Board dogfood host', () => {
       emptyLaneDisplay: 'hidden',
       issueLinks: 'hidden',
       copy: {
-        heading: 'Ideas from users',
-        submitLabel: 'Add idea',
-        upvoteLabel: 'Upvote',
+        heading: 'Ideas from beta users',
+        description:
+          'Share feedback, vote on what matters, and follow requests as they move from open to shipped.',
+        submitLabel: 'Share feedback',
+        upvoteLabel: 'Vote',
         upvotedLabel: 'Voted',
       },
       theme: {
-        accent: '#2563eb',
+        accent: '#0f766e',
         background: '#f8fafc',
-        buttonRadius: '8px',
+        borderWidth: '0px',
+        buttonRadius: '999px',
         itemRadius: '10px',
         maxWidth: '100%',
         surface: '#ffffff',
-        surfaceAlt: '#f1f5f9',
+        surfaceAlt: '#f3f7f4',
       },
     });
     expect(JSON.stringify(config)).not.toContain(boardSecret);
@@ -78,10 +81,13 @@ describe('BugDrop Board dogfood host', () => {
     const html = await response.text();
 
     expect(html).toContain('<title>BugDrop Feature Board Demo</title>');
-    expect(html).toContain('<div class="brand">Launch Console</div>');
-    expect(html).toContain('<h1>Feature requests</h1>');
-    expect(html).toContain('Add ideas, vote once on what matters');
-    expect(html).toContain('Demo viewer A');
+    expect(html).toContain('<span class="brand-mark">N</span>Northstar');
+    expect(html).toContain('Closed beta feedback board');
+    expect(html).toContain('<h1>Shape the roadmap</h1>');
+    expect(html).toContain('Invite beta users to add ideas');
+    expect(html).toContain('Maya Chen, beta user');
+    expect(html).toContain('Synced with GitHub Issues');
+    expect(html).not.toContain('Launch Console');
     expect(html).not.toContain('BugDrop Board Dogfood');
     expect(html).not.toContain('Signed in as dogfood viewer');
   });


### PR DESCRIPTION
## Summary
- add GoalBuddy prep board for guided demo polish
- reframe /board-dogfood as a closed-beta customer workspace
- add board intro copy, summary chips, customer-style theme, and clearer vote labels

## Verification
- npx vitest run test/boardDogfood.test.ts
- npm run validate
- npx knip
- npm run check:actions-node24