### PR TITLE
fix: support hosted board dogfood claims

### DIFF
--- a/src/lib/boardDogfood.ts
+++ b/src/lib/boardDogfood.ts
@@ -7,12 +7,16 @@ const TOKEN_TTL_SECONDS = 300;
 
 interface BoardDogfoodConfig {
   boardId: string;
+  tenantId?: string;
+  appId?: string;
   tokenAudience: string;
   tokenIssuer: string;
 }
 
 interface BoardTokenClaims {
   boardId: string;
+  tenantId?: string;
+  appId?: string;
   externalUserId: string;
   displayName: string;
   exp: number;
@@ -30,6 +34,8 @@ export async function createBoardDogfoodToken(env: Env, rawViewer: string | null
   const config = dogfoodConfig(env);
   const claims: BoardTokenClaims = {
     boardId: config.boardId,
+    ...(config.tenantId ? { tenantId: config.tenantId } : {}),
+    ...(config.appId ? { appId: config.appId } : {}),
     externalUserId: `bugdrop-dev-dogfood-${viewer}`,
     displayName: `BugDrop Demo ${viewer.toUpperCase()}`,
     exp: Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS,
@@ -44,6 +50,8 @@ export async function createBoardDogfoodToken(env: Env, rawViewer: string | null
 function dogfoodConfig(env: Env): BoardDogfoodConfig {
   return {
     boardId: envValue(env.BUGDROP_BOARD_ID) ?? DEFAULT_BOARD_ID,
+    tenantId: envValue(env.BUGDROP_BOARD_TENANT_ID),
+    appId: envValue(env.BUGDROP_BOARD_APP_ID),
     tokenAudience: envValue(env.BUGDROP_BOARD_TOKEN_AUDIENCE) ?? DEFAULT_TOKEN_AUDIENCE,
     tokenIssuer: envValue(env.BUGDROP_BOARD_TOKEN_ISSUER) ?? DEFAULT_TOKEN_ISSUER,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export interface Env {
   AUTH_TOKEN_REQUIRED_FOR_CHECK?: string; // Optional gate for /check installation lookups
   BUGDROP_BOARD_TOKEN_SECRET?: string; // Optional signer secret for the /board embedded demo
   BUGDROP_BOARD_ID?: string; // Optional override for the demo board id
+  BUGDROP_BOARD_TENANT_ID?: string; // Optional hosted beta tenant claim for the demo board token
+  BUGDROP_BOARD_APP_ID?: string; // Optional hosted beta app claim for the demo board token
   BUGDROP_BOARD_TOKEN_AUDIENCE?: string; // Optional override for board token audience
   BUGDROP_BOARD_TOKEN_ISSUER?: string; // Optional override for board token issuer
 

--- a/test/boardDogfood.test.ts
+++ b/test/boardDogfood.test.ts
@@ -52,8 +52,30 @@ describe('BugDrop Board dogfood host', () => {
       aud: 'bugdrop-board',
       iss: 'bugdrop-board-production-host',
     });
+    expect(claims).not.toHaveProperty('tenantId');
+    expect(claims).not.toHaveProperty('appId');
     expect(claims.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
     expect(claims.exp).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + 300);
+  });
+
+  it('adds hosted tenant and app claims when configured', async () => {
+    const response = await app.fetch(
+      new Request('https://bugdrop.dev/api/bugdrop-board-token?viewer=a'),
+      {
+        ...env,
+        BUGDROP_BOARD_TENANT_ID: 'tenant_mean_weasel',
+        BUGDROP_BOARD_APP_ID: 'app_mean_weasel_bugdrop_dogfood',
+      }
+    );
+    const body = (await response.json()) as { token: string };
+    const claims = await verifyBoardToken(body.token, boardSecret);
+
+    expect(response.status).toBe(200);
+    expect(claims).toMatchObject({
+      boardId,
+      tenantId: 'tenant_mean_weasel',
+      appId: 'app_mean_weasel_bugdrop_dogfood',
+    });
   });
 
   it('rejects token requests when the board signing secret is missing', async () => {
@@ -71,6 +93,8 @@ describe('BugDrop Board dogfood host', () => {
 
 interface BoardTokenClaims {
   boardId: string;
+  tenantId?: string;
+  appId?: string;
   externalUserId: string;
   displayName: string;
   exp: number;


### PR DESCRIPTION
## Summary
- add optional `BUGDROP_BOARD_TENANT_ID` and `BUGDROP_BOARD_APP_ID` env vars for the BugDrop Board demo token endpoint
- include `tenantId` and `appId` claims only when those vars are configured
- keep the current self-host/production dogfood default token shape unchanged

## Proof
- red test first: hosted claim test failed before implementation because the claims were absent
- `npx vitest run test/boardDogfood.test.ts`
- `npm run validate`
- `make check`

## Notes
No deploy, credential, or secret changes. This only prepares the host token endpoint for a future hosted HMAC dogfood provisioning.