### PR TITLE
fix: make board demo messaging more succinct

### DIFF
--- a/src/lib/boardDogfood.ts
+++ b/src/lib/boardDogfood.ts
@@ -31,7 +31,7 @@ const boardCustomization = {
   issueLinks: 'hidden',
   copy: {
     heading: 'Feature requests',
-    description: 'Add ideas, vote once, and track what ships.',
+    description: 'Add ideas, vote, and track progress.',
     titleLabel: 'What should we improve?',
     titlePlaceholder: 'A short product idea',
     descriptionLabel: 'Why does this matter?',
@@ -169,12 +169,12 @@ export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): stri
           <div class="topbar">
             <div class="intro">
               <div class="intro-row">
-                <span class="kicker">BugDrop Board demo</span>
-                <span class="stat">Embedded widget</span>
+                <span class="kicker">BugDrop Board</span>
+                <span class="stat">Demo</span>
               </div>
-              <h1>Feature requests, embedded in your app</h1>
-              <p>Users add ideas, vote once, and track progress from Open to Shipped.</p>
-              <p class="demo-framing">This demo shows BugDrop themed inside Northstar, a fictional customer app, with requests synced to GitHub Issues.</p>
+              <h1>Embedded feedback board</h1>
+              <p>Collect feature requests, votes, and status updates inside your app.</p>
+              <p class="demo-framing">Shown here themed for Northstar and synced to GitHub Issues.</p>
             </div>
             <span class="viewer">${viewerDisplayName(viewer)}</span>
           </div>
@@ -182,11 +182,11 @@ export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): stri
             <span class="stat">11 requests</span>
             <span class="stat">18 votes</span>
             <span class="stat">Private beta workspace</span>
-            <span class="stat">GitHub Issues sync</span>
+            <span class="stat">GitHub sync</span>
             <span class="stat">Self-hostable</span>
           </div>
           <div class="board-frame">
-            <span class="board-label">Live embedded board</span>
+            <span class="board-label">Demo board</span>
             <section class="board-surface" id="bugdrop-board-dogfood"></section>
           </div>
         </section>

--- a/test/boardDogfood.test.ts
+++ b/test/boardDogfood.test.ts
@@ -53,7 +53,7 @@ describe('BugDrop Board dogfood host', () => {
       issueLinks: 'hidden',
       copy: {
         heading: 'Feature requests',
-        description: 'Add ideas, vote once, and track what ships.',
+        description: 'Add ideas, vote, and track progress.',
         submitLabel: 'Add idea',
         upvoteLabel: 'Vote',
         upvotedLabel: 'Voted',
@@ -84,20 +84,18 @@ describe('BugDrop Board dogfood host', () => {
 
     expect(html).toContain('<title>BugDrop Feature Board Demo</title>');
     expect(html).toContain('<span class="brand-mark">N</span>Northstar');
-    expect(html).toContain('BugDrop Board demo');
-    expect(html).toContain('<h1>Feature requests, embedded in your app</h1>');
-    expect(html).toContain('Users add ideas, vote once, and track progress from Open to Shipped.');
-    expect(html).toContain(
-      'This demo shows BugDrop themed inside Northstar, a fictional customer app, with requests synced to GitHub Issues.'
-    );
-    expect(html).toContain('Live embedded board');
+    expect(html).toContain('BugDrop Board');
+    expect(html).toContain('<span class="stat">Demo</span>');
+    expect(html).toContain('<h1>Embedded feedback board</h1>');
+    expect(html).toContain('Collect feature requests, votes, and status updates inside your app.');
+    expect(html).toContain('Shown here themed for Northstar and synced to GitHub Issues.');
+    expect(html).toContain('Demo board');
     expect(html).toContain('Maya Chen, beta user');
-    expect(html).toContain('Embedded widget');
-    expect(html).toContain('GitHub Issues sync');
+    expect(html).toContain('GitHub sync');
     expect(html).toContain('Self-hostable');
-    expect(html).not.toContain('Closed beta feedback board');
-    expect(html).not.toContain('Shape the roadmap');
-    expect(html).not.toContain('This is what your users would see inside your app');
+    expect(html).not.toContain('GitHub Issues sync');
+    expect(html).not.toContain('Feature requests, embedded in your app');
+    expect(html).not.toContain('This demo shows BugDrop themed inside Northstar');
     expect(html).not.toContain('Launch Console');
     expect(html).not.toContain('BugDrop Board Dogfood');
     expect(html).not.toContain('Signed in as dogfood viewer');


### PR DESCRIPTION
## Summary
- shorten the first-viewport demo framing to product name, demo pill, and a direct H1
- tighten the supporting sentence, demo note, chips, and board label
- shorten embedded board description to match the simpler page framing

## Verification
- npm test -- test/boardDogfood.test.ts
- npm run validate
- Local Playwright screenshot proof: /Users/neonwatty/Desktop/bugdrop/test-results/local-board-more-succinct-messaging/desktop.png and mobile.png

## Burden of proof
Strongest failure mode checked: the copy could become too terse and stop explaining what the demo shows. Local Playwright proof showed product frame true, demo frame true, chips true, old copy absent, board heading/description updated, Add idea CTA still 75x30, no browser errors, no request failures, and zero horizontal overflow on desktop/mobile.