### PR TITLE
Make feedback modal draggable

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -61,6 +61,23 @@ async function getWidgetRepo(page: Page) {
   });
 }
 
+async function dragModalHeader(page: Page, deltaX: number, deltaY: number) {
+  const header = page.locator('#bugdrop-host').locator('css=.bd-header');
+  await expect(header).toBeVisible();
+
+  const headerBox = await header.boundingBox();
+  expect(headerBox).not.toBeNull();
+
+  await page.mouse.move(headerBox!.x + headerBox!.width / 2, headerBox!.y + headerBox!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(
+    headerBox!.x + headerBox!.width / 2 + deltaX,
+    headerBox!.y + headerBox!.height / 2 + deltaY,
+    { steps: 8 }
+  );
+  await page.mouse.up();
+}
+
 test.describe('Widget Loading', () => {
   test('page loads without console errors', async ({ page }) => {
     const errors: string[] = [];
@@ -353,6 +370,50 @@ test.describe('Widget Interaction', () => {
     // Modal should appear (or installation prompt if not installed)
     const modal = page.locator('#bugdrop-host').locator('css=.bd-modal');
     await expect(modal).toBeVisible({ timeout: 5000 });
+  });
+
+  test('feedback modal can be moved by dragging the header on desktop', async ({ page }) => {
+    await page.goto('/test/');
+
+    const button = page.locator('#bugdrop-host').locator('css=.bd-trigger');
+    await expect(button).toBeVisible({ timeout: 5000 });
+    await button.click();
+
+    const modal = page.locator('#bugdrop-host').locator('css=.bd-modal');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    const before = await modal.boundingBox();
+    expect(before).not.toBeNull();
+
+    await dragModalHeader(page, -90, 70);
+
+    const after = await modal.boundingBox();
+    expect(after).not.toBeNull();
+    expect(after!.x).toBeLessThan(before!.x - 50);
+    expect(after!.y).toBeGreaterThan(before!.y + 40);
+  });
+
+  test('feedback modal shows a centered drag indicator in the header', async ({ page }) => {
+    await page.goto('/test/');
+
+    const button = page.locator('#bugdrop-host').locator('css=.bd-trigger');
+    await expect(button).toBeVisible({ timeout: 5000 });
+    await button.click();
+
+    const modal = page.locator('#bugdrop-host').locator('css=.bd-modal');
+    const indicator = page.locator('#bugdrop-host').locator('css=.bd-modal-drag-indicator');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+    await expect(indicator).toBeVisible();
+
+    const modalBox = await modal.boundingBox();
+    const indicatorBox = await indicator.boundingBox();
+    expect(modalBox).not.toBeNull();
+    expect(indicatorBox).not.toBeNull();
+
+    const modalCenter = modalBox!.x + modalBox!.width / 2;
+    const indicatorCenter = indicatorBox!.x + indicatorBox!.width / 2;
+    expect(Math.abs(indicatorCenter - modalCenter)).toBeLessThanOrEqual(4);
+    expect(indicatorBox!.y).toBeLessThan(modalBox!.y + 16);
   });
 
   test('element picker handles SVG elements without errors', async ({ page }) => {

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -416,6 +416,46 @@ test.describe('Widget Interaction', () => {
     expect(indicatorBox!.y).toBeLessThan(modalBox!.y + 16);
   });
 
+  test('dragged feedback modal releases fixed sizing on mobile resize', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/test/');
+
+    const button = page.locator('#bugdrop-host').locator('css=.bd-trigger');
+    await expect(button).toBeVisible({ timeout: 5000 });
+    await button.click();
+
+    const modal = page.locator('#bugdrop-host').locator('css=.bd-modal');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    await dragModalHeader(page, -90, 70);
+    await page.setViewportSize({ width: 390, height: 720 });
+
+    const afterResize = await modal.boundingBox();
+    expect(afterResize).not.toBeNull();
+    expect(afterResize!.x).toBeGreaterThanOrEqual(0);
+    expect(afterResize!.width).toBeLessThanOrEqual(390);
+  });
+
+  test('dragged feedback modal reflows fixed sizing on narrow desktop resize', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/test/');
+
+    const button = page.locator('#bugdrop-host').locator('css=.bd-trigger');
+    await expect(button).toBeVisible({ timeout: 5000 });
+    await button.click();
+
+    const modal = page.locator('#bugdrop-host').locator('css=.bd-modal');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    await dragModalHeader(page, -90, 70);
+    await page.setViewportSize({ width: 660, height: 720 });
+
+    const afterResize = await modal.boundingBox();
+    expect(afterResize).not.toBeNull();
+    expect(afterResize!.width).toBeLessThanOrEqual(594);
+    expect(afterResize!.x + afterResize!.width).toBeLessThanOrEqual(660);
+  });
+
   test('element picker handles SVG elements without errors', async ({ page }) => {
     // Track console errors - specifically looking for className.split errors
     const errors: string[] = [];

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -10,6 +10,8 @@ import { DEFAULT_ACCENT_COLOR, getAccentHoverColor } from '../defaults';
 declare const __BUGDROP_VERSION__: string;
 
 const MODAL_VIEWPORT_MARGIN_PX = 8;
+const DISABLE_MODAL_DRAG_MEDIA_QUERY = '(hover: none), (pointer: coarse)';
+const MOBILE_MODAL_MEDIA_QUERY = '(max-width: 640px)';
 
 interface WidgetConfig {
   repo: string;
@@ -1274,7 +1276,12 @@ export function createModal(
 }
 
 function attachModalDragBehavior(overlay: HTMLElement): void {
-  if (window.matchMedia('(hover: none), (pointer: coarse)').matches) return;
+  if (
+    typeof window.matchMedia !== 'function' ||
+    window.matchMedia(DISABLE_MODAL_DRAG_MEDIA_QUERY).matches
+  ) {
+    return;
+  }
 
   const modal = overlay.querySelector<HTMLElement>('.bd-modal');
   const header = overlay.querySelector<HTMLElement>('.bd-header');
@@ -1288,9 +1295,16 @@ function attachModalDragBehavior(overlay: HTMLElement): void {
   let startLeft = 0;
   let startTop = 0;
 
-  const cleanupResize = () => {
+  let cleanupComplete = false;
+  let removalObserver: MutationObserver | null = null;
+
+  const cleanup = () => {
+    if (cleanupComplete) return;
+    cleanupComplete = true;
+    endDrag();
     window.removeEventListener('resize', handleResize);
     window.visualViewport?.removeEventListener('resize', handleResize);
+    removalObserver?.disconnect();
   };
 
   function clampPosition(left: number, top: number): { left: number; top: number } {
@@ -1318,13 +1332,35 @@ function attachModalDragBehavior(overlay: HTMLElement): void {
 
   function handleResize(): void {
     if (!overlay.isConnected) {
-      cleanupResize();
+      cleanup();
       return;
     }
 
     if (!modalEl.classList.contains('bd-modal--positioned')) return;
+    if (window.matchMedia(MOBILE_MODAL_MEDIA_QUERY).matches) {
+      resetPositionedModal();
+      return;
+    }
+
+    reflowPositionedModalWidth();
     const rect = modalEl.getBoundingClientRect();
     setModalPosition(rect.left, rect.top);
+  }
+
+  function reflowPositionedModalWidth(): void {
+    modalEl.style.removeProperty('width');
+    modalEl.style.removeProperty('max-width');
+    const rect = modalEl.getBoundingClientRect();
+    modalEl.style.width = `${rect.width}px`;
+    modalEl.style.maxWidth = 'none';
+  }
+
+  function resetPositionedModal(): void {
+    modalEl.classList.remove('bd-modal--positioned', 'bd-modal--dragging');
+    modalEl.style.removeProperty('left');
+    modalEl.style.removeProperty('top');
+    modalEl.style.removeProperty('width');
+    modalEl.style.removeProperty('max-width');
   }
 
   function endDrag(): void {
@@ -1376,6 +1412,13 @@ function attachModalDragBehavior(overlay: HTMLElement): void {
 
   window.addEventListener('resize', handleResize);
   window.visualViewport?.addEventListener('resize', handleResize);
+
+  if (overlay.parentNode) {
+    removalObserver = new MutationObserver(() => {
+      if (!overlay.isConnected) cleanup();
+    });
+    removalObserver.observe(overlay.parentNode, { childList: true });
+  }
 }
 
 export function showSuccessModal(

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -9,6 +9,8 @@ import { DEFAULT_ACCENT_COLOR, getAccentHoverColor } from '../defaults';
 
 declare const __BUGDROP_VERSION__: string;
 
+const MODAL_VIEWPORT_MARGIN_PX = 8;
+
 interface WidgetConfig {
   repo: string;
   apiUrl: string;
@@ -419,6 +421,16 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       animation: bd-slideUp var(--bd-transition-slow);
     }
 
+    .bd-modal--positioned {
+      position: fixed;
+      margin: 0;
+      animation: none;
+    }
+
+    .bd-modal--dragging {
+      user-select: none;
+    }
+
     .bd-modal--annotator {
       width: min(96vw, 1100px);
       max-width: 1100px;
@@ -426,6 +438,7 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
 
     /* Modal Header */
     .bd-header {
+      position: relative;
       padding: 16px 20px;
       border-bottom: var(--bd-border-style);
       display: flex;
@@ -433,6 +446,38 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       align-items: center;
       background: var(--bd-bg-primary);
       animation: bd-fadeIn 0.2s ease 0.05s both;
+      cursor: grab;
+      user-select: none;
+      touch-action: none;
+    }
+
+    .bd-modal-drag-indicator {
+      position: absolute;
+      top: 6px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 28px;
+      height: 10px;
+      display: grid;
+      grid-template-columns: repeat(3, 4px);
+      grid-auto-rows: 4px;
+      gap: 3px 5px;
+      justify-content: center;
+      align-content: center;
+      color: var(--bd-text-muted);
+      opacity: 0.8;
+      pointer-events: none;
+    }
+
+    .bd-modal-drag-indicator span {
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background: currentColor;
+    }
+
+    .bd-modal--dragging .bd-header {
+      cursor: grabbing;
     }
 
     .bd-title {
@@ -1005,6 +1050,11 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
         animation: bd-slideUpMobile var(--bd-transition-slow);
       }
 
+      .bd-modal--positioned {
+        position: static;
+        width: 100%;
+      }
+
       .bd-modal--annotator {
         width: calc(100% - 16px);
         max-width: calc(100% - 16px);
@@ -1121,6 +1171,16 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
         transform: scale(1);
       }
 
+      .bd-header {
+        cursor: default;
+        user-select: auto;
+        touch-action: auto;
+      }
+
+      .bd-modal-drag-indicator {
+        display: none;
+      }
+
       .bd-btn:hover {
         background: inherit;
       }
@@ -1194,6 +1254,10 @@ export function createModal(
   overlay.innerHTML = `
     <div class="${modalClasses}">
       <div class="bd-header">
+        <span class="bd-modal-drag-indicator" aria-hidden="true">
+          <span></span><span></span><span></span>
+          <span></span><span></span><span></span>
+        </span>
         <h2 class="bd-title">${escapeHtml(title)}</h2>
         <button class="bd-close">&times;</button>
       </div>
@@ -1205,7 +1269,113 @@ export function createModal(
   `;
 
   container.appendChild(overlay);
+  attachModalDragBehavior(overlay);
   return overlay;
+}
+
+function attachModalDragBehavior(overlay: HTMLElement): void {
+  if (window.matchMedia('(hover: none), (pointer: coarse)').matches) return;
+
+  const modal = overlay.querySelector<HTMLElement>('.bd-modal');
+  const header = overlay.querySelector<HTMLElement>('.bd-header');
+  if (!modal || !header) return;
+  const modalEl = modal;
+  const headerEl = header;
+
+  let pointerId: number | null = null;
+  let startPointerX = 0;
+  let startPointerY = 0;
+  let startLeft = 0;
+  let startTop = 0;
+
+  const cleanupResize = () => {
+    window.removeEventListener('resize', handleResize);
+    window.visualViewport?.removeEventListener('resize', handleResize);
+  };
+
+  function clampPosition(left: number, top: number): { left: number; top: number } {
+    const rect = modalEl.getBoundingClientRect();
+    const maxLeft = Math.max(
+      MODAL_VIEWPORT_MARGIN_PX,
+      window.innerWidth - rect.width - MODAL_VIEWPORT_MARGIN_PX
+    );
+    const maxTop = Math.max(
+      MODAL_VIEWPORT_MARGIN_PX,
+      window.innerHeight - rect.height - MODAL_VIEWPORT_MARGIN_PX
+    );
+
+    return {
+      left: Math.min(Math.max(left, MODAL_VIEWPORT_MARGIN_PX), maxLeft),
+      top: Math.min(Math.max(top, MODAL_VIEWPORT_MARGIN_PX), maxTop),
+    };
+  }
+
+  function setModalPosition(left: number, top: number): void {
+    const position = clampPosition(left, top);
+    modalEl.style.left = `${position.left}px`;
+    modalEl.style.top = `${position.top}px`;
+  }
+
+  function handleResize(): void {
+    if (!overlay.isConnected) {
+      cleanupResize();
+      return;
+    }
+
+    if (!modalEl.classList.contains('bd-modal--positioned')) return;
+    const rect = modalEl.getBoundingClientRect();
+    setModalPosition(rect.left, rect.top);
+  }
+
+  function endDrag(): void {
+    if (pointerId === null) return;
+    pointerId = null;
+    modalEl.classList.remove('bd-modal--dragging');
+    window.removeEventListener('pointermove', handlePointerMove);
+    window.removeEventListener('pointerup', handlePointerUp);
+    window.removeEventListener('pointercancel', handlePointerCancel);
+  }
+
+  function handlePointerMove(e: PointerEvent): void {
+    if (pointerId !== e.pointerId) return;
+    setModalPosition(startLeft + e.clientX - startPointerX, startTop + e.clientY - startPointerY);
+  }
+
+  function handlePointerUp(e: PointerEvent): void {
+    if (pointerId !== e.pointerId) return;
+    endDrag();
+  }
+
+  function handlePointerCancel(e: PointerEvent): void {
+    if (pointerId !== e.pointerId) return;
+    endDrag();
+  }
+
+  headerEl.addEventListener('pointerdown', e => {
+    if ((e.target as HTMLElement).closest('button, a, input, textarea, select, label')) return;
+
+    e.preventDefault();
+    const rect = modalEl.getBoundingClientRect();
+
+    pointerId = e.pointerId;
+    startPointerX = e.clientX;
+    startPointerY = e.clientY;
+    startLeft = rect.left;
+    startTop = rect.top;
+
+    modalEl.classList.add('bd-modal--positioned', 'bd-modal--dragging');
+    modalEl.style.width = `${rect.width}px`;
+    modalEl.style.maxWidth = 'none';
+    setModalPosition(startLeft, startTop);
+
+    headerEl.setPointerCapture(e.pointerId);
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointercancel', handlePointerCancel);
+  });
+
+  window.addEventListener('resize', handleResize);
+  window.visualViewport?.addEventListener('resize', handleResize);
 }
 
 export function showSuccessModal(

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -1,6 +1,14 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from 'vitest';
-import { injectStyles } from '../src/widget/ui';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createModal, injectStyles } from '../src/widget/ui';
+
+const originalMatchMedia = window.matchMedia;
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+  vi.restoreAllMocks();
+  document.body.innerHTML = '';
+});
 
 describe('widget UI styles', () => {
   it('defines the default border style where the border color is available', () => {
@@ -22,5 +30,29 @@ describe('widget UI styles', () => {
     expect(rootBlock).toContain(
       '--bd-border-style: var(--bd-border-width) solid var(--bd-border);'
     );
+  });
+
+  it('opens modals when matchMedia is unavailable', () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    delete (window as Partial<Window>).matchMedia;
+
+    expect(() => createModal(root, 'Feedback', '<p>Body</p>')).not.toThrow();
+    expect(root.querySelector('.bd-modal')).not.toBeNull();
+  });
+
+  it('cleans up modal resize listeners when the modal is removed', async () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as unknown as typeof matchMedia;
+    const addListener = vi.spyOn(window, 'addEventListener');
+    const removeListener = vi.spyOn(window, 'removeEventListener');
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+
+    const modal = createModal(root, 'Feedback', '<p>Body</p>');
+    modal.remove();
+    await new Promise(resolve => window.setTimeout(resolve, 0));
+
+    expect(addListener).toHaveBeenCalledWith('resize', expect.any(Function));
+    expect(removeListener).toHaveBeenCalledWith('resize', expect.any(Function));
   });
 });


### PR DESCRIPTION
Closes #213

## What changed

This makes BugDrop modals draggable on desktop by using the modal header as the drag surface and adding a small centered dot indicator so the affordance is visible. The modal is clamped inside the viewport, while touch/mobile behavior remains unchanged.

## Why this shape

Detailed feedback often depends on seeing the page content behind the form. Keeping the modal open while it can be moved away avoids forcing users to close or cancel their partially written feedback just to check the visual detail they are reporting.

The drag behavior is attached to the shared modal factory rather than only the feedback form, so install prompts, success/error states, and screenshot-related dialogs behave consistently. The behavior is disabled for coarse-pointer/touch contexts because dragging a modal competes with normal mobile scrolling and form interactions.

## Test plan

- `npm run validate` passed: lint, formatting, type checks, and 299 unit tests.
- `npx playwright test --project=chromium` passed: 208 local Chromium browser tests.
- `npm run test:e2e` was also run as the full configured suite. The local Chromium portion passed, but the live/deployed-preview section failed because the live preview page did not render the BugDrop widget, and Firefox/WebKit live checks could not start because those Playwright browser binaries are not installed locally.
