### PR TITLE
Restart screenshot picker after capture failure

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -4268,11 +4268,11 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     await expect(errorText).toBeVisible({ timeout: 20000 });
     await expect(errorText).toContainText('Failed to capture screenshot');
 
-    // Verify retry and skip buttons are available
+    // Verify the user can skip or return to the method picker.
     const skipBtn = host.locator('css=[data-action="skip"]');
-    const retryBtn = host.locator('css=[data-action="retry"]');
+    const chooseAgainBtn = host.locator('css=[data-action="choose-again"]');
     await expect(skipBtn).toBeVisible();
-    await expect(retryBtn).toBeVisible();
+    await expect(chooseAgainBtn).toBeVisible();
   });
 
   test('closing screenshot options returns to the form without submitting', async ({ page }) => {
@@ -4370,8 +4370,10 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     expect(payloads[0].screenshot).toBeNull();
   });
 
-  test('retry button on error modal re-attempts capture', async ({ page }) => {
-    // First call fails, second call succeeds
+  test('capture failure can return to screenshot options and select another method', async ({
+    page,
+  }) => {
+    // First call fails, second call succeeds after the user chooses a method again.
     await mockHtmlToImage(
       page,
       `function(el, opts) {
@@ -4391,11 +4393,10 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     const errorText = host.locator('css=.bd-error-message__text');
     await expect(errorText).toBeVisible({ timeout: 5000 });
 
-    // Click "Try Again"
-    const retryBtn = host.locator('css=[data-action="retry"]');
-    await retryBtn.click();
+    await host.locator('css=[data-action="choose-again"]').click();
+    await expect(host.locator('css=[data-action="capture"]')).toBeVisible({ timeout: 5000 });
+    await host.locator('css=[data-action="capture"]').click();
 
-    // Second attempt succeeds — annotation canvas should appear
     const annotationCanvas = host.locator('css=#annotation-canvas');
     await expect(annotationCanvas).toBeVisible({ timeout: 10000 });
   });
@@ -4573,7 +4574,7 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     expect(payloads[0].screenshot).toEqual(expect.stringMatching(/^data:image\/png;base64,/));
   });
 
-  test('retries native viewport capture from the capture error modal', async ({ page }) => {
+  test('returns to screenshot options after native viewport capture fails', async ({ page }) => {
     await mockGetDisplayMedia(
       page,
       `function() {
@@ -4605,7 +4606,9 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
       )
       .toBe(1);
 
-    await host.locator('css=[data-action="retry"]').click();
+    await host.locator('css=[data-action="choose-again"]').click();
+    await expect(host.locator('css=[data-action="viewport"]')).toBeVisible({ timeout: 5000 });
+    await host.locator('css=[data-action="viewport"]').click();
 
     await expect(host.locator('css=.bd-modal--annotator')).toBeVisible({ timeout: 10000 });
     await expect

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -5508,6 +5508,30 @@ test.describe('Screenshot Mode Configuration', () => {
     ).toBe(1);
   });
 
+  test('auto mode capture failure can skip without offering the manual picker', async ({
+    page,
+  }) => {
+    await setupInstalledApp(page);
+    await page.addInitScript(`window.__bugdropMockToPng = function() {
+      return Promise.reject(new Error('auto capture failed'));
+    };`);
+    const getPayload = await setupSuccessfulSubmit(page);
+
+    await page.goto('/test/?screenshot=auto');
+    const host = await openForm(page);
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=.bd-error-message__text')).toContainText(
+      'Failed to capture screenshot',
+      { timeout: 5000 }
+    );
+    await expect(host.locator('css=[data-action="choose-again"]')).not.toBeAttached();
+    await host.locator('css=[data-action="skip"]').click();
+
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+    expect(getPayload()?.screenshot).toBeNull();
+  });
+
   test('auto mode warns users about automatic full-page screenshots', async ({ page }) => {
     await setupInstalledApp(page);
     await mockSuccessfulCapture(page);

--- a/src/widget/capture-flow.ts
+++ b/src/widget/capture-flow.ts
@@ -8,7 +8,7 @@ import {
 import { getElementContextCaptureTarget } from './element-context';
 import { createElementPicker } from './picker';
 import { getElementSelector, getFullElementSelector } from './selector-metadata';
-import { beginViewportCapture, getRedactionCount, isFullPageDisabled } from './screenshot';
+import { getRedactionCount, isFullPageDisabled } from './screenshot';
 import { showScreenshotOptions, type ScreenshotChoice } from './screenshot-options';
 import { DEFAULT_SELECTED_ELEMENT_SCREENSHOT_PIXEL_RATIO } from '../defaults';
 
@@ -49,6 +49,7 @@ type ChosenCaptureResult =
       redactionLimitations: boolean;
     } & ElementMetadata)
   | { kind: 'returnToForm' }
+  | { kind: 'chooseAgain' }
   | ({
       kind: 'empty';
       reason: EmptyCaptureReason;
@@ -74,6 +75,7 @@ export async function runScreenshotCaptureFlow(
     if (result.kind === 'returnToForm') {
       return { ...emptyCaptureResult(), returnToForm: true };
     }
+    if (result.kind === 'chooseAgain') continue;
 
     if (result.kind === 'empty') {
       if (!screenshotRequired && shouldRememberComplexScreenshotSkip(result.reason)) {
@@ -170,16 +172,12 @@ async function captureFromViewportChoice(
   choice: Extract<ScreenshotChoice, { kind: 'viewport' }>,
   screenshotRequired: boolean
 ): Promise<ChosenCaptureResult> {
-  const result = await capturePromiseWithLoading(
-    root,
-    choice.capture,
-    () => beginViewportCapture(),
-    {
-      allowSkip: !screenshotRequired,
-      showLoading: false,
-    }
-  );
+  const result = await capturePromiseWithLoading(root, choice.capture, {
+    allowSkip: !screenshotRequired,
+    showLoading: false,
+  });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
+  if (result.kind === 'choose-again') return { kind: 'chooseAgain' };
   if (result.kind === 'skipped') {
     return emptyChosenCaptureResult('capture-failure-skip');
   }
@@ -203,6 +201,7 @@ async function captureFromFullPageChoice(
     allowSkip: !screenshotRequired,
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
+  if (result.kind === 'choose-again') return { kind: 'chooseAgain' };
   if (result.kind === 'skipped') {
     return emptyChosenCaptureResult('capture-failure-skip');
   }
@@ -247,6 +246,7 @@ async function captureFromElementChoice(
     },
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
+  if (result.kind === 'choose-again') return { kind: 'chooseAgain' };
   if (result.kind === 'skipped') {
     return emptyChosenCaptureResult('capture-failure-skip', elementMetadata);
   }
@@ -276,6 +276,7 @@ async function captureFromAreaChoice(
     allowSkip: !screenshotRequired,
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
+  if (result.kind === 'choose-again') return { kind: 'chooseAgain' };
   if (result.kind === 'skipped') {
     return emptyChosenCaptureResult('capture-failure-skip');
   }

--- a/src/widget/capture-flow.ts
+++ b/src/widget/capture-flow.ts
@@ -61,13 +61,9 @@ export async function runScreenshotCaptureFlow(
   includeScreenshot: boolean,
   onComplexScreenshotSkipped: () => void
 ): Promise<CaptureFlowResult> {
-  if (config.screenshotMode === 'auto') {
-    return captureAutomaticScreenshot(root, config);
-  }
+  if (config.screenshotMode === 'auto') return captureAutomaticScreenshot(root, config);
 
-  if (!includeScreenshot) {
-    return emptyCaptureResult();
-  }
+  if (!includeScreenshot) return emptyCaptureResult();
 
   const screenshotRequired = config.screenshotMode === 'required';
   while (true) {
@@ -123,7 +119,9 @@ async function captureAutomaticScreenshot(
     return emptyCaptureResult();
   }
 
-  const result = await captureWithLoading(root, undefined, config.screenshotScale);
+  const result = await captureWithLoading(root, undefined, config.screenshotScale, {
+    allowChooseAgain: false,
+  });
   if (result.kind === 'cancelled') {
     return { ...emptyCaptureResult(), returnToForm: true };
   }

--- a/src/widget/capture-loading.ts
+++ b/src/widget/capture-loading.ts
@@ -9,6 +9,7 @@ import { createModal } from './ui';
 
 export type CaptureWithLoadingResult =
   | { kind: 'ok'; dataUrl: string; redaction?: CapturedScreenshot['redaction'] }
+  | { kind: 'choose-again' }
   | { kind: 'skipped' }
   | { kind: 'cancelled' };
 
@@ -23,7 +24,6 @@ export async function captureWithLoading(
   return capturePromiseWithLoading(
     root,
     captureScreenshot(element, screenshotScale, opts?.captureOptions),
-    () => captureScreenshot(element, screenshotScale, opts?.captureOptions),
     opts
   );
 }
@@ -37,7 +37,6 @@ export async function captureAreaWithLoading(
   return capturePromiseWithLoading(
     root,
     captureAreaScreenshot(rect, screenshotScale, opts?.captureOptions),
-    () => captureAreaScreenshot(rect, screenshotScale, opts?.captureOptions),
     opts
   );
 }
@@ -45,7 +44,6 @@ export async function captureAreaWithLoading(
 export async function capturePromiseWithLoading(
   root: HTMLElement,
   capturePromise: Promise<CapturePayload>,
-  retryCapture: () => Promise<CapturePayload>,
   opts?: { allowSkip?: boolean; showLoading?: boolean }
 ): Promise<CaptureWithLoadingResult> {
   const loadingModal =
@@ -87,8 +85,8 @@ export async function capturePromiseWithLoading(
             <span class="bd-error-message__text">Failed to capture screenshot. The page may be too complex or browser restrictions may apply.</span>
           </div>
           <div class="bd-actions">
-            <button class="bd-btn bd-btn-secondary" data-action="skip">${allowSkip ? 'Skip Screenshot' : 'Choose Another Method'}</button>
-            <button class="bd-btn bd-btn-primary" data-action="retry">Try Again</button>
+            ${allowSkip ? '<button class="bd-btn bd-btn-secondary" data-action="skip">Skip Screenshot</button>' : ''}
+            <button class="bd-btn bd-btn-primary" data-action="choose-again">Choose Another Method</button>
           </div>
         `,
         true
@@ -96,7 +94,9 @@ export async function capturePromiseWithLoading(
 
       const closeBtn = errorModal.querySelector('.bd-close') as HTMLElement;
       const skipBtn = errorModal.querySelector('[data-action="skip"]') as HTMLElement;
-      const retryBtn = errorModal.querySelector('[data-action="retry"]') as HTMLElement;
+      const chooseAgainBtn = errorModal.querySelector(
+        '[data-action="choose-again"]'
+      ) as HTMLElement;
 
       closeBtn?.addEventListener('click', () => {
         errorModal.remove();
@@ -108,10 +108,9 @@ export async function capturePromiseWithLoading(
         resolve({ kind: 'skipped' });
       });
 
-      retryBtn?.addEventListener('click', async () => {
+      chooseAgainBtn?.addEventListener('click', () => {
         errorModal.remove();
-        const result = await capturePromiseWithLoading(root, retryCapture(), retryCapture, opts);
-        resolve(result);
+        resolve({ kind: 'choose-again' });
       });
     });
   }

--- a/src/widget/capture-loading.ts
+++ b/src/widget/capture-loading.ts
@@ -14,12 +14,18 @@ export type CaptureWithLoadingResult =
   | { kind: 'cancelled' };
 
 type CapturePayload = string | CapturedScreenshot;
+type CaptureLoadingOptions = {
+  allowSkip?: boolean;
+  allowChooseAgain?: boolean;
+  showLoading?: boolean;
+  captureOptions?: CaptureScreenshotOptions;
+};
 
 export async function captureWithLoading(
   root: HTMLElement,
   element?: Element,
   screenshotScale?: number,
-  opts?: { allowSkip?: boolean; captureOptions?: CaptureScreenshotOptions }
+  opts?: CaptureLoadingOptions
 ): Promise<CaptureWithLoadingResult> {
   return capturePromiseWithLoading(
     root,
@@ -32,7 +38,7 @@ export async function captureAreaWithLoading(
   root: HTMLElement,
   rect: DOMRect,
   screenshotScale?: number,
-  opts?: { allowSkip?: boolean; captureOptions?: CaptureScreenshotOptions }
+  opts?: CaptureLoadingOptions
 ): Promise<CaptureWithLoadingResult> {
   return capturePromiseWithLoading(
     root,
@@ -44,7 +50,7 @@ export async function captureAreaWithLoading(
 export async function capturePromiseWithLoading(
   root: HTMLElement,
   capturePromise: Promise<CapturePayload>,
-  opts?: { allowSkip?: boolean; showLoading?: boolean }
+  opts?: CaptureLoadingOptions
 ): Promise<CaptureWithLoadingResult> {
   const loadingModal =
     opts?.showLoading === false
@@ -68,6 +74,7 @@ export async function capturePromiseWithLoading(
     console.warn('[BugDrop] Screenshot capture failed:', error);
     loadingModal?.remove();
     const allowSkip = opts?.allowSkip !== false;
+    const allowChooseAgain = opts?.allowChooseAgain !== false;
 
     if (error instanceof MaskApplicationError) {
       return showMaskFailureModal(root);
@@ -86,7 +93,7 @@ export async function capturePromiseWithLoading(
           </div>
           <div class="bd-actions">
             ${allowSkip ? '<button class="bd-btn bd-btn-secondary" data-action="skip">Skip Screenshot</button>' : ''}
-            <button class="bd-btn bd-btn-primary" data-action="choose-again">Choose Another Method</button>
+            ${allowChooseAgain ? '<button class="bd-btn bd-btn-primary" data-action="choose-again">Choose Another Method</button>' : ''}
           </div>
         `,
         true

--- a/test/captureFlow.test.ts
+++ b/test/captureFlow.test.ts
@@ -34,8 +34,12 @@ async function loadCaptureFlowWithMocks(opts: {
   screenshotChoices?: ScreenshotChoice[];
   pickedElement?: Element | null;
   pickedElements?: Array<Element | null>;
+  pickedArea?: DOMRect | null;
+  pickedAreas?: Array<DOMRect | null>;
   captureResult?: CaptureWithLoadingResult;
   captureResults?: CaptureWithLoadingResult[];
+  areaCaptureResult?: CaptureWithLoadingResult;
+  areaCaptureResults?: CaptureWithLoadingResult[];
   annotationResult?: string | 'retake' | 'cancel';
   annotationResults?: Array<string | 'retake' | 'cancel'>;
 }) {
@@ -52,12 +56,22 @@ async function loadCaptureFlowWithMocks(opts: {
   }
   elementPickerMock.mockResolvedValue(opts.pickedElement ?? null);
 
+  const areaPickerMock = vi.fn();
+  for (const area of opts.pickedAreas ?? []) {
+    areaPickerMock.mockResolvedValueOnce(area);
+  }
+  areaPickerMock.mockResolvedValue(opts.pickedArea ?? null);
+
   const captureWithLoadingMock = vi.fn();
   for (const result of opts.captureResults ?? []) {
     captureWithLoadingMock.mockResolvedValueOnce(result);
   }
   captureWithLoadingMock.mockResolvedValue(opts.captureResult ?? { kind: 'skipped' });
   const captureAreaWithLoadingMock = vi.fn();
+  for (const result of opts.areaCaptureResults ?? []) {
+    captureAreaWithLoadingMock.mockResolvedValueOnce(result);
+  }
+  captureAreaWithLoadingMock.mockResolvedValue(opts.areaCaptureResult ?? { kind: 'skipped' });
 
   const annotationMock = vi.fn();
   for (const result of opts.annotationResults ?? []) {
@@ -72,7 +86,7 @@ async function loadCaptureFlowWithMocks(opts: {
     createElementPicker: elementPickerMock,
   }));
   vi.doMock('../src/widget/area-picker', () => ({
-    createAreaPicker: vi.fn(),
+    createAreaPicker: areaPickerMock,
   }));
   vi.doMock('../src/widget/capture-loading', () => ({
     captureWithLoading: captureWithLoadingMock,
@@ -90,6 +104,7 @@ async function loadCaptureFlowWithMocks(opts: {
 
   return {
     ...(await import('../src/widget/capture-flow')),
+    screenshotOptionsMock,
     captureWithLoadingMock,
     captureAreaWithLoadingMock,
   };
@@ -540,6 +555,40 @@ describe('capture flow state decisions', () => {
       fullElementSelector: null,
       returnToForm: true,
     });
+    expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
+  });
+
+  it('returns to screenshot options after a capture failure so another method can be selected', async () => {
+    const {
+      runScreenshotCaptureFlow,
+      screenshotOptionsMock,
+      captureWithLoadingMock,
+      captureAreaWithLoadingMock,
+    } = await loadCaptureFlowWithMocks({
+      screenshotChoices: [{ kind: 'capture' }, { kind: 'area' }],
+      captureResult: { kind: 'choose-again' } as CaptureWithLoadingResult,
+      pickedArea: rect(200, 120, 10, 20),
+      areaCaptureResult: { kind: 'ok', dataUrl: 'data:image/png;base64,AREA' },
+      annotationResult: 'data:image/png;base64,ANNOTATED_AREA',
+    });
+    const onComplexScreenshotSkipped = vi.fn();
+
+    const result = await runScreenshotCaptureFlow(
+      document.createElement('div'),
+      baseConfig,
+      true,
+      onComplexScreenshotSkipped
+    );
+
+    expect(result).toEqual({
+      screenshot: 'data:image/png;base64,ANNOTATED_AREA',
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: false,
+    });
+    expect(screenshotOptionsMock).toHaveBeenCalledTimes(2);
+    expect(captureWithLoadingMock).toHaveBeenCalledTimes(1);
+    expect(captureAreaWithLoadingMock).toHaveBeenCalledTimes(1);
     expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
   });
 

--- a/test/captureFlow.test.ts
+++ b/test/captureFlow.test.ts
@@ -592,6 +592,32 @@ describe('capture flow state decisions', () => {
     expect(onComplexScreenshotSkipped).not.toHaveBeenCalled();
   });
 
+  it('does not offer choose-again recovery for automatic screenshots without a picker', async () => {
+    const { runScreenshotCaptureFlow, captureWithLoadingMock, screenshotOptionsMock } =
+      await loadCaptureFlowWithMocks({
+        captureResult: { kind: 'skipped' },
+      });
+    const root = document.createElement('div');
+
+    const result = await runScreenshotCaptureFlow(
+      root,
+      { ...baseConfig, screenshotMode: 'auto' },
+      true,
+      vi.fn()
+    );
+
+    expect(result).toEqual({
+      screenshot: null,
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: false,
+    });
+    expect(screenshotOptionsMock).not.toHaveBeenCalled();
+    expect(captureWithLoadingMock).toHaveBeenCalledWith(root, undefined, undefined, {
+      allowChooseAgain: false,
+    });
+  });
+
   it('returns to form when the annotation step is cancelled', async () => {
     const { runScreenshotCaptureFlow } = await loadCaptureFlowWithMocks({
       screenshotChoice: { kind: 'capture' },


### PR DESCRIPTION
Closes #230

## What changed
Capture failures now return users to the screenshot method picker instead of offering a retry of the same failed method. Optional screenshot flows still allow users to continue without a screenshot.

## Why this shape
The observed mobile failure was tied to the selected capture path rather than a transient request. Retrying immediately would re-run the same browser-side rendering path, so the useful recovery action is to let the user choose a different capture method.

Viewport capture still has to start from a fresh user gesture. Returning to the method picker preserves that browser requirement because the next viewport capture begins from the user's explicit click on the viewport option.

---

## Test plan
- [x] `npm ci`
- [x] `npm run validate` (lint, format check, type-check, 316 unit tests)
- [x] `npx playwright test e2e/widget.spec.ts --project=chromium --grep "shows error modal when capture times out|capture failure can return to screenshot options and select another method|returns to screenshot options after native viewport capture fails"`
- [x] Pre-push hook type-check
