### PR TITLE
Prevent duplicate feedback flows from rapid clicks

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -355,6 +355,40 @@ test.describe('Widget Interaction', () => {
     await expect(modal).toBeVisible({ timeout: 5000 });
   });
 
+  test('rapid feedback button clicks during startup open one modal', async ({ page }) => {
+    await page.route('**/api/check**', async route => {
+      await page.waitForTimeout(500);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/');
+    await page.evaluate(() =>
+      localStorage.removeItem('bugdrop_welcomed_mean-weasel/bugdrop-widget-test')
+    );
+
+    const button = page.locator('#bugdrop-host').locator('css=.bd-trigger');
+    await expect(button).toBeVisible({ timeout: 5000 });
+
+    await button.evaluate(trigger => {
+      if (!(trigger instanceof HTMLElement)) {
+        throw new Error('BugDrop trigger not found');
+      }
+      trigger.click();
+      trigger.click();
+      trigger.click();
+    });
+
+    const modal = page.locator('#bugdrop-host').locator('css=.bd-modal');
+    await expect(modal).toHaveCount(1, { timeout: 5000 });
+    await expect(page.locator('#bugdrop-host').locator('css=.bd-title')).toHaveText(
+      'Share Your Feedback'
+    );
+  });
+
   test('element picker handles SVG elements without errors', async ({ page }) => {
     // Track console errors - specifically looking for className.split errors
     const errors: string[] = [];

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -1008,6 +1008,10 @@ async function openFeedbackFlow(
   config: WidgetConfig,
   opts?: { skipWelcome?: boolean }
 ) {
+  if (_isModalOpen) {
+    return;
+  }
+
   // Mark modal as open
   _isModalOpen = true;
 


### PR DESCRIPTION
Closes #215

## What changed
BugDrop now ignores attempts to start a new feedback flow while one is already opening or open. The regression test delays the installation check and rapidly clicks the floating feedback button to prove only one dialog appears.

## Why this shape
The public `BugDrop.open()` API already avoided duplicate flows by checking the shared open state before starting. The floating button called the flow directly, so the fix moves that protection into the flow entry point itself. That keeps button clicks, API calls, and any future internal callers aligned without adding separate button-only debounce state.

---

## Test plan
- `npx playwright test e2e/widget.spec.ts --project=chromium --grep "rapid feedback button clicks during startup open one modal"` failed before the fix with 3 dialogs, then passed after the fix.
- `npx playwright test e2e/widget.spec.ts --project=chromium --grep "BugDrop\\.open\\(\\)|BugDrop\\.isOpen\\(\\)|rapid feedback button clicks during startup open one modal"` passed: 6 tests.
- `npm run validate` passed: lint, formatting, type checks, and 299 unit tests.
- `npx playwright test --project=chromium` first exposed the local `.dev.vars` environment was set to `production`; after temporarily restoring `ENVIRONMENT=development` for the test run, it passed: 207 tests. `.dev.vars` was restored afterward.
