### PR TITLE
[codex] add board social preview metadata

### DIFF
--- a/public/board/index.html
+++ b/public/board/index.html
@@ -8,6 +8,41 @@
       name="description"
       content="BugDrop Board is an embedded, self-hostable feedback board that turns user ideas into GitHub Issues with authenticated upvotes."
     />
+    <link rel="canonical" href="https://bugdrop.dev/board/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="BugDrop" />
+    <meta
+      property="og:title"
+      content="BugDrop Board | Embedded feedback boards backed by GitHub"
+    />
+    <meta
+      property="og:description"
+      content="BugDrop Board is an embedded, self-hostable feedback board that turns user ideas into GitHub Issues with authenticated upvotes."
+    />
+    <meta property="og:url" content="https://bugdrop.dev/board/" />
+    <meta property="og:image" content="https://bugdrop.dev/board/assets/launch-dark.png" />
+    <meta property="og:image:secure_url" content="https://bugdrop.dev/board/assets/launch-dark.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="1280" />
+    <meta property="og:image:height" content="720" />
+    <meta
+      property="og:image:alt"
+      content="Dark launch-planning feedback board UI preview for BugDrop Board."
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="BugDrop Board | Embedded feedback boards backed by GitHub"
+    />
+    <meta
+      name="twitter:description"
+      content="BugDrop Board is an embedded, self-hostable feedback board that turns user ideas into GitHub Issues with authenticated upvotes."
+    />
+    <meta name="twitter:image" content="https://bugdrop.dev/board/assets/launch-dark.png" />
+    <meta
+      name="twitter:image:alt"
+      content="Dark launch-planning feedback board UI preview for BugDrop Board."
+    />
     <style>
       :root {
         color-scheme: light;

--- a/test/boardLanding.test.ts
+++ b/test/boardLanding.test.ts
@@ -52,6 +52,24 @@ describe('BugDrop Board landing page', () => {
     expect(html).toContain('BugDrop Board');
   });
 
+  it('declares a social preview image for Discord and other unfurlers', () => {
+    expect(boardLandingHtml).toContain(
+      '<link rel="canonical" href="https://bugdrop.dev/board/" />'
+    );
+    expect(boardLandingHtml).toContain('<meta property="og:type" content="website" />');
+    expect(boardLandingHtml).toContain(
+      '<meta property="og:image" content="https://bugdrop.dev/board/assets/launch-dark.png" />'
+    );
+    expect(boardLandingHtml).toContain('<meta property="og:image:width" content="1280" />');
+    expect(boardLandingHtml).toContain('<meta property="og:image:height" content="720" />');
+    expect(boardLandingHtml).toContain(
+      '<meta name="twitter:card" content="summary_large_image" />'
+    );
+    expect(boardLandingHtml).toContain(
+      '<meta name="twitter:image" content="https://bugdrop.dev/board/assets/launch-dark.png" />'
+    );
+  });
+
   it('embeds the live first-party board in the static page without dogfood framing', () => {
     expect(boardLandingHtml).toContain('id="live-demo"');
     expect(boardLandingHtml).toContain('Try the embedded board.');


### PR DESCRIPTION
## Summary
- add canonical, Open Graph, and Twitter large-card metadata to the BugDrop Board landing page
- point social unfurls at the existing published 1280x720 board preview image
- add a board landing regression test so the preview image metadata stays present

## Validation
- npm run validate
- npx vitest run test/boardLanding.test.ts
- npx prettier --check public/board/index.html test/boardLanding.test.ts
- git diff --check
- crawler-style local extraction confirmed og:image, image dimensions, twitter:card, and twitter:image
- curl confirmed https://bugdrop.dev/board/assets/launch-dark.png returns 200 image/png and is 1280x720