### PR TITLE
Square off board demo feedback CTA

### DIFF
--- a/src/lib/boardDogfood.ts
+++ b/src/lib/boardDogfood.ts
@@ -54,7 +54,7 @@ const boardCustomization = {
     border: '#d8e2dc',
     borderWidth: '0px',
     buttonBackground: '#0f766e',
-    buttonRadius: '999px',
+    buttonRadius: '9px',
     buttonText: '#ffffff',
     fieldBackground: '#ffffff',
     fieldRadius: '8px',

--- a/test/boardDogfood.test.ts
+++ b/test/boardDogfood.test.ts
@@ -63,7 +63,7 @@ describe('BugDrop Board dogfood host', () => {
         accent: '#0f766e',
         background: '#f8fafc',
         borderWidth: '0px',
-        buttonRadius: '999px',
+        buttonRadius: '9px',
         itemRadius: '10px',
         maxWidth: '100%',
         surface: '#ffffff',


### PR DESCRIPTION
## Summary
- reduce the board dogfood demo primary button radius from pill-style to a calmer app button
- keep compact vote pills unchanged through widget kanban styling

## Verification
- npx vitest run test/boardDogfood.test.ts
- npm run validate