### PR TITLE
chore: add manual Discord release posts

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -4,6 +4,25 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to post, such as v1.49.0
+        required: true
+        type: string
+      message:
+        description: Optional custom message above the release embed
+        required: false
+        type: string
+      image_url:
+        description: Optional public image URL to include in the embed
+        required: false
+        type: string
+      dry_run:
+        description: Print the Discord payload without posting
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -16,59 +35,122 @@ jobs:
       - name: Send release notification
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
-            echo "DISCORD_RELEASE_WEBHOOK_URL is not set; skipping Discord notification."
-            exit 0
-          fi
-
           node <<'NODE'
           const fs = require('node:fs');
 
           const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
-          const release = event.release;
-          const releaseName = release.name || release.tag_name;
           const repository = process.env.GITHUB_REPOSITORY;
-          const body = (release.body || '').trim();
-          const maxDescriptionLength = 3500;
-          const description =
-            body.length > maxDescriptionLength
-              ? `${body.slice(0, maxDescriptionLength - 20).trimEnd()}...`
-              : body || 'Release notes are available on GitHub.';
+          const inputs = event.inputs || {};
+          const isManualRun = process.env.GITHUB_EVENT_NAME === 'workflow_dispatch';
 
-          const payload = {
-            username: 'GitHub Releases',
-            allowed_mentions: {
-              parse: [],
-            },
-            content: `BugDrop ${release.tag_name} is out.`,
-            embeds: [
-              {
-                title: releaseName,
-                url: release.html_url,
-                description,
-                color: 0x238636,
-                fields: [
-                  {
-                    name: 'Repository',
-                    value: repository,
-                    inline: true,
-                  },
-                  {
-                    name: 'Tag',
-                    value: `\`${release.tag_name}\``,
-                    inline: true,
-                  },
-                ],
-                footer: {
-                  text: `Published by ${release.author?.login || 'GitHub'}`,
+          async function fetchReleaseByTag(tag) {
+            const headers = {
+              Accept: 'application/vnd.github+json',
+              'User-Agent': 'bugdrop-discord-release-workflow',
+            };
+
+            if (process.env.GITHUB_TOKEN) {
+              headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+            }
+
+            const response = await fetch(
+              `https://api.github.com/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`,
+              { headers },
+            );
+
+            if (!response.ok) {
+              const responseBody = await response.text();
+              throw new Error(
+                `GitHub release lookup failed for ${tag} with ${response.status}: ${responseBody}`,
+              );
+            }
+
+            return response.json();
+          }
+
+          async function getRelease() {
+            if (!isManualRun) {
+              return event.release;
+            }
+
+            const tag = (inputs.tag || '').trim();
+            if (!tag) {
+              throw new Error('Manual runs require a release tag.');
+            }
+
+            return fetchReleaseByTag(tag);
+          }
+
+          function buildPayload(release) {
+            const releaseName = release.name || release.tag_name;
+            const body = (release.body || '').trim();
+            const maxDescriptionLength = 3500;
+            const description =
+              body.length > maxDescriptionLength
+                ? `${body.slice(0, maxDescriptionLength - 20).trimEnd()}...`
+                : body || 'Release notes are available on GitHub.';
+            const imageUrl = (inputs.image_url || '').trim();
+            const content = (inputs.message || '').trim() || `BugDrop ${release.tag_name} is out.`;
+
+            const embed = {
+              title: releaseName,
+              url: release.html_url,
+              description,
+              color: 0x238636,
+              fields: [
+                {
+                  name: 'Repository',
+                  value: repository,
+                  inline: true,
                 },
-                timestamp: release.published_at,
+                {
+                  name: 'Tag',
+                  value: `\`${release.tag_name}\``,
+                  inline: true,
+                },
+              ],
+              footer: {
+                text: `Published by ${release.author?.login || 'GitHub'}`,
               },
-            ],
-          };
+              timestamp: release.published_at,
+            };
+
+            if (imageUrl) {
+              embed.image = {
+                url: imageUrl,
+              };
+            }
+
+            return {
+              username: 'GitHub Releases',
+              allowed_mentions: {
+                parse: [],
+              },
+              content,
+              embeds: [embed],
+            };
+          }
+
+          function isDryRun() {
+            return String(inputs.dry_run || '').toLowerCase() === 'true';
+          }
 
           async function main() {
+            const release = await getRelease();
+            const payload = buildPayload(release);
+
+            if (isDryRun()) {
+              console.log(JSON.stringify(payload, null, 2));
+              return;
+            }
+
+            if (!process.env.DISCORD_WEBHOOK_URL) {
+              console.log('DISCORD_RELEASE_WEBHOOK_URL is not set; skipping Discord notification.');
+              return;
+            }
+
             const response = await fetch(process.env.DISCORD_WEBHOOK_URL, {
               method: 'POST',
               headers: {


### PR DESCRIPTION
## Summary
- add workflow_dispatch inputs for retroactive Discord release posts
- support optional custom message, optional embed image URL, and dry-run payload output
- reuse the same payload builder for published releases and manual runs

## Validation
- npm run validate
- npm run check:actions-node24
- npx prettier --check .github/workflows/discord-release.yml
- synthetic release event posted to a fake local Discord endpoint
- manual dry-run fetched v1.49.0 and verified custom message, image_url, tag field, and disabled mentions
