### PR TITLE
feat: embed board demo on BugDrop page

### DIFF
--- a/public/board/index.html
+++ b/public/board/index.html
@@ -223,6 +223,23 @@
         margin-top: 34px;
       }
 
+      .live-demo {
+        padding-top: 34px;
+      }
+
+      .live-board-shell {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        box-shadow: var(--shadow);
+        margin-top: 30px;
+        padding: clamp(16px, 3vw, 28px);
+      }
+
+      .board-surface {
+        min-height: 520px;
+      }
+
       .feature {
         background: var(--surface);
         border: 1px solid var(--line);
@@ -391,7 +408,7 @@
         </a>
         <div class="nav-actions">
           <a href="https://github.com/mean-weasel/bugdrop-board">GitHub</a>
-          <a href="https://board.bugdrop.dev">Live board</a>
+          <a href="#live-demo">Live board</a>
           <a class="button secondary" href="https://github.com/mean-weasel/bugdrop-board#readme">
             Self-host
           </a>
@@ -409,7 +426,7 @@
             </p>
             <div class="hero-actions">
               <a class="button" href="https://github.com/mean-weasel/bugdrop-board">View on GitHub</a>
-              <a class="button secondary" href="https://board.bugdrop.dev">Open the dogfood board</a>
+              <a class="button secondary" href="#live-demo">Try the live board</a>
             </div>
             <div class="proof-strip" aria-label="BugDrop Board proof points">
               <div>
@@ -431,6 +448,23 @@
             <img src="/board/assets/launch-dark.png" alt="Dark launch-planning board UI" />
             <img src="/board/assets/health-portal.png" alt="Care portal board UI" />
             <img src="/board/assets/developer-portal.png" alt="Developer portal board UI" />
+          </div>
+        </section>
+
+        <section class="section live-demo" id="live-demo" aria-labelledby="live-demo-title">
+          <div class="section-header">
+            <h2 id="live-demo-title">Try the embedded board.</h2>
+            <p>
+              This is the live BugDrop Board mounted inside a BugDrop-owned page. Add ideas, vote,
+              and see the same GitHub-backed workflow a self-hosted app can install.
+            </p>
+          </div>
+          <div class="live-board-shell">
+            <section
+              class="board-surface"
+              id="bugdrop-board-demo"
+              aria-label="Live BugDrop Board demo"
+            ></section>
           </div>
         </section>
 
@@ -541,5 +575,73 @@
         GitHub-backed, polling-based, upvotes-only.
       </footer>
     </div>
+    <script type="application/json" id="bugdrop-board-demo-config">
+      {
+        "composer": "collapsed",
+        "layout": "kanban",
+        "density": "comfortable",
+        "emptyLaneDisplay": "hidden",
+        "issueLinks": "hidden",
+        "copy": {
+          "heading": "Feature requests",
+          "description": "Add ideas, vote, and track progress.",
+          "titleLabel": "What should we improve?",
+          "titlePlaceholder": "A short product idea",
+          "descriptionLabel": "Why does this matter?",
+          "descriptionPlaceholder": "Who needs this, and what would it unlock?",
+          "submitLabel": "Add idea",
+          "submittingLabel": "Adding...",
+          "loadingLabel": "Loading feature requests...",
+          "emptyLabel": "No ideas yet. Add the first one for the team to review.",
+          "errorTitle": "We couldn't load feature requests.",
+          "retryLabel": "Try again",
+          "issuePrefix": "GitHub #",
+          "upvoteLabel": "Vote",
+          "upvotedLabel": "Voted"
+        },
+        "theme": {
+          "accent": "#17864f",
+          "accentSoft": "#d9fbe7",
+          "background": "transparent",
+          "border": "#d9d4cb",
+          "borderWidth": "0px",
+          "buttonBackground": "#17864f",
+          "buttonPadding": "6px 10px",
+          "buttonRadius": "9px",
+          "buttonText": "#ffffff",
+          "fieldBackground": "#ffffff",
+          "fieldRadius": "8px",
+          "fieldText": "#171717",
+          "focus": "#17864f",
+          "fontSize": "14px",
+          "gap": "12px",
+          "headingSize": "22px",
+          "itemRadius": "10px",
+          "itemPadding": "14px",
+          "itemShadow": "0 12px 28px rgba(24, 24, 27, 0.08)",
+          "padding": "0",
+          "maxWidth": "100%",
+          "muted": "#5f5b55",
+          "radius": "12px",
+          "shadow": "none",
+          "surface": "#ffffff",
+          "surfaceAlt": "#f8f5ef",
+          "text": "#171717",
+          "upvoteBackground": "#effaf3",
+          "upvoteBorder": "#a7e8bd",
+          "upvoteText": "#0f5f3d"
+        }
+      }
+    </script>
+    <script
+      src="https://board.bugdrop.dev/board.js"
+      data-board-id="board_mean_weasel_bugdrop_board_production_dogfood"
+      data-api-url="https://board.bugdrop.dev"
+      data-token-endpoint="/api/bugdrop-board-token?viewer=a"
+      data-poll-interval="750"
+      data-color="#17864f"
+      data-mount-selector="#bugdrop-board-demo"
+      data-config-selector="#bugdrop-board-demo-config"
+    ></script>
   </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { logger } from 'hono/logger';
 import type { Env } from './types';
 import api from './routes/api';
-import { createBoardDogfoodToken, renderBoardDogfoodPage } from './lib/boardDogfood';
+import { createBoardDogfoodToken } from './lib/boardDogfood';
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -69,8 +69,9 @@ app.get('/', c => {
 });
 
 app.get('/board-dogfood', c => {
-  const viewer = c.req.query('viewer') ?? null;
-  return c.html(renderBoardDogfoodPage(c.env, viewer));
+  const viewer = c.req.query('viewer');
+  const suffix = viewer ? `?viewer=${encodeURIComponent(viewer)}` : '';
+  return c.redirect(`/board${suffix}`, 302);
 });
 
 app.get('/board', c => {

--- a/src/lib/boardDogfood.ts
+++ b/src/lib/boardDogfood.ts
@@ -1,15 +1,12 @@
 import type { Env } from '../types';
 
 const DEFAULT_BOARD_ID = 'board_mean_weasel_bugdrop_board_production_dogfood';
-const DEFAULT_WORKER_ORIGIN = 'https://board.bugdrop.dev';
 const DEFAULT_TOKEN_AUDIENCE = 'bugdrop-board';
 const DEFAULT_TOKEN_ISSUER = 'bugdrop-board-production-host';
-const BOARD_CONFIG_SCRIPT_ID = 'bugdrop-board-dogfood-config';
 const TOKEN_TTL_SECONDS = 300;
 
 interface BoardDogfoodConfig {
   boardId: string;
-  workerOrigin: string;
   tokenAudience: string;
   tokenIssuer: string;
 }
@@ -21,196 +18,6 @@ interface BoardTokenClaims {
   exp: number;
   aud: string;
   iss: string;
-}
-
-const boardCustomization = {
-  composer: 'collapsed',
-  layout: 'kanban',
-  density: 'comfortable',
-  emptyLaneDisplay: 'hidden',
-  issueLinks: 'hidden',
-  copy: {
-    heading: 'Feature requests',
-    description: 'Add ideas, vote, and track progress.',
-    titleLabel: 'What should we improve?',
-    titlePlaceholder: 'A short product idea',
-    descriptionLabel: 'Why does this matter?',
-    descriptionPlaceholder: 'Who needs this, and what would it unlock?',
-    submitLabel: 'Add idea',
-    submittingLabel: 'Adding...',
-    loadingLabel: 'Loading feature requests...',
-    emptyLabel: 'No ideas yet. Add the first one for the team to review.',
-    errorTitle: "We couldn't load feature requests.",
-    retryLabel: 'Try again',
-    issuePrefix: 'GitHub #',
-    upvoteLabel: 'Vote',
-    upvotedLabel: 'Voted',
-  },
-  theme: {
-    accent: '#0f766e',
-    accentSoft: '#ccfbf1',
-    background: 'transparent',
-    border: '#d8e2dc',
-    borderWidth: '0px',
-    buttonBackground: '#0f766e',
-    buttonPadding: '6px 10px',
-    buttonRadius: '9px',
-    buttonText: '#ffffff',
-    fieldBackground: '#ffffff',
-    fieldRadius: '8px',
-    fieldText: '#172026',
-    focus: '#0f766e',
-    fontSize: '14px',
-    gap: '12px',
-    headingSize: '22px',
-    itemRadius: '10px',
-    itemPadding: '14px',
-    itemShadow: '0 12px 28px rgba(15, 23, 42, 0.06)',
-    padding: '0',
-    maxWidth: '100%',
-    muted: '#60736f',
-    radius: '12px',
-    shadow: 'none',
-    surface: '#ffffff',
-    surfaceAlt: '#f3f7f4',
-    text: '#172026',
-    upvoteBackground: '#ecfdf5',
-    upvoteBorder: '#99f6e4',
-    upvoteText: '#0f766e',
-  },
-};
-
-const DOGFOOD_PAGE_STYLE = `
-      * { box-sizing: border-box; }
-      body {
-        background: #f4f7f5; color: #172026;
-        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        margin: 0;
-      }
-      main { min-height: 100vh; }
-      h1 { font-size: 32px; line-height: 1.2; margin: 0; }
-      p { color: #64748b; margin: 0; }
-      .demo-app { display: grid; grid-template-columns: 232px minmax(0, 1fr); min-height: 100vh; }
-      .sidebar { background: #10201d; color: #dce8e3; padding: 24px; }
-      .brand {
-        align-items: center; display: flex; gap: 10px;
-        font-size: 18px; font-weight: 800; margin-bottom: 28px;
-      }
-      .brand-mark {
-        background: #14b8a6; border-radius: 8px; color: #ffffff;
-        display: inline-grid; font-size: 13px; height: 30px;
-        place-items: center; width: 30px;
-      }
-      .nav-item {
-        border-radius: 8px; color: #bfd0ca; display: block;
-        font-size: 14px; font-weight: 650; padding: 10px 12px;
-      }
-      .nav-item.active { background: #17342f; color: #ffffff; }
-      .workspace { padding: 30px; }
-      .topbar {
-        align-items: center; display: flex; gap: 16px;
-        justify-content: space-between; margin: 0 0 18px;
-      }
-      .viewer, .stat {
-        background: #ffffff; border: 1px solid #d8e2dc; border-radius: 999px;
-        color: #40524e; font-size: 13px; font-weight: 650;
-      }
-      .viewer { padding: 8px 12px; }
-      .kicker {
-        color: #0f766e; font-size: 12px; font-weight: 800;
-        letter-spacing: 0; text-transform: uppercase;
-      }
-      .demo-framing {
-        color: #40524e; font-size: 14px; line-height: 1.55;
-      }
-      .intro { display: grid; gap: 8px; max-width: 720px; }
-      .intro-row { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; }
-      .stats { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 22px; }
-      .stat { padding: 7px 10px; }
-      .board-frame { display: grid; gap: 10px; max-width: 1180px; }
-      .board-label {
-        color: #60736f; font-size: 12px; font-weight: 750;
-        letter-spacing: 0; text-transform: uppercase;
-      }
-      .board-surface { max-width: 1180px; }
-      @media (max-width: 760px) {
-        .demo-app { grid-template-columns: 1fr; }
-        .sidebar { display: none; }
-        .workspace { padding: 18px; }
-        .topbar { align-items: flex-start; flex-direction: column; }
-      }
-`;
-
-export function renderBoardDogfoodPage(env: Env, rawViewer: string | null): string {
-  const viewer = normalizeViewer(rawViewer);
-  const config = dogfoodConfig(env);
-
-  return `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>BugDrop Feature Board Demo</title>
-    <style>${DOGFOOD_PAGE_STYLE}</style>
-  </head>
-  <body>
-    <main>
-      <div class="demo-app">
-        <aside class="sidebar" aria-label="Demo app navigation">
-          <div class="brand"><span class="brand-mark">N</span>Northstar</div>
-          <span class="nav-item">Overview</span>
-          <span class="nav-item">Accounts</span>
-          <span class="nav-item active">Feedback</span>
-          <span class="nav-item">Roadmap</span>
-          <span class="nav-item">Customers</span>
-          <span class="nav-item">Settings</span>
-        </aside>
-        <section class="workspace" aria-label="Demo app workspace">
-          <div class="topbar">
-            <div class="intro">
-              <div class="intro-row">
-                <span class="kicker">BugDrop Board</span>
-                <span class="stat">Demo</span>
-              </div>
-              <h1>Embedded feedback board</h1>
-              <p>Collect feature requests, votes, and status updates inside your app.</p>
-              <p class="demo-framing">Shown here themed for Northstar and synced to GitHub Issues.</p>
-            </div>
-            <span class="viewer">${viewerDisplayName(viewer)}</span>
-          </div>
-          <div class="stats" aria-label="Feedback board summary">
-            <span class="stat">11 requests</span>
-            <span class="stat">18 votes</span>
-            <span class="stat">Private beta workspace</span>
-            <span class="stat">GitHub sync</span>
-            <span class="stat">Self-hostable</span>
-          </div>
-          <div class="board-frame">
-            <span class="board-label">Demo board</span>
-            <section class="board-surface" id="bugdrop-board-dogfood"></section>
-          </div>
-        </section>
-      </div>
-    </main>
-    <script type="application/json" id="${BOARD_CONFIG_SCRIPT_ID}">${escapeScriptJson(
-      boardCustomization
-    )}</script>
-    <script
-      src="${escapeAttribute(config.workerOrigin)}/board.js"
-      data-board-id="${escapeAttribute(config.boardId)}"
-      data-api-url="${escapeAttribute(config.workerOrigin)}"
-      data-token-endpoint="/api/bugdrop-board-token?viewer=${viewer}"
-      data-poll-interval="750"
-      data-color="#0f766e"
-      data-mount-selector="#bugdrop-board-dogfood"
-      data-config-selector="#${BOARD_CONFIG_SCRIPT_ID}"
-    ></script>
-  </body>
-</html>`;
-}
-
-function viewerDisplayName(viewer: 'a' | 'b'): string {
-  return viewer === 'b' ? 'Jordan Lee, beta user' : 'Maya Chen, beta user';
 }
 
 export async function createBoardDogfoodToken(env: Env, rawViewer: string | null): Promise<string> {
@@ -237,9 +44,6 @@ export async function createBoardDogfoodToken(env: Env, rawViewer: string | null
 function dogfoodConfig(env: Env): BoardDogfoodConfig {
   return {
     boardId: envValue(env.BUGDROP_BOARD_ID) ?? DEFAULT_BOARD_ID,
-    workerOrigin: stripTrailingSlash(
-      envValue(env.BUGDROP_BOARD_WORKER_ORIGIN) ?? DEFAULT_WORKER_ORIGIN
-    ),
     tokenAudience: envValue(env.BUGDROP_BOARD_TOKEN_AUDIENCE) ?? DEFAULT_TOKEN_AUDIENCE,
     tokenIssuer: envValue(env.BUGDROP_BOARD_TOKEN_ISSUER) ?? DEFAULT_TOKEN_ISSUER,
   };
@@ -252,10 +56,6 @@ function normalizeViewer(value: string | null): 'a' | 'b' {
 function envValue(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
-}
-
-function stripTrailingSlash(value: string): string {
-  return value.replace(/\/+$/, '');
 }
 
 async function sign(payload: string, secret: string): Promise<string> {
@@ -278,16 +78,4 @@ function base64UrlEncodeBytes(bytes: Uint8Array): string {
   let binary = '';
   for (const byte of bytes) binary += String.fromCharCode(byte);
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
-}
-
-function escapeAttribute(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('"', '&quot;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;');
-}
-
-function escapeScriptJson(value: unknown): string {
-  return JSON.stringify(value).replaceAll('</', '<\\/');
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,9 +15,8 @@ export interface Env {
   AUTH_TOKEN_AUDIENCE?: string; // Optional expected token audience claim
   AUTH_TOKEN_ISSUER?: string; // Optional expected token issuer claim
   AUTH_TOKEN_REQUIRED_FOR_CHECK?: string; // Optional gate for /check installation lookups
-  BUGDROP_BOARD_TOKEN_SECRET?: string; // Optional signer secret for /board-dogfood tokens
-  BUGDROP_BOARD_ID?: string; // Optional override for the dogfood board id
-  BUGDROP_BOARD_WORKER_ORIGIN?: string; // Optional override for the board Worker origin
+  BUGDROP_BOARD_TOKEN_SECRET?: string; // Optional signer secret for the /board embedded demo
+  BUGDROP_BOARD_ID?: string; // Optional override for the demo board id
   BUGDROP_BOARD_TOKEN_AUDIENCE?: string; // Optional override for board token audience
   BUGDROP_BOARD_TOKEN_ISSUER?: string; // Optional override for board token issuer
 

--- a/test/boardDogfood.test.ts
+++ b/test/boardDogfood.test.ts
@@ -4,7 +4,6 @@ import type { Env } from '../src/types';
 
 const boardSecret = 'board-dogfood-secret-with-at-least-32-bytes';
 const boardId = 'board_mean_weasel_bugdrop_board_production_dogfood';
-const workerOrigin = 'https://board.bugdrop.dev';
 
 const env = {
   GITHUB_APP_ID: 'test-app-id',
@@ -18,87 +17,21 @@ const env = {
 } satisfies Env;
 
 describe('BugDrop Board dogfood host', () => {
-  it('renders the board dogfood page with production board embed config', async () => {
+  it('redirects legacy board dogfood traffic to the first-party board demo', async () => {
     const response = await app.fetch(
-      new Request('https://bugdrop.dev/board-dogfood?viewer=a'),
+      new Request('https://bugdrop.dev/board-dogfood?viewer=b'),
       env
     );
-    const html = await response.text();
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get('content-type')).toContain('text/html');
-    expect(html).toContain(`src="${workerOrigin}/board.js"`);
-    expect(html).toContain(`data-api-url="${workerOrigin}"`);
-    expect(html).toContain(`data-board-id="${boardId}"`);
-    expect(html).toContain('data-token-endpoint="/api/bugdrop-board-token?viewer=a"');
-    expect(html).toContain('<section class="board-surface" id="bugdrop-board-dogfood"></section>');
-    expect(html).toContain('data-mount-selector="#bugdrop-board-dogfood"');
-    expect(html).toContain('data-config-selector="#bugdrop-board-dogfood-config"');
-    expect(html).not.toContain(boardSecret);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('/board?viewer=b');
   });
 
-  it('renders a clean embedded feature-board customization config for the demo board', async () => {
-    const response = await app.fetch(
-      new Request('https://bugdrop.dev/board-dogfood?viewer=a'),
-      env
-    );
-    const html = await response.text();
-    const config = extractDogfoodConfig(html);
+  it('redirects legacy board dogfood traffic without a viewer query', async () => {
+    const response = await app.fetch(new Request('https://bugdrop.dev/board-dogfood'), env);
 
-    expect(config).toMatchObject({
-      composer: 'collapsed',
-      layout: 'kanban',
-      density: 'comfortable',
-      emptyLaneDisplay: 'hidden',
-      issueLinks: 'hidden',
-      copy: {
-        heading: 'Feature requests',
-        description: 'Add ideas, vote, and track progress.',
-        submitLabel: 'Add idea',
-        upvoteLabel: 'Vote',
-        upvotedLabel: 'Voted',
-      },
-      theme: {
-        accent: '#0f766e',
-        background: 'transparent',
-        borderWidth: '0px',
-        buttonRadius: '9px',
-        buttonPadding: '6px 10px',
-        gap: '12px',
-        itemPadding: '14px',
-        itemRadius: '10px',
-        maxWidth: '100%',
-        surface: '#ffffff',
-        surfaceAlt: '#f3f7f4',
-      },
-    });
-    expect(JSON.stringify(config)).not.toContain(boardSecret);
-  });
-
-  it('frames the board as an embedded demo app instead of internal dogfood tooling', async () => {
-    const response = await app.fetch(
-      new Request('https://bugdrop.dev/board-dogfood?viewer=a'),
-      env
-    );
-    const html = await response.text();
-
-    expect(html).toContain('<title>BugDrop Feature Board Demo</title>');
-    expect(html).toContain('<span class="brand-mark">N</span>Northstar');
-    expect(html).toContain('BugDrop Board');
-    expect(html).toContain('<span class="stat">Demo</span>');
-    expect(html).toContain('<h1>Embedded feedback board</h1>');
-    expect(html).toContain('Collect feature requests, votes, and status updates inside your app.');
-    expect(html).toContain('Shown here themed for Northstar and synced to GitHub Issues.');
-    expect(html).toContain('Demo board');
-    expect(html).toContain('Maya Chen, beta user');
-    expect(html).toContain('GitHub sync');
-    expect(html).toContain('Self-hostable');
-    expect(html).not.toContain('GitHub Issues sync');
-    expect(html).not.toContain('Feature requests, embedded in your app');
-    expect(html).not.toContain('This demo shows BugDrop themed inside Northstar');
-    expect(html).not.toContain('Launch Console');
-    expect(html).not.toContain('BugDrop Board Dogfood');
-    expect(html).not.toContain('Signed in as dogfood viewer');
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('/board');
   });
 
   it('signs a short-lived board token for viewer b without exposing the secret', async () => {
@@ -143,14 +76,6 @@ interface BoardTokenClaims {
   exp: number;
   aud: string;
   iss: string;
-}
-
-function extractDogfoodConfig(html: string): unknown {
-  const match = html.match(
-    /<script type="application\/json" id="bugdrop-board-dogfood-config">([^<]+)<\/script>/
-  );
-  expect(match?.[1]).toBeTruthy();
-  return JSON.parse(match?.[1] ?? '{}');
 }
 
 async function verifyBoardToken(token: string, secret: string): Promise<BoardTokenClaims> {

--- a/test/boardLanding.test.ts
+++ b/test/boardLanding.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 import app from '../src/index';
 import type { Env } from '../src/types';
+
+const boardLandingHtml = readFileSync('public/board/index.html', 'utf8');
 
 function createEnv(): Env {
   return {
@@ -14,7 +17,7 @@ function createEnv(): Env {
       fetch: async request => {
         const pathname = new URL(request.url).pathname;
         if (pathname === '/board/index.html') {
-          return new Response('<html><h1>BugDrop Board fits inside your app.</h1></html>', {
+          return new Response(boardLandingHtml, {
             headers: { 'content-type': 'text/html; charset=utf-8' },
           });
         }
@@ -32,17 +35,41 @@ function createEnv(): Env {
 describe('BugDrop Board landing page', () => {
   it('serves /board from the static board page asset', async () => {
     const response = await app.fetch(new Request('http://localhost/board'), createEnv());
+    const html = await response.text();
 
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toContain('text/html');
-    expect(await response.text()).toContain('BugDrop Board fits inside your app.');
+    expect(html).toContain('BugDrop Board fits inside your app.');
+    expect(html).toContain('data-mount-selector="#bugdrop-board-demo"');
   });
 
   it('serves /board/ from the static board page asset', async () => {
     const response = await app.fetch(new Request('http://localhost/board/'), createEnv());
+    const html = await response.text();
 
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toContain('text/html');
+    expect(html).toContain('BugDrop Board');
+  });
+
+  it('embeds the live first-party board in the static page without dogfood framing', () => {
+    expect(boardLandingHtml).toContain('id="live-demo"');
+    expect(boardLandingHtml).toContain('Try the embedded board.');
+    expect(boardLandingHtml).toContain('id="bugdrop-board-demo"');
+    expect(boardLandingHtml).toContain('id="bugdrop-board-demo-config"');
+    expect(boardLandingHtml).toContain('src="https://board.bugdrop.dev/board.js"');
+    expect(boardLandingHtml).toContain(
+      'data-board-id="board_mean_weasel_bugdrop_board_production_dogfood"'
+    );
+    expect(boardLandingHtml).toContain('data-api-url="https://board.bugdrop.dev"');
+    expect(boardLandingHtml).toContain('data-token-endpoint="/api/bugdrop-board-token?viewer=a"');
+    expect(boardLandingHtml).toContain('data-mount-selector="#bugdrop-board-demo"');
+    expect(boardLandingHtml).toContain('data-config-selector="#bugdrop-board-demo-config"');
+    expect(boardLandingHtml).toContain('"layout": "kanban"');
+    expect(boardLandingHtml).toContain('"heading": "Feature requests"');
+    expect(boardLandingHtml).toContain('"submitLabel": "Add idea"');
+    expect(boardLandingHtml).not.toContain('Northstar');
+    expect(boardLandingHtml).not.toContain('Open the dogfood board');
   });
 
   it('passes through board gallery assets', async () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -36,7 +36,7 @@ preview_id = "ff8f3809037d4403befd09369a9f7e36"
 # GITHUB_APP_ID
 # GITHUB_PRIVATE_KEY
 # AUTH_TOKEN_SECRET  # Optional: set to require signed host-app auth tokens for /feedback
-# BUGDROP_BOARD_TOKEN_SECRET  # Optional: enables /board-dogfood board token signing
+# BUGDROP_BOARD_TOKEN_SECRET  # Optional: enables /board embedded demo token signing
 
 # Preview environment for live E2E tests (deployed in merge queue)
 [env.preview]


### PR DESCRIPTION
## Summary
- Embed the live BugDrop Board demo directly in the static /board landing page
- Redirect legacy /board-dogfood traffic to /board while keeping the token endpoint intact
- Remove the old Northstar/dogfood renderer path and update tests for the static asset model

## Proof
- npm test -- test/boardLanding.test.ts test/boardDogfood.test.ts
- npm run validate
- Playwright local Wrangler proof at http://127.0.0.1:8787/board?viewer=a with real board.js and mocked authenticated board reads
- Screenshots: test-results/local-board-owned-demo-page/desktop.png and test-results/local-board-owned-demo-page/mobile.png

## Burden of proof
Strongest failure mode tested: Cloudflare/Wrangler serves public/board/index.html before Worker /board route code, so a Worker-rendered demo would not appear. Verified through Wrangler local warning plus browser proof against the static asset route: mount exists, real widget shadow root renders, kanban labels and vote counts appear, no Northstar/dogfood CTA, and no horizontal overflow on desktop/mobile.