### PR TITLE
fix: clarify board demo UX

### DIFF
--- a/src/lib/boardDogfood.ts
+++ b/src/lib/boardDogfood.ts
@@ -30,15 +30,14 @@ const boardCustomization = {
   emptyLaneDisplay: 'hidden',
   issueLinks: 'hidden',
   copy: {
-    heading: 'Ideas from beta users',
-    description:
-      'Share feedback, vote on what matters, and follow requests as they move from open to shipped.',
+    heading: 'Beta roadmap ideas',
+    description: 'Users submit ideas, vote once, and follow progress from Open to Shipped.',
     titleLabel: 'What should we improve?',
     titlePlaceholder: 'A short product idea',
     descriptionLabel: 'Why does this matter?',
     descriptionPlaceholder: 'Who needs this, and what would it unlock?',
-    submitLabel: 'Share feedback',
-    submittingLabel: 'Sharing...',
+    submitLabel: 'Add idea',
+    submittingLabel: 'Adding...',
     loadingLabel: 'Loading feature requests...',
     emptyLabel: 'No ideas yet. Add the first one for the team to review.',
     errorTitle: "We couldn't load feature requests.",
@@ -50,10 +49,11 @@ const boardCustomization = {
   theme: {
     accent: '#0f766e',
     accentSoft: '#ccfbf1',
-    background: '#f8fafc',
+    background: 'transparent',
     border: '#d8e2dc',
     borderWidth: '0px',
     buttonBackground: '#0f766e',
+    buttonPadding: '6px 10px',
     buttonRadius: '9px',
     buttonText: '#ffffff',
     fieldBackground: '#ffffff',
@@ -61,8 +61,10 @@ const boardCustomization = {
     fieldText: '#172026',
     focus: '#0f766e',
     fontSize: '14px',
+    gap: '12px',
     headingSize: '22px',
     itemRadius: '10px',
+    itemPadding: '14px',
     itemShadow: '0 12px 28px rgba(15, 23, 42, 0.06)',
     padding: '0',
     maxWidth: '100%',
@@ -118,9 +120,18 @@ const DOGFOOD_PAGE_STYLE = `
         color: #0f766e; font-size: 12px; font-weight: 800;
         letter-spacing: 0; text-transform: uppercase;
       }
+      .demo-framing {
+        color: #40524e; font-size: 14px; line-height: 1.55;
+      }
       .intro { display: grid; gap: 8px; max-width: 720px; }
+      .intro-row { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; }
       .stats { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 22px; }
       .stat { padding: 7px 10px; }
+      .board-frame { display: grid; gap: 10px; max-width: 1180px; }
+      .board-label {
+        color: #60736f; font-size: 12px; font-weight: 750;
+        letter-spacing: 0; text-transform: uppercase;
+      }
       .board-surface { max-width: 1180px; }
       @media (max-width: 760px) {
         .demo-app { grid-template-columns: 1fr; }
@@ -157,9 +168,13 @@ export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): stri
         <section class="workspace" aria-label="Demo app workspace">
           <div class="topbar">
             <div class="intro">
-              <span class="kicker">Closed beta feedback board</span>
+              <div class="intro-row">
+                <span class="kicker">BugDrop embedded demo</span>
+                <span class="stat">Closed beta feedback board</span>
+              </div>
               <h1>Shape the roadmap</h1>
               <p>Invite beta users to add ideas, vote once on what matters, and see what the team is reviewing, building, and shipping.</p>
+              <p class="demo-framing">This is what your users would see inside your app: a native-feeling BugDrop board themed for Northstar.</p>
             </div>
             <span class="viewer">${viewerDisplayName(viewer)}</span>
           </div>
@@ -167,9 +182,13 @@ export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): stri
             <span class="stat">11 requests</span>
             <span class="stat">18 votes</span>
             <span class="stat">Private beta workspace</span>
-            <span class="stat">Synced with GitHub Issues</span>
+            <span class="stat">Ideas sync to GitHub Issues</span>
+            <span class="stat">Hosted or self-hosted</span>
           </div>
-          <section class="board-surface" id="bugdrop-board-dogfood"></section>
+          <div class="board-frame">
+            <span class="board-label">Example in-app board</span>
+            <section class="board-surface" id="bugdrop-board-dogfood"></section>
+          </div>
         </section>
       </div>
     </main>

--- a/test/boardDogfood.test.ts
+++ b/test/boardDogfood.test.ts
@@ -52,18 +52,20 @@ describe('BugDrop Board dogfood host', () => {
       emptyLaneDisplay: 'hidden',
       issueLinks: 'hidden',
       copy: {
-        heading: 'Ideas from beta users',
-        description:
-          'Share feedback, vote on what matters, and follow requests as they move from open to shipped.',
-        submitLabel: 'Share feedback',
+        heading: 'Beta roadmap ideas',
+        description: 'Users submit ideas, vote once, and follow progress from Open to Shipped.',
+        submitLabel: 'Add idea',
         upvoteLabel: 'Vote',
         upvotedLabel: 'Voted',
       },
       theme: {
         accent: '#0f766e',
-        background: '#f8fafc',
+        background: 'transparent',
         borderWidth: '0px',
         buttonRadius: '9px',
+        buttonPadding: '6px 10px',
+        gap: '12px',
+        itemPadding: '14px',
         itemRadius: '10px',
         maxWidth: '100%',
         surface: '#ffffff',
@@ -82,11 +84,15 @@ describe('BugDrop Board dogfood host', () => {
 
     expect(html).toContain('<title>BugDrop Feature Board Demo</title>');
     expect(html).toContain('<span class="brand-mark">N</span>Northstar');
+    expect(html).toContain('BugDrop embedded demo');
+    expect(html).toContain('This is what your users would see inside your app');
     expect(html).toContain('Closed beta feedback board');
     expect(html).toContain('<h1>Shape the roadmap</h1>');
     expect(html).toContain('Invite beta users to add ideas');
+    expect(html).toContain('Example in-app board');
     expect(html).toContain('Maya Chen, beta user');
-    expect(html).toContain('Synced with GitHub Issues');
+    expect(html).toContain('Ideas sync to GitHub Issues');
+    expect(html).toContain('Hosted or self-hosted');
     expect(html).not.toContain('Launch Console');
     expect(html).not.toContain('BugDrop Board Dogfood');
     expect(html).not.toContain('Signed in as dogfood viewer');


### PR DESCRIPTION
## Summary
- make the demo explicitly frame BugDrop as an embedded board inside the example Northstar app
- rename the collapsed composer CTA to Add idea and tighten board lifecycle copy
- add low-noise GitHub sync and hosted/self-hosted value signals
- tune the demo theme to rely on the widget's transparent kanban shell while keeping cards white

## Verification
- npm test -- test/boardDogfood.test.ts
- npm run validate
- curl -fsS http://127.0.0.1:8787/board-dogfood | rg -n "BugDrop embedded demo|This is what your users would see|Add idea|Hosted or self-hosted"
- Local Playwright proof: /Users/neonwatty/Desktop/bugdrop/test-results/local-board-ux-comprehension-polish/desktop.png and mobile.png

## Burden of proof
Strongest failure mode checked: the demo could explain BugDrop better but clutter or break the embedded board. Local Playwright proof showed BugDrop framing true, self-host signal true, Add idea CTA 75x30, transparent board shell, four lanes rendered, selected/unselected vote states distinct, zero overflow, and no browser errors.