### PR TITLE
Show screenshot loading before capture starts

### DIFF
--- a/src/widget/capture-loading.ts
+++ b/src/widget/capture-loading.ts
@@ -13,6 +13,7 @@ export type CaptureWithLoadingResult =
   | { kind: 'cancelled' };
 
 type CapturePayload = string | CapturedScreenshot;
+type CaptureOperation = Promise<CapturePayload> | (() => Promise<CapturePayload>);
 
 export async function captureWithLoading(
   root: HTMLElement,
@@ -20,12 +21,8 @@ export async function captureWithLoading(
   screenshotScale?: number,
   opts?: { allowSkip?: boolean; captureOptions?: CaptureScreenshotOptions }
 ): Promise<CaptureWithLoadingResult> {
-  return capturePromiseWithLoading(
-    root,
-    captureScreenshot(element, screenshotScale, opts?.captureOptions),
-    () => captureScreenshot(element, screenshotScale, opts?.captureOptions),
-    opts
-  );
+  const startCapture = () => captureScreenshot(element, screenshotScale, opts?.captureOptions);
+  return capturePromiseWithLoading(root, startCapture, startCapture, opts);
 }
 
 export async function captureAreaWithLoading(
@@ -34,17 +31,13 @@ export async function captureAreaWithLoading(
   screenshotScale?: number,
   opts?: { allowSkip?: boolean; captureOptions?: CaptureScreenshotOptions }
 ): Promise<CaptureWithLoadingResult> {
-  return capturePromiseWithLoading(
-    root,
-    captureAreaScreenshot(rect, screenshotScale, opts?.captureOptions),
-    () => captureAreaScreenshot(rect, screenshotScale, opts?.captureOptions),
-    opts
-  );
+  const startCapture = () => captureAreaScreenshot(rect, screenshotScale, opts?.captureOptions);
+  return capturePromiseWithLoading(root, startCapture, startCapture, opts);
 }
 
 export async function capturePromiseWithLoading(
   root: HTMLElement,
-  capturePromise: Promise<CapturePayload>,
+  captureOperation: CaptureOperation,
   retryCapture: () => Promise<CapturePayload>,
   opts?: { allowSkip?: boolean; showLoading?: boolean }
 ): Promise<CaptureWithLoadingResult> {
@@ -63,6 +56,11 @@ export async function capturePromiseWithLoading(
         );
 
   try {
+    if (loadingModal) {
+      await waitForLoadingPaint();
+    }
+    const capturePromise =
+      typeof captureOperation === 'function' ? captureOperation() : captureOperation;
     const screenshot = await capturePromise;
     loadingModal?.remove();
     return normalizeCaptureResult(screenshot);
@@ -115,6 +113,18 @@ export async function capturePromiseWithLoading(
       });
     });
   }
+}
+
+function waitForLoadingPaint(): Promise<void> {
+  if (typeof requestAnimationFrame !== 'function') {
+    return new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  return new Promise(resolve => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
 }
 
 function showMaskFailureModal(root: HTMLElement): Promise<CaptureWithLoadingResult> {

--- a/src/widget/capture-loading.ts
+++ b/src/widget/capture-loading.ts
@@ -108,7 +108,7 @@ export async function capturePromiseWithLoading(
 
       retryBtn?.addEventListener('click', async () => {
         errorModal.remove();
-        const result = await capturePromiseWithLoading(root, retryCapture(), retryCapture, opts);
+        const result = await capturePromiseWithLoading(root, retryCapture, retryCapture, opts);
         resolve(result);
       });
     });

--- a/test/captureLoading.test.ts
+++ b/test/captureLoading.test.ts
@@ -21,10 +21,20 @@ function trackLoadingAppend(root: HTMLElement, events: string[]) {
   }) as typeof root.appendChild;
 }
 
