### PR TITLE
fix: keep BugDrop usable inside Radix dialogs

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -14,6 +14,9 @@ type CaptureOptions = Record<string, unknown> & {
 declare global {
   interface Window {
     __hostKeystrokeCount?: number;
+    __hostModalOpen?: boolean;
+    __hostDismissEvents?: string[];
+    __hostFocusTrapEvents?: string[];
     __captureOpts?: CaptureOptions;
     __captureTargetInfo?: {
       tagName: string;
@@ -111,6 +114,128 @@ test.describe('Widget Loading', () => {
     // Access button inside shadow DOM
     const button = page.locator('#bugdrop-host').locator('css=.bd-trigger');
     await expect(button).toBeVisible();
+  });
+
+  test('widget pointer interactions do not dismiss Radix-style host modals', async ({ page }) => {
+    await page.route('**/api/check**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/welcome-disabled.html');
+    await page.evaluate(() => {
+      window.__hostModalOpen = true;
+      window.__hostDismissEvents = [];
+
+      document.addEventListener(
+        'pointerdown',
+        event => {
+          const host = document.getElementById('bugdrop-host');
+          if (!host || !event.composedPath().includes(host)) {
+            return;
+          }
+
+          for (const eventType of [
+            'dismissableLayer.pointerDownOutside',
+            'dismissableLayer.interactOutside',
+          ]) {
+            const outsideEvent = new CustomEvent(eventType, {
+              bubbles: true,
+              cancelable: true,
+              composed: true,
+              detail: { originalEvent: event },
+            });
+
+            window.__hostDismissEvents?.push(eventType);
+            document.dispatchEvent(outsideEvent);
+
+            if (!outsideEvent.defaultPrevented) {
+              window.__hostModalOpen = false;
+            }
+          }
+        },
+        true
+      );
+    });
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await expect(host.locator('css=#title')).toBeVisible({ timeout: 5000 });
+
+    await expect.poll(() => page.evaluate(() => window.__hostModalOpen)).toBe(true);
+    await expect
+      .poll(() => page.evaluate(() => window.__hostDismissEvents))
+      .toEqual(['dismissableLayer.pointerDownOutside', 'dismissableLayer.interactOutside']);
+
+    await host.locator('css=#title').click();
+
+    await expect.poll(() => page.evaluate(() => window.__hostModalOpen)).toBe(true);
+    await expect
+      .poll(() => page.evaluate(() => window.__hostDismissEvents))
+      .toEqual([
+        'dismissableLayer.pointerDownOutside',
+        'dismissableLayer.interactOutside',
+        'dismissableLayer.pointerDownOutside',
+        'dismissableLayer.interactOutside',
+      ]);
+  });
+
+  test('widget text fields remain editable inside Radix-style focus traps', async ({ page }) => {
+    await page.route('**/api/check**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/welcome-disabled.html');
+    await page.evaluate(() => {
+      window.__hostFocusTrapEvents = [];
+
+      const hostDialog = document.createElement('div');
+      hostDialog.id = 'host-dialog-content';
+      hostDialog.tabIndex = -1;
+      hostDialog.textContent = 'Host dialog';
+      document.body.appendChild(hostDialog);
+      hostDialog.focus();
+
+      document.addEventListener(
+        'focusin',
+        event => {
+          const host = document.getElementById('bugdrop-host');
+          const target = event.target as Node | null;
+          if (!host || !target || hostDialog.contains(target)) {
+            return;
+          }
+
+          if (event.composedPath().includes(host)) {
+            window.__hostFocusTrapEvents?.push((target as Element).id || 'bugdrop-host');
+            hostDialog.focus();
+          }
+        },
+        true
+      );
+    });
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await expect(host.locator('css=#title')).toBeVisible({ timeout: 5000 });
+
+    const titleInput = host.locator('css=#title');
+    await titleInput.click();
+    await page.keyboard.type('Radix title');
+    await expect(titleInput).toHaveValue('Radix title');
+
+    const descriptionInput = host.locator('css=#description');
+    await descriptionInput.click();
+    await page.keyboard.type('Radix description');
+    await expect(descriptionInput).toHaveValue('Radix description');
+
+    await expect.poll(() => page.evaluate(() => window.__hostFocusTrapEvents)).toEqual([]);
   });
 
   test('feedback button is an edge label with a drag handle', async ({ page }) => {

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -17,6 +17,7 @@ declare global {
     __hostModalOpen?: boolean;
     __hostDismissEvents?: string[];
     __hostFocusTrapEvents?: string[];
+    __hostFocusOutTrapEvents?: string[];
     __captureOpts?: CaptureOptions;
     __captureTargetInfo?: {
       tagName: string;
@@ -129,6 +130,7 @@ test.describe('Widget Loading', () => {
     await page.evaluate(() => {
       window.__hostModalOpen = true;
       window.__hostDismissEvents = [];
+      document.body.style.pointerEvents = 'none';
 
       document.addEventListener(
         'pointerdown',
@@ -162,6 +164,7 @@ test.describe('Widget Loading', () => {
     });
 
     const host = page.locator('#bugdrop-host');
+    await expect(host).toHaveCSS('pointer-events', 'auto');
     await host.locator('css=.bd-trigger').click();
     await expect(host.locator('css=#title')).toBeVisible({ timeout: 5000 });
 
@@ -236,6 +239,153 @@ test.describe('Widget Loading', () => {
     await expect(descriptionInput).toHaveValue('Radix description');
 
     await expect.poll(() => page.evaluate(() => window.__hostFocusTrapEvents)).toEqual([]);
+  });
+
+  test('widget text fields remain editable inside Radix-style focusout traps', async ({ page }) => {
+    await page.route('**/api/check**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/welcome-disabled.html');
+    await page.evaluate(() => {
+      window.__hostFocusOutTrapEvents = [];
+
+      const hostDialog = document.createElement('div');
+      hostDialog.id = 'host-dialog-content';
+      hostDialog.tabIndex = -1;
+      hostDialog.textContent = 'Host dialog';
+      document.body.appendChild(hostDialog);
+      hostDialog.focus();
+
+      document.addEventListener('focusout', event => {
+        const relatedTarget = event.relatedTarget as Node | null;
+        if (!relatedTarget || hostDialog.contains(relatedTarget)) {
+          return;
+        }
+
+        window.__hostFocusOutTrapEvents?.push((relatedTarget as Element).id || 'bugdrop-host');
+        hostDialog.focus();
+      });
+    });
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await expect(host.locator('css=#title')).toBeVisible({ timeout: 5000 });
+
+    const titleInput = host.locator('css=#title');
+    await titleInput.click();
+    await page.keyboard.type('Radix title');
+    await expect(titleInput).toHaveValue('Radix title');
+
+    const descriptionInput = host.locator('css=#description');
+    await descriptionInput.click();
+    await page.keyboard.type('Radix description');
+    await expect(descriptionInput).toHaveValue('Radix description');
+
+    await expect.poll(() => page.evaluate(() => window.__hostFocusOutTrapEvents)).toEqual([]);
+  });
+
+  test('host dialog can receive focus again after editing BugDrop fields', async ({ page }) => {
+    await page.route('**/api/check**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/welcome-disabled.html');
+    await page.evaluate(() => {
+      const hostDialog = document.createElement('div');
+      hostDialog.id = 'host-dialog-content';
+      hostDialog.innerHTML = `
+        <input id="host-first" aria-label="Host first input" />
+        <input id="host-second" aria-label="Host second input" />
+      `;
+      document.body.appendChild(hostDialog);
+
+      window.__hostFocusTrapEvents = [];
+
+      document.addEventListener('focusin', event => {
+        const target = event.target as Element | null;
+        if (target && hostDialog.contains(target)) {
+          window.__hostFocusTrapEvents?.push(target.id);
+        }
+      });
+
+      const firstInput = document.getElementById('host-first') as HTMLInputElement;
+      firstInput.focus();
+      window.__hostFocusTrapEvents = [];
+    });
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await expect(host.locator('css=#title')).toBeVisible({ timeout: 5000 });
+
+    const titleInput = host.locator('css=#title');
+    await titleInput.click();
+    await page.keyboard.type('Radix title');
+    await expect(titleInput).toHaveValue('Radix title');
+
+    await page.locator('#host-second').focus();
+    await expect(page.locator('#host-second')).toBeFocused();
+    await expect
+      .poll(() => page.evaluate(() => window.__hostFocusTrapEvents))
+      .toEqual(['host-second']);
+  });
+
+  test('keyboard focus into BugDrop fields stays editable inside focusout traps', async ({
+    page,
+  }) => {
+    await page.route('**/api/check**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
+    await page.goto('/test/welcome-disabled.html');
+    await page.evaluate(() => {
+      const hostDialog = document.createElement('div');
+      hostDialog.id = 'host-dialog-content';
+      hostDialog.innerHTML = '<input id="host-title" aria-label="Host title" />';
+      document.body.appendChild(hostDialog);
+
+      const hostTitle = document.getElementById('host-title') as HTMLInputElement;
+      document.addEventListener('focusout', event => {
+        const relatedTarget = event.relatedTarget as Node | null;
+        if (!relatedTarget || hostDialog.contains(relatedTarget)) {
+          return;
+        }
+
+        hostTitle.focus();
+      });
+
+      hostTitle.focus();
+    });
+
+    const host = page.locator('#bugdrop-host');
+    await host.locator('css=.bd-trigger').click();
+    await expect(host.locator('css=#title')).toBeVisible({ timeout: 5000 });
+
+    await page.locator('#host-title').focus();
+    const titleInput = host.locator('css=#title');
+    await titleInput.focus();
+    await expect(titleInput).toBeFocused();
+    await page.keyboard.type('Keyboard title');
+    await expect(titleInput).toHaveValue('Keyboard title');
+
+    await page.locator('#host-title').focus();
+    const descriptionInput = host.locator('css=#description');
+    await descriptionInput.focus();
+    await expect(descriptionInput).toBeFocused();
+    await page.keyboard.type('Keyboard description');
+    await expect(descriptionInput).toHaveValue('Keyboard description');
   });
 
   test('feedback button is an edge label with a drag handle', async ({ page }) => {

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -763,15 +763,26 @@ function createPullTab(root: HTMLElement, config: WidgetConfig): HTMLElement {
   return tab;
 }
 
-function installRadixDialogCompatibility(host: HTMLElement) {
+function installRadixDialogCompatibility(host: HTMLElement): void {
   const preventBugDropDismissal = (event: Event) => {
     if (isBugDropInteraction(host, event)) {
       event.preventDefault();
     }
   };
   const keepBugDropFocus = (event: Event) => {
-    if (isBugDropInteraction(host, event)) {
-      event.stopPropagation();
+    if (isBugDropFocusEvent(host, event)) {
+      if (event.type === 'focusin') {
+        event.stopImmediatePropagation();
+        return;
+      }
+
+      if (event.type === 'focusout') {
+        replayHostFocusOut(event);
+        event.stopImmediatePropagation();
+        return;
+      }
+
+      event.stopImmediatePropagation();
     }
   };
 
@@ -782,9 +793,10 @@ function installRadixDialogCompatibility(host: HTMLElement) {
     document.addEventListener(eventType, preventBugDropDismissal, true);
   }
   window.addEventListener('focusin', keepBugDropFocus, true);
+  window.addEventListener('focusout', keepBugDropFocus, true);
 }
 
-function isBugDropInteraction(host: HTMLElement, event: Event) {
+function isBugDropInteraction(host: HTMLElement, event: Event): boolean {
   const originalEvent = (event as CustomEvent<{ originalEvent?: Event }>).detail?.originalEvent;
   const path =
     typeof originalEvent?.composedPath === 'function'
@@ -798,6 +810,47 @@ function isBugDropInteraction(host: HTMLElement, event: Event) {
   }
 
   return (originalEvent?.target ?? event.target) === host;
+}
+
+function isBugDropFocusEvent(host: HTMLElement, event: Event): boolean {
+  if (!(event instanceof FocusEvent)) {
+    return isBugDropInteraction(host, event);
+  }
+
+  if (event.type === 'focusin') {
+    return isBugDropInteraction(host, event);
+  }
+
+  if (event.type !== 'focusout') {
+    return false;
+  }
+
+  const nextFocusedNode = event.relatedTarget;
+  const nextFocusIsBugDrop =
+    nextFocusedNode === host ||
+    (nextFocusedNode instanceof Node && (host.shadowRoot?.contains(nextFocusedNode) ?? false));
+  return nextFocusIsBugDrop && !isBugDropInteraction(host, event);
+}
+
+function replayHostFocusOut(event: Event): void {
+  const path = typeof event.composedPath === 'function' ? event.composedPath() : [];
+  for (const node of path) {
+    if (!(node instanceof HTMLElement)) {
+      continue;
+    }
+
+    node.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: false,
+        composed: false,
+        relatedTarget: event instanceof FocusEvent ? event.relatedTarget : null,
+      })
+    );
+
+    if (node === document.body) {
+      break;
+    }
+  }
 }
 
 function initWidget(config: WidgetConfig) {
@@ -819,9 +872,9 @@ function initWidget(config: WidgetConfig) {
   host.id = 'bugdrop-host';
   host.style.pointerEvents = 'auto';
   document.body.appendChild(host);
-  installRadixDialogCompatibility(host);
 
   const shadow = host.attachShadow({ mode: 'open' });
+  installRadixDialogCompatibility(host);
 
   // Prevent keyboard events from leaking to host page (e.g., ERPNext console shortcuts)
   for (const eventType of ['keydown', 'keypress', 'keyup'] as const) {

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -763,6 +763,43 @@ function createPullTab(root: HTMLElement, config: WidgetConfig): HTMLElement {
   return tab;
 }
 
+function installRadixDialogCompatibility(host: HTMLElement) {
+  const preventBugDropDismissal = (event: Event) => {
+    if (isBugDropInteraction(host, event)) {
+      event.preventDefault();
+    }
+  };
+  const keepBugDropFocus = (event: Event) => {
+    if (isBugDropInteraction(host, event)) {
+      event.stopPropagation();
+    }
+  };
+
+  for (const eventType of [
+    'dismissableLayer.pointerDownOutside',
+    'dismissableLayer.interactOutside',
+  ] as const) {
+    document.addEventListener(eventType, preventBugDropDismissal, true);
+  }
+  window.addEventListener('focusin', keepBugDropFocus, true);
+}
+
+function isBugDropInteraction(host: HTMLElement, event: Event) {
+  const originalEvent = (event as CustomEvent<{ originalEvent?: Event }>).detail?.originalEvent;
+  const path =
+    typeof originalEvent?.composedPath === 'function'
+      ? originalEvent.composedPath()
+      : typeof event.composedPath === 'function'
+        ? event.composedPath()
+        : [];
+
+  if (path.includes(host)) {
+    return true;
+  }
+
+  return (originalEvent?.target ?? event.target) === host;
+}
+
 function initWidget(config: WidgetConfig) {
   // Store config for API access
   _widgetConfig = config;
@@ -780,7 +817,9 @@ function initWidget(config: WidgetConfig) {
   // Create Shadow DOM for style isolation
   const host = document.createElement('div');
   host.id = 'bugdrop-host';
+  host.style.pointerEvents = 'auto';
   document.body.appendChild(host);
+  installRadixDialogCompatibility(host);
 
   const shadow = host.attachShadow({ mode: 'open' });
 


### PR DESCRIPTION
Closes #237
Fixes #236

## What changed
BugDrop now treats interactions that originate inside its widget host as internal when a Radix/shadcn dialog is open. That keeps the host dialog from closing on BugDrop clicks and keeps BugDrop's Title and Description fields editable while the host dialog's focus trap is active.

## Why this shape
Radix surfaces outside interactions through cancelable custom events, so the widget can cancel only the Radix dismissal path when the original event came from BugDrop. That is narrower than blocking all page pointer events, and it avoids requiring every host application to add BugDrop-specific exceptions to its own Dialog/Sheet/Drawer components.

The focus issue needs a separate guard because preventing dismissal alone still leaves Radix's focus trap free to pull typing back into the host dialog. BugDrop stops focus events that start inside its own host before the host dialog can reclaim focus, without changing focus behavior for the rest of the page.

## Test plan
- `CI=1 npx playwright test e2e/widget.spec.ts -g "widget pointer interactions do not dismiss Radix-style host modals|widget text fields remain editable inside Radix-style focus traps" --project=chromium` failed before the widget fix, reproducing both the modal-dismiss and field-editing failures.
- `CI=1 npx playwright test e2e/widget.spec.ts -g "widget pointer interactions do not dismiss Radix-style host modals|widget text fields remain editable inside Radix-style focus traps" --project=chromium` passed after the fix.
- `npm run validate` passed: lint, format check, typecheck, and 315 Vitest tests.
- `CI=1 npx playwright test --project=chromium` passed with 216 passed and 2 flaky tests that passed on retry.
- Pre-push hook passed typecheck while pushing `codex/radix-modal-compat`.
