### PR TITLE
Include optional console logs in feedback issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
 | `data-label`                    | Any string                                           | `Feedback`       |
 | `data-category-labels`          | JSON mapping for self-hosted category labels         | built-in labels  |
 | `data-button`                   | `true`, `false`                                      | `true`           |
+| `data-send-console-logs`        | `true`, `false`                                      | `false`          |
 | `data-element-context-max-area` | Viewport-area multiplier for Select Element context  | `0`              |
 
 See [full documentation](https://bugdrop.dev/docs/configuration) for all options including styling, submitter info, and dismissible button.

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -19,6 +19,7 @@ These attributes control the fundamental behavior of the widget.
 | `data-auth-token-provider` | none | Name of a global function that returns a self-hosted auth token |
 | `data-welcome` | `"Report a bug or request a feature"` | Welcome message displayed at the top of the form |
 | `data-show-issue-link` | `"public"` | Show the GitHub issue link after submission: `"public"`, `"always"`, or `"never"` |
+| `data-send-console-logs` | `"false"` | Start the "Send Console Logs" checkbox checked |
 
 ### Basic Example
 
@@ -110,6 +111,21 @@ Control whether the feedback form collects the submitter's name and email addres
 ```
 
 When submitter information is collected, it is included in the GitHub Issue body so your team knows who reported the issue.
+
+## Console Logs
+
+BugDrop can include recent browser console output in the GitHub Issue. The feedback form shows a "Send Console Logs" checkbox. It is unchecked by default.
+
+```html
+<!-- Start with Send Console Logs checked -->
+<script
+  src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="owner/repo"
+  data-send-console-logs="true"
+></script>
+```
+
+When the checkbox is checked, the issue body includes a collapsed console-log section. BugDrop limits the amount of output and redacts obvious secret-like values such as passwords, tokens, cookies, authorization headers, and long random strings.
 
 ## Dismissible Button
 

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -409,7 +409,11 @@ test.describe('Widget Interaction', () => {
 
     await page.evaluate(() => {
       console.log('customer dashboard failed to save');
-      console.warn('retry count token=abc123456789abcdefghijklmnopqrstuvwxyz');
+      console.warn('retry count', {
+        token: 'abc123456789abcdefghijklmnopqrstuvwxyz',
+        password: 'hunter2',
+        cookie: 'sid=short',
+      });
     });
 
     await host.locator('css=.bd-trigger').click();
@@ -421,7 +425,8 @@ test.describe('Widget Interaction', () => {
 
     await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
     expect(payloads).toHaveLength(1);
-    expect(payloads[0].consoleLogs).toEqual(
+    const logs = payloads[0].consoleLogs;
+    expect(logs).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           level: 'log',
@@ -433,6 +438,9 @@ test.describe('Widget Interaction', () => {
         }),
       ])
     );
+    expect(JSON.stringify(logs)).not.toContain('abc123456789abcdefghijklmnopqrstuvwxyz');
+    expect(JSON.stringify(logs)).not.toContain('hunter2');
+    expect(JSON.stringify(logs)).not.toContain('sid=short');
   });
 
   test('element picker handles SVG elements without errors', async ({ page }) => {

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -404,12 +404,14 @@ test.describe('Widget Interaction', () => {
     });
 
     await page.goto('/test/');
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').waitFor({ state: 'visible', timeout: 5000 });
+
     await page.evaluate(() => {
       console.log('customer dashboard failed to save');
       console.warn('retry count token=abc123456789abcdefghijklmnopqrstuvwxyz');
     });
 
-    const host = page.locator('#bugdrop-host');
     await host.locator('css=.bd-trigger').click();
     await host.locator('css=[data-action="continue"]').click();
     await host.locator('css=#title').fill('Console log test');

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -355,6 +355,84 @@ test.describe('Widget Interaction', () => {
     await expect(modal).toBeVisible({ timeout: 5000 });
   });
 
+  test('console logs checkbox is unchecked by default', async ({ page }) => {
+    await page.route('**/api/check**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/');
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+
+    const consoleLogsCheckbox = host.locator('css=#send-console-logs');
+    await expect(consoleLogsCheckbox).toBeVisible({ timeout: 5000 });
+    await expect(consoleLogsCheckbox).not.toBeChecked();
+  });
+
+  test('console logs checkbox can default to checked from script settings', async ({ page }) => {
+    await page.route('**/api/check**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/?sendConsoleLogs=true');
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+
+    await expect(host.locator('css=#send-console-logs')).toBeChecked({ timeout: 5000 });
+  });
+
+  test('checked console logs option submits captured browser logs', async ({ page }) => {
+    const payloads = await trackFeedbackPayloads(page);
+    await page.route('**/api/check**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/');
+    await page.evaluate(() => {
+      console.log('customer dashboard failed to save');
+      console.warn('retry count token=abc123456789abcdefghijklmnopqrstuvwxyz');
+    });
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+    await host.locator('css=#title').fill('Console log test');
+    await host.locator('css=#include-screenshot').uncheck();
+    await host.locator('css=#send-console-logs').check();
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].consoleLogs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: 'log',
+          message: expect.stringContaining('customer dashboard failed to save'),
+        }),
+        expect.objectContaining({
+          level: 'warn',
+          message: expect.stringContaining('[redacted]'),
+        }),
+      ])
+    );
+  });
+
   test('element picker handles SVG elements without errors', async ({ page }) => {
     // Track console errors - specifically looking for className.split errors
     const errors: string[] = [];

--- a/public/test/index.html
+++ b/public/test/index.html
@@ -609,6 +609,7 @@
         requireEmail: 'requireEmail',
         categoryLabels: 'categoryLabels',
         showIssueLink: 'showIssueLink',
+        sendConsoleLogs: 'sendConsoleLogs',
       },
     });
   </script>

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,6 +1,7 @@
 import { Hono, type Context, type Next } from 'hono';
 import { cors } from 'hono/cors';
 import type { ConsoleLogEntry, Env, FeedbackCategory, FeedbackPayload } from '../types';
+import { redactConsoleLogMessage } from '../widget/console-log-redaction';
 import {
   getInstallationToken,
   createIssue,
@@ -30,10 +31,6 @@ const MAX_LABELS_PER_CATEGORY = 5;
 const MAX_CONSOLE_LOG_ENTRIES = 50;
 const MAX_CONSOLE_LOG_BODY_CHARS = 12_000;
 const MAX_CONSOLE_LOG_MESSAGE_CHARS = 1_000;
-const SECRET_WORD_PATTERN =
-  /\b(password|passwd|pwd|token|api[_-]?key|secret|authorization|auth|cookie)\b(\s*[:=]\s*)(["']?)[^"',\s}&]+/gi;
-const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
-const LONG_SECRET_PATTERN = /\b[A-Za-z0-9+/_=-]{32,}\b/g;
 // GitHub enforces a 50-char limit on label names; keep validation in lockstep
 // so over-long configured labels surface as a clear local warning rather than
 // going out, getting rejected, and triggering the GitHub-error fallback path.
@@ -781,13 +778,6 @@ function formatConsoleLogSource(entry: ConsoleLogEntry): string {
 
 function isConsoleLogLevel(value: unknown): value is ConsoleLogEntry['level'] {
   return value === 'log' || value === 'info' || value === 'warn' || value === 'error';
-}
-
-function redactConsoleLogMessage(value: string): string {
-  return value
-    .replace(BEARER_PATTERN, 'Bearer [redacted]')
-    .replace(SECRET_WORD_PATTERN, '$1$2$3[redacted]')
-    .replace(LONG_SECRET_PATTERN, '[redacted]');
 }
 
 function formatFencedBlock(value: string): string {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,6 +1,6 @@
 import { Hono, type Context, type Next } from 'hono';
 import { cors } from 'hono/cors';
-import type { Env, FeedbackCategory, FeedbackPayload } from '../types';
+import type { ConsoleLogEntry, Env, FeedbackCategory, FeedbackPayload } from '../types';
 import {
   getInstallationToken,
   createIssue,
@@ -27,6 +27,13 @@ const DEFAULT_CATEGORY_LABELS: Record<FeedbackCategory, string[]> = {
 
 const CATEGORY_KEYS: FeedbackCategory[] = ['bug', 'feature', 'question'];
 const MAX_LABELS_PER_CATEGORY = 5;
+const MAX_CONSOLE_LOG_ENTRIES = 50;
+const MAX_CONSOLE_LOG_BODY_CHARS = 12_000;
+const MAX_CONSOLE_LOG_MESSAGE_CHARS = 1_000;
+const SECRET_WORD_PATTERN =
+  /\b(password|passwd|pwd|token|api[_-]?key|secret|authorization|auth|cookie)\b(\s*[:=]\s*)(["']?)[^"',\s}&]+/gi;
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const LONG_SECRET_PATTERN = /\b[A-Za-z0-9+/_=-]{32,}\b/g;
 // GitHub enforces a 50-char limit on label names; keep validation in lockstep
 // so over-long configured labels surface as a clear local warning rather than
 // going out, getting rejected, and triggering the GitHub-error fallback path.
@@ -629,6 +636,12 @@ function formatIssueBody(
     sections.push('');
   }
 
+  const consoleLogsSection = formatConsoleLogsSection(payload.consoleLogs);
+  if (consoleLogsSection) {
+    sections.push(consoleLogsSection);
+    sections.push('');
+  }
+
   // System Info
   sections.push('<details>');
   sections.push('<summary>System Info</summary>');
@@ -711,6 +724,77 @@ function formatMarkdownInlineCode(value: string): string {
   const longestBacktickRun = Math.max(...inlineSafeValue.match(/`+/g)!.map(match => match.length));
   const fence = '`'.repeat(longestBacktickRun + 1);
   return `${fence} ${inlineSafeValue} ${fence}`;