+async function findRetryButton(root: HTMLElement): Promise<HTMLButtonElement> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const button = root.querySelector<HTMLButtonElement>('[data-action="retry"]');
+    if (button) return button;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  throw new Error('Retry button was not shown');
+}
+
 afterEach(() => {
   document.body.innerHTML = '';
   vi.doUnmock('../src/widget/screenshot');
   vi.resetModules();
+  vi.restoreAllMocks();
 });
 
 describe('capture loading timing', () => {
@@ -66,5 +76,31 @@ describe('capture loading timing', () => {
     await captureAreaWithLoading(root, new DOMRect(0, 0, 100, 100));
 
     expect(events).toEqual(['loading:append', 'capture:start']);
+  });
+
+  it('shows the loading modal before retry capture starts', async () => {
+    const events: string[] = [];
+    const root = document.createElement('div');
+    trackLoadingAppend(root, events);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { capturePromiseWithLoading } = await import('../src/widget/capture-loading');
+
+    const resultPromise = capturePromiseWithLoading(
+      root,
+      async () => {
+        throw new Error('first attempt failed');
+      },
+      async () => {
+        events.push('retry:capture:start');
+        return successfulCapture;
+      }
+    );
+
+    const retryButton = await findRetryButton(root);
+    events.length = 0;
+    retryButton.click();
+
+    await expect(resultPromise).resolves.toMatchObject({ kind: 'ok' });
+    expect(events).toEqual(['loading:append', 'retry:capture:start']);
   });
 });

--- a/test/captureLoading.test.ts
+++ b/test/captureLoading.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const successfulCapture = {
+  dataUrl: 'data:image/png;base64,AAAA',
+  redaction: {
+    count: 0,
+    hasLimitations: false,
+    maskedSelectors: [],
+    unsupportedSurfaces: [],
+  },
+};
+
+function trackLoadingAppend(root: HTMLElement, events: string[]) {
+  const appendChild = root.appendChild.bind(root);
+  root.appendChild = ((child: Node) => {
+    if (child.textContent?.includes('Capturing screenshot')) {
+      events.push('loading:append');
+    }
+    return appendChild(child);
+  }) as typeof root.appendChild;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.doUnmock('../src/widget/screenshot');
+  vi.resetModules();
+});
+
+describe('capture loading timing', () => {
+  it('shows the loading modal before full-page or element capture starts', async () => {
+    const events: string[] = [];
+    vi.resetModules();
+    vi.doMock('../src/widget/screenshot', () => ({
+      captureScreenshot: vi.fn(async () => {
+        events.push('capture:start');
+        return successfulCapture;
+      }),
+      captureAreaScreenshot: vi.fn(),
+    }));
+
+    const root = document.createElement('div');
+    trackLoadingAppend(root, events);
+    const { captureWithLoading } = await import('../src/widget/capture-loading');
+
+    await captureWithLoading(root, document.createElement('section'));
+
+    expect(events).toEqual(['loading:append', 'capture:start']);
+  });
+
+  it('shows the loading modal before selected-area capture starts', async () => {
+    const events: string[] = [];
+    vi.resetModules();
+    vi.doMock('../src/widget/screenshot', () => ({
+      captureScreenshot: vi.fn(),
+      captureAreaScreenshot: vi.fn(async () => {
+        events.push('capture:start');
+        return successfulCapture;
+      }),
+    }));
+
+    const root = document.createElement('div');
+    trackLoadingAppend(root, events);
+    const { captureAreaWithLoading } = await import('../src/widget/capture-loading');
+
+    await captureAreaWithLoading(root, new DOMRect(0, 0, 100, 100));
+
+    expect(events).toEqual(['loading:append', 'capture:start']);
+  });
+});


### PR DESCRIPTION
Closes #234

## What changed

BugDrop now inserts and paints the screenshot loading modal before starting full-page, selected-element, or selected-area screenshot capture. The capture helper accepts a lazy capture operation for those flows while still allowing already-started captures for the browser viewport permission path.

## Why this shape

The tempting fix is to keep passing an already-created promise and just move UI code around it. That does not solve the pause, because creating the promise is the point where screenshot setup starts. Passing a function for normal screenshot capture delays that setup until after the loading state is present.

Viewport capture is intentionally left able to pass an already-started promise because browser display-capture prompts need to originate from the user's click. The loading-delay fix is aimed at the html-to-image based capture paths where the expensive work is under BugDrop's control.

---

## Test plan

- [x] `npm test -- test/captureLoading.test.ts`
- [x] `npm test`
- [x] `npm run typecheck`
