### PR TITLE
Configure hosted board demo claims

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,6 +20,8 @@ ENVIRONMENT = "development"
 ALLOWED_ORIGINS = "*"  # "*" for dev, comma-separated URLs for production
 GITHUB_APP_NAME = "neonwatty-bugdrop"  # Your GitHub App's URL slug
 MAX_SCREENSHOT_SIZE_MB = "5"  # Maximum screenshot size in MB
+BUGDROP_BOARD_TENANT_ID = "tenant_mean_weasel"
+BUGDROP_BOARD_APP_ID = "app_mean_weasel_bugdrop_dogfood"
 
 # Production configuration example (uncomment and customize for deployment)
 # [env.production.vars]


### PR DESCRIPTION
## Summary
- Add the hosted BugDrop Board tenant/app IDs to the BugDrop Worker config so /api/bugdrop-board-token emits hosted beta claims for the dogfood board
- Keep the change limited to non-secret config; no credentials are included

## Verification
- `npm run test -- test/boardDogfood.test.ts`
- `npm run validate`

## Rollout note
This is intentionally sequenced before deploying the latest Board Worker hosted-auth behavior. Extra tenant/app claims remain backward-compatible with the currently deployed legacy board-token path, while the hosted Board Worker will require them after deploy.