### PR TITLE
Allow additional BugDrop auth token secrets

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -168,22 +168,23 @@ The release tag (e.g., `v1.2.0`) becomes the version number for the widget files
 
 ### Environment Variables
 
-| Variable                        | Required | Description                                                           |
-| ------------------------------- | -------- | --------------------------------------------------------------------- |
-| `GITHUB_APP_ID`                 | Yes      | Your GitHub App's numeric ID                                          |
-| `GITHUB_PRIVATE_KEY`            | Yes      | Private key from GitHub App settings                                  |
-| `ENVIRONMENT`                   | No       | `development` disables rate limiting; `production` enables all checks |
-| `ALLOWED_ORIGINS`               | No       | Comma-separated allowed domains (default: `*`)                        |
-| `GITHUB_APP_NAME`               | No       | Your app's URL slug for install links                                 |
-| `MAX_SCREENSHOT_SIZE_MB`        | No       | Max screenshot size in MB (default: `5`)                              |
-| `CATEGORY_LABELS`               | No       | JSON mapping from repos/categories to GitHub labels                   |
-| `ALLOW_CLIENT_CATEGORY_LABELS`  | No       | Set to `true` to trust `data-category-labels` from your own pages     |
-| `ROOT_REDIRECT_URL`             | No       | Landing page URL for `/` redirects (default: `https://bugdrop.dev`)   |
-| `AUTH_TOKEN_SECRET`             | No       | HMAC secret that requires signed host-app tokens for `/feedback`      |
-| `AUTH_TOKEN_AUDIENCE`           | No       | Expected token `aud` claim, usually your BugDrop worker hostname      |
-| `AUTH_TOKEN_ISSUER`             | No       | Expected token `iss` claim, usually your app hostname                 |
-| `AUTH_TOKEN_REQUIRED_FOR_CHECK` | No       | Set to `true` to require auth tokens for `/check/:owner/:repo` too    |
-| `RATE_LIMIT`                    | No       | KV namespace binding for rate limiting (see section 5)                |
+| Variable                        | Required | Description                                                                                   |
+| ------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `GITHUB_APP_ID`                 | Yes      | Your GitHub App's numeric ID                                                                  |
+| `GITHUB_PRIVATE_KEY`            | Yes      | Private key from GitHub App settings                                                          |
+| `ENVIRONMENT`                   | No       | `development` disables rate limiting; `production` enables all checks                         |
+| `ALLOWED_ORIGINS`               | No       | Comma-separated allowed domains (default: `*`)                                                |
+| `GITHUB_APP_NAME`               | No       | Your app's URL slug for install links                                                         |
+| `MAX_SCREENSHOT_SIZE_MB`        | No       | Max screenshot size in MB (default: `5`)                                                      |
+| `CATEGORY_LABELS`               | No       | JSON mapping from repos/categories to GitHub labels                                           |
+| `ALLOW_CLIENT_CATEGORY_LABELS`  | No       | Set to `true` to trust `data-category-labels` from your own pages                             |
+| `ROOT_REDIRECT_URL`             | No       | Landing page URL for `/` redirects (default: `https://bugdrop.dev`)                           |
+| `AUTH_TOKEN_SECRET`             | No       | HMAC secret that requires signed host-app tokens for `/feedback`                              |
+| `AUTH_TOKEN_ADDITIONAL_SECRETS` | No       | Comma/newline-separated extra HMAC secrets accepted during rotation or multi-app self-hosting |
+| `AUTH_TOKEN_AUDIENCE`           | No       | Expected token `aud` claim, usually your BugDrop worker hostname                              |
+| `AUTH_TOKEN_ISSUER`             | No       | Expected token `iss` claim, usually your app hostname                                         |
+| `AUTH_TOKEN_REQUIRED_FOR_CHECK` | No       | Set to `true` to require auth tokens for `/check/:owner/:repo` too                            |
+| `RATE_LIMIT`                    | No       | KV namespace binding for rate limiting (see section 5)                                        |
 
 ### Custom Category Labels
 
