### PR TITLE
docs: link BugDrop showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ See [full documentation](https://bugdrop.dev/docs/configuration) for all options
 ## Documentation
 
 - [Full Documentation](https://bugdrop.dev/docs)
+- [Built with BugDrop Showcase](https://bugdrop.dev/showcase)
 - [GitHub Marketplace](https://github.com/marketplace/bugdrop-in-app-feedback-to-github-issues)
 - [Configuration](https://bugdrop.dev/docs/configuration)
 - [Styling](https://bugdrop.dev/docs/styling)


### PR DESCRIPTION
## Summary
- add the Built with BugDrop showcase to the README documentation links

## Verification
- git diff --check
- pre-commit/lint-staged ran Prettier on README.md during commit

Companion web PR: https://github.com/mean-weasel/bugdrop-web/pull/53