### PR TITLE
chore: run live production tests after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,9 @@
 name: Deploy
 
 # Fires only on actual pushes to main. Merge-queue rulesets gate which commits
-# reach main, so the SHA here has already passed ci.yml in the merge_group
-# context — no need to re-run tests.
+# reach main, so the SHA here has already passed ci.yml in the merge_group context.
+# After the release tag is created and production deploys, run live E2E against
+# production so the post-release widget/version path is covered too.
 
 on:
   push:
@@ -64,3 +65,11 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  live-production-tests:
+    name: Live Production Tests
+    needs: [deploy]
+    uses: ./.github/workflows/live-tests.yml
+    with:
+      target: production
+    secrets: inherit

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -73,28 +73,28 @@ jobs:
       - name: Record expected widget asset
         run: |
           if [ "$LIVE_TARGET" = "preview" ]; then
-            VERSION=$(git describe --tags --abbrev=0) npm run build:widget
-            echo "EXPECTED_WIDGET_ORIGIN=https://bugdrop-preview.neonwatty.workers.dev" >> "$GITHUB_ENV"
-            echo "EXPECTED_WIDGET_SHA256=$(shasum -a 256 public/widget.js | awk '{print $1}')" >> "$GITHUB_ENV"
+            WIDGET_ORIGIN="https://bugdrop-preview.neonwatty.workers.dev"
           else
-            echo "EXPECTED_WIDGET_ORIGIN=https://bugdrop.neonwatty.workers.dev" >> "$GITHUB_ENV"
+            WIDGET_ORIGIN="https://bugdrop.neonwatty.workers.dev"
           fi
+          VERSION=$(git describe --tags --abbrev=0) npm run build:widget
+          echo "EXPECTED_WIDGET_ORIGIN=$WIDGET_ORIGIN" >> "$GITHUB_ENV"
+          echo "EXPECTED_WIDGET_SHA256=$(shasum -a 256 public/widget.js | awk '{print $1}')" >> "$GITHUB_ENV"
 
-      - name: Wait for expected preview widget asset
-        if: env.LIVE_TARGET == 'preview'
+      - name: Wait for expected widget asset
         run: |
-          WIDGET_URL="https://bugdrop-preview.neonwatty.workers.dev/widget.js"
+          WIDGET_URL="$EXPECTED_WIDGET_ORIGIN/widget.js"
           echo "Waiting for $WIDGET_URL to serve $EXPECTED_WIDGET_SHA256..."
           for i in $(seq 1 30); do
             ACTUAL_SHA="$(curl -sSf "$WIDGET_URL" | shasum -a 256 | awk '{print $1}')"
             if [ "$ACTUAL_SHA" = "$EXPECTED_WIDGET_SHA256" ]; then
-              echo "Preview widget asset matched after $((i * 5))s"
+              echo "$LIVE_TARGET widget asset matched after $((i * 5))s"
               exit 0
             fi
             echo "Attempt $i/30 served $ACTUAL_SHA; waiting 5s..."
             sleep 5
           done
-          echo "Preview widget did not serve expected asset $EXPECTED_WIDGET_SHA256"
+          echo "$LIVE_TARGET widget did not serve expected asset $EXPECTED_WIDGET_SHA256"
           exit 1
 
       - name: Run live E2E tests


### PR DESCRIPTION
## Summary
- run the reusable live widget tests after production deploys from main
- make live-tests hash-check the deployed widget asset for both preview and production before Playwright starts
- keep production tests pointed at the production Vercel venue and Cloudflare Worker

## Verification
- npx prettier --check .github/workflows/deploy.yml .github/workflows/live-tests.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false .github/workflows/deploy.yml .github/workflows/live-tests.yml
- npm run check:actions-node24
- npm run validate
- VERSION=$(git describe --tags --abbrev=0) npm run build:widget, then compared local public/widget.js SHA to production widget.js SHA: both 2f41f3cb9da3443f28872c359d75b483253a7910681f1b7813b335df0d68975f
- codex-review clean: no accepted/actionable findings reported