@@ -267,7 +268,9 @@ AUTH_TOKEN_ISSUER = "app.yourdomain.com"
 AUTH_TOKEN_REQUIRED_FOR_CHECK = "true"
 ```
 
-When `AUTH_TOKEN_SECRET` is set, `/feedback` requires an `Authorization: Bearer <token>` header. `/check/:owner/:repo` remains public by default for backwards compatibility; set `AUTH_TOKEN_REQUIRED_FOR_CHECK = "true"` if even installation status should be visible only to authenticated users.
+When `AUTH_TOKEN_SECRET` or `AUTH_TOKEN_ADDITIONAL_SECRETS` is set, `/feedback` requires an `Authorization: Bearer <token>` header. `/check/:owner/:repo` remains public by default for backwards compatibility; set `AUTH_TOKEN_REQUIRED_FOR_CHECK = "true"` if even installation status should be visible only to authenticated users.
+
+Use `AUTH_TOKEN_ADDITIONAL_SECRETS` when rotating tokens or when one self-hosted worker is shared by multiple authenticated host apps. Keep the existing `AUTH_TOKEN_SECRET` as the primary secret, then add comma- or newline-separated additional secrets so newly migrated apps can verify without breaking apps that still sign with the primary value.
 
 Your application should expose a same-origin endpoint that returns a token only after checking its own session:
 

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -245,7 +245,7 @@ Then reference that function on the BugDrop script tag:
 
 The provider may return either a raw token or a value already prefixed with `Bearer `. BugDrop calls it before installation checks and feedback submissions, then sends the token in the `Authorization` header.
 
-This attribute only adds the client-side header. Your self-hosted worker must also set `AUTH_TOKEN_SECRET` to enforce the token gate. The worker secret and the host app's token-signing secret must be byte-for-byte identical; if a valid-looking `bd1` token is rejected, check for trailing newlines or quoting differences. See the [Self-Hosting guide](https://github.com/mean-weasel/bugdrop/blob/main/SELF_HOSTING.md) for the worker environment variables, secret hygiene notes, and token claim format.
+This attribute only adds the client-side header. Your self-hosted worker must also set `AUTH_TOKEN_SECRET` or `AUTH_TOKEN_ADDITIONAL_SECRETS` to enforce the token gate. One configured worker secret must be byte-for-byte identical to the host app's token-signing secret; if a valid-looking `bd1` token is rejected, check for trailing newlines or quoting differences. See the [Self-Hosting guide](https://github.com/mean-weasel/bugdrop/blob/main/SELF_HOSTING.md) for the worker environment variables, secret hygiene notes, and token claim format.
 
 ### Rules and behavior
 

--- a/docs/website/security.mdx
+++ b/docs/website/security.mdx
@@ -222,6 +222,8 @@ If you run your own instance of BugDrop:
 
 For private or authenticated applications, self-hosted workers can require a signed token on feedback submissions. Set `AUTH_TOKEN_SECRET` on the BugDrop worker, mint short-lived tokens from your own backend after checking the user's session, and configure the widget with `data-auth-token-provider`.
 
+When rotating secrets or sharing one worker across multiple authenticated host apps, keep the current `AUTH_TOKEN_SECRET` in place and add comma- or newline-separated verifier secrets with `AUTH_TOKEN_ADDITIONAL_SECRETS`. BugDrop accepts tokens signed by any configured secret, so one app can migrate without breaking another app that still signs with the primary secret.
+
 This protects the feedback endpoint from direct API calls that bypass browser CORS. CORS still matters for browser isolation, but it is not an authentication boundary. The token should include the exact target repository and expire quickly, usually within 5 minutes.
 
 If installation status is also sensitive, set `AUTH_TOKEN_REQUIRED_FOR_CHECK = "true"` so the widget's `/check/:owner/:repo` request requires the same token.

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,11 @@ app.use('*', async (c, next) => {
         '[BugDrop] AUTH_TOKEN_SECRET should be a long random value of at least 32 characters.'
       );
     }
+    if (hasWeakAdditionalAuthTokenSecret(c.env.AUTH_TOKEN_ADDITIONAL_SECRETS)) {
+      console.warn(
+        '[BugDrop] AUTH_TOKEN_ADDITIONAL_SECRETS contains a value shorter than 32 characters.'
+      );
+    }
 
     envChecked = true;
   }
@@ -43,6 +48,14 @@ app.route('/api', api);
 
 export function isWeakAuthTokenSecret(secret?: string): boolean {
   return typeof secret === 'string' && secret.length > 0 && secret.length < 32;
+}
+
+export function hasWeakAdditionalAuthTokenSecret(value?: string): boolean {
+  if (!value) return false;
+  return value
+    .split(/[,\n]/)
+    .map(secret => secret.trim())
+    .some(isWeakAuthTokenSecret);
 }
 
 export function resolveRootRedirectUrl(rawUrl?: string): string {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -291,7 +291,7 @@ async function requireBugDropFeedbackAuthToken(
   c: Context<ApiEnv>,
   next: Next
 ): Promise<Response | void> {
-  if (!c.env.AUTH_TOKEN_SECRET || c.req.method !== 'POST') return next();
+  if (!hasBugDropAuthTokenSecret(c.env) || c.req.method !== 'POST') return next();
 
   try {
     const payload = (await c.req.raw.clone().json()) as FeedbackPayload;
@@ -312,15 +312,16 @@ function getBearerToken(value: string | undefined): string | undefined {
 }
 
 async function requireBugDropAuthToken(c: Context<ApiEnv>, repo: string): Promise<Response | null> {
-  if (!c.env.AUTH_TOKEN_SECRET) return null;
+  const secrets = getBugDropAuthTokenSecrets(c.env);
+  if (secrets.length === 0) return null;
 
   try {
-    await verifyBugDropAuthToken(getBearerToken(c.req.header('Authorization')), {
-      secret: c.env.AUTH_TOKEN_SECRET,
-      repo,
-      audience: c.env.AUTH_TOKEN_AUDIENCE,
-      issuer: c.env.AUTH_TOKEN_ISSUER,
-    });
+    await verifyBugDropAuthTokenWithAnySecret(
+      getBearerToken(c.req.header('Authorization')),
+      secrets,
+      c,
+      repo
+    );
     return null;
   } catch (error) {
     console.warn('[BugDrop] rejected auth token', {
@@ -329,6 +330,51 @@ async function requireBugDropAuthToken(c: Context<ApiEnv>, repo: string): Promis
     });
     return c.json({ error: 'BugDrop auth token required' }, 401);
   }
+}
+
+function hasBugDropAuthTokenSecret(env: Env): boolean {
+  return getBugDropAuthTokenSecrets(env).length > 0;
+}
+
+function getBugDropAuthTokenSecrets(env: Env): string[] {
+  return [
+    env.AUTH_TOKEN_SECRET,
+    ...splitAdditionalAuthTokenSecrets(env.AUTH_TOKEN_ADDITIONAL_SECRETS),
+  ]
+    .map(secret => secret?.trim())
+    .filter((secret): secret is string => Boolean(secret));
+}
+
+function splitAdditionalAuthTokenSecrets(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(/[,\n]/)
+    .map(secret => secret.trim())
+    .filter(Boolean);
+}
+
+async function verifyBugDropAuthTokenWithAnySecret(
+  token: string | undefined,
+  secrets: string[],
+  c: Context<ApiEnv>,
+  repo: string
+): Promise<void> {
+  let lastError: unknown;
+  for (const secret of secrets) {
+    try {
+      await verifyBugDropAuthToken(token, {
+        secret,
+        repo,
+        audience: c.env.AUTH_TOKEN_AUDIENCE,
+        issuer: c.env.AUTH_TOKEN_ISSUER,
+      });
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError ?? new Error('Missing BugDrop auth token');
 }
 
 type ScreenshotValidationResult = { valid: true } | { valid: false; error: string };

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface Env {
   ALLOW_CLIENT_CATEGORY_LABELS?: string; // Self-host escape hatch for script-tag mappings
   ROOT_REDIRECT_URL?: string; // Optional landing page for self-hosted deployments
   AUTH_TOKEN_SECRET?: string; // Optional HMAC secret for host-app submission tokens
+  AUTH_TOKEN_ADDITIONAL_SECRETS?: string; // Optional comma/newline-separated extra HMAC secrets
   AUTH_TOKEN_AUDIENCE?: string; // Optional expected token audience claim
   AUTH_TOKEN_ISSUER?: string; // Optional expected token issuer claim
   AUTH_TOKEN_REQUIRED_FOR_CHECK?: string; // Optional gate for /check installation lookups

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -167,6 +167,42 @@ describe('API Routes', () => {
       expect(mockGetInstallationToken).not.toHaveBeenCalled();
     });
 
+    it('should accept check tokens signed by an additional configured secret', async () => {
+      mockGetInstallationToken.mockResolvedValue('test-token');
+      const env = {
+        ...mockEnv,
+        AUTH_TOKEN_SECRET: 'primary-secret-with-at-least-32-bytes',
+        AUTH_TOKEN_ADDITIONAL_SECRETS: 'deckchecker-secret-with-at-least-32-bytes',
+        AUTH_TOKEN_REQUIRED_FOR_CHECK: 'true',
+      };
+      const now = Math.floor(Date.now() / 1000);
+      const token = await createBugDropAuthTokenForTest(
+        {
+          sub: 'user-123',
+          repo: 'testowner/testrepo',
+          iat: now,
+          exp: now + 300,
+          jti: 'jti-123',
+        },
+        'deckchecker-secret-with-at-least-32-bytes'
+      );
+
+      const req = new Request('http://localhost/check/testowner/testrepo', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      const res = await app.fetch(req, env);
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data).toMatchObject({
+        installed: true,
+        repo: 'testowner/testrepo',
+      });
+      expect(mockGetInstallationToken).toHaveBeenCalledWith(env, 'testowner', 'testrepo');
+    });
+
     it('should handle special characters in repo names', async () => {
       mockGetInstallationToken.mockResolvedValue('test-token');
 
@@ -343,6 +379,48 @@ describe('API Routes', () => {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
           Origin: 'https://app.example.com',
+        },
+        body: JSON.stringify(validPayload),
+      });
+      const res = await app.fetch(req, env);
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data).toMatchObject({
+        success: true,
+        issueNumber: 42,
+      });
+      expect(mockCreateIssue).toHaveBeenCalledOnce();
+    });
+
+    it('should create issue with a bearer token signed by an additional configured secret', async () => {
+      const env = {
+        ...mockEnv,
+        AUTH_TOKEN_SECRET: 'primary-secret-with-at-least-32-bytes',
+        AUTH_TOKEN_ADDITIONAL_SECRETS:
+          'other-rotating-secret-with-at-least-32-bytes, deckchecker-secret-with-at-least-32-bytes',
+        AUTH_TOKEN_AUDIENCE: 'bugdrop.example.workers.dev',
+        AUTH_TOKEN_ISSUER: 'app.example.com',
+      };
+      const now = Math.floor(Date.now() / 1000);
+      const token = await createBugDropAuthTokenForTest(
+        {
+          iss: 'app.example.com',
+          aud: 'bugdrop.example.workers.dev',
+          sub: 'user-123',
+          repo: 'testowner/testrepo',
+          iat: now,
+          exp: now + 300,
+          jti: 'jti-123',
+        },
+        'deckchecker-secret-with-at-least-32-bytes'
+      );
+
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(validPayload),
       });

--- a/test/rootRedirect.test.ts
+++ b/test/rootRedirect.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { isWeakAuthTokenSecret, resolveRootRedirectUrl } from '../src/index';
+import {
+  hasWeakAdditionalAuthTokenSecret,
+  isWeakAuthTokenSecret,
+  resolveRootRedirectUrl,
+} from '../src/index';
 
 describe('resolveRootRedirectUrl', () => {
   it('uses the hosted site by default', () => {
@@ -35,5 +39,13 @@ describe('isWeakAuthTokenSecret', () => {
 
   it('accepts secrets with at least 32 characters', () => {
     expect(isWeakAuthTokenSecret('x'.repeat(32))).toBe(false);
+  });
+
+  it('flags weak additional secrets in comma or newline separated values', () => {
+    const strongSecret = 'x'.repeat(32);
+    const anotherStrongSecret = 'y'.repeat(32);
+
+    expect(hasWeakAdditionalAuthTokenSecret(`${strongSecret}\nshort`)).toBe(true);
+    expect(hasWeakAdditionalAuthTokenSecret(`${strongSecret}, ${anotherStrongSecret}`)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add `AUTH_TOKEN_ADDITIONAL_SECRETS` so a self-hosted worker can accept extra HMAC verifier secrets without replacing the primary `AUTH_TOKEN_SECRET`
- require auth when either primary or additional secrets are configured
- warn on weak additional secrets and document rotation / multi-app self-hosting usage

## Why
DeckChecker production mints a valid-looking BugDrop token for `mean-weasel/deckchecker`, but `bugdrop-personal` rejects it with `Invalid token signature`. The personal worker is shared by other apps, so replacing `AUTH_TOKEN_SECRET` would risk breaking existing integrations. This lets us add a DeckChecker-specific/newly-rotated verifier secret while preserving the current primary secret.

## Proof
- Reproduced live worker rejection via `wrangler tail bugdrop-personal`: `[BugDrop] rejected auth token { repo: 'mean-weasel/deckchecker', reason: 'Invalid token signature' }`
- `npx vitest run test/api.test.ts test/rootRedirect.test.ts` -> 91 passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `npm run format:check` -> passed
- `npm test` -> 21 files / 314 tests passed

## Follow-up after deploy
1. Generate a fresh DeckChecker BugDrop token secret.
2. Store it in the `bugdrop-personal` worker as `AUTH_TOKEN_ADDITIONAL_SECRETS` while leaving `AUTH_TOKEN_SECRET` untouched.
3. Store the same value in DeckChecker Vercel production as `BUGDROP_AUTH_TOKEN_SECRET` and redeploy DeckChecker.
4. Verify `/api/check/mean-weasel/deckchecker` returns 200 with a fresh DeckChecker token, then verify the production widget reaches the feedback form.
