### PR TITLE
fix: tighten board demo messaging

### DIFF
--- a/src/lib/boardDogfood.ts
+++ b/src/lib/boardDogfood.ts
@@ -30,8 +30,8 @@ const boardCustomization = {
   emptyLaneDisplay: 'hidden',
   issueLinks: 'hidden',
   copy: {
-    heading: 'Beta roadmap ideas',
-    description: 'Users submit ideas, vote once, and follow progress from Open to Shipped.',
+    heading: 'Feature requests',
+    description: 'Add ideas, vote once, and track what ships.',
     titleLabel: 'What should we improve?',
     titlePlaceholder: 'A short product idea',
     descriptionLabel: 'Why does this matter?',
@@ -169,12 +169,12 @@ export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): stri
           <div class="topbar">
             <div class="intro">
               <div class="intro-row">
-                <span class="kicker">BugDrop embedded demo</span>
-                <span class="stat">Closed beta feedback board</span>
+                <span class="kicker">BugDrop Board demo</span>
+                <span class="stat">Embedded widget</span>
               </div>
-              <h1>Shape the roadmap</h1>
-              <p>Invite beta users to add ideas, vote once on what matters, and see what the team is reviewing, building, and shipping.</p>
-              <p class="demo-framing">This is what your users would see inside your app: a native-feeling BugDrop board themed for Northstar.</p>
+              <h1>Feature requests, embedded in your app</h1>
+              <p>Users add ideas, vote once, and track progress from Open to Shipped.</p>
+              <p class="demo-framing">This demo shows BugDrop themed inside Northstar, a fictional customer app, with requests synced to GitHub Issues.</p>
             </div>
             <span class="viewer">${viewerDisplayName(viewer)}</span>
           </div>
@@ -182,11 +182,11 @@ export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): stri
             <span class="stat">11 requests</span>
             <span class="stat">18 votes</span>
             <span class="stat">Private beta workspace</span>
-            <span class="stat">Ideas sync to GitHub Issues</span>
-            <span class="stat">Hosted or self-hosted</span>
+            <span class="stat">GitHub Issues sync</span>
+            <span class="stat">Self-hostable</span>
           </div>
           <div class="board-frame">
-            <span class="board-label">Example in-app board</span>
+            <span class="board-label">Live embedded board</span>
             <section class="board-surface" id="bugdrop-board-dogfood"></section>
           </div>
         </section>

--- a/test/boardDogfood.test.ts
+++ b/test/boardDogfood.test.ts
@@ -52,8 +52,8 @@ describe('BugDrop Board dogfood host', () => {
       emptyLaneDisplay: 'hidden',
       issueLinks: 'hidden',
       copy: {
-        heading: 'Beta roadmap ideas',
-        description: 'Users submit ideas, vote once, and follow progress from Open to Shipped.',
+        heading: 'Feature requests',
+        description: 'Add ideas, vote once, and track what ships.',
         submitLabel: 'Add idea',
         upvoteLabel: 'Vote',
         upvotedLabel: 'Voted',
@@ -84,15 +84,20 @@ describe('BugDrop Board dogfood host', () => {
 
     expect(html).toContain('<title>BugDrop Feature Board Demo</title>');
     expect(html).toContain('<span class="brand-mark">N</span>Northstar');
-    expect(html).toContain('BugDrop embedded demo');
-    expect(html).toContain('This is what your users would see inside your app');
-    expect(html).toContain('Closed beta feedback board');
-    expect(html).toContain('<h1>Shape the roadmap</h1>');
-    expect(html).toContain('Invite beta users to add ideas');
-    expect(html).toContain('Example in-app board');
+    expect(html).toContain('BugDrop Board demo');
+    expect(html).toContain('<h1>Feature requests, embedded in your app</h1>');
+    expect(html).toContain('Users add ideas, vote once, and track progress from Open to Shipped.');
+    expect(html).toContain(
+      'This demo shows BugDrop themed inside Northstar, a fictional customer app, with requests synced to GitHub Issues.'
+    );
+    expect(html).toContain('Live embedded board');
     expect(html).toContain('Maya Chen, beta user');
-    expect(html).toContain('Ideas sync to GitHub Issues');
-    expect(html).toContain('Hosted or self-hosted');
+    expect(html).toContain('Embedded widget');
+    expect(html).toContain('GitHub Issues sync');
+    expect(html).toContain('Self-hostable');
+    expect(html).not.toContain('Closed beta feedback board');
+    expect(html).not.toContain('Shape the roadmap');
+    expect(html).not.toContain('This is what your users would see inside your app');
     expect(html).not.toContain('Launch Console');
     expect(html).not.toContain('BugDrop Board Dogfood');
     expect(html).not.toContain('Signed in as dogfood viewer');


### PR DESCRIPTION
## Summary
- make the first viewport state the product and demo purpose more directly
- shorten the board heading/description copy
- replace longer status chips with concise embed/GitHub/self-host signals

## Verification
- npm test -- test/boardDogfood.test.ts
- npm run validate
- Local Playwright screenshot proof: /Users/neonwatty/Desktop/bugdrop/test-results/local-board-succinct-messaging/desktop.png and mobile.png

## Burden of proof
Strongest failure mode checked: the shorter copy could make the demo less clear or break the embedded board layout. Local Playwright proof showed product frame true, demo frame true, concise chips true, board heading/description updated, Add idea CTA still 75x30, no browser errors, no request failures, and zero horizontal overflow on desktop/mobile.