### PR TITLE
Add feedback file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
 | `data-label`                    | Any string                                           | `Feedback`       |
 | `data-category-labels`          | JSON mapping for self-hosted category labels         | built-in labels  |
 | `data-button`                   | `true`, `false`                                      | `true`           |
+| `data-send-console-logs`        | `true`, `false`                                      | `false`          |
 | `data-element-context-max-area` | Viewport-area multiplier for Select Element context  | `0`              |
 
 See [full documentation](https://bugdrop.dev/docs/configuration) for all options including styling, submitter info, and dismissible button.

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -19,6 +19,7 @@ These attributes control the fundamental behavior of the widget.
 | `data-auth-token-provider` | none | Name of a global function that returns a self-hosted auth token |
 | `data-welcome` | `"Report a bug or request a feature"` | Welcome message displayed at the top of the form |
 | `data-show-issue-link` | `"public"` | Show the GitHub issue link after submission: `"public"`, `"always"`, or `"never"` |
+| `data-send-console-logs` | `"false"` | Start the "Send Console Logs" checkbox checked |
 
 ### Basic Example
 
@@ -110,6 +111,21 @@ Control whether the feedback form collects the submitter's name and email addres
 ```
 
 When submitter information is collected, it is included in the GitHub Issue body so your team knows who reported the issue.
+
+## Console Logs
+
+BugDrop can include recent browser console output in the GitHub Issue. The feedback form shows a "Send Console Logs" checkbox. It is unchecked by default.
+
+```html
+<!-- Start with Send Console Logs checked -->
+<script
+  src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="owner/repo"
+  data-send-console-logs="true"
+></script>
+```
+
+When the checkbox is checked, the issue body includes a collapsed console-log section. BugDrop limits the amount of output and redacts obvious secret-like values such as passwords, tokens, cookies, authorization headers, and long random strings.
 
 ## Dismissible Button
 

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -409,7 +409,11 @@ test.describe('Widget Interaction', () => {
 
     await page.evaluate(() => {
       console.log('customer dashboard failed to save');
-      console.warn('retry count token=abc123456789abcdefghijklmnopqrstuvwxyz');
+      console.warn('retry count', {
+        token: 'abc123456789abcdefghijklmnopqrstuvwxyz',
+        password: 'hunter2',
+        cookie: 'sid=short',
+      });
     });
 
     await host.locator('css=.bd-trigger').click();
@@ -421,7 +425,8 @@ test.describe('Widget Interaction', () => {
 
     await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
     expect(payloads).toHaveLength(1);
-    expect(payloads[0].consoleLogs).toEqual(
+    const logs = payloads[0].consoleLogs;
+    expect(logs).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           level: 'log',
@@ -433,6 +438,9 @@ test.describe('Widget Interaction', () => {
         }),
       ])
     );
+    expect(JSON.stringify(logs)).not.toContain('abc123456789abcdefghijklmnopqrstuvwxyz');
+    expect(JSON.stringify(logs)).not.toContain('hunter2');
+    expect(JSON.stringify(logs)).not.toContain('sid=short');
   });
 
   test('element picker handles SVG elements without errors', async ({ page }) => {

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -5330,6 +5330,12 @@ test.describe('Screenshot Mode Configuration', () => {
     const host = await openForm(page);
 
     await expect(host.locator('css=#include-screenshot')).not.toBeAttached();
+    await host.locator('css=#attachment-upload').setInputFiles({
+      name: 'notes.pdf',
+      mimeType: 'application/pdf',
+      buffer: Buffer.from('%PDF-1.4\n'),
+    });
+    await expect(host.locator('css=.bd-upload-item')).toContainText('notes.pdf');
     await host.locator('css=#submit-btn').click();
 
     await expect(host.locator('css=[data-action="skip"]')).not.toBeAttached();
@@ -5339,7 +5345,15 @@ test.describe('Screenshot Mode Configuration', () => {
     await host.locator('css=[data-action="done"]').click();
 
     await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
-    expect(getPayload()?.screenshot).toEqual(expect.stringMatching(/^data:image\/png;base64,/));
+    const payload = getPayload();
+    expect(payload?.screenshot).toEqual(expect.stringMatching(/^data:image\/png;base64,/));
+    expect(payload?.attachments).toEqual([
+      expect.objectContaining({
+        name: 'notes.pdf',
+        type: 'application/pdf',
+        dataUrl: expect.stringMatching(/^data:application\/pdf;base64,/),
+      }),
+    ]);
   });
 
   test('annotation actions use distinct labels and submit from one primary action', async ({

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -355,6 +355,87 @@ test.describe('Widget Interaction', () => {
     await expect(modal).toBeVisible({ timeout: 5000 });
   });
 
+  test('uploaded files can be selected, removed, and submitted', async ({ page }) => {
+    const payloads = await trackFeedbackPayloads(page);
+    await page.route('**/api/check**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/');
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+
+    const uploadInput = host.locator('css=#attachment-upload');
+    await uploadInput.setInputFiles([
+      {
+        name: 'first.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from(
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+          'base64'
+        ),
+      },
+      {
+        name: 'notes.pdf',
+        mimeType: 'application/pdf',
+        buffer: Buffer.from('%PDF-1.4\n'),
+      },
+    ]);
+
+    await expect(host.locator('css=.bd-upload-item')).toHaveCount(2);
+    await expect(host.locator('css=.bd-upload-item').first()).toContainText('first.png');
+    await host.locator('css=.bd-upload-remove').first().click();
+    await expect(host.locator('css=.bd-upload-item')).toHaveCount(1);
+    await expect(host.locator('css=.bd-upload-item').first()).toContainText('notes.pdf');
+
+    await host.locator('css=#title').fill('Uploaded evidence');
+    await host.locator('css=#include-screenshot').uncheck();
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].screenshot).toBeNull();
+    expect(payloads[0].attachments).toEqual([
+      expect.objectContaining({
+        name: 'notes.pdf',
+        type: 'application/pdf',
+        dataUrl: expect.stringMatching(/^data:application\/pdf;base64,/),
+      }),
+    ]);
+  });
+
+  test('unsupported uploaded files show a clear message', async ({ page }) => {
+    await page.route('**/api/check**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/');
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+    await host.locator('css=#attachment-upload').setInputFiles({
+      name: 'archive.zip',
+      mimeType: 'application/zip',
+      buffer: Buffer.from('zip'),
+    });
+
+    await expect(host.locator('css=#attachment-error')).toContainText(
+      'That file type is not supported'
+    );
+    await expect(host.locator('css=.bd-upload-item')).toHaveCount(0);
+  });
+
   test('element picker handles SVG elements without errors', async ({ page }) => {
     // Track console errors - specifically looking for className.split errors
     const errors: string[] = [];
@@ -4030,8 +4111,8 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     const skipBtn = host.locator('css=[data-action="skip"]');
     await skipBtn.click();
 
-    // Error modal should be gone and submission should proceed
-    await expect(errorText).not.toBeVisible({ timeout: 3000 });
+    // Capture failure modal should be gone and submission should proceed.
+    await expect(errorText).not.toHaveText(/Failed to capture screenshot/, { timeout: 3000 });
   });
 
   test('privacy masking failure shows a dedicated modal and submits without a screenshot', async ({

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -404,12 +404,14 @@ test.describe('Widget Interaction', () => {
     });
 
     await page.goto('/test/');
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').waitFor({ state: 'visible', timeout: 5000 });
+
     await page.evaluate(() => {
       console.log('customer dashboard failed to save');
       console.warn('retry count token=abc123456789abcdefghijklmnopqrstuvwxyz');
     });
 
-    const host = page.locator('#bugdrop-host');
     await host.locator('css=.bd-trigger').click();
     await host.locator('css=[data-action="continue"]').click();
     await host.locator('css=#title').fill('Console log test');

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -355,6 +355,84 @@ test.describe('Widget Interaction', () => {
     await expect(modal).toBeVisible({ timeout: 5000 });
   });
 
+  test('console logs checkbox is unchecked by default', async ({ page }) => {
+    await page.route('**/api/check**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/');
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+
+    const consoleLogsCheckbox = host.locator('css=#send-console-logs');
+    await expect(consoleLogsCheckbox).toBeVisible({ timeout: 5000 });
+    await expect(consoleLogsCheckbox).not.toBeChecked();
+  });
+
+  test('console logs checkbox can default to checked from script settings', async ({ page }) => {
+    await page.route('**/api/check**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/?sendConsoleLogs=true');
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+
+    await expect(host.locator('css=#send-console-logs')).toBeChecked({ timeout: 5000 });
+  });
+
+  test('checked console logs option submits captured browser logs', async ({ page }) => {
+    const payloads = await trackFeedbackPayloads(page);
+    await page.route('**/api/check**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/');
+    await page.evaluate(() => {
+      console.log('customer dashboard failed to save');
+      console.warn('retry count token=abc123456789abcdefghijklmnopqrstuvwxyz');
+    });
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await host.locator('css=[data-action="continue"]').click();
+    await host.locator('css=#title').fill('Console log test');
+    await host.locator('css=#include-screenshot').uncheck();
+    await host.locator('css=#send-console-logs').check();
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].consoleLogs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: 'log',
+          message: expect.stringContaining('customer dashboard failed to save'),
+        }),
+        expect.objectContaining({
+          level: 'warn',
+          message: expect.stringContaining('[redacted]'),
+        }),
+      ])
+    );
+  });
+
   test('element picker handles SVG elements without errors', async ({ page }) => {
     // Track console errors - specifically looking for className.split errors
     const errors: string[] = [];

--- a/public/test/index.html
+++ b/public/test/index.html
@@ -609,6 +609,7 @@
         requireEmail: 'requireEmail',
         categoryLabels: 'categoryLabels',
         showIssueLink: 'showIssueLink',
+        sendConsoleLogs: 'sendConsoleLogs',
       },
     });
   </script>

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,5 +1,5 @@
 import { generateGitHubAppJWT } from './jwt';
-import type { Env, GitHubIssue } from '../types';
+import type { Env, FeedbackAttachment, GitHubIssue } from '../types';
 
 const GITHUB_API = 'https://api.github.com';
 
@@ -202,9 +202,6 @@ export async function uploadScreenshotAsAsset(
   repo: string,
   base64DataUrl: string
 ): Promise<string> {
-  // Ensure the screenshot branch exists
-  await ensureScreenshotBranch(token, owner, repo);
-
   // Remove data URL prefix and extract the base64 content
   const content = base64DataUrl.replace(/^data:image\/\w+;base64,/, '');
 
@@ -212,11 +209,52 @@ export async function uploadScreenshotAsAsset(
   const timestamp = Date.now();
   const filename = `.bugdrop/screenshots/${timestamp}.png`;
 
+  return uploadBase64Asset(
+    token,
+    owner,
+    repo,
+    filename,
+    content,
+    `Add BugDrop screenshot ${timestamp}`
+  );
+}
+
+export async function uploadAttachmentAsAsset(
+  token: string,
+  owner: string,
+  repo: string,
+  attachment: FeedbackAttachment
+): Promise<string> {
+  const timestamp = Date.now();
+  const filename = `.bugdrop/uploads/${timestamp}-${sanitizeAttachmentFilename(attachment.name)}`;
+  const content = attachment.dataUrl.replace(/^data:[^;]+;base64,/, '');
+
+  return uploadBase64Asset(
+    token,
+    owner,
+    repo,
+    filename,
+    content,
+    `Add BugDrop upload ${timestamp}`
+  );
+}
+
+async function uploadBase64Asset(
+  token: string,
+  owner: string,
+  repo: string,
+  filename: string,
+  content: string,
+  message: string
+): Promise<string> {
+  // Ensure the screenshot branch exists
+  await ensureScreenshotBranch(token, owner, repo);
+
   const response = await fetch(`${GITHUB_API}/repos/${owner}/${repo}/contents/${filename}`, {
     method: 'PUT',
     headers: headers(token),
     body: JSON.stringify({
-      message: `Add BugDrop screenshot ${timestamp}`,
+      message,
       content: content,
       branch: SCREENSHOT_BRANCH,
     }),
@@ -229,4 +267,15 @@ export async function uploadScreenshotAsAsset(
 
   const data = (await response.json()) as { content: { html_url: string } };
   return data.content.html_url + '?raw=true';
+}
+
+function sanitizeAttachmentFilename(name: string): string {
+  const safe = name
+    .trim()
+    .replace(/[/\\]/g, '-')
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+
+  return safe || 'upload';
 }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,6 +1,7 @@
 import { Hono, type Context, type Next } from 'hono';
 import { cors } from 'hono/cors';
 import type { ConsoleLogEntry, Env, FeedbackCategory, FeedbackPayload } from '../types';
+import { redactConsoleLogMessage } from '../widget/console-log-redaction';
 import {
   getInstallationToken,
   createIssue,
@@ -30,10 +31,6 @@ const MAX_LABELS_PER_CATEGORY = 5;
 const MAX_CONSOLE_LOG_ENTRIES = 50;
 const MAX_CONSOLE_LOG_BODY_CHARS = 12_000;
 const MAX_CONSOLE_LOG_MESSAGE_CHARS = 1_000;
-const SECRET_WORD_PATTERN =
-  /\b(password|passwd|pwd|token|api[_-]?key|secret|authorization|auth|cookie)\b(\s*[:=]\s*)(["']?)[^"',\s}&]+/gi;
-const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
-const LONG_SECRET_PATTERN = /\b[A-Za-z0-9+/_=-]{32,}\b/g;
 // GitHub enforces a 50-char limit on label names; keep validation in lockstep
 // so over-long configured labels surface as a clear local warning rather than
 // going out, getting rejected, and triggering the GitHub-error fallback path.
@@ -781,13 +778,6 @@ function formatConsoleLogSource(entry: ConsoleLogEntry): string {
 
 function isConsoleLogLevel(value: unknown): value is ConsoleLogEntry['level'] {
   return value === 'log' || value === 'info' || value === 'warn' || value === 'error';
-}
-
-function redactConsoleLogMessage(value: string): string {
-  return value
-    .replace(BEARER_PATTERN, 'Bearer [redacted]')
-    .replace(SECRET_WORD_PATTERN, '$1$2$3[redacted]')
-    .replace(LONG_SECRET_PATTERN, '[redacted]');
 }
 
 function formatFencedBlock(value: string): string {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,6 +1,6 @@
 import { Hono, type Context, type Next } from 'hono';
 import { cors } from 'hono/cors';
-import type { Env, FeedbackCategory, FeedbackPayload } from '../types';
+import type { ConsoleLogEntry, Env, FeedbackCategory, FeedbackPayload } from '../types';
 import {
   getInstallationToken,
   createIssue,
@@ -27,6 +27,13 @@ const DEFAULT_CATEGORY_LABELS: Record<FeedbackCategory, string[]> = {
 
 const CATEGORY_KEYS: FeedbackCategory[] = ['bug', 'feature', 'question'];
 const MAX_LABELS_PER_CATEGORY = 5;
+const MAX_CONSOLE_LOG_ENTRIES = 50;
+const MAX_CONSOLE_LOG_BODY_CHARS = 12_000;
+const MAX_CONSOLE_LOG_MESSAGE_CHARS = 1_000;
+const SECRET_WORD_PATTERN =
+  /\b(password|passwd|pwd|token|api[_-]?key|secret|authorization|auth|cookie)\b(\s*[:=]\s*)(["']?)[^"',\s}&]+/gi;
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const LONG_SECRET_PATTERN = /\b[A-Za-z0-9+/_=-]{32,}\b/g;
 // GitHub enforces a 50-char limit on label names; keep validation in lockstep
 // so over-long configured labels surface as a clear local warning rather than
 // going out, getting rejected, and triggering the GitHub-error fallback path.
@@ -629,6 +636,12 @@ function formatIssueBody(
     sections.push('');
   }
 
+  const consoleLogsSection = formatConsoleLogsSection(payload.consoleLogs);
+  if (consoleLogsSection) {
+    sections.push(consoleLogsSection);
+    sections.push('');
+  }
+
   // System Info
   sections.push('<details>');
   sections.push('<summary>System Info</summary>');
@@ -711,6 +724,77 @@ function formatMarkdownInlineCode(value: string): string {
   const longestBacktickRun = Math.max(...inlineSafeValue.match(/`+/g)!.map(match => match.length));
   const fence = '`'.repeat(longestBacktickRun + 1);
   return `${fence} ${inlineSafeValue} ${fence}`;
+}
+
+function formatConsoleLogsSection(entries: ConsoleLogEntry[] | undefined): string | null {
+  if (!Array.isArray(entries) || entries.length === 0) return null;
+
+  const logs = entries.slice(0, MAX_CONSOLE_LOG_ENTRIES).map(formatConsoleLogEntry).filter(Boolean);
+  if (logs.length === 0) return null;
+
+  if (entries.length > MAX_CONSOLE_LOG_ENTRIES) {
+    logs.push(
+      `Console logs truncated: showing ${MAX_CONSOLE_LOG_ENTRIES} of ${entries.length} entries.`
+    );
+  }
+
+  let body = logs.join('\n');
+  if (body.length > MAX_CONSOLE_LOG_BODY_CHARS) {
+    body = `${body.slice(0, MAX_CONSOLE_LOG_BODY_CHARS)}\nConsole logs truncated because the output was too large.`;
+  }
+
+  return [
+    '<details>',
+    '<summary>Console Logs</summary>',
+    '',
+    formatFencedBlock(body),
+    '</details>',
+  ].join('\n');
+}
+
+function formatConsoleLogEntry(entry: ConsoleLogEntry): string {
+  if (!entry || typeof entry.message !== 'string') return '';
+
+  const level = isConsoleLogLevel(entry.level) ? entry.level : 'log';
+  const timestamp =
+    typeof entry.timestamp === 'string' ? normalizeMarkdownValue(entry.timestamp) : '';
+  const source = formatConsoleLogSource(entry);
+  const message = redactConsoleLogMessage(normalizeMarkdownValue(entry.message)).slice(
+    0,
+    MAX_CONSOLE_LOG_MESSAGE_CHARS
+  );
+  const prefix = timestamp ? `${timestamp} [${level}]` : `[${level}]`;
+  return `${prefix} ${message}${source}`;
+}
+
+function formatConsoleLogSource(entry: ConsoleLogEntry): string {
+  if (!entry.sourceUrl) return '';
+
+  const source = redactConsoleLogMessage(normalizeMarkdownValue(entry.sourceUrl));
+  const line = Number.isFinite(entry.lineNumber) ? entry.lineNumber : undefined;
+  const column = Number.isFinite(entry.columnNumber) ? entry.columnNumber : undefined;
+
+  if (line !== undefined && column !== undefined) return ` (${source}:${line}:${column})`;
+  if (line !== undefined) return ` (${source}:${line})`;
+  return ` (${source})`;
+}
+
+function isConsoleLogLevel(value: unknown): value is ConsoleLogEntry['level'] {
+  return value === 'log' || value === 'info' || value === 'warn' || value === 'error';
+}
+
+function redactConsoleLogMessage(value: string): string {
+  return value
+    .replace(BEARER_PATTERN, 'Bearer [redacted]')
+    .replace(SECRET_WORD_PATTERN, '$1$2$3[redacted]')
+    .replace(LONG_SECRET_PATTERN, '[redacted]');
+}
+
+function formatFencedBlock(value: string): string {
+  const matches = value.match(/`+/g);
+  const longestBacktickRun = matches ? Math.max(...matches.map(match => match.length)) : 0;
+  const fence = '`'.repeat(Math.max(3, longestBacktickRun + 1));
+  return `${fence}\n${value}\n${fence}`;
 }
 
 function normalizeMarkdownValue(value: string): string {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,10 +1,11 @@
 import { Hono, type Context, type Next } from 'hono';
 import { cors } from 'hono/cors';
-import type { Env, FeedbackCategory, FeedbackPayload } from '../types';
+import type { Env, FeedbackAttachment, FeedbackCategory, FeedbackPayload } from '../types';
 import {
   getInstallationToken,
   createIssue,
   uploadScreenshotAsAsset,
+  uploadAttachmentAsAsset,
   isRepoPublic,
   GitHubLabelError,
 } from '../lib/github';
@@ -27,6 +28,17 @@ const DEFAULT_CATEGORY_LABELS: Record<FeedbackCategory, string[]> = {
 
 const CATEGORY_KEYS: FeedbackCategory[] = ['bug', 'feature', 'question'];
 const MAX_LABELS_PER_CATEGORY = 5;
+const MAX_ATTACHMENTS = 5;
+const ALLOWED_ATTACHMENT_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'video/mp4',
+  'video/webm',
+  'video/quicktime',
+]);
 // GitHub enforces a 50-char limit on label names; keep validation in lockstep
 // so over-long configured labels surface as a clear local warning rather than
 // going out, getting rejected, and triggering the GitHub-error fallback path.
@@ -140,6 +152,10 @@ api.post('/feedback', async c => {
       return c.json({ error: validation.error }, 400);
     }
   }
+  const attachmentValidation = validateAttachments(payload.attachments, maxSizeMB);
+  if (!attachmentValidation.valid) {
+    return c.json({ error: attachmentValidation.error }, 400);
+  }
 
   // Parse owner/repo
   const [owner, repo] = payload.repo.split('/');
@@ -180,6 +196,11 @@ api.post('/feedback', async c => {
         // Continue without screenshot rather than failing the whole submission
       }
     }
+    const uploadedAttachments: UploadedAttachment[] = [];
+    for (const attachment of payload.attachments ?? []) {
+      const url = await uploadAttachmentAsAsset(token, owner, repo, attachment);
+      uploadedAttachments.push({ ...attachment, url });
+    }
 
     const labelResolution = resolveCategoryLabels(payload, c.env, payload.repo);
     if (labelResolution.warnings.length > 0) {
@@ -195,7 +216,12 @@ api.post('/feedback', async c => {
     // Check repo visibility (for UI to decide whether to show issue link)
     const isPublic = await isRepoPublic(token, owner, repo);
 
-    let body = formatIssueBody(payload, screenshotUrl, labelResolution.warnings);
+    let body = formatIssueBody(
+      payload,
+      screenshotUrl,
+      uploadedAttachments,
+      labelResolution.warnings
+    );
     let issue;
     try {
       issue = await createIssue(token, owner, repo, payload.title, body, labelResolution.labels);
@@ -209,7 +235,7 @@ api.post('/feedback', async c => {
         ...labelResolution.warnings,
         `GitHub rejected the configured labels (${formatLabelList(labelResolution.labels)}), so BugDrop retried with default labels (${formatLabelList(fallbackLabels)}).`,
       ];
-      body = formatIssueBody(payload, screenshotUrl, warning);
+      body = formatIssueBody(payload, screenshotUrl, uploadedAttachments, warning);
       try {
         issue = await createIssue(token, owner, repo, payload.title, body, fallbackLabels);
       } catch (fallbackError) {
@@ -301,6 +327,7 @@ type LabelResolution = {
   warnings: string[];
   usedCustomLabels: boolean;
 };
+type UploadedAttachment = FeedbackAttachment & { url: string };
 
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
@@ -347,6 +374,80 @@ function validateScreenshotDataUrl(dataUrl: string, maxSizeMB: number): Screensh
       valid: false,
       error: 'Invalid screenshot format. Expected PNG image data.',
     };
+  }
+
+  return { valid: true };
+}
+
+function validateAttachments(
+  attachments: FeedbackAttachment[] | undefined,
+  maxSizeMB: number
+): ScreenshotValidationResult {
+  if (attachments === undefined) return { valid: true };
+  if (!Array.isArray(attachments)) {
+    return { valid: false, error: 'Invalid upload format. Expected a list of files.' };
+  }
+  if (attachments.length > MAX_ATTACHMENTS) {
+    return { valid: false, error: `Too many files. Upload up to ${MAX_ATTACHMENTS} files.` };
+  }
+
+  for (const attachment of attachments) {
+    const validation = validateAttachment(attachment, maxSizeMB);
+    if (!validation.valid) return validation;
+  }
+
+  return { valid: true };
+}
+
+function validateAttachment(
+  attachment: FeedbackAttachment,
+  maxSizeMB: number
+): ScreenshotValidationResult {
+  if (!isPlainObject(attachment)) {
+    return { valid: false, error: 'Invalid upload format. Expected file details.' };
+  }
+
+  const name = attachment.name;
+  const type = attachment.type;
+  const size = attachment.size;
+  const dataUrl = attachment.dataUrl;
+  if (
+    typeof name !== 'string' ||
+    !name.trim() ||
+    hasControlChars(name) ||
+    typeof type !== 'string' ||
+    typeof dataUrl !== 'string' ||
+    typeof size !== 'number' ||
+    !Number.isFinite(size)
+  ) {
+    return { valid: false, error: 'Invalid upload format. Expected file name, type, and data.' };
+  }
+
+  if (!ALLOWED_ATTACHMENT_TYPES.has(type)) {
+    return { valid: false, error: `Unsupported file type: ${type || 'unknown'}.` };
+  }
+
+  const match = dataUrl.match(/^data:([^;,]+);base64,([A-Za-z0-9+/]+={0,2})$/);
+  if (!match || match[1] !== type || !match[2]) {
+    return { valid: false, error: 'Invalid upload format. Expected a matching file data URL.' };
+  }
+
+  const estimatedSizeBytes =
+    Math.floor((match[2].length * 3) / 4) -
+    (match[2].endsWith('==') ? 2 : match[2].endsWith('=') ? 1 : 0);
+  const largerSizeBytes = Math.max(estimatedSizeBytes, size);
+  const estimatedSizeMB = largerSizeBytes / (1024 * 1024);
+  if (estimatedSizeMB > maxSizeMB) {
+    return {
+      valid: false,
+      error: `File is too large: ${estimatedSizeMB.toFixed(1)}MB exceeds ${maxSizeMB}MB limit.`,
+    };
+  }
+
+  try {
+    base64ToBytes(match[2]);
+  } catch {
+    return { valid: false, error: 'Invalid upload format. Expected valid file data.' };
   }
 
   return { valid: true };
@@ -583,6 +684,7 @@ function hasPngSignature(bytes: Uint8Array): boolean {
 function formatIssueBody(
   payload: FeedbackPayload,
   screenshotDataUrl?: string,
+  uploadedAttachments: UploadedAttachment[] = [],
   labelWarnings: string[] = []
 ): string {
   const sections: string[] = [];
@@ -617,6 +719,19 @@ function formatIssueBody(
       sections.push(
         `_Selected element is indicated by the rounded highlight border (${formatMarkdownInlineCode(getSelectedElementHighlightColor(payload))})._`
       );
+    }
+    sections.push('');
+  }
+
+  if (uploadedAttachments.length > 0) {
+    sections.push('## Attachments');
+    for (const attachment of uploadedAttachments) {
+      const safeName = normalizeMarkdownValue(attachment.name);
+      if (attachment.type.startsWith('image/')) {
+        sections.push(`![${safeName}](${attachment.url})`);
+      } else {
+        sections.push(`- [${safeName}](${attachment.url})`);
+      }
     }
     sections.push('');
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface FeedbackPayload {
   categoryLabels?: CategoryLabelConfig; // Optional self-host category-to-GitHub-label mapping
   screenshot?: string; // base64 data URL
   annotations?: string; // base64 annotated image
+  consoleLogs?: ConsoleLogEntry[];
   submitter?: {
     // Optional submitter info (configured per widget)
     name?: string;
@@ -55,6 +56,15 @@ export interface FeedbackPayload {
     devicePixelRatio?: number;
     language?: string;
   };
+}
+
+export interface ConsoleLogEntry {
+  level: 'log' | 'info' | 'warn' | 'error';
+  message: string;
+  timestamp: string;
+  sourceUrl?: string;
+  lineNumber?: number;
+  columnNumber?: number;
 }
 
 export interface GitHubIssue {

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface FeedbackPayload {
   categoryLabels?: CategoryLabelConfig; // Optional self-host category-to-GitHub-label mapping
   screenshot?: string; // base64 data URL
   annotations?: string; // base64 annotated image
+  attachments?: FeedbackAttachment[];
   submitter?: {
     // Optional submitter info (configured per widget)
     name?: string;
@@ -57,6 +58,13 @@ export interface FeedbackPayload {
     devicePixelRatio?: number;
     language?: string;
   };
+}
+
+export interface FeedbackAttachment {
+  name: string;
+  type: string;
+  size: number;
+  dataUrl: string;
 }
 
 export interface GitHubIssue {

--- a/src/widget/console-log-redaction.ts
+++ b/src/widget/console-log-redaction.ts
@@ -1,0 +1,29 @@
+const SECRET_KEY_PATTERN = String.raw`(?:"|')?\b(?:password|passwd|pwd|token|api[_-]?key|secret|authorization|auth|cookie)\b(?:"|')?`;
+const QUOTED_SECRET_PATTERN = new RegExp(
+  String.raw`(${SECRET_KEY_PATTERN}\s*[:=]\s*)(["'])(?!Bearer\b)(?:\\[\s\S]|(?!\2)[^\\])*?\2`,
+  'gi'
+);
+const UNTERMINATED_QUOTED_SECRET_PATTERN = new RegExp(
+  String.raw`(${SECRET_KEY_PATTERN}\s*[:=]\s*)(["'])(?!Bearer\b)(?:\\[^\r\n]|(?!\2)[^\\\r\n])*(?=\r?\n|$)`,
+  'gi'
+);
+const STRUCTURED_SECRET_PATTERN = new RegExp(
+  String.raw`(${SECRET_KEY_PATTERN}\s*[:=]\s*)(?:\[[^\]\r\n]*\]|\{[^\}\r\n]*\})`,
+  'gi'
+);
+const UNQUOTED_SECRET_PATTERN = new RegExp(
+  String.raw`(${SECRET_KEY_PATTERN}\s*[:=]\s*)(?!Bearer\b)[^"',\s}&]+`,
+  'gi'
+);
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const LONG_SECRET_PATTERN = /\b[A-Za-z0-9+/_=-]{32,}\b/g;
+
+export function redactConsoleLogMessage(value: string): string {
+  return value
+    .replace(BEARER_PATTERN, 'Bearer [redacted]')
+    .replace(STRUCTURED_SECRET_PATTERN, '$1[redacted]')
+    .replace(QUOTED_SECRET_PATTERN, '$1$2[redacted]$2')
+    .replace(UNTERMINATED_QUOTED_SECRET_PATTERN, '$1$2[redacted]')
+    .replace(UNQUOTED_SECRET_PATTERN, '$1[redacted]')
+    .replace(LONG_SECRET_PATTERN, '[redacted]');
+}

--- a/src/widget/console-logs.ts
+++ b/src/widget/console-logs.ts
@@ -1,3 +1,5 @@
+import { redactConsoleLogMessage } from './console-log-redaction';
+
 type ConsoleLogLevel = 'log' | 'info' | 'warn' | 'error';
 
 export interface ConsoleLogEntry {
@@ -11,10 +13,6 @@ export interface ConsoleLogEntry {
 
 const MAX_ENTRIES = 50;
 const MAX_MESSAGE_LENGTH = 1000;
-const SECRET_WORD_PATTERN =
-  /\b(password|passwd|pwd|token|api[_-]?key|secret|authorization|auth|cookie)\b(\s*[:=]\s*)(["']?)[^"',\s}&]+/gi;
-const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
-const LONG_SECRET_PATTERN = /\b[A-Za-z0-9+/_=-]{32,}\b/g;
 
 const capturedLogs: ConsoleLogEntry[] = [];
 let hasStarted = false;
@@ -89,13 +87,6 @@ function formatConsoleValue(value: unknown): string {
   } catch {
     return String(value);
   }
-}
-
-function redactConsoleLogMessage(value: string): string {
-  return value
-    .replace(BEARER_PATTERN, 'Bearer [redacted]')
-    .replace(SECRET_WORD_PATTERN, '$1$2$3[redacted]')
-    .replace(LONG_SECRET_PATTERN, '[redacted]');
 }
 
 function getConsoleSource(): Pick<ConsoleLogEntry, 'sourceUrl' | 'lineNumber' | 'columnNumber'> {

--- a/src/widget/console-logs.ts
+++ b/src/widget/console-logs.ts
@@ -1,4 +1,4 @@
-export type ConsoleLogLevel = 'log' | 'info' | 'warn' | 'error';
+type ConsoleLogLevel = 'log' | 'info' | 'warn' | 'error';
 
 export interface ConsoleLogEntry {
   level: ConsoleLogLevel;

--- a/src/widget/console-logs.ts
+++ b/src/widget/console-logs.ts
@@ -1,0 +1,117 @@
+export type ConsoleLogLevel = 'log' | 'info' | 'warn' | 'error';
+
+export interface ConsoleLogEntry {
+  level: ConsoleLogLevel;
+  message: string;
+  timestamp: string;
+  sourceUrl?: string;
+  lineNumber?: number;
+  columnNumber?: number;
+}
+
+const MAX_ENTRIES = 50;
+const MAX_MESSAGE_LENGTH = 1000;
+const SECRET_WORD_PATTERN =
+  /\b(password|passwd|pwd|token|api[_-]?key|secret|authorization|auth|cookie)\b(\s*[:=]\s*)(["']?)[^"',\s}&]+/gi;
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const LONG_SECRET_PATTERN = /\b[A-Za-z0-9+/_=-]{32,}\b/g;
+
+const capturedLogs: ConsoleLogEntry[] = [];
+let hasStarted = false;
+
+export function startConsoleLogCapture(): void {
+  if (hasStarted || typeof window === 'undefined' || typeof console === 'undefined') return;
+  hasStarted = true;
+
+  patchConsoleMethod('log');
+  patchConsoleMethod('info');
+  patchConsoleMethod('warn');
+  patchConsoleMethod('error');
+
+  window.addEventListener('error', event => {
+    addLog({
+      level: 'error',
+      message: event.message || 'Unhandled error',
+      timestamp: new Date().toISOString(),
+      sourceUrl: event.filename || undefined,
+      lineNumber: event.lineno || undefined,
+      columnNumber: event.colno || undefined,
+    });
+  });
+
+  window.addEventListener('unhandledrejection', event => {
+    addLog({
+      level: 'error',
+      message: `Unhandled promise rejection: ${formatConsoleValue(event.reason)}`,
+      timestamp: new Date().toISOString(),
+    });
+  });
+}
+
+export function getConsoleLogSnapshot(): ConsoleLogEntry[] {
+  return capturedLogs.map(entry => ({ ...entry }));
+}
+
+function patchConsoleMethod(level: ConsoleLogLevel): void {
+  const original = console[level];
+  if (typeof original !== 'function') return;
+
+  console[level] = (...args: unknown[]) => {
+    addLog({
+      level,
+      message: args.map(formatConsoleValue).join(' '),
+      timestamp: new Date().toISOString(),
+      ...getConsoleSource(),
+    });
+    original.apply(console, args);
+  };
+}
+
+function addLog(entry: ConsoleLogEntry): void {
+  capturedLogs.push({
+    ...entry,
+    message: redactConsoleLogMessage(entry.message).slice(0, MAX_MESSAGE_LENGTH),
+  });
+  while (capturedLogs.length > MAX_ENTRIES) {
+    capturedLogs.shift();
+  }
+}
+
+function formatConsoleValue(value: unknown): string {
+  if (value instanceof Error) {
+    return value.stack || value.message;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function redactConsoleLogMessage(value: string): string {
+  return value
+    .replace(BEARER_PATTERN, 'Bearer [redacted]')
+    .replace(SECRET_WORD_PATTERN, '$1$2$3[redacted]')
+    .replace(LONG_SECRET_PATTERN, '[redacted]');
+}
+
+function getConsoleSource(): Pick<ConsoleLogEntry, 'sourceUrl' | 'lineNumber' | 'columnNumber'> {
+  const stack = new Error().stack;
+  if (!stack) return {};
+
+  for (const line of stack.split('\n').slice(2)) {
+    if (line.includes('console-logs')) continue;
+    const match = line.match(/\(?((?:https?:|file:|\/)[^():]+):(\d+):(\d+)\)?$/);
+    if (!match) continue;
+    return {
+      sourceUrl: match[1],
+      lineNumber: Number(match[2]),
+      columnNumber: Number(match[3]),
+    };
+  }
+
+  return {};
+}

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -28,6 +28,12 @@ import { resolveAccentColor } from '../defaults';
 
 type FeedbackCategory = 'bug' | 'feature' | 'question';
 type CategoryLabelConfig = Partial<Record<FeedbackCategory, string | string[]>>;
+type FeedbackAttachment = {
+  name: string;
+  type: string;
+  size: number;
+  dataUrl: string;
+};
 
 interface WidgetConfig {
   repo: string;
@@ -95,6 +101,7 @@ interface FeedbackData {
   description: string;
   category: FeedbackCategory;
   screenshot: string | null;
+  attachments: FeedbackAttachment[];
   elementSelector: string | null;
   fullElementSelector: string | null;
   selectedElementHighlightColor: string | null;
@@ -110,6 +117,18 @@ const BUGDROP_COMPLEX_SCREENSHOT_SKIPPED_PREFIX = 'bugdrop_complex_screenshot_sk
 const COMPLEX_SCREENSHOT_SKIP_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const TRIGGER_VIEWPORT_MARGIN_PX = 8;
 const TRIGGER_KEYBOARD_MOVE_PX = 16;
+const MAX_UPLOAD_FILES = 5;
+const MAX_UPLOAD_SIZE_BYTES = 5 * 1024 * 1024;
+const ACCEPTED_UPLOAD_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'video/mp4',
+  'video/webm',
+  'video/quicktime',
+];
 
 // Parse user agent to extract browser info
 function parseBrowser(ua: string): { name: string; version: string } {
@@ -1072,6 +1091,7 @@ async function openFeedbackFlow(
       name: formResult.name,
       email: formResult.email,
       screenshot: screenshotResult.screenshot,
+      attachments: formResult.attachments,
       elementSelector: screenshotResult.elementSelector,
       fullElementSelector: screenshotResult.fullElementSelector,
       selectedElementHighlightColor: screenshotResult.elementSelector
@@ -1188,6 +1208,7 @@ interface FeedbackFormResult {
   name?: string;
   email?: string;
   includeScreenshot: boolean;
+  attachments: FeedbackAttachment[];
 }
 
 function showFeedbackFormWithScreenshotOption(
@@ -1248,7 +1269,17 @@ function showFeedbackFormWithScreenshotOption(
           </div>
           ${nameFieldHtml}
           ${emailFieldHtml}
-          ${getScreenshotFormControl(config, initialValues)}
+          <div class="bd-evidence-block">
+            <div class="bd-evidence-row">
+              ${getScreenshotFormControl(config, initialValues)}
+              ${getUploadFormControl()}
+            </div>
+            <input type="file" id="attachment-upload" accept="${ACCEPTED_UPLOAD_TYPES.join(',')}" multiple class="bd-upload-input" />
+            <div id="attachment-list" class="bd-upload-list" aria-live="polite">${
+              initialValues?.attachments.length ? '' : ''
+            }</div>
+            <p id="attachment-error" class="bd-field-error" hidden></p>
+          </div>
           <div class="bd-actions">
             <button type="button" class="bd-btn bd-btn-secondary" data-action="cancel">Cancel</button>
             <button type="submit" class="bd-btn bd-btn-primary" id="submit-btn">${config.screenshotMode === 'auto' ? 'Submit' : 'Continue'}</button>
@@ -1265,8 +1296,13 @@ function showFeedbackFormWithScreenshotOption(
     const screenshotCheckbox = modal.querySelector(
       '#include-screenshot'
     ) as HTMLInputElement | null;
+    const uploadInput = modal.querySelector('#attachment-upload') as HTMLInputElement;
+    const uploadButton = modal.querySelector('[data-action="choose-uploads"]') as HTMLButtonElement;
+    const uploadList = modal.querySelector('#attachment-list') as HTMLElement;
+    const uploadError = modal.querySelector('#attachment-error') as HTMLElement;
     const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
     const cancelBtn = modal.querySelector('[data-action="cancel"]') as HTMLElement;
+    let attachments = [...(initialValues?.attachments ?? [])];
 
     const closeModal = () => {
       modal.remove();
@@ -1305,8 +1341,9 @@ function showFeedbackFormWithScreenshotOption(
         'input[name="category"]:checked'
       ) as HTMLInputElement;
       const category = (categoryInput?.value || 'bug') as FeedbackCategory;
+      const hasUploads = attachments.length > 0;
       const includeScreenshot =
-        config.screenshotMode === 'optional' ? (screenshotCheckbox?.checked ?? false) : true;
+        config.screenshotMode === 'optional' ? (screenshotCheckbox?.checked ?? false) : !hasUploads;
       if (config.screenshotMode === 'optional' && includeScreenshot) {
         clearComplexScreenshotsSkipped(config.repo);
       }
@@ -1319,6 +1356,7 @@ function showFeedbackFormWithScreenshotOption(
         name: nameInput?.value.trim() || undefined,
         email: emailInput?.value.trim() || undefined,
         includeScreenshot,
+        attachments,
       });
     });
 
@@ -1326,7 +1364,132 @@ function showFeedbackFormWithScreenshotOption(
     titleInput.addEventListener('input', () => titleInput.classList.remove('bd-input--error'));
     nameInput?.addEventListener('input', () => nameInput.classList.remove('bd-input--error'));
     emailInput?.addEventListener('input', () => emailInput.classList.remove('bd-input--error'));
+
+    const rerenderUploads = () => {
+      renderUploadList(uploadList, attachments, index => {
+        attachments = attachments.filter((_, itemIndex) => itemIndex !== index);
+        rerenderUploads();
+      });
+    };
+
+    uploadButton.addEventListener('click', () => uploadInput.click());
+    uploadInput.addEventListener('change', async () => {
+      const files = Array.from(uploadInput.files ?? []);
+      uploadInput.value = '';
+      uploadError.textContent = '';
+      uploadError.hidden = true;
+
+      const remainingSlots = MAX_UPLOAD_FILES - attachments.length;
+      if (files.length > remainingSlots) {
+        showUploadError(
+          uploadError,
+          `Upload up to ${MAX_UPLOAD_FILES} files. Remove a file before adding another.`
+        );
+        return;
+      }
+
+      for (const file of files) {
+        const validationError = validateUploadFile(file);
+        if (validationError) {
+          showUploadError(uploadError, validationError);
+          return;
+        }
+      }
+
+      try {
+        const nextAttachments = await Promise.all(files.map(fileToAttachment));
+        attachments = [...attachments, ...nextAttachments];
+        rerenderUploads();
+      } catch {
+        showUploadError(uploadError, 'Could not read that file. Try another one.');
+      }
+    });
+
+    rerenderUploads();
   });
+}
+
+function getUploadFormControl(): string {
+  return `
+    <div class="bd-upload-group">
+      <div class="bd-upload-row" aria-label="Uploads">
+        <button type="button" class="bd-btn bd-btn-secondary bd-upload-button" data-action="choose-uploads" aria-label="Upload files">
+          <svg class="bd-upload-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <path d="M8 11V3" />
+            <path d="M4.5 6.5 8 3l3.5 3.5" />
+            <path d="M3 12.5h10" />
+          </svg>
+          Upload
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+function validateUploadFile(file: File): string | null {
+  if (!ACCEPTED_UPLOAD_TYPES.includes(file.type)) {
+    return 'That file type is not supported. Upload an image, PDF, or short video.';
+  }
+  if (file.size > MAX_UPLOAD_SIZE_BYTES) {
+    return `File is too large. Upload files up to ${formatFileSize(MAX_UPLOAD_SIZE_BYTES)}.`;
+  }
+  return null;
+}
+
+function showUploadError(target: HTMLElement, message: string) {
+  target.textContent = message;
+  target.hidden = false;
+}
+
+function renderUploadList(
+  target: HTMLElement,
+  attachments: FeedbackAttachment[],
+  onRemove: (index: number) => void
+) {
+  target.innerHTML = attachments
+    .map(
+      (attachment, index) => `
+        <div class="bd-upload-item">
+          <span class="bd-upload-item__name">${escapeHtml(attachment.name)}</span>
+          <span class="bd-upload-item__meta">${formatFileSize(attachment.size)}</span>
+          <button type="button" class="bd-upload-remove" data-index="${index}" aria-label="Remove ${escapeHtml(attachment.name)}">&times;</button>
+        </div>
+      `
+    )
+    .join('');
+
+  target.querySelectorAll('.bd-upload-remove').forEach(button => {
+    button.addEventListener('click', () => {
+      const index = Number((button as HTMLElement).dataset.index);
+      if (Number.isInteger(index)) onRemove(index);
+    });
+  });
+}
+
+function fileToAttachment(file: File): Promise<FeedbackAttachment> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', () => {
+      if (typeof reader.result !== 'string') {
+        reject(new Error('Could not read file.'));
+        return;
+      }
+      resolve({
+        name: file.name,
+        type: file.type,
+        size: file.size,
+        dataUrl: reader.result,
+      });
+    });
+    reader.addEventListener('error', () => reject(new Error('Could not read file.')));
+    reader.readAsDataURL(file);
+  });
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${Math.round((bytes / (1024 * 1024)) * 10) / 10} MB`;
 }
 
 function getScreenshotFormControl(
@@ -1358,9 +1521,9 @@ function getScreenshotFormControl(
     (!isFullPageDisabled() || !hasSkippedComplexScreenshots(config.repo));
 
   return `
-    <div class="bd-form-group" style="display: flex; align-items: center; gap: 10px; margin-top: 8px;">
-      <input type="checkbox" id="include-screenshot" ${includeScreenshot ? 'checked' : ''} style="width: 18px; height: 18px; accent-color: var(--bd-primary); cursor: pointer;" />
-      <label for="include-screenshot" style="font-size: 0.95rem; color: var(--bd-text-secondary); cursor: pointer; user-select: none;">
+    <div class="bd-screenshot-control">
+      <input type="checkbox" id="include-screenshot" ${includeScreenshot ? 'checked' : ''} class="bd-checkbox" />
+      <label for="include-screenshot" class="bd-checkbox-label">
         📸 Include a screenshot
       </label>
     </div>
@@ -1408,6 +1571,7 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
         category: data.category,
         categoryLabels: config.categoryLabels,
         screenshot: data.screenshot,
+        attachments: data.attachments,
         submitter,
         metadata: {
           url: systemInfo.url, // Redacted URL (no query params)

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -24,6 +24,11 @@ import {
   resolveAuthTokenProvider,
   type BugDropAuthTokenProvider,
 } from './auth-token';
+import {
+  getConsoleLogSnapshot,
+  startConsoleLogCapture,
+  type ConsoleLogEntry,
+} from './console-logs';
 import { resolveAccentColor } from '../defaults';
 
 type FeedbackCategory = 'bug' | 'feature' | 'question';
@@ -70,6 +75,7 @@ interface WidgetConfig {
   screenshotScale?: number; // Minimum pixel ratio for captures (default: 2)
   elementContextMaxArea?: number; // Max ancestor capture area as a viewport multiplier
   issueLinkVisibility: IssueLinkVisibility;
+  sendConsoleLogs: boolean;
 }
 
 // BugDrop JavaScript API interface
@@ -98,6 +104,7 @@ interface FeedbackData {
   elementSelector: string | null;
   fullElementSelector: string | null;
   selectedElementHighlightColor: string | null;
+  sendConsoleLogs: boolean;
   name?: string;
   email?: string;
 }
@@ -440,7 +447,10 @@ const config: WidgetConfig = {
   screenshotScale,
   elementContextMaxArea,
   issueLinkVisibility,
+  sendConsoleLogs: script?.dataset.sendConsoleLogs === 'true',
 };
+
+startConsoleLogCapture();
 
 // Validate config
 if (!config.repo) {
@@ -1077,6 +1087,7 @@ async function openFeedbackFlow(
       selectedElementHighlightColor: screenshotResult.elementSelector
         ? resolveAccentColor(config.accentColor)
         : null,
+      sendConsoleLogs: formResult.sendConsoleLogs,
     });
     break;
   }
@@ -1188,6 +1199,7 @@ interface FeedbackFormResult {
   name?: string;
   email?: string;
   includeScreenshot: boolean;
+  sendConsoleLogs: boolean;
 }
 
 function showFeedbackFormWithScreenshotOption(
@@ -1249,6 +1261,7 @@ function showFeedbackFormWithScreenshotOption(
           ${nameFieldHtml}
           ${emailFieldHtml}
           ${getScreenshotFormControl(config, initialValues)}
+          ${getConsoleLogsFormControl(config, initialValues)}
           <div class="bd-actions">
             <button type="button" class="bd-btn bd-btn-secondary" data-action="cancel">Cancel</button>
             <button type="submit" class="bd-btn bd-btn-primary" id="submit-btn">${config.screenshotMode === 'auto' ? 'Submit' : 'Continue'}</button>
@@ -1265,6 +1278,7 @@ function showFeedbackFormWithScreenshotOption(
     const screenshotCheckbox = modal.querySelector(
       '#include-screenshot'
     ) as HTMLInputElement | null;
+    const consoleLogsCheckbox = modal.querySelector('#send-console-logs') as HTMLInputElement;
     const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
     const cancelBtn = modal.querySelector('[data-action="cancel"]') as HTMLElement;
 
@@ -1319,6 +1333,7 @@ function showFeedbackFormWithScreenshotOption(
         name: nameInput?.value.trim() || undefined,
         email: emailInput?.value.trim() || undefined,
         includeScreenshot,
+        sendConsoleLogs: consoleLogsCheckbox.checked,
       });
     });
 
@@ -1367,6 +1382,22 @@ function getScreenshotFormControl(
   `;
 }
 
+function getConsoleLogsFormControl(
+  config: WidgetConfig,
+  initialValues?: FeedbackFormResult | null
+): string {
+  const sendConsoleLogs = initialValues?.sendConsoleLogs ?? config.sendConsoleLogs;
+
+  return `
+    <div class="bd-form-group" style="display: flex; align-items: center; gap: 10px; margin-top: 8px;">
+      <input type="checkbox" id="send-console-logs" ${sendConsoleLogs ? 'checked' : ''} style="width: 18px; height: 18px; accent-color: var(--bd-primary); cursor: pointer;" />
+      <label for="send-console-logs" style="font-size: 0.95rem; color: var(--bd-text-secondary); cursor: pointer; user-select: none;">
+        Send Console Logs
+      </label>
+    </div>
+  `;
+}
+
 function getCategoryChecked(
   initialValues: FeedbackFormResult | null | undefined,
   category: FeedbackCategory
@@ -1394,6 +1425,9 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
     // Collect system info
     const systemInfo = getSystemInfo();
     const domNodeCount = getDomNodeCount();
+    const consoleLogs: ConsoleLogEntry[] | undefined = data.sendConsoleLogs
+      ? getConsoleLogSnapshot()
+      : undefined;
 
     const response = await fetch(`${config.apiUrl}/feedback`, {
       method: 'POST',
@@ -1408,6 +1442,7 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
         category: data.category,
         categoryLabels: config.categoryLabels,
         screenshot: data.screenshot,
+        consoleLogs,
         submitter,
         metadata: {
           url: systemInfo.url, // Redacted URL (no query params)

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -1341,9 +1341,8 @@ function showFeedbackFormWithScreenshotOption(
         'input[name="category"]:checked'
       ) as HTMLInputElement;
       const category = (categoryInput?.value || 'bug') as FeedbackCategory;
-      const hasUploads = attachments.length > 0;
       const includeScreenshot =
-        config.screenshotMode === 'optional' ? (screenshotCheckbox?.checked ?? false) : !hasUploads;
+        config.screenshotMode === 'optional' ? (screenshotCheckbox?.checked ?? false) : true;
       if (config.screenshotMode === 'optional' && includeScreenshot) {
         clearComplexScreenshotsSkipped(config.repo);
       }

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -585,6 +585,126 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
       cursor: not-allowed;
     }
 
+    .bd-evidence-block {
+      margin: 8px 0 16px;
+    }
+
+    .bd-evidence-row {
+      display: grid;
+      grid-template-columns: minmax(220px, 1fr) auto;
+      align-items: center;
+      gap: 14px;
+    }
+
+    .bd-screenshot-control {
+      min-height: 36px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding-top: 3px;
+    }
+
+    .bd-checkbox {
+      width: 18px;
+      height: 18px;
+      accent-color: var(--bd-primary);
+      cursor: pointer;
+      flex: 0 0 auto;
+    }
+
+    .bd-checkbox-label {
+      color: var(--bd-text-secondary);
+      cursor: pointer;
+      font-size: 0.95rem;
+      line-height: 1.35;
+      user-select: none;
+    }
+
+    .bd-upload-group {
+      min-width: 0;
+      justify-self: end;
+    }
+
+    .bd-upload-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .bd-upload-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      min-height: 32px;
+      padding: 6px 9px;
+      font-size: 13px;
+      white-space: nowrap;
+    }
+
+    .bd-upload-icon {
+      width: 14px;
+      height: 14px;
+      flex: 0 0 auto;
+    }
+
+    .bd-upload-input {
+      display: none;
+    }
+
+    .bd-upload-list {
+      display: grid;
+      gap: 6px;
+      margin-top: 10px;
+    }
+
+    .bd-upload-item {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto 28px;
+      align-items: center;
+      gap: 8px;
+      min-height: 34px;
+      padding: 5px 5px 5px 10px;
+      background: var(--bd-bg-secondary);
+      border: var(--bd-border-style);
+      border-radius: var(--bd-radius-sm);
+    }
+
+    .bd-upload-item__name {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--bd-text-primary);
+      font-size: 13px;
+    }
+
+    .bd-upload-item__meta {
+      color: var(--bd-text-secondary);
+      font-size: 12px;
+      white-space: nowrap;
+    }
+
+    .bd-upload-remove {
+      width: 28px;
+      height: 28px;
+      display: inline-grid;
+      place-items: center;
+      border: none;
+      border-radius: var(--bd-radius-sm);
+      background: transparent;
+      color: var(--bd-text-secondary);
+      cursor: pointer;
+      font-size: 20px;
+      line-height: 1;
+      transition: background var(--bd-transition), color var(--bd-transition);
+    }
+
+    .bd-upload-remove:hover {
+      background: var(--bd-bg-tertiary);
+      color: var(--bd-text-primary);
+    }
+
     /* Loading States */
     .bd-btn--loading {
       color: transparent !important;
@@ -1053,6 +1173,17 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
 
       .bd-textarea {
         min-height: 120px;
+      }
+
+      .bd-evidence-row {
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 8px;
+      }
+
+      .bd-upload-button {
+        min-height: 34px;
+        padding: 7px 10px;
+        font-size: 14px;
       }
 
       .bd-actions {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -7,6 +7,7 @@ import { createBugDropAuthTokenForTest } from '../src/lib/authToken';
 const mockGetInstallationToken = vi.fn();
 const mockCreateIssue = vi.fn();
 const mockUploadScreenshotAsAsset = vi.fn();
+const mockUploadAttachmentAsAsset = vi.fn();
 const mockIsRepoPublic = vi.fn();
 
 class TestGitHubLabelError extends Error {
@@ -22,6 +23,7 @@ vi.mock('../src/lib/github', () => ({
   getInstallationToken: (...args: unknown[]) => mockGetInstallationToken(...args),
   createIssue: (...args: unknown[]) => mockCreateIssue(...args),
   uploadScreenshotAsAsset: (...args: unknown[]) => mockUploadScreenshotAsAsset(...args),
+  uploadAttachmentAsAsset: (...args: unknown[]) => mockUploadAttachmentAsAsset(...args),
   isRepoPublic: (...args: unknown[]) => mockIsRepoPublic(...args),
   GitHubLabelError: TestGitHubLabelError,
 }));
@@ -51,6 +53,7 @@ describe('API Routes', () => {
     mockGetInstallationToken.mockReset();
     mockCreateIssue.mockReset();
     mockUploadScreenshotAsAsset.mockReset();
+    mockUploadAttachmentAsAsset.mockReset();
     mockIsRepoPublic.mockReset();
     // Set default mock return values
     mockGetInstallationToken.mockResolvedValue('test-token');
@@ -1215,6 +1218,126 @@ describe('API Routes', () => {
         expect.stringContaining(uploadedUrl),
         ['bug', 'bugdrop']
       );
+    });
+
+    it('should upload selected files and include attachment links in issue body', async () => {
+      const uploadedImageUrl =
+        'https://raw.githubusercontent.com/testowner/testrepo/main/.bugdrop/uploads/photo.png';
+      const uploadedPdfUrl =
+        'https://raw.githubusercontent.com/testowner/testrepo/main/.bugdrop/uploads/notes.pdf';
+      mockUploadAttachmentAsAsset
+        .mockResolvedValueOnce(uploadedImageUrl)
+        .mockResolvedValueOnce(uploadedPdfUrl);
+
+      const payloadWithAttachments = {
+        ...validPayload,
+        attachments: [
+          {
+            name: 'photo.png',
+            type: 'image/png',
+            size: 68,
+            dataUrl: validPngDataUrl,
+          },
+          {
+            name: 'notes.pdf',
+            type: 'application/pdf',
+            size: 12,
+            dataUrl: 'data:application/pdf;base64,JVBERi0xLjQK',
+          },
+        ],
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payloadWithAttachments),
+      });
+      const res = await app.fetch(req, mockEnv);
+
+      expect(res.status).toBe(200);
+      expect(mockUploadAttachmentAsAsset).toHaveBeenCalledTimes(2);
+      expect(mockUploadAttachmentAsAsset).toHaveBeenNthCalledWith(
+        1,
+        'test-token',
+        'testowner',
+        'testrepo',
+        expect.objectContaining({
+          name: 'photo.png',
+          type: 'image/png',
+          dataUrl: validPngDataUrl,
+        })
+      );
+      expect(mockUploadAttachmentAsAsset).toHaveBeenNthCalledWith(
+        2,
+        'test-token',
+        'testowner',
+        'testrepo',
+        expect.objectContaining({
+          name: 'notes.pdf',
+          type: 'application/pdf',
+          dataUrl: 'data:application/pdf;base64,JVBERi0xLjQK',
+        })
+      );
+
+      const issueBody = mockCreateIssue.mock.calls[0][4];
+      expect(issueBody).toContain('## Attachments');
+      expect(issueBody).toContain(`![photo.png](${uploadedImageUrl})`);
+      expect(issueBody).toContain(`[notes.pdf](${uploadedPdfUrl})`);
+    });
+
+    it('should reject unsupported uploaded file types', async () => {
+      const payloadWithUnsupportedAttachment = {
+        ...validPayload,
+        attachments: [
+          {
+            name: 'archive.zip',
+            type: 'application/zip',
+            size: 12,
+            dataUrl: 'data:application/zip;base64,UEsDBAo=',
+          },
+        ],
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payloadWithUnsupportedAttachment),
+      });
+      const res = await app.fetch(req, mockEnv);
+      const data = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(data.error).toContain('Unsupported file type');
+      expect(mockUploadAttachmentAsAsset).not.toHaveBeenCalled();
+      expect(mockCreateIssue).not.toHaveBeenCalled();
+    });
+
+    it('should reject uploaded files exceeding the size limit', async () => {
+      const payloadWithLargeAttachment = {
+        ...validPayload,
+        attachments: [
+          {
+            name: 'large.png',
+            type: 'image/png',
+            size: 6 * 1024 * 1024,
+            dataUrl: validPngDataUrl,
+          },
+        ],
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payloadWithLargeAttachment),
+      });
+      const res = await app.fetch(req, mockEnv);
+      const data = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(data.error).toContain('File is too large');
+      expect(data.error).toContain('exceeds 5MB limit');
+      expect(mockUploadAttachmentAsAsset).not.toHaveBeenCalled();
+      expect(mockCreateIssue).not.toHaveBeenCalled();
     });
 
     it('should add a selected-element screenshot caption when an element was chosen', async () => {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1478,7 +1478,7 @@ describe('API Routes', () => {
           },
           {
             level: 'warn',
-            message: 'Retrying cart request',
+            message: '{"token":"abc123","password":"hunter2","cookie":"sid=short"}',
             timestamp: '2026-06-08T10:00:01.000Z',
           },
         ],
@@ -1495,7 +1495,12 @@ describe('API Routes', () => {
       expect(issueBody).toContain('<summary>Console Logs</summary>');
       expect(issueBody).toContain('[error] Checkout failed with token=[redacted]');
       expect(issueBody).toContain('https://example.test/app.js?token=[redacted]:12:4');
-      expect(issueBody).toContain('[warn] Retrying cart request');
+      expect(issueBody).toContain(
+        '[warn] {"token":"[redacted]","password":"[redacted]","cookie":"[redacted]"}'
+      );
+      expect(issueBody).not.toContain('abc123');
+      expect(issueBody).not.toContain('hunter2');
+      expect(issueBody).not.toContain('sid=short');
     });
 
     it('should omit full CSS path row when metadata is absent', async () => {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1458,6 +1458,46 @@ describe('API Routes', () => {
       expect(issueBody).toContain('Submitted via');
     });
 
+    it('should include redacted console logs in the issue body when submitted', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      mockCreateIssue.mockResolvedValue({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+
+      const payloadWithConsoleLogs = {
+        ...validPayload,
+        consoleLogs: [
+          {
+            level: 'error',
+            message: 'Checkout failed with token=[redacted]',
+            sourceUrl: 'https://example.test/app.js?token=abc123456789abcdefghijklmnopqrstuvwxyz',
+            lineNumber: 12,
+            columnNumber: 4,
+            timestamp: '2026-06-08T10:00:00.000Z',
+          },
+          {
+            level: 'warn',
+            message: 'Retrying cart request',
+            timestamp: '2026-06-08T10:00:01.000Z',
+          },
+        ],
+      };
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payloadWithConsoleLogs),
+      });
+      await app.fetch(req, mockEnv);
+
+      const issueBody = mockCreateIssue.mock.calls[0][4];
+      expect(issueBody).toContain('<summary>Console Logs</summary>');
+      expect(issueBody).toContain('[error] Checkout failed with token=[redacted]');
+      expect(issueBody).toContain('https://example.test/app.js?token=[redacted]:12:4');
+      expect(issueBody).toContain('[warn] Retrying cart request');
+    });
+
     it('should omit full CSS path row when metadata is absent', async () => {
       mockGetInstallationToken.mockResolvedValue('test-token');
       mockCreateIssue.mockResolvedValue({

--- a/test/consoleLogRedaction.test.ts
+++ b/test/consoleLogRedaction.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { redactConsoleLogMessage } from '../src/widget/console-log-redaction';
+
+describe('console log redaction', () => {
+  it('redacts key/value and JSON-shaped secret fields', () => {
+    expect(redactConsoleLogMessage('token=abc123')).toBe('token=[redacted]');
+    expect(
+      redactConsoleLogMessage('{"token":"abc123","password":"hunter2","cookie":"sid=short"}')
+    ).toBe('{"token":"[redacted]","password":"[redacted]","cookie":"[redacted]"}');
+  });
+
+  it('redacts quoted secret values containing common delimiters', () => {
+    expect(redactConsoleLogMessage('{"password":"correct horse"}')).toBe(
+      '{"password":"[redacted]"}'
+    );
+    expect(redactConsoleLogMessage('{"cookie":"sid=short; theme=dark"}')).toBe(
+      '{"cookie":"[redacted]"}'
+    );
+    expect(redactConsoleLogMessage('token="abc,123&def"}')).toBe('token="[redacted]"}');
+    expect(redactConsoleLogMessage('password="abc\\"def"')).toBe('password="[redacted]"');
+  });
+
+  it('redacts structured values under secret keys', () => {
+    expect(redactConsoleLogMessage('{"password":["hunter2"]}')).toBe('{"password":[redacted]}');
+    expect(redactConsoleLogMessage('{"cookie":["sid=short"]}')).toBe('{"cookie":[redacted]}');
+    expect(redactConsoleLogMessage('retry {"password":{"value":"hunter2"}} done')).toBe(
+      'retry {"password":[redacted]} done'
+    );
+    expect(redactConsoleLogMessage('{"password":["hunter2"],"message":"kept"}')).toBe(
+      '{"password":[redacted],"message":"kept"}'
+    );
+  });
+
+  it('redacts unterminated quoted secret values', () => {
+    expect(redactConsoleLogMessage('password="hunter2')).toBe('password="[redacted]');
+    expect(redactConsoleLogMessage('token="short,secret')).toBe('token="[redacted]');
+    expect(redactConsoleLogMessage('{"password":"hunter2}')).toBe('{"password":"[redacted]');
+    expect(redactConsoleLogMessage('password="hunter2\nstack line')).toBe(
+      'password="[redacted]\nstack line'
+    );
+    expect(redactConsoleLogMessage('password="abc\\"def')).toBe('password="[redacted]');
+    expect(redactConsoleLogMessage('password="abc\\"def\nstack line')).toBe(
+      'password="[redacted]\nstack line'
+    );
+  });
+
+  it('redacts bearer tokens without damaging the authorization prefix', () => {
+    expect(redactConsoleLogMessage('Authorization: Bearer abc.def.ghi')).toBe(
+      'Authorization: Bearer [redacted]'
+    );
+  });
+});


### PR DESCRIPTION
Closes TheWebEng/webeng-bugdrop#8

## What changed

BugDrop reports can now include uploaded evidence files alongside or instead of a captured screenshot.

The widget adds a compact upload control next to the screenshot checkbox, shows selected files below those controls, and lets people remove files before submitting. The API validates uploaded file count, size, and type, then saves accepted files through the existing feedback asset branch. Uploaded images are embedded in the generated issue body, while PDFs and videos are linked.

## Test plan

- [x] `make check`
- [x] `npm run validate`
- [x] `make build-all`
- [x] `make test-e2e`