+}
+
+function formatConsoleLogsSection(entries: ConsoleLogEntry[] | undefined): string | null {
+  if (!Array.isArray(entries) || entries.length === 0) return null;
+
+  const logs = entries.slice(0, MAX_CONSOLE_LOG_ENTRIES).map(formatConsoleLogEntry).filter(Boolean);
+  if (logs.length === 0) return null;
+
+  if (entries.length > MAX_CONSOLE_LOG_ENTRIES) {
+    logs.push(
+      `Console logs truncated: showing ${MAX_CONSOLE_LOG_ENTRIES} of ${entries.length} entries.`
+    );
+  }
+
+  let body = logs.join('\n');
+  if (body.length > MAX_CONSOLE_LOG_BODY_CHARS) {
+    body = `${body.slice(0, MAX_CONSOLE_LOG_BODY_CHARS)}\nConsole logs truncated because the output was too large.`;
+  }
+
+  return [
+    '<details>',
+    '<summary>Console Logs</summary>',
+    '',
+    formatFencedBlock(body),
+    '</details>',
+  ].join('\n');
+}
+
+function formatConsoleLogEntry(entry: ConsoleLogEntry): string {
+  if (!entry || typeof entry.message !== 'string') return '';
+
+  const level = isConsoleLogLevel(entry.level) ? entry.level : 'log';
+  const timestamp =
+    typeof entry.timestamp === 'string' ? normalizeMarkdownValue(entry.timestamp) : '';
+  const source = formatConsoleLogSource(entry);
+  const message = redactConsoleLogMessage(normalizeMarkdownValue(entry.message)).slice(
+    0,
+    MAX_CONSOLE_LOG_MESSAGE_CHARS
+  );
+  const prefix = timestamp ? `${timestamp} [${level}]` : `[${level}]`;
+  return `${prefix} ${message}${source}`;
+}
+
+function formatConsoleLogSource(entry: ConsoleLogEntry): string {
+  if (!entry.sourceUrl) return '';
+
+  const source = redactConsoleLogMessage(normalizeMarkdownValue(entry.sourceUrl));
+  const line = Number.isFinite(entry.lineNumber) ? entry.lineNumber : undefined;
+  const column = Number.isFinite(entry.columnNumber) ? entry.columnNumber : undefined;
+
+  if (line !== undefined && column !== undefined) return ` (${source}:${line}:${column})`;
+  if (line !== undefined) return ` (${source}:${line})`;
+  return ` (${source})`;
+}
+
+function isConsoleLogLevel(value: unknown): value is ConsoleLogEntry['level'] {
+  return value === 'log' || value === 'info' || value === 'warn' || value === 'error';
+}
+
+function redactConsoleLogMessage(value: string): string {
+  return value
+    .replace(BEARER_PATTERN, 'Bearer [redacted]')
+    .replace(SECRET_WORD_PATTERN, '$1$2$3[redacted]')
+    .replace(LONG_SECRET_PATTERN, '[redacted]');
+}
+
+function formatFencedBlock(value: string): string {
+  const matches = value.match(/`+/g);
+  const longestBacktickRun = matches ? Math.max(...matches.map(match => match.length)) : 0;
+  const fence = '`'.repeat(Math.max(3, longestBacktickRun + 1));
+  return `${fence}\n${value}\n${fence}`;
 }
 
 function normalizeMarkdownValue(value: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface FeedbackPayload {
   categoryLabels?: CategoryLabelConfig; // Optional self-host category-to-GitHub-label mapping
   screenshot?: string; // base64 data URL
   annotations?: string; // base64 annotated image
+  consoleLogs?: ConsoleLogEntry[];
   submitter?: {
     // Optional submitter info (configured per widget)
     name?: string;
@@ -55,6 +56,15 @@ export interface FeedbackPayload {
     devicePixelRatio?: number;
     language?: string;
   };
+}
+
+export interface ConsoleLogEntry {
+  level: 'log' | 'info' | 'warn' | 'error';
+  message: string;
+  timestamp: string;
+  sourceUrl?: string;
+  lineNumber?: number;
+  columnNumber?: number;
 }
 
 export interface GitHubIssue {

--- a/src/widget/console-log-redaction.ts
+++ b/src/widget/console-log-redaction.ts
@@ -1,0 +1,29 @@
+const SECRET_KEY_PATTERN = String.raw`(?:"|')?\b(?:password|passwd|pwd|token|api[_-]?key|secret|authorization|auth|cookie)\b(?:"|')?`;
+const QUOTED_SECRET_PATTERN = new RegExp(
+  String.raw`(${SECRET_KEY_PATTERN}\s*[:=]\s*)(["'])(?!Bearer\b)(?:\\[\s\S]|(?!\2)[^\\])*?\2`,
+  'gi'
+);
+const UNTERMINATED_QUOTED_SECRET_PATTERN = new RegExp(
+  String.raw`(${SECRET_KEY_PATTERN}\s*[:=]\s*)(["'])(?!Bearer\b)(?:\\[^\r\n]|(?!\2)[^\\\r\n])*(?=\r?\n|$)`,
+  'gi'
+);
+const STRUCTURED_SECRET_PATTERN = new RegExp(
+  String.raw`(${SECRET_KEY_PATTERN}\s*[:=]\s*)(?:\[[^\]\r\n]*\]|\{[^\}\r\n]*\})`,
+  'gi'
+);
+const UNQUOTED_SECRET_PATTERN = new RegExp(
+  String.raw`(${SECRET_KEY_PATTERN}\s*[:=]\s*)(?!Bearer\b)[^"',\s}&]+`,
+  'gi'
+);
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const LONG_SECRET_PATTERN = /\b[A-Za-z0-9+/_=-]{32,}\b/g;
+
+export function redactConsoleLogMessage(value: string): string {
+  return value
+    .replace(BEARER_PATTERN, 'Bearer [redacted]')
+    .replace(STRUCTURED_SECRET_PATTERN, '$1[redacted]')
+    .replace(QUOTED_SECRET_PATTERN, '$1$2[redacted]$2')
+    .replace(UNTERMINATED_QUOTED_SECRET_PATTERN, '$1$2[redacted]')
+    .replace(UNQUOTED_SECRET_PATTERN, '$1[redacted]')
+    .replace(LONG_SECRET_PATTERN, '[redacted]');
+}

--- a/src/widget/console-logs.ts
+++ b/src/widget/console-logs.ts
@@ -1,3 +1,5 @@
+import { redactConsoleLogMessage } from './console-log-redaction';
+
 type ConsoleLogLevel = 'log' | 'info' | 'warn' | 'error';
 
 export interface ConsoleLogEntry {
@@ -11,10 +13,6 @@ export interface ConsoleLogEntry {
 
 const MAX_ENTRIES = 50;
 const MAX_MESSAGE_LENGTH = 1000;
-const SECRET_WORD_PATTERN =
-  /\b(password|passwd|pwd|token|api[_-]?key|secret|authorization|auth|cookie)\b(\s*[:=]\s*)(["']?)[^"',\s}&]+/gi;
-const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
-const LONG_SECRET_PATTERN = /\b[A-Za-z0-9+/_=-]{32,}\b/g;
 
 const capturedLogs: ConsoleLogEntry[] = [];
 let hasStarted = false;
@@ -89,13 +87,6 @@ function formatConsoleValue(value: unknown): string {
   } catch {
     return String(value);
   }
-}
-
-function redactConsoleLogMessage(value: string): string {
-  return value
-    .replace(BEARER_PATTERN, 'Bearer [redacted]')
-    .replace(SECRET_WORD_PATTERN, '$1$2$3[redacted]')
-    .replace(LONG_SECRET_PATTERN, '[redacted]');
 }
 
 function getConsoleSource(): Pick<ConsoleLogEntry, 'sourceUrl' | 'lineNumber' | 'columnNumber'> {

--- a/src/widget/console-logs.ts
+++ b/src/widget/console-logs.ts
@@ -1,4 +1,4 @@
-export type ConsoleLogLevel = 'log' | 'info' | 'warn' | 'error';
+type ConsoleLogLevel = 'log' | 'info' | 'warn' | 'error';
 
 export interface ConsoleLogEntry {
   level: ConsoleLogLevel;

--- a/src/widget/console-logs.ts
+++ b/src/widget/console-logs.ts
@@ -1,0 +1,117 @@
+export type ConsoleLogLevel = 'log' | 'info' | 'warn' | 'error';
+
+export interface ConsoleLogEntry {
+  level: ConsoleLogLevel;
+  message: string;
+  timestamp: string;
+  sourceUrl?: string;
+  lineNumber?: number;
+  columnNumber?: number;
+}
+
+const MAX_ENTRIES = 50;
+const MAX_MESSAGE_LENGTH = 1000;
+const SECRET_WORD_PATTERN =
+  /\b(password|passwd|pwd|token|api[_-]?key|secret|authorization|auth|cookie)\b(\s*[:=]\s*)(["']?)[^"',\s}&]+/gi;
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const LONG_SECRET_PATTERN = /\b[A-Za-z0-9+/_=-]{32,}\b/g;
+
+const capturedLogs: ConsoleLogEntry[] = [];
+let hasStarted = false;
+
+export function startConsoleLogCapture(): void {
+  if (hasStarted || typeof window === 'undefined' || typeof console === 'undefined') return;
+  hasStarted = true;
+
+  patchConsoleMethod('log');
+  patchConsoleMethod('info');
+  patchConsoleMethod('warn');
+  patchConsoleMethod('error');
+
+  window.addEventListener('error', event => {
+    addLog({
+      level: 'error',
+      message: event.message || 'Unhandled error',
+      timestamp: new Date().toISOString(),
+      sourceUrl: event.filename || undefined,
+      lineNumber: event.lineno || undefined,
+      columnNumber: event.colno || undefined,
+    });
+  });
+
+  window.addEventListener('unhandledrejection', event => {
+    addLog({
+      level: 'error',
+      message: `Unhandled promise rejection: ${formatConsoleValue(event.reason)}`,
+      timestamp: new Date().toISOString(),
+    });
+  });
+}
+
+export function getConsoleLogSnapshot(): ConsoleLogEntry[] {
+  return capturedLogs.map(entry => ({ ...entry }));
+}
+
+function patchConsoleMethod(level: ConsoleLogLevel): void {
+  const original = console[level];
+  if (typeof original !== 'function') return;
+
+  console[level] = (...args: unknown[]) => {
+    addLog({
+      level,
+      message: args.map(formatConsoleValue).join(' '),
+      timestamp: new Date().toISOString(),
+      ...getConsoleSource(),
+    });
+    original.apply(console, args);
+  };
+}
+
+function addLog(entry: ConsoleLogEntry): void {
+  capturedLogs.push({
+    ...entry,
+    message: redactConsoleLogMessage(entry.message).slice(0, MAX_MESSAGE_LENGTH),
+  });
+  while (capturedLogs.length > MAX_ENTRIES) {
+    capturedLogs.shift();
+  }
+}
+
+function formatConsoleValue(value: unknown): string {
+  if (value instanceof Error) {
+    return value.stack || value.message;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function redactConsoleLogMessage(value: string): string {
+  return value
+    .replace(BEARER_PATTERN, 'Bearer [redacted]')
+    .replace(SECRET_WORD_PATTERN, '$1$2$3[redacted]')
+    .replace(LONG_SECRET_PATTERN, '[redacted]');
+}
+
+function getConsoleSource(): Pick<ConsoleLogEntry, 'sourceUrl' | 'lineNumber' | 'columnNumber'> {
+  const stack = new Error().stack;
+  if (!stack) return {};
+
+  for (const line of stack.split('\n').slice(2)) {
+    if (line.includes('console-logs')) continue;
+    const match = line.match(/\(?((?:https?:|file:|\/)[^():]+):(\d+):(\d+)\)?$/);
+    if (!match) continue;
+    return {
+      sourceUrl: match[1],
+      lineNumber: Number(match[2]),
+      columnNumber: Number(match[3]),
+    };
+  }
+
+  return {};
+}

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -24,6 +24,11 @@ import {
   resolveAuthTokenProvider,
   type BugDropAuthTokenProvider,
 } from './auth-token';
+import {
+  getConsoleLogSnapshot,
+  startConsoleLogCapture,
+  type ConsoleLogEntry,
+} from './console-logs';
 import { resolveAccentColor } from '../defaults';
 
 type FeedbackCategory = 'bug' | 'feature' | 'question';
@@ -70,6 +75,7 @@ interface WidgetConfig {
   screenshotScale?: number; // Minimum pixel ratio for captures (default: 2)
   elementContextMaxArea?: number; // Max ancestor capture area as a viewport multiplier
   issueLinkVisibility: IssueLinkVisibility;
+  sendConsoleLogs: boolean;
 }
 
 // BugDrop JavaScript API interface
@@ -98,6 +104,7 @@ interface FeedbackData {
   elementSelector: string | null;
   fullElementSelector: string | null;
   selectedElementHighlightColor: string | null;
+  sendConsoleLogs: boolean;
   name?: string;
   email?: string;
 }
@@ -440,7 +447,10 @@ const config: WidgetConfig = {
   screenshotScale,
   elementContextMaxArea,
   issueLinkVisibility,
+  sendConsoleLogs: script?.dataset.sendConsoleLogs === 'true',
 };
+
+startConsoleLogCapture();
 
 // Validate config
 if (!config.repo) {
@@ -1077,6 +1087,7 @@ async function openFeedbackFlow(
       selectedElementHighlightColor: screenshotResult.elementSelector
         ? resolveAccentColor(config.accentColor)
         : null,
+      sendConsoleLogs: formResult.sendConsoleLogs,
     });
     break;
   }
@@ -1188,6 +1199,7 @@ interface FeedbackFormResult {
   name?: string;
   email?: string;
   includeScreenshot: boolean;
+  sendConsoleLogs: boolean;
 }
 
 function showFeedbackFormWithScreenshotOption(
@@ -1249,6 +1261,7 @@ function showFeedbackFormWithScreenshotOption(
           ${nameFieldHtml}
           ${emailFieldHtml}
           ${getScreenshotFormControl(config, initialValues)}
+          ${getConsoleLogsFormControl(config, initialValues)}
           <div class="bd-actions">
             <button type="button" class="bd-btn bd-btn-secondary" data-action="cancel">Cancel</button>
             <button type="submit" class="bd-btn bd-btn-primary" id="submit-btn">${config.screenshotMode === 'auto' ? 'Submit' : 'Continue'}</button>
@@ -1265,6 +1278,7 @@ function showFeedbackFormWithScreenshotOption(
     const screenshotCheckbox = modal.querySelector(
       '#include-screenshot'
     ) as HTMLInputElement | null;
+    const consoleLogsCheckbox = modal.querySelector('#send-console-logs') as HTMLInputElement;
     const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
     const cancelBtn = modal.querySelector('[data-action="cancel"]') as HTMLElement;
 
@@ -1319,6 +1333,7 @@ function showFeedbackFormWithScreenshotOption(
         name: nameInput?.value.trim() || undefined,
         email: emailInput?.value.trim() || undefined,
         includeScreenshot,
+        sendConsoleLogs: consoleLogsCheckbox.checked,
       });
     });
 
@@ -1367,6 +1382,22 @@ function getScreenshotFormControl(
   `;
 }
 
+function getConsoleLogsFormControl(
+  config: WidgetConfig,
+  initialValues?: FeedbackFormResult | null
+): string {
+  const sendConsoleLogs = initialValues?.sendConsoleLogs ?? config.sendConsoleLogs;
+
+  return `
+    <div class="bd-form-group" style="display: flex; align-items: center; gap: 10px; margin-top: 8px;">
+      <input type="checkbox" id="send-console-logs" ${sendConsoleLogs ? 'checked' : ''} style="width: 18px; height: 18px; accent-color: var(--bd-primary); cursor: pointer;" />
+      <label for="send-console-logs" style="font-size: 0.95rem; color: var(--bd-text-secondary); cursor: pointer; user-select: none;">
+        Send Console Logs
+      </label>
+    </div>
+  `;
+}
+
 function getCategoryChecked(
   initialValues: FeedbackFormResult | null | undefined,
   category: FeedbackCategory
@@ -1394,6 +1425,9 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
     // Collect system info
     const systemInfo = getSystemInfo();
     const domNodeCount = getDomNodeCount();
+    const consoleLogs: ConsoleLogEntry[] | undefined = data.sendConsoleLogs
+      ? getConsoleLogSnapshot()
+      : undefined;
 
     const response = await fetch(`${config.apiUrl}/feedback`, {
       method: 'POST',
@@ -1408,6 +1442,7 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
         category: data.category,
         categoryLabels: config.categoryLabels,
         screenshot: data.screenshot,
+        consoleLogs,
         submitter,
         metadata: {
           url: systemInfo.url, // Redacted URL (no query params)

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1478,7 +1478,7 @@ describe('API Routes', () => {
           },
           {
             level: 'warn',
-            message: 'Retrying cart request',
+            message: '{"token":"abc123","password":"hunter2","cookie":"sid=short"}',
             timestamp: '2026-06-08T10:00:01.000Z',
           },
         ],
@@ -1495,7 +1495,12 @@ describe('API Routes', () => {
       expect(issueBody).toContain('<summary>Console Logs</summary>');
       expect(issueBody).toContain('[error] Checkout failed with token=[redacted]');
       expect(issueBody).toContain('https://example.test/app.js?token=[redacted]:12:4');
-      expect(issueBody).toContain('[warn] Retrying cart request');
+      expect(issueBody).toContain(
+        '[warn] {"token":"[redacted]","password":"[redacted]","cookie":"[redacted]"}'
+      );
+      expect(issueBody).not.toContain('abc123');
+      expect(issueBody).not.toContain('hunter2');
+      expect(issueBody).not.toContain('sid=short');
     });
 
     it('should omit full CSS path row when metadata is absent', async () => {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1458,6 +1458,46 @@ describe('API Routes', () => {
       expect(issueBody).toContain('Submitted via');
     });
 
+    it('should include redacted console logs in the issue body when submitted', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const payloadWithConsoleLogs = {
+        ...validPayload,
+        consoleLogs: [
+          {
+            level: 'error',
+            message: 'Checkout failed with token=[redacted]',
+            sourceUrl: 'https://example.test/app.js?token=abc123456789abcdefghijklmnopqrstuvwxyz',
+            lineNumber: 12,
+            columnNumber: 4,
+            timestamp: '2026-06-08T10:00:00.000Z',
+          },
+          {
+            level: 'warn',
+            message: 'Retrying cart request',
+            timestamp: '2026-06-08T10:00:01.000Z',
+          },
+        ],
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payloadWithConsoleLogs),
+      });
+      await app.fetch(req, mockEnv);
+
+      const issueBody = mockCreateIssue.mock.calls[0][4];
+      expect(issueBody).toContain('<summary>Console Logs</summary>');
+      expect(issueBody).toContain('[error] Checkout failed with token=[redacted]');
+      expect(issueBody).toContain('https://example.test/app.js?token=[redacted]:12:4');
+      expect(issueBody).toContain('[warn] Retrying cart request');
+    });
+
     it('should omit full CSS path row when metadata is absent', async () => {
       mockGetInstallationToken.mockResolvedValue('test-token');
       mockCreateIssue.mockResolvedValue({

--- a/test/consoleLogRedaction.test.ts
+++ b/test/consoleLogRedaction.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { redactConsoleLogMessage } from '../src/widget/console-log-redaction';
+
+describe('console log redaction', () => {
+  it('redacts key/value and JSON-shaped secret fields', () => {
+    expect(redactConsoleLogMessage('token=abc123')).toBe('token=[redacted]');
+    expect(
+      redactConsoleLogMessage('{"token":"abc123","password":"hunter2","cookie":"sid=short"}')
+    ).toBe('{"token":"[redacted]","password":"[redacted]","cookie":"[redacted]"}');
+  });
+
+  it('redacts quoted secret values containing common delimiters', () => {
+    expect(redactConsoleLogMessage('{"password":"correct horse"}')).toBe(
+      '{"password":"[redacted]"}'
+    );
+    expect(redactConsoleLogMessage('{"cookie":"sid=short; theme=dark"}')).toBe(
+      '{"cookie":"[redacted]"}'
+    );
+    expect(redactConsoleLogMessage('token="abc,123&def"}')).toBe('token="[redacted]"}');
+    expect(redactConsoleLogMessage('password="abc\\"def"')).toBe('password="[redacted]"');
+  });
+
+  it('redacts structured values under secret keys', () => {
+    expect(redactConsoleLogMessage('{"password":["hunter2"]}')).toBe('{"password":[redacted]}');
+    expect(redactConsoleLogMessage('{"cookie":["sid=short"]}')).toBe('{"cookie":[redacted]}');
+    expect(redactConsoleLogMessage('retry {"password":{"value":"hunter2"}} done')).toBe(
+      'retry {"password":[redacted]} done'
+    );
+    expect(redactConsoleLogMessage('{"password":["hunter2"],"message":"kept"}')).toBe(
+      '{"password":[redacted],"message":"kept"}'
+    );
+  });
+
+  it('redacts unterminated quoted secret values', () => {
+    expect(redactConsoleLogMessage('password="hunter2')).toBe('password="[redacted]');
+    expect(redactConsoleLogMessage('token="short,secret')).toBe('token="[redacted]');
+    expect(redactConsoleLogMessage('{"password":"hunter2}')).toBe('{"password":"[redacted]');
+    expect(redactConsoleLogMessage('password="hunter2\nstack line')).toBe(
+      'password="[redacted]\nstack line'
+    );
+    expect(redactConsoleLogMessage('password="abc\\"def')).toBe('password="[redacted]');
+    expect(redactConsoleLogMessage('password="abc\\"def\nstack line')).toBe(
+      'password="[redacted]\nstack line'
+    );
+  });
+
+  it('redacts bearer tokens without damaging the authorization prefix', () => {
+    expect(redactConsoleLogMessage('Authorization: Bearer abc.def.ghi')).toBe(
+      'Authorization: Bearer [redacted]'
+    );
+  });
+});


### PR DESCRIPTION
Closes #219

## What changed

BugDrop can now include recent browser console output in feedback issues when the reporter opts in from the feedback form. The widget also supports `data-send-console-logs="true"` for teams that want that checkbox checked by default.

## Why this shape

Console output can include sensitive values, so this is not collected silently. The form keeps it as an explicit reporter-controlled checkbox, while the script setting only changes the default state. The widget and the API both apply redaction so direct API callers do not bypass the browser-side cleanup.

The issue body uses a collapsed section and bounded output. That keeps ordinary reports readable, while still giving maintainers the diagnostic context that screenshots and user-written descriptions often miss.

## Out of scope

This does not try to capture logs from before BugDrop loads. The widget can only intercept console calls after its script has initialized.

---

## Test plan

- `npm run validate` - passed: lint, format check, typecheck, and 300 unit tests.
- `npm run build:widget` - passed and rebuilt the widget bundles.
- `npm run build` - passed.
- `npx playwright test --project=chromium` - passed: 209 local Chromium tests, including the new console-log checkbox and submission coverage.
- `npm run test:e2e` - attempted with the full configured suite after installing Firefox/WebKit and setting the local temp worktree env to development. Result: 224 passed, 2 skipped, 9 failed. The failures were in deployed/live-site checks plus one saved-position local flake that passed on the follow-up local Chromium rerun.
