### PR TITLE
Ignore hidden images during screenshot capture

### DIFF
--- a/src/widget/screenshot.ts
+++ b/src/widget/screenshot.ts
@@ -104,7 +104,7 @@ export async function captureScreenshot(
     cacheBust: false,
     imagePlaceholder: TRANSPARENT_IMAGE_PLACEHOLDER,
     pixelRatio,
-    filter: (node: HTMLElement) => node.id !== 'bugdrop-host',
+    filter: shouldIncludeCaptureNode,
   };
 
   const redactionSnapshot = createRedactionSnapshot(target);
@@ -158,7 +158,7 @@ export async function captureAreaScreenshot(
       width: `${document.documentElement.scrollWidth}px`,
       height: `${document.documentElement.scrollHeight}px`,
     },
-    filter: (node: HTMLElement) => node.id !== 'bugdrop-host',
+    filter: shouldIncludeCaptureNode,
   };
 
   const redactionSnapshot = createRedactionSnapshot(document.body);
@@ -191,6 +191,24 @@ export async function captureAreaScreenshot(
 
 export function getRedactionCount(element?: Element, rect?: DOMRect): number {
   return countMaskRects(element ?? document.body, rect);
+}
+
+function shouldIncludeCaptureNode(node: HTMLElement): boolean {
+  if (node.id === 'bugdrop-host') return false;
+
+  if (node instanceof HTMLImageElement && isInvisibleOrZeroSize(node)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isInvisibleOrZeroSize(element: HTMLElement): boolean {
+  const style = getComputedStyle(element);
+  if (style.display === 'none' || style.visibility === 'hidden') return true;
+
+  const rect = element.getBoundingClientRect();
+  return rect.width <= 0 || rect.height <= 0;
 }
 
 function getToPng(): typeof htmlToImage.toPng {

--- a/src/widget/screenshot.ts
+++ b/src/widget/screenshot.ts
@@ -196,15 +196,19 @@ export function getRedactionCount(element?: Element, rect?: DOMRect): number {
 function shouldIncludeCaptureNode(node: HTMLElement): boolean {
   if (node.id === 'bugdrop-host') return false;
 
-  if (node instanceof HTMLImageElement && isInvisibleOrZeroSize(node)) {
+  if (isHtmlImage(node) && isInvisibleOrZeroSize(node)) {
     return false;
   }
 
   return true;
 }
 
+function isHtmlImage(element: HTMLElement): boolean {
+  return element.tagName?.toUpperCase() === 'IMG';
+}
+
 function isInvisibleOrZeroSize(element: HTMLElement): boolean {
-  const style = getComputedStyle(element);
+  const style = (element.ownerDocument.defaultView ?? window).getComputedStyle(element);
   if (style.display === 'none' || style.visibility === 'hidden') return true;
 
   const rect = element.getBoundingClientRect();

--- a/test/cropScreenshot.test.ts
+++ b/test/cropScreenshot.test.ts
@@ -291,6 +291,75 @@ describe('captureScreenshot integrates with mask pipeline', () => {
     });
   });
 
+  it('excludes invisible and zero-size images from DOM capture', async () => {
+    const visibleImage = document.createElement('img');
+    visibleImage.id = 'visible-image';
+    visibleImage.getBoundingClientRect = () =>
+      ({
+        x: 10,
+        y: 10,
+        width: 120,
+        height: 80,
+        top: 10,
+        left: 10,
+        bottom: 90,
+        right: 130,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const hiddenBeacon = document.createElement('img');
+    hiddenBeacon.id = 'batBeacon-test';
+    hiddenBeacon.style.display = 'none';
+    hiddenBeacon.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const zeroSizeImage = document.createElement('img');
+    zeroSizeImage.id = 'zero-size-image';
+    zeroSizeImage.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    document.body.append(visibleImage, hiddenBeacon, zeroSizeImage);
+
+    const STUB =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+    const toPng = vi.fn(() => Promise.resolve(STUB));
+    (window as unknown as { __bugdropMockToPng: typeof toPng }).__bugdropMockToPng = toPng;
+
+    await captureScreenshot();
+
+    const captureOptions = toPng.mock.calls[0][1];
+    const filter = captureOptions.filter as (node: HTMLElement) => boolean;
+    expect(filter(visibleImage)).toBe(true);
+    expect(filter(hiddenBeacon)).toBe(false);
+    expect(filter(zeroSizeImage)).toBe(false);
+  });
+
   it('completes element-scoped capture when the picked element has a masked descendant', async () => {
     const target = document.createElement('section');
     target.getBoundingClientRect = () =>

--- a/test/cropScreenshot.test.ts
+++ b/test/cropScreenshot.test.ts
@@ -360,6 +360,61 @@ describe('captureScreenshot integrates with mask pipeline', () => {
     expect(filter(zeroSizeImage)).toBe(false);
   });
 
+  it('allows non-element child nodes through the DOM capture filter', async () => {
+    document.body.appendChild(document.createTextNode('plain page text'));
+
+    const STUB =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+    const toPng = vi.fn(() => Promise.resolve(STUB));
+    (window as unknown as { __bugdropMockToPng: typeof toPng }).__bugdropMockToPng = toPng;
+
+    await captureScreenshot();
+
+    const captureOptions = toPng.mock.calls[0][1];
+    const filter = captureOptions.filter as (node: HTMLElement) => boolean;
+    expect(filter(document.createTextNode('hello') as unknown as HTMLElement)).toBe(true);
+  });
+
+  it('excludes hidden images from same-origin iframe captures', async () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    const iframeDocument = iframe.contentDocument;
+    expect(iframeDocument).not.toBeNull();
+
+    const iframeHiddenBeacon = iframeDocument!.createElement('img');
+    iframeHiddenBeacon.id = 'iframe-batBeacon-test';
+    iframeHiddenBeacon.style.display = 'none';
+    iframeHiddenBeacon.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+    iframeDocument!.body.appendChild(iframeHiddenBeacon);
+
+    expect(iframeHiddenBeacon).not.toBeInstanceOf(HTMLImageElement);
+
+    const STUB =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+    const toPng = vi.fn(() => Promise.resolve(STUB));
+    (window as unknown as { __bugdropMockToPng: typeof toPng }).__bugdropMockToPng = toPng;
+
+    await captureScreenshot();
+
+    const captureOptions = toPng.mock.calls[0][1];
+    const filter = captureOptions.filter as (node: HTMLElement) => boolean;
+    expect(filter(iframeHiddenBeacon as unknown as HTMLElement)).toBe(false);
+  });
+
   it('completes element-scoped capture when the picked element has a masked descendant', async () => {
     const target = document.createElement('section');
     target.getBoundingClientRect = () =>


### PR DESCRIPTION
Closes #232

## What changed
BugDrop now filters invisible and zero-size images out of DOM screenshot rendering while still keeping visible images in the capture. This applies to the shared capture filter used by full-page, selected-element, and area screenshot paths.

## Why this shape
The observed failure came from a hidden tracking beacon image, not from visible page content. Removing non-rendered image nodes from the html-to-image clone avoids letting blocked or broken analytics pixels fail a screenshot that would never have shown those pixels to the user.

The filter is intentionally limited to images that are hidden or have no rendered dimensions. It preserves other hidden DOM nodes for now because broad filtering can accidentally change layout or masking behavior; this patch targets the concrete asset-loading failure without changing the visible page capture contract.

---

## Test plan
- [x] `npm ci`
- [x] `npm test -- --run test/cropScreenshot.test.ts` (23 tests)
- [x] `npm run validate` (lint, format check, type-check, 316 unit tests)
- [x] `npm run build:widget`
- [x] Pre-push hook type-check
