### PR TITLE
feat: add data-locale option with Dutch and Polish widget translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
 | `data-locale`                   | `en`, `nl`, `pl` (region subtags accepted)           | `<html lang>` or `en` |
 | `data-position`                 | `bottom-right`, `bottom-left`                        | `bottom-right`        |
 | `data-color`                    | Accent color for buttons/highlights (e.g. `#FF6B35`) | `#14b8a6` (teal)      |
-| `data-label`                    | Any string                                           | `Feedback`            |
+| `data-label`                    | Any string                                           | localized label       |
 | `data-category-labels`          | JSON mapping for self-hosted category labels         | built-in labels       |
 | `data-button`                   | `true`, `false`                                      | `true`                |
 | `data-send-console-logs`        | `true`, `false`                                      | `false`               |

--- a/README.md
+++ b/README.md
@@ -43,17 +43,18 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
 
 ## Widget Options
 
-| Attribute                       | Values                                               | Default          |
-| ------------------------------- | ---------------------------------------------------- | ---------------- |
-| `data-repo`                     | `owner/repo`                                         | **required**     |
-| `data-theme`                    | `light`, `dark`, `auto`                              | `auto`           |
-| `data-position`                 | `bottom-right`, `bottom-left`                        | `bottom-right`   |
-| `data-color`                    | Accent color for buttons/highlights (e.g. `#FF6B35`) | `#14b8a6` (teal) |
-| `data-label`                    | Any string                                           | `Feedback`       |
-| `data-category-labels`          | JSON mapping for self-hosted category labels         | built-in labels  |
-| `data-button`                   | `true`, `false`                                      | `true`           |
-| `data-send-console-logs`        | `true`, `false`                                      | `false`          |
-| `data-element-context-max-area` | Viewport-area multiplier for Select Element context  | `0`              |
+| Attribute                       | Values                                               | Default               |
+| ------------------------------- | ---------------------------------------------------- | --------------------- |
+| `data-repo`                     | `owner/repo`                                         | **required**          |
+| `data-theme`                    | `light`, `dark`, `auto`                              | `auto`                |
+| `data-locale`                   | `en`, `nl`, `pl` (region subtags accepted)           | `<html lang>` or `en` |
+| `data-position`                 | `bottom-right`, `bottom-left`                        | `bottom-right`        |
+| `data-color`                    | Accent color for buttons/highlights (e.g. `#FF6B35`) | `#14b8a6` (teal)      |
+| `data-label`                    | Any string                                           | `Feedback`            |
+| `data-category-labels`          | JSON mapping for self-hosted category labels         | built-in labels       |
+| `data-button`                   | `true`, `false`                                      | `true`                |
+| `data-send-console-logs`        | `true`, `false`                                      | `false`               |
+| `data-element-context-max-area` | Viewport-area multiplier for Select Element context  | `0`                   |
 
 See [full documentation](https://bugdrop.dev/docs/configuration) for all options including styling, submitter info, and dismissible button.
 

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -10,6 +10,7 @@ These attributes control the fundamental behavior of the widget.
 |-----------|---------|-------------|
 | `data-repo` | **(required)** | GitHub repository in `owner/repo` format |
 | `data-theme` | `"auto"` | Widget theme: `"light"`, `"dark"`, or `"auto"` |
+| `data-locale` | `<html lang>` or `"en"` | UI language: `"en"`, `"nl"`, or `"pl"` |
 | `data-position` | `"bottom-right"` | Button position: `"bottom-right"` or `"bottom-left"` |
 | `data-color` | `"#14b8a6"` | Primary accent color (any CSS color value) |
 | `data-icon` | *(default bug icon)* | Custom icon: URL to an image, `"none"` to hide, or omit for default |
@@ -55,6 +56,33 @@ The `data-theme` attribute controls the overall color scheme of the widget:
 <script src="https://bugdrop.neonwatty.workers.dev/widget.js"
   data-repo="owner/repo" data-theme="dark"></script>
 ```
+
+### Language Options
+
+The `data-locale` attribute controls the language of every user-facing string in the
+widget -- the feedback form, screenshot flow, annotation tools, and success/error
+messages. Supported locales: **`en`** (English), **`nl`** (Dutch), **`pl`** (Polish).
+
+Resolution order:
+
+1. `data-locale` on the script tag
+2. The page's `<html lang="...">` attribute
+3. English
+
+Matching is case-insensitive and region subtags are accepted in both BCP 47 and
+underscore formats (`nl-NL`, `nl_NL`, and `NL` all resolve to Dutch). An unsupported
+value falls back to English and logs a console warning.
+
+```html
+<!-- Dutch UI -->
+<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="owner/repo" data-locale="nl"></script>
+```
+
+To contribute a new language, add `src/widget/locales/<code>.ts` implementing the
+`WidgetStrings` interface, register it in `src/widget/i18n.ts`, and extend the
+supported-locale union -- a unit test enforces that every dictionary exposes exactly
+the same keys as English.
 
 ### Position Options
 

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -14,7 +14,7 @@ These attributes control the fundamental behavior of the widget.
 | `data-position` | `"bottom-right"` | Button position: `"bottom-right"` or `"bottom-left"` |
 | `data-color` | `"#14b8a6"` | Primary accent color (any CSS color value) |
 | `data-icon` | *(default bug icon)* | Custom icon: URL to an image, `"none"` to hide, or omit for default |
-| `data-label` | `"Feedback"` | Text label displayed next to the button icon |
+| `data-label` | localized label | Text label displayed next to the button icon |
 | `data-category-labels` | built-in labels | Self-hosted JSON mapping from built-in categories to GitHub labels |
 | `data-button` | `"true"` | Show the floating button: `"true"` or `"false"` |
 | `data-auth-token-provider` | none | Name of a global function that returns a self-hosted auth token |
@@ -59,9 +59,10 @@ The `data-theme` attribute controls the overall color scheme of the widget:
 
 ### Language Options
 
-The `data-locale` attribute controls the language of every user-facing string in the
-widget -- the feedback form, screenshot flow, annotation tools, and success/error
-messages. Supported locales: **`en`** (English), **`nl`** (Dutch), **`pl`** (Polish).
+The `data-locale` attribute controls BugDrop's built-in widget UI text -- the
+feedback form, screenshot flow, annotation tools, and most success/error messages.
+Brand attribution, custom labels, and server-provided error text may remain as
+provided. Supported locales: **`en`** (English), **`nl`** (Dutch), **`pl`** (Polish).
 
 Resolution order:
 
@@ -80,9 +81,8 @@ value falls back to English and logs a console warning.
 ```
 
 To contribute a new language, add `src/widget/locales/<code>.ts` implementing the
-`WidgetStrings` interface, register it in `src/widget/i18n.ts`, and extend the
-supported-locale union -- a unit test enforces that every dictionary exposes exactly
-the same keys as English.
+`WidgetStrings` interface and register it in `src/widget/i18n.ts` -- a unit test
+enforces that every dictionary exposes exactly the same keys as English.
 
 ### Position Options
 

--- a/e2e/locale.spec.ts
+++ b/e2e/locale.spec.ts
@@ -1,14 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
 
-/**
- * E2E tests for widget localization (data-locale).
- *
- * These tests load /test/ with ?locale=... (mapped to data-locale by the test
- * harness in public/test/index.html), open the widget, and assert on the
- * welcome-screen title inside the shadow DOM — the title is rendered from the
- * active locale dictionary, so it proves the full resolve → setLocale → render
- * chain.
- */
+// public/test maps query params to widget data attributes; these tests assert
+// rendered localized UI through the widget shadow DOM.
 
 const WELCOME_TITLES = {
   en: 'Share Your Feedback',
@@ -16,7 +9,11 @@ const WELCOME_TITLES = {
   pl: 'Podziel się opinią',
 } as const;
 
-async function openWidget(page: Page, params: Record<string, string> = {}) {
+async function openWidget(
+  page: Page,
+  params: Record<string, string> = {},
+  options: { htmlLang?: string } = {}
+) {
   await page.route('**/api/check**', async route => {
     await route.fulfill({
       status: 200,
@@ -25,7 +22,10 @@ async function openWidget(page: Page, params: Record<string, string> = {}) {
     });
   });
 
-  const qs = new URLSearchParams(params).toString();
+  const qs = new URLSearchParams({
+    ...params,
+    ...(options.htmlLang ? { htmlLang: options.htmlLang } : {}),
+  }).toString();
   await page.goto(`/test/${qs ? '?' + qs : ''}`);
   // Force the welcome screen so its (translated) title is what opens first.
   await page.evaluate(() =>
@@ -50,6 +50,10 @@ function modalTitle(page: Page) {
   return page.locator('#bugdrop-host').locator('css=.bd-title');
 }
 
+function host(page: Page) {
+  return page.locator('#bugdrop-host');
+}
+
 test.describe('Widget localization', () => {
   test('defaults to English without data-locale', async ({ page }) => {
     await openWidget(page);
@@ -71,6 +75,16 @@ test.describe('Widget localization', () => {
     await expect(modalTitle(page)).toHaveText(WELCOME_TITLES.nl);
   });
 
+  test('falls back to html lang when data-locale is absent', async ({ page }) => {
+    await openWidget(page, {}, { htmlLang: 'pl-PL' });
+    await expect(modalTitle(page)).toHaveText(WELCOME_TITLES.pl);
+  });
+
+  test('data-locale takes precedence over html lang', async ({ page }) => {
+    await openWidget(page, { locale: 'nl' }, { htmlLang: 'pl-PL' });
+    await expect(modalTitle(page)).toHaveText(WELCOME_TITLES.nl);
+  });
+
   test('unsupported locale falls back to English and warns', async ({ page }) => {
     const warnings: string[] = [];
     page.on('console', msg => {
@@ -83,5 +97,64 @@ test.describe('Widget localization', () => {
     await openWidget(page, { locale: 'xx' });
     await expect(modalTitle(page)).toHaveText(WELCOME_TITLES.en);
     expect(warnings.some(w => w.includes('[BugDrop] Unsupported data-locale'))).toBe(true);
+  });
+
+  test('localizes trigger text and keeps data-label as a visible-label override', async ({
+    page,
+  }) => {
+    await openWidget(page, { locale: 'pl', label: 'Custom CTA' });
+
+    const trigger = host(page).locator('css=.bd-trigger');
+    await expect(trigger.locator('css=.bd-trigger-label')).toHaveText('Custom CTA');
+    await expect(trigger).toHaveAttribute('aria-label', 'Zgłoś błąd lub wyślij opinię');
+  });
+
+  test('renders Polish form and success UI for a no-screenshot submission', async ({ page }) => {
+    await page.route('**/feedback', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, issueNumber: 42, issueUrl: '#', isPublic: false }),
+      });
+    });
+
+    await openWidget(page, { locale: 'pl' });
+    const widget = host(page);
+
+    await widget.locator('css=[data-action="continue"]').click();
+    await expect(modalTitle(page)).toHaveText('Wyślij opinię');
+    await expect(widget.locator('css=label[for="title"]')).toHaveText('Tytuł *');
+    await expect(widget.locator('css=label[for="description"]')).toHaveText('Opis');
+    await expect(widget.locator('css=#include-screenshot + label')).toHaveText(
+      '📸 Dołącz zrzut ekranu'
+    );
+
+    await widget.locator('css=#title').fill('Test lokalizacji');
+    await widget.locator('css=#include-screenshot').uncheck();
+    await widget.locator('css=#submit-btn').click();
+
+    await expect(modalTitle(page)).toHaveText('Opinia wysłana!');
+    await expect(widget.locator('css=.bd-success-issue')).toHaveText(
+      'Twoja opinia została pomyślnie wysłana.'
+    );
+    await expect(widget.locator('css=[data-action="done"]')).toHaveText('Gotowe');
+  });
+
+  test('renders Dutch screenshot choices', async ({ page }) => {
+    await openWidget(page, { locale: 'nl' });
+    const widget = host(page);
+
+    await widget.locator('css=[data-action="continue"]').click();
+    await widget.locator('css=#title').fill('Schermafbeelding testen');
+    await widget.locator('css=#include-screenshot').check();
+    await widget.locator('css=#submit-btn').click();
+
+    await expect(modalTitle(page)).toHaveText('Schermafbeelding maken');
+    await expect(widget.locator('css=[data-action="capture"]')).toHaveText('Volledige pagina');
+    await expect(widget.locator('css=[data-action="area"]')).toHaveText('Gebied selecteren');
+    await expect(widget.locator('css=[data-action="element"]')).toHaveText('Element selecteren');
+    await expect(widget.locator('css=[data-action="skip"]')).toHaveText(
+      'Schermafbeelding overslaan'
+    );
   });
 });

--- a/e2e/locale.spec.ts
+++ b/e2e/locale.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * E2E tests for widget localization (data-locale).
+ *
+ * These tests load /test/ with ?locale=... (mapped to data-locale by the test
+ * harness in public/test/index.html), open the widget, and assert on the
+ * welcome-screen title inside the shadow DOM — the title is rendered from the
+ * active locale dictionary, so it proves the full resolve → setLocale → render
+ * chain.
+ */
+
+const WELCOME_TITLES = {
+  en: 'Share Your Feedback',
+  nl: 'Deel uw feedback',
+  pl: 'Podziel się opinią',
+} as const;
+
+async function openWidget(page: Page, params: Record<string, string> = {}) {
+  await page.route('**/api/check**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ installed: true }),
+    });
+  });
+
+  const qs = new URLSearchParams(params).toString();
+  await page.goto(`/test/${qs ? '?' + qs : ''}`);
+  // Force the welcome screen so its (translated) title is what opens first.
+  await page.evaluate(() =>
+    localStorage.removeItem('bugdrop_welcomed_mean-weasel/bugdrop-widget-test')
+  );
+
+  const button = page.locator('#bugdrop-host').locator('css=.bd-trigger');
+  await expect(button).toBeVisible({ timeout: 5000 });
+  await button.evaluate(trigger => {
+    if (!(trigger instanceof HTMLElement)) {
+      throw new Error('BugDrop trigger not found');
+    }
+    trigger.click();
+  });
+
+  await expect(page.locator('#bugdrop-host').locator('css=.bd-modal')).toHaveCount(1, {
+    timeout: 5000,
+  });
+}
+
+function modalTitle(page: Page) {
+  return page.locator('#bugdrop-host').locator('css=.bd-title');
+}
+
+test.describe('Widget localization', () => {
+  test('defaults to English without data-locale', async ({ page }) => {
+    await openWidget(page);
+    await expect(modalTitle(page)).toHaveText(WELCOME_TITLES.en);
+  });
+
+  test('data-locale="nl" renders the Dutch UI', async ({ page }) => {
+    await openWidget(page, { locale: 'nl' });
+    await expect(modalTitle(page)).toHaveText(WELCOME_TITLES.nl);
+  });
+
+  test('data-locale="pl" renders the Polish UI', async ({ page }) => {
+    await openWidget(page, { locale: 'pl' });
+    await expect(modalTitle(page)).toHaveText(WELCOME_TITLES.pl);
+  });
+
+  test('region subtags resolve to the base language', async ({ page }) => {
+    await openWidget(page, { locale: 'nl-NL' });
+    await expect(modalTitle(page)).toHaveText(WELCOME_TITLES.nl);
+  });
+
+  test('unsupported locale falls back to English and warns', async ({ page }) => {
+    const warnings: string[] = [];
+    page.on('console', msg => {
+      const type = msg.type();
+      if (type === 'warning' || type === 'warn') {
+        warnings.push(msg.text());
+      }
+    });
+
+    await openWidget(page, { locale: 'xx' });
+    await expect(modalTitle(page)).toHaveText(WELCOME_TITLES.en);
+    expect(warnings.some(w => w.includes('[BugDrop] Unsupported data-locale'))).toBe(true);
+  });
+});

--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -50,6 +50,40 @@ async function mockInstalledRepo(page: Page) {
   });
 }
 
+async function loadDeployedWidgetFixture(page: Page, dataset: Record<string, string>) {
+  const widgetOrigin = expectedWidgetOrigin || 'https://bugdrop-preview.neonwatty.workers.dev';
+  const fixturePath = '/bugdrop-live-locale-fixture';
+  const dataAttributes = Object.entries(dataset)
+    .map(([key, value]) => `data-${key}="${value}"`)
+    .join('\n          ');
+
+  await page.route(`**${fixturePath}`, async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: `
+        <!doctype html>
+        <html lang="en-US">
+          <head><title>BugDrop live fixture</title></head>
+          <body>
+            <main>
+              <h1>BugDrop live fixture</h1>
+              <p>Fixture page for deployed widget smoke tests.</p>
+            </main>
+            <script
+              src="${widgetOrigin}/widget.js"
+              data-repo="mean-weasel/bugdrop-widget-test"
+              ${dataAttributes}
+            ></script>
+          </body>
+        </html>
+      `,
+    });
+  });
+
+  await page.goto(fixturePath);
+}
+
 async function addCorsBlockedImage(page: Page) {
   await page.route('https://third-party.test/no-cors-badge.svg', async route => {
     await route.fulfill({
@@ -333,6 +367,23 @@ test.describe('Widget Loading (Live)', () => {
       const body = await response.body();
       expect(sha256(body)).toBe(expectedWidgetSha256);
     }
+  });
+});
+
+test.describe('Localization (Live)', () => {
+  test('deployed widget asset honors data-locale from the script tag', async ({ page }) => {
+    await mockInstalledRepo(page);
+    await loadDeployedWidgetFixture(page, { locale: 'pl' });
+
+    const host = page.locator('#bugdrop-host');
+    const trigger = host.locator('css=.bd-trigger');
+    await expect(trigger).toBeVisible({ timeout: 10_000 });
+    await expect(trigger.locator('css=.bd-trigger-label')).toHaveText('Opinia');
+    await expect(trigger).toHaveAttribute('aria-label', 'Zgłoś błąd lub wyślij opinię');
+
+    await trigger.click();
+    await expect(host.locator('css=.bd-title')).toHaveText('Podziel się opinią');
+    await expect(host.locator('css=[data-action="continue"]')).toHaveText('Rozpocznij');
   });
 });
 

--- a/public/test/index.html
+++ b/public/test/index.html
@@ -593,6 +593,12 @@
   <!-- Load BugDrop (use ?theme=light to test light mode) -->
   <script src="/test/load-widget.js"></script>
   <script>
+    const bugdropTestParams = new URLSearchParams(window.location.search);
+    const bugdropTestHtmlLang = bugdropTestParams.get('htmlLang');
+    if (bugdropTestHtmlLang) {
+      document.documentElement.lang = bugdropTestHtmlLang;
+    }
+
     window.loadBugDropTestWidget({
       id: 'bugdrop-script',
       dataset: {
@@ -602,6 +608,7 @@
       queryDataset: {
         theme: 'theme',
         locale: 'locale',
+        label: 'label',
         bg: 'bg',
         screenshot: 'screenshot',
         showName: 'showName',

--- a/public/test/index.html
+++ b/public/test/index.html
@@ -601,6 +601,7 @@
       },
       queryDataset: {
         theme: 'theme',
+        locale: 'locale',
         bg: 'bg',
         screenshot: 'screenshot',
         showName: 'showName',

--- a/src/widget/annotation-flow.ts
+++ b/src/widget/annotation-flow.ts
@@ -1,6 +1,6 @@
 import { createAnnotator, type Tool } from './annotator';
 import { createModal, redactionNoteHtml } from './ui';
-import { t } from './i18n';
+import { escapeWidgetText, t } from './i18n';
 
 export function showAnnotationStep(
   root: HTMLElement,
@@ -42,20 +42,20 @@ export function showAnnotationStep(
       `
         ${redactionNote}
         <p style="margin: 0 0 12px; color: var(--bd-text-secondary); font-size: 13px;">
-          ${t().annotationInstruction}
+          ${escapeWidgetText(t().annotationInstruction)}
         </p>
         ${selectedElementNote}
         <div class="bd-tools">
-          <button class="bd-tool active" data-tool="draw">✏️ ${t().toolDraw}</button>
-          <button class="bd-tool" data-tool="arrow">➡️ ${t().toolArrow}</button>
-          <button class="bd-tool" data-tool="rect">▢ ${t().toolRectangle}</button>
-          <button class="bd-tool" data-tool="redact">${t().toolRedact}</button>
-          <button class="bd-tool" data-action="undo">↶ ${t().undo}</button>
+          <button class="bd-tool active" data-tool="draw">✏️ ${escapeWidgetText(t().toolDraw)}</button>
+          <button class="bd-tool" data-tool="arrow">➡️ ${escapeWidgetText(t().toolArrow)}</button>
+          <button class="bd-tool" data-tool="rect">▢ ${escapeWidgetText(t().toolRectangle)}</button>
+          <button class="bd-tool" data-tool="redact">${escapeWidgetText(t().toolRedact)}</button>
+          <button class="bd-tool" data-action="undo">↶ ${escapeWidgetText(t().undo)}</button>
         </div>
         <div id="annotation-canvas" class="bd-annotation-stage"></div>
         <div class="bd-actions">
-          <button class="bd-btn bd-btn-secondary" data-action="retake">${t().retake}</button>
-          <button class="bd-btn bd-btn-primary" data-action="done">${t().submitFeedback}</button>
+          <button class="bd-btn bd-btn-secondary" data-action="retake">${escapeWidgetText(t().retake)}</button>
+          <button class="bd-btn bd-btn-primary" data-action="done">${escapeWidgetText(t().submitFeedback)}</button>
         </div>
       `,
       false,

--- a/src/widget/annotation-flow.ts
+++ b/src/widget/annotation-flow.ts
@@ -1,5 +1,6 @@
 import { createAnnotator, type Tool } from './annotator';
 import { createModal, redactionNoteHtml } from './ui';
+import { t } from './i18n';
 
 export function showAnnotationStep(
   root: HTMLElement,
@@ -14,51 +15,47 @@ export function showAnnotationStep(
   return new Promise(resolve => {
     const redactionMessages: string[] = [];
     if (opts?.redactionUnavailable) {
-      redactionMessages.push(
-        'This browser viewport capture could not apply automatic private-field masks. Review and cover any sensitive areas before sending.'
-      );
+      redactionMessages.push(t().viewportRedactionUnavailableNote);
     } else {
       if (redactionCount > 0) {
-        redactionMessages.push(
-          `${redactionCount} private ${redactionCount === 1 ? 'item was' : 'items were'} marked for redaction in this screenshot. Review before sending.`
-        );
+        redactionMessages.push(t().redactionCountNote(redactionCount));
       }
       if (opts?.redactionLimitations) {
-        redactionMessages.push(
-          'BugDrop only covered the measured marked boxes. It does not inspect pixels inside embedded or rendered content such as iframes, canvas, images, SVGs, videos, CSS backgrounds, or custom controls. Confirm the black box fully covers the sensitive region before sending, or retake after marking a larger wrapper.'
-        );
+        redactionMessages.push(t().redactionLimitationsNote);
       }
     }
     const redactionNote = redactionMessages.length
       ? redactionNoteHtml(redactionMessages.join(' '))
       : '';
+    const configLinkHtml =
+      '<a href="https://bugdrop.dev/docs/configuration#select-element-screenshots" target="_blank" rel="noopener noreferrer">data-element-context-max-area</a>';
     const selectedElementNote = opts?.selectedElementCapture
       ? `
         <p class="bd-selected-element-note" style="margin: -4px 0 12px; color: var(--bd-text-secondary); font-size: 13px;">
-          Need more surrounding context? Adjust <a href="https://bugdrop.dev/docs/configuration#select-element-screenshots" target="_blank" rel="noopener noreferrer">data-element-context-max-area</a> on the BugDrop script tag.
+          ${t().selectedElementNote(configLinkHtml)}
         </p>
       `
       : '';
     const modal = createModal(
       root,
-      'Review Screenshot',
+      t().reviewScreenshotTitle,
       `
         ${redactionNote}
         <p style="margin: 0 0 12px; color: var(--bd-text-secondary); font-size: 13px;">
-          Check that no sensitive information is visible before sending. Cover sensitive areas before submitting. Redactions are baked into the uploaded image.
+          ${t().annotationInstruction}
         </p>
         ${selectedElementNote}
         <div class="bd-tools">
-          <button class="bd-tool active" data-tool="draw">✏️ Draw</button>
-          <button class="bd-tool" data-tool="arrow">➡️ Arrow</button>
-          <button class="bd-tool" data-tool="rect">▢ Rectangle</button>
-          <button class="bd-tool" data-tool="redact">Redact</button>
-          <button class="bd-tool" data-action="undo">↶ Undo</button>
+          <button class="bd-tool active" data-tool="draw">✏️ ${t().toolDraw}</button>
+          <button class="bd-tool" data-tool="arrow">➡️ ${t().toolArrow}</button>
+          <button class="bd-tool" data-tool="rect">▢ ${t().toolRectangle}</button>
+          <button class="bd-tool" data-tool="redact">${t().toolRedact}</button>
+          <button class="bd-tool" data-action="undo">↶ ${t().undo}</button>
         </div>
         <div id="annotation-canvas" class="bd-annotation-stage"></div>
         <div class="bd-actions">
-          <button class="bd-btn bd-btn-secondary" data-action="retake">Retake</button>
-          <button class="bd-btn bd-btn-primary" data-action="done">Submit Feedback</button>
+          <button class="bd-btn bd-btn-secondary" data-action="retake">${t().retake}</button>
+          <button class="bd-btn bd-btn-primary" data-action="done">${t().submitFeedback}</button>
         </div>
       `,
       false,

--- a/src/widget/area-picker.ts
+++ b/src/widget/area-picker.ts
@@ -1,11 +1,8 @@
 import type { PickerStyle } from './picker';
 import { resolvePickerStyle } from './picker';
+import { t } from './i18n';
 
 const MIN_SELECTION_SIZE = 10;
-const AREA_PICKER_INSTRUCTION = 'Draw a selection around the area to capture';
-const AREA_PICKER_REDACTION_INSTRUCTION =
-  'Draw a selection around the area to capture. Marked private fields may be masked if included.';
-const AREA_PICKER_DESKTOP_CANCEL_INSTRUCTION = 'ESC to cancel';
 type ResolvedAreaPickerStyle = ReturnType<typeof resolvePickerStyle>;
 
 export function createAreaPicker(
@@ -34,8 +31,8 @@ function startAreaPicker(
   document.body.appendChild(selectionBorder);
 
   const instruction = opts?.redactionsAvailable
-    ? AREA_PICKER_REDACTION_INSTRUCTION
-    : AREA_PICKER_INSTRUCTION;
+    ? t().areaPickerRedactionInstruction
+    : t().areaPickerInstruction;
   const showInlineCancel = usesCoarsePointer();
   const tooltip = createTooltip(
     { accent, fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder },
@@ -222,7 +219,7 @@ function createTooltip(
     const cancelButton = document.createElement('button');
     cancelButton.id = 'bugdrop-area-picker-cancel';
     cancelButton.type = 'button';
-    cancelButton.textContent = 'Cancel';
+    cancelButton.textContent = t().cancel;
     cancelButton.style.cssText = `
       align-items: center;
       appearance: none;
@@ -247,7 +244,7 @@ function createTooltip(
     `;
     tooltip.append(text, ' (', cancelButton, ')');
   } else {
-    tooltip.textContent = `${text} (${AREA_PICKER_DESKTOP_CANCEL_INSTRUCTION})`;
+    tooltip.textContent = `${text} (${t().escToCancel})`;
   }
   return tooltip;
 }

--- a/src/widget/capture-loading.ts
+++ b/src/widget/capture-loading.ts
@@ -6,7 +6,7 @@ import {
   type CaptureScreenshotOptions,
 } from './screenshot';
 import { createModal } from './ui';
-import { t } from './i18n';
+import { escapeWidgetText, t } from './i18n';
 
 export type CaptureWithLoadingResult =
   | { kind: 'ok'; dataUrl: string; redaction?: CapturedScreenshot['redaction'] }
@@ -57,7 +57,7 @@ export async function capturePromiseWithLoading(
           `
             <div style="display: flex; flex-direction: column; align-items: center; padding: 20px;">
               <div class="bd-spinner bd-spinner--lg"></div>
-              <p class="bd-loading-text" style="margin-top: 12px;">${t().capturingScreenshot}</p>
+              <p class="bd-loading-text" style="margin-top: 12px;">${escapeWidgetText(t().capturingScreenshot)}</p>
             </div>
           `
         );
@@ -90,11 +90,11 @@ export async function capturePromiseWithLoading(
             <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
               <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-9.5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5.5zm0 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
             </svg>
-            <span class="bd-error-message__text">${t().captureFailedMessage}</span>
+            <span class="bd-error-message__text">${escapeWidgetText(t().captureFailedMessage)}</span>
           </div>
           <div class="bd-actions">
-            ${allowSkip ? `<button class="bd-btn bd-btn-secondary" data-action="skip">${t().skipScreenshot}</button>` : ''}
-            ${allowChooseAgain ? `<button class="bd-btn bd-btn-primary" data-action="choose-again">${t().chooseAnotherMethod}</button>` : ''}
+            ${allowSkip ? `<button class="bd-btn bd-btn-secondary" data-action="skip">${escapeWidgetText(t().skipScreenshot)}</button>` : ''}
+            ${allowChooseAgain ? `<button class="bd-btn bd-btn-primary" data-action="choose-again">${escapeWidgetText(t().chooseAnotherMethod)}</button>` : ''}
           </div>
         `,
         true
@@ -146,10 +146,10 @@ function showMaskFailureModal(root: HTMLElement): Promise<CaptureWithLoadingResu
           <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
             <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-9.5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5.5zm0 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
           </svg>
-          <span class="bd-error-message__text">${t().maskFailureMessage}</span>
+          <span class="bd-error-message__text">${escapeWidgetText(t().maskFailureMessage)}</span>
         </div>
         <div class="bd-actions">
-          <button class="bd-btn bd-btn-primary" data-action="skip">${t().continueWithoutScreenshot}</button>
+          <button class="bd-btn bd-btn-primary" data-action="skip">${escapeWidgetText(t().continueWithoutScreenshot)}</button>
         </div>
       `,
       true

--- a/src/widget/capture-loading.ts
+++ b/src/widget/capture-loading.ts
@@ -6,6 +6,7 @@ import {
   type CaptureScreenshotOptions,
 } from './screenshot';
 import { createModal } from './ui';
+import { t } from './i18n';
 
 export type CaptureWithLoadingResult =
   | { kind: 'ok'; dataUrl: string; redaction?: CapturedScreenshot['redaction'] }
@@ -52,11 +53,11 @@ export async function capturePromiseWithLoading(
       ? null
       : createModal(
           root,
-          'Capturing...',
+          t().capturingTitle,
           `
             <div style="display: flex; flex-direction: column; align-items: center; padding: 20px;">
               <div class="bd-spinner bd-spinner--lg"></div>
-              <p class="bd-loading-text" style="margin-top: 12px;">Capturing screenshot...</p>
+              <p class="bd-loading-text" style="margin-top: 12px;">${t().capturingScreenshot}</p>
             </div>
           `
         );
@@ -83,17 +84,17 @@ export async function capturePromiseWithLoading(
     return new Promise(resolve => {
       const errorModal = createModal(
         root,
-        'Capture Failed',
+        t().captureFailedTitle,
         `
           <div class="bd-error-message">
             <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
               <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-9.5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5.5zm0 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
             </svg>
-            <span class="bd-error-message__text">Failed to capture screenshot. The page may be too complex or browser restrictions may apply.</span>
+            <span class="bd-error-message__text">${t().captureFailedMessage}</span>
           </div>
           <div class="bd-actions">
-            ${allowSkip ? '<button class="bd-btn bd-btn-secondary" data-action="skip">Skip Screenshot</button>' : ''}
-            ${allowChooseAgain ? '<button class="bd-btn bd-btn-primary" data-action="choose-again">Choose Another Method</button>' : ''}
+            ${allowSkip ? `<button class="bd-btn bd-btn-secondary" data-action="skip">${t().skipScreenshot}</button>` : ''}
+            ${allowChooseAgain ? `<button class="bd-btn bd-btn-primary" data-action="choose-again">${t().chooseAnotherMethod}</button>` : ''}
           </div>
         `,
         true
@@ -139,16 +140,16 @@ function showMaskFailureModal(root: HTMLElement): Promise<CaptureWithLoadingResu
   return new Promise(resolve => {
     const modal = createModal(
       root,
-      'Privacy masking failed',
+      t().maskFailureTitle,
       `
         <div class="bd-error-message">
           <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
             <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-9.5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5.5zm0 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
           </svg>
-          <span class="bd-error-message__text">Automatic redaction of private fields could not be applied. To protect your data, this screenshot was discarded. You can still submit feedback without one.</span>
+          <span class="bd-error-message__text">${t().maskFailureMessage}</span>
         </div>
         <div class="bd-actions">
-          <button class="bd-btn bd-btn-primary" data-action="skip">Continue without screenshot</button>
+          <button class="bd-btn bd-btn-primary" data-action="skip">${t().continueWithoutScreenshot}</button>
         </div>
       `,
       true

--- a/src/widget/capture-timeout.ts
+++ b/src/widget/capture-timeout.ts
@@ -1,12 +1,11 @@
+import { t } from './i18n';
+
 const CAPTURE_TIMEOUT_MS = 15_000;
 
 export function withCaptureTimeout<T>(capturePromise: Promise<T>): Promise<T> {
   let timer: ReturnType<typeof setTimeout>;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    timer = setTimeout(
-      () => reject(new Error('Screenshot capture timed out — the page may be too complex')),
-      CAPTURE_TIMEOUT_MS
-    );
+    timer = setTimeout(() => reject(new Error(t().captureTimeout)), CAPTURE_TIMEOUT_MS);
   });
 
   return Promise.race([capturePromise, timeoutPromise]).finally(() => clearTimeout(timer!));

--- a/src/widget/i18n.ts
+++ b/src/widget/i18n.ts
@@ -1,0 +1,137 @@
+import { en } from './locales/en';
+import { nl } from './locales/nl';
+import { pl } from './locales/pl';
+
+export type SupportedLocale = 'en' | 'nl' | 'pl';
+
+export interface WidgetStrings {
+  // Trigger button & pull tab
+  triggerLabel: string;
+  triggerAriaLabel: string;
+  dismissButtonAriaLabel: string;
+  pullTabAriaLabel: string;
+  dragHandleTitle: string;
+  // Install prompt
+  installRequiredTitle: string;
+  connectionErrorTitle: string;
+  installRequiredMessage: string;
+  apiUnreachableMessage: string;
+  installApp: string;
+  // Welcome screen
+  welcomeTitle: string;
+  welcomeHeadline: string;
+  welcomeBodyLine1: string;
+  welcomeBodyLine2: string;
+  getStarted: string;
+  // Feedback form
+  feedbackFormTitle: string;
+  categoryLabel: string;
+  categoryBug: string;
+  categoryFeature: string;
+  categoryQuestion: string;
+  nameLabel: string;
+  namePlaceholder: string;
+  emailLabel: string;
+  emailPlaceholder: string;
+  titleLabel: string;
+  titlePlaceholder: string;
+  descriptionLabel: string;
+  descriptionPlaceholder: string;
+  screenshotAutoNote: string;
+  screenshotAutoRedactionNote: string;
+  screenshotRequiredNote: string;
+  includeScreenshotLabel: string;
+  sendConsoleLogsLabel: string;
+  // Uploads
+  uploadsAriaLabel: string;
+  uploadFilesAriaLabel: string;
+  uploadButton: string;
+  uploadTooMany: (max: number) => string;
+  uploadUnsupportedType: string;
+  uploadTooLarge: (maxSize: string) => string;
+  uploadReadError: string;
+  removeAttachmentAriaLabel: (name: string) => string;
+  // Common buttons
+  cancel: string;
+  continueButton: string;
+  submit: string;
+  // Submission
+  submittingTitle: string;
+  creatingIssue: string;
+  rateLimited: (minutes: number) => string;
+  submitFailedFallback: string;
+  networkError: string;
+  submissionFailedTitle: string;
+  tryAgain: string;
+  // Success modal
+  successTitle: string;
+  issueCreated: (issueNumberHtml: string) => string;
+  feedbackSubmittedMessage: string;
+  viewOnGitHub: string;
+  done: string;
+  // Screenshot options
+  captureScreenshotTitle: string;
+  chooseWhatToCapture: string;
+  viewportRedactionWarning: string;
+  redactionReviewNote: string;
+  pageTooComplexViewportNote: string;
+  pageTooComplexElementNote: string;
+  fullPage: string;
+  captureViewport: string;
+  selectArea: string;
+  selectElement: string;
+  skipScreenshot: string;
+  // Element & area pickers
+  areaPickerInstruction: string;
+  areaPickerRedactionInstruction: string;
+  elementPickerInstruction: string;
+  elementPickerTouchInstruction: string;
+  escToCancel: string;
+  // Capture loading & failures
+  capturingTitle: string;
+  capturingScreenshot: string;
+  captureFailedTitle: string;
+  captureFailedMessage: string;
+  chooseAnotherMethod: string;
+  maskFailureTitle: string;
+  maskFailureMessage: string;
+  continueWithoutScreenshot: string;
+  // Annotation step
+  reviewScreenshotTitle: string;
+  viewportRedactionUnavailableNote: string;
+  redactionCountNote: (count: number) => string;
+  redactionLimitationsNote: string;
+  annotationInstruction: string;
+  selectedElementNote: (linkHtml: string) => string;
+  toolDraw: string;
+  toolArrow: string;
+  toolRectangle: string;
+  toolRedact: string;
+  undo: string;
+  retake: string;
+  submitFeedback: string;
+  // Capture timeout
+  captureTimeout: string;
+}
+
+const DICTIONARIES: Record<SupportedLocale, WidgetStrings> = { en, nl, pl };
+
+export function resolveLocale(raw: string | undefined | null): SupportedLocale {
+  if (!raw) return 'en';
+  // Accept both BCP 47 ("nl-NL") and POSIX/Symfony ("nl_NL") region formats.
+  const base = raw.toLowerCase().split(/[-_]/)[0];
+  if (base === 'en' || base === 'nl' || base === 'pl') return base;
+  console.warn(`[BugDrop] Unsupported data-locale "${raw}"; falling back to English.`);
+  return 'en';
+}
+
+// The widget is a per-page singleton, so module-level locale state is acceptable.
+let currentStrings: WidgetStrings = en;
+
+export function setLocale(locale: SupportedLocale): void {
+  currentStrings = DICTIONARIES[locale];
+}
+
+export function t(): WidgetStrings {
+  return currentStrings;
+}

--- a/src/widget/i18n.ts
+++ b/src/widget/i18n.ts
@@ -1,8 +1,7 @@
 import { en } from './locales/en';
 import { nl } from './locales/nl';
 import { pl } from './locales/pl';
-
-export type SupportedLocale = 'en' | 'nl' | 'pl';
+import { escapeHtml } from './sanitize';
 
 export interface WidgetStrings {
   // Trigger button & pull tab
@@ -65,6 +64,7 @@ export interface WidgetStrings {
   tryAgain: string;
   // Success modal
   successTitle: string;
+  // Callers pass a trusted issue-number HTML fragment; dictionaries own surrounding text only.
   issueCreated: (issueNumberHtml: string) => string;
   feedbackSubmittedMessage: string;
   viewOnGitHub: string;
@@ -102,6 +102,7 @@ export interface WidgetStrings {
   redactionCountNote: (count: number) => string;
   redactionLimitationsNote: string;
   annotationInstruction: string;
+  // Callers pass a trusted configuration-link HTML fragment; dictionaries own surrounding text only.
   selectedElementNote: (linkHtml: string) => string;
   toolDraw: string;
   toolArrow: string;
@@ -114,13 +115,20 @@ export interface WidgetStrings {
   captureTimeout: string;
 }
 
-const DICTIONARIES: Record<SupportedLocale, WidgetStrings> = { en, nl, pl };
+const DICTIONARIES = { en, nl, pl } satisfies Record<string, WidgetStrings>;
+
+export type SupportedLocale = keyof typeof DICTIONARIES;
+
+// Use this for dictionary strings inserted into raw HTML templates.
+export function escapeWidgetText(value: string): string {
+  return escapeHtml(value);
+}
 
 export function resolveLocale(raw: string | undefined | null): SupportedLocale {
   if (!raw) return 'en';
   // Accept both BCP 47 ("nl-NL") and POSIX/Symfony ("nl_NL") region formats.
   const base = raw.toLowerCase().split(/[-_]/)[0];
-  if (base === 'en' || base === 'nl' || base === 'pl') return base;
+  if (Object.prototype.hasOwnProperty.call(DICTIONARIES, base)) return base as SupportedLocale;
   console.warn(`[BugDrop] Unsupported data-locale "${raw}"; falling back to English.`);
   return 'en';
 }

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -29,7 +29,7 @@ import {
   startConsoleLogCapture,
   type ConsoleLogEntry,
 } from './console-logs';
-import { resolveLocale, setLocale, t, type SupportedLocale } from './i18n';
+import { escapeWidgetText, resolveLocale, setLocale, t, type SupportedLocale } from './i18n';
 import { resolveAccentColor } from '../defaults';
 
 type FeedbackCategory = 'bug' | 'feature' | 'question';
@@ -62,7 +62,7 @@ interface WidgetConfig {
   accentColor?: string;
   // Custom icon URL (replaces default bug emoji), or 'none' to hide the icon
   iconUrl?: string;
-  // Custom trigger button label text (default: 'Feedback')
+  // Custom trigger button label text; defaults to the active locale's triggerLabel
   label?: string;
   // Optional mapping from built-in feedback categories to GitHub labels
   categoryLabels?: CategoryLabelConfig;
@@ -1250,10 +1250,10 @@ function showInstallPrompt(
     root,
     title,
     `
-      <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">${message}</p>
+      <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">${escapeHtml(message)}</p>
       <div class="bd-actions">
-        <button class="bd-btn bd-btn-secondary" data-action="cancel">${t().cancel}</button>
-        ${!errorMessage ? `<a href="${installUrl}" target="_blank" class="bd-btn bd-btn-primary" style="text-decoration: none;">${t().installApp}</a>` : ''}
+        <button class="bd-btn bd-btn-secondary" data-action="cancel">${escapeWidgetText(t().cancel)}</button>
+        ${!errorMessage ? `<a href="${installUrl}" target="_blank" class="bd-btn bd-btn-primary" style="text-decoration: none;">${escapeWidgetText(t().installApp)}</a>` : ''}
       </div>
     `,
     true
@@ -1281,15 +1281,15 @@ function showWelcomeScreen(root: HTMLElement): Promise<boolean> {
         <div style="text-align: center; padding: 8px 0 16px;">
           <div style="font-size: 3rem; margin-bottom: 12px;">💬</div>
           <p style="margin: 0 0 12px; color: var(--bd-text-primary); font-size: 1.05rem; font-weight: 500;">
-            ${t().welcomeHeadline}
+            ${escapeWidgetText(t().welcomeHeadline)}
           </p>
           <p style="margin: 0 0 8px; color: var(--bd-text-secondary); font-size: 0.95rem; line-height: 1.6;">
-            ${t().welcomeBodyLine1}<br/>
-            ${t().welcomeBodyLine2}
+            ${escapeWidgetText(t().welcomeBodyLine1)}<br/>
+            ${escapeWidgetText(t().welcomeBodyLine2)}
           </p>
         </div>
         <div class="bd-actions" style="justify-content: center;">
-          <button class="bd-btn bd-btn-primary" data-action="continue">${t().getStarted}</button>
+          <button class="bd-btn bd-btn-primary" data-action="continue">${escapeWidgetText(t().getStarted)}</button>
         </div>
       `,
       true
@@ -1331,8 +1331,8 @@ function showFeedbackFormWithScreenshotOption(
     const nameFieldHtml = config.showName
       ? `
           <div class="bd-form-group">
-            <label class="bd-label" for="name">${t().nameLabel}${config.requireName ? ' *' : ''}</label>
-            <input type="text" id="name" class="bd-input" ${config.requireName ? 'required' : ''} placeholder="${t().namePlaceholder}" value="${escapeHtml(initialValues?.name || '')}" />
+            <label class="bd-label" for="name">${escapeWidgetText(t().nameLabel)}${config.requireName ? ' *' : ''}</label>
+            <input type="text" id="name" class="bd-input" ${config.requireName ? 'required' : ''} placeholder="${escapeWidgetText(t().namePlaceholder)}" value="${escapeHtml(initialValues?.name || '')}" />
           </div>
         `
       : '';
@@ -1341,8 +1341,8 @@ function showFeedbackFormWithScreenshotOption(
     const emailFieldHtml = config.showEmail
       ? `
           <div class="bd-form-group">
-            <label class="bd-label" for="email">${t().emailLabel}${config.requireEmail ? ' *' : ''}</label>
-            <input type="email" id="email" class="bd-input" ${config.requireEmail ? 'required' : ''} placeholder="${t().emailPlaceholder}" value="${escapeHtml(initialValues?.email || '')}" />
+            <label class="bd-label" for="email">${escapeWidgetText(t().emailLabel)}${config.requireEmail ? ' *' : ''}</label>
+            <input type="email" id="email" class="bd-input" ${config.requireEmail ? 'required' : ''} placeholder="${escapeWidgetText(t().emailPlaceholder)}" value="${escapeHtml(initialValues?.email || '')}" />
           </div>
         `
       : '';
@@ -1353,29 +1353,29 @@ function showFeedbackFormWithScreenshotOption(
       `
         <form id="feedback-form">
           <div class="bd-form-group">
-            <label class="bd-label">${t().categoryLabel}</label>
+            <label class="bd-label">${escapeWidgetText(t().categoryLabel)}</label>
             <div class="bd-category-selector" style="display: flex; gap: 8px; margin-top: 6px;">
               <label class="bd-category-option" style="flex: 1; display: flex; align-items: center; gap: 6px; padding: 8px 12px; border: var(--bd-border-style); border-radius: var(--bd-radius-sm); cursor: pointer; transition: all 0.15s ease;">
                 <input type="radio" name="category" value="bug" ${getCategoryChecked(initialValues, 'bug')} style="accent-color: var(--bd-primary);" />
-                <span style="font-size: 0.9rem;">🐛 ${t().categoryBug}</span>
+                <span style="font-size: 0.9rem;">🐛 ${escapeWidgetText(t().categoryBug)}</span>
               </label>
               <label class="bd-category-option" style="flex: 1; display: flex; align-items: center; gap: 6px; padding: 8px 12px; border: var(--bd-border-style); border-radius: var(--bd-radius-sm); cursor: pointer; transition: all 0.15s ease;">
                 <input type="radio" name="category" value="feature" ${getCategoryChecked(initialValues, 'feature')} style="accent-color: var(--bd-primary);" />
-                <span style="font-size: 0.9rem;">✨ ${t().categoryFeature}</span>
+                <span style="font-size: 0.9rem;">✨ ${escapeWidgetText(t().categoryFeature)}</span>
               </label>
               <label class="bd-category-option" style="flex: 1; display: flex; align-items: center; gap: 6px; padding: 8px 12px; border: var(--bd-border-style); border-radius: var(--bd-radius-sm); cursor: pointer; transition: all 0.15s ease;">
                 <input type="radio" name="category" value="question" ${getCategoryChecked(initialValues, 'question')} style="accent-color: var(--bd-primary);" />
-                <span style="font-size: 0.9rem;">❓ ${t().categoryQuestion}</span>
+                <span style="font-size: 0.9rem;">❓ ${escapeWidgetText(t().categoryQuestion)}</span>
               </label>
             </div>
           </div>
           <div class="bd-form-group">
-            <label class="bd-label" for="title">${t().titleLabel} *</label>
-            <input type="text" id="title" class="bd-input" required placeholder="${t().titlePlaceholder}" value="${escapeHtml(initialValues?.title || '')}" />
+            <label class="bd-label" for="title">${escapeWidgetText(t().titleLabel)} *</label>
+            <input type="text" id="title" class="bd-input" required placeholder="${escapeWidgetText(t().titlePlaceholder)}" value="${escapeHtml(initialValues?.title || '')}" />
           </div>
           <div class="bd-form-group">
-            <label class="bd-label" for="description">${t().descriptionLabel}</label>
-            <textarea id="description" class="bd-textarea" placeholder="${t().descriptionPlaceholder}">${escapeHtml(initialValues?.description || '')}</textarea>
+            <label class="bd-label" for="description">${escapeWidgetText(t().descriptionLabel)}</label>
+            <textarea id="description" class="bd-textarea" placeholder="${escapeWidgetText(t().descriptionPlaceholder)}">${escapeHtml(initialValues?.description || '')}</textarea>
           </div>
           ${nameFieldHtml}
           ${emailFieldHtml}
@@ -1392,8 +1392,8 @@ function showFeedbackFormWithScreenshotOption(
             ${getConsoleLogsFormControl(config, initialValues)}
           </div>
           <div class="bd-actions">
-            <button type="button" class="bd-btn bd-btn-secondary" data-action="cancel">${t().cancel}</button>
-            <button type="submit" class="bd-btn bd-btn-primary" id="submit-btn">${config.screenshotMode === 'auto' ? t().submit : t().continueButton}</button>
+            <button type="button" class="bd-btn bd-btn-secondary" data-action="cancel">${escapeWidgetText(t().cancel)}</button>
+            <button type="submit" class="bd-btn bd-btn-primary" id="submit-btn">${config.screenshotMode === 'auto' ? escapeWidgetText(t().submit) : escapeWidgetText(t().continueButton)}</button>
           </div>
         </form>
       `
@@ -1521,14 +1521,14 @@ function showFeedbackFormWithScreenshotOption(
 function getUploadFormControl(): string {
   return `
     <div class="bd-upload-group">
-      <div class="bd-upload-row" aria-label="${t().uploadsAriaLabel}">
-        <button type="button" class="bd-btn bd-btn-secondary bd-upload-button" data-action="choose-uploads" aria-label="${t().uploadFilesAriaLabel}">
+      <div class="bd-upload-row" aria-label="${escapeWidgetText(t().uploadsAriaLabel)}">
+        <button type="button" class="bd-btn bd-btn-secondary bd-upload-button" data-action="choose-uploads" aria-label="${escapeWidgetText(t().uploadFilesAriaLabel)}">
           <svg class="bd-upload-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
             <path d="M8 11V3" />
             <path d="M4.5 6.5 8 3l3.5 3.5" />
             <path d="M3 12.5h10" />
           </svg>
-          ${t().uploadButton}
+          ${escapeWidgetText(t().uploadButton)}
         </button>
       </div>
     </div>
@@ -1561,7 +1561,7 @@ function renderUploadList(
         <div class="bd-upload-item">
           <span class="bd-upload-item__name">${escapeHtml(attachment.name)}</span>
           <span class="bd-upload-item__meta">${formatFileSize(attachment.size)}</span>
-          <button type="button" class="bd-upload-remove" data-index="${index}" aria-label="${t().removeAttachmentAriaLabel(escapeHtml(attachment.name))}">&times;</button>
+          <button type="button" class="bd-upload-remove" data-index="${index}" aria-label="${escapeWidgetText(t().removeAttachmentAriaLabel(attachment.name))}">&times;</button>
         </div>
       `
     )
@@ -1606,10 +1606,11 @@ function getScreenshotFormControl(
   initialValues?: FeedbackFormResult | null
 ): string {
   if (config.screenshotMode === 'auto') {
-    const redactionNote = getRedactionCount() > 0 ? ` ${t().screenshotAutoRedactionNote}` : '';
+    const redactionNote =
+      getRedactionCount() > 0 ? ` ${escapeWidgetText(t().screenshotAutoRedactionNote)}` : '';
     return `
       <p style="margin: 8px 0 0; color: var(--bd-text-secondary); font-size: 0.95rem;">
-        ${t().screenshotAutoNote}${redactionNote}
+        ${escapeWidgetText(t().screenshotAutoNote)}${redactionNote}
       </p>
     `;
   }
@@ -1617,7 +1618,7 @@ function getScreenshotFormControl(
   if (config.screenshotMode === 'required') {
     return `
       <p style="margin: 8px 0 0; color: var(--bd-text-secondary); font-size: 0.95rem;">
-        ${t().screenshotRequiredNote}
+        ${escapeWidgetText(t().screenshotRequiredNote)}
       </p>
     `;
   }
@@ -1630,7 +1631,7 @@ function getScreenshotFormControl(
     <div class="bd-screenshot-control">
       <input type="checkbox" id="include-screenshot" ${includeScreenshot ? 'checked' : ''} class="bd-checkbox" />
       <label for="include-screenshot" class="bd-checkbox-label">
-        ${t().includeScreenshotLabel}
+        ${escapeWidgetText(t().includeScreenshotLabel)}
       </label>
     </div>
   `;
@@ -1646,7 +1647,7 @@ function getConsoleLogsFormControl(
     <div class="bd-form-group" style="display: flex; align-items: center; gap: 10px; margin-top: 8px;">
       <input type="checkbox" id="send-console-logs" ${sendConsoleLogs ? 'checked' : ''} style="width: 18px; height: 18px; accent-color: var(--bd-primary); cursor: pointer;" />
       <label for="send-console-logs" style="font-size: 0.95rem; color: var(--bd-text-secondary); cursor: pointer; user-select: none;">
-        ${t().sendConsoleLogsLabel}
+        ${escapeWidgetText(t().sendConsoleLogsLabel)}
       </label>
     </div>
   `;
@@ -1667,7 +1668,7 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
     `
       <div style="display: flex; flex-direction: column; align-items: center; padding: 20px;">
         <div class="bd-spinner bd-spinner--lg"></div>
-        <p class="bd-loading-text" style="margin-top: 12px;">${t().creatingIssue}</p>
+        <p class="bd-loading-text" style="margin-top: 12px;">${escapeWidgetText(t().creatingIssue)}</p>
       </div>
     `
   );
@@ -1763,11 +1764,11 @@ function showSubmitError(
         <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
           <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-9.5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5.5zm0 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
         </svg>
-        <span class="bd-error-message__text">${errorMessage}</span>
+        <span class="bd-error-message__text">${escapeHtml(errorMessage)}</span>
       </div>
       <div class="bd-actions">
-        <button class="bd-btn bd-btn-secondary" data-action="cancel">${t().cancel}</button>
-        <button class="bd-btn bd-btn-primary" data-action="retry">${t().tryAgain}</button>
+        <button class="bd-btn bd-btn-secondary" data-action="cancel">${escapeWidgetText(t().cancel)}</button>
+        <button class="bd-btn bd-btn-primary" data-action="retry">${escapeWidgetText(t().tryAgain)}</button>
       </div>
     `,
     true

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -29,6 +29,7 @@ import {
   startConsoleLogCapture,
   type ConsoleLogEntry,
 } from './console-logs';
+import { resolveLocale, setLocale, t, type SupportedLocale } from './i18n';
 import { resolveAccentColor } from '../defaults';
 
 type FeedbackCategory = 'bug' | 'feature' | 'question';
@@ -82,6 +83,8 @@ interface WidgetConfig {
   elementContextMaxArea?: number; // Max ancestor capture area as a viewport multiplier
   issueLinkVisibility: IssueLinkVisibility;
   sendConsoleLogs: boolean;
+  // UI language for widget texts
+  locale: SupportedLocale;
 }
 
 // BugDrop JavaScript API interface
@@ -373,6 +376,7 @@ const rawTheme = script?.dataset.theme;
 if (rawTheme && !isValidTheme(rawTheme)) {
   console.warn(`[BugDrop] Invalid data-theme "${rawTheme}". Expected "light", "dark", or "auto".`);
 }
+const locale = resolveLocale(script?.dataset.locale || document.documentElement.lang);
 const requireName = script?.dataset.requireName === 'true';
 const requireEmail = script?.dataset.requireEmail === 'true';
 const rawPosition = script?.dataset.position;
@@ -467,7 +471,10 @@ const config: WidgetConfig = {
   elementContextMaxArea,
   issueLinkVisibility,
   sendConsoleLogs: script?.dataset.sendConsoleLogs === 'true',
+  locale,
 };
+
+setLocale(config.locale);
 
 startConsoleLogCapture();
 
@@ -484,7 +491,7 @@ if (!config.repo) {
 
 // Build the trigger button label text
 function getTriggerLabel(config: WidgetConfig): string {
-  return config.label !== undefined ? config.label : 'Feedback';
+  return config.label !== undefined ? config.label : t().triggerLabel;
 }
 
 function appendTriggerContent(trigger: HTMLElement, config: WidgetConfig): void {
@@ -529,7 +536,7 @@ function createTriggerDragHandle(): HTMLElement {
   const handle = document.createElement('span');
   handle.className = 'bd-trigger-drag-handle';
   handle.setAttribute('aria-hidden', 'true');
-  handle.title = 'Drag feedback button';
+  handle.title = t().dragHandleTitle;
   handle.innerHTML = `
     <svg viewBox="0 0 12 24" aria-hidden="true" focusable="false">
       <circle cx="4" cy="5" r="1.5" fill="currentColor"></circle>
@@ -732,7 +739,7 @@ function createPullTab(root: HTMLElement, config: WidgetConfig): HTMLElement {
   tab.innerHTML = '<span class="bd-pull-tab-chevron">‹</span>';
   tab.setAttribute('role', 'button');
   tab.setAttribute('tabindex', '0');
-  tab.setAttribute('aria-label', 'Show feedback button');
+  tab.setAttribute('aria-label', t().pullTabAriaLabel);
 
   const handleRestore = () => {
     // Clear dismissed state
@@ -898,14 +905,14 @@ function initWidget(config: WidgetConfig) {
     const trigger = document.createElement('button');
     trigger.className = getTriggerClassName(config);
     appendTriggerContent(trigger, config);
-    trigger.setAttribute('aria-label', 'Report a bug or send feedback');
+    trigger.setAttribute('aria-label', t().triggerAriaLabel);
 
     // Add close button if dismissible
     if (config.buttonDismissible) {
       const closeBtn = document.createElement('button');
       closeBtn.className = 'bd-trigger-close';
       closeBtn.textContent = '×';
-      closeBtn.setAttribute('aria-label', 'Dismiss feedback button');
+      closeBtn.setAttribute('aria-label', t().dismissButtonAriaLabel);
       trigger.appendChild(closeBtn);
 
       // Handle close button click
@@ -1072,13 +1079,13 @@ function createTriggerButton(root: HTMLElement, config: WidgetConfig, isRestorin
   const trigger = document.createElement('button');
   trigger.className = getTriggerClassName(config, isRestoring);
   appendTriggerContent(trigger, config);
-  trigger.setAttribute('aria-label', 'Report a bug or send feedback');
+  trigger.setAttribute('aria-label', t().triggerAriaLabel);
 
   if (config.buttonDismissible) {
     const closeBtn = document.createElement('button');
     closeBtn.className = 'bd-trigger-close';
     closeBtn.textContent = '×';
-    closeBtn.setAttribute('aria-label', 'Dismiss feedback button');
+    closeBtn.setAttribute('aria-label', t().dismissButtonAriaLabel);
     trigger.appendChild(closeBtn);
 
     closeBtn.addEventListener('click', e => {
@@ -1143,12 +1150,7 @@ async function openFeedbackFlow(
     return;
   }
   if (installStatus === 'unreachable') {
-    showInstallPrompt(
-      root,
-      config,
-      'Unable to reach BugDrop API. Check your network connection or script tag URL.',
-      appName
-    );
+    showInstallPrompt(root, config, t().apiUnreachableMessage, appName);
     return;
   }
 
@@ -1242,16 +1244,16 @@ function showInstallPrompt(
       ? 'neonwatty-bugdrop'
       : config.apiUrl.replace(/https?:\/\//, '').replace(/\..*/, ''));
   const installUrl = `https://github.com/apps/${appName}/installations/new`;
-  const message = errorMessage || 'BugDrop requires GitHub App installation to create issues.';
-  const title = errorMessage ? 'Connection Error' : 'Install Required';
+  const message = errorMessage || t().installRequiredMessage;
+  const title = errorMessage ? t().connectionErrorTitle : t().installRequiredTitle;
   const modal = createModal(
     root,
     title,
     `
       <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">${message}</p>
       <div class="bd-actions">
-        <button class="bd-btn bd-btn-secondary" data-action="cancel">Cancel</button>
-        ${!errorMessage ? `<a href="${installUrl}" target="_blank" class="bd-btn bd-btn-primary" style="text-decoration: none;">Install App</a>` : ''}
+        <button class="bd-btn bd-btn-secondary" data-action="cancel">${t().cancel}</button>
+        ${!errorMessage ? `<a href="${installUrl}" target="_blank" class="bd-btn bd-btn-primary" style="text-decoration: none;">${t().installApp}</a>` : ''}
       </div>
     `,
     true
@@ -1274,20 +1276,20 @@ function showWelcomeScreen(root: HTMLElement): Promise<boolean> {
   return new Promise(resolve => {
     const modal = createModal(
       root,
-      'Share Your Feedback',
+      t().welcomeTitle,
       `
         <div style="text-align: center; padding: 8px 0 16px;">
           <div style="font-size: 3rem; margin-bottom: 12px;">💬</div>
           <p style="margin: 0 0 12px; color: var(--bd-text-primary); font-size: 1.05rem; font-weight: 500;">
-            Help us improve by sharing your thoughts
+            ${t().welcomeHeadline}
           </p>
           <p style="margin: 0 0 8px; color: var(--bd-text-secondary); font-size: 0.95rem; line-height: 1.6;">
-            Report bugs, suggest features, or leave feedback.<br/>
-            You can optionally include annotated screenshots.
+            ${t().welcomeBodyLine1}<br/>
+            ${t().welcomeBodyLine2}
           </p>
         </div>
         <div class="bd-actions" style="justify-content: center;">
-          <button class="bd-btn bd-btn-primary" data-action="continue">Get Started</button>
+          <button class="bd-btn bd-btn-primary" data-action="continue">${t().getStarted}</button>
         </div>
       `,
       true
@@ -1329,8 +1331,8 @@ function showFeedbackFormWithScreenshotOption(
     const nameFieldHtml = config.showName
       ? `
           <div class="bd-form-group">
-            <label class="bd-label" for="name">Name${config.requireName ? ' *' : ''}</label>
-            <input type="text" id="name" class="bd-input" ${config.requireName ? 'required' : ''} placeholder="Your name" value="${escapeHtml(initialValues?.name || '')}" />
+            <label class="bd-label" for="name">${t().nameLabel}${config.requireName ? ' *' : ''}</label>
+            <input type="text" id="name" class="bd-input" ${config.requireName ? 'required' : ''} placeholder="${t().namePlaceholder}" value="${escapeHtml(initialValues?.name || '')}" />
           </div>
         `
       : '';
@@ -1339,41 +1341,41 @@ function showFeedbackFormWithScreenshotOption(
     const emailFieldHtml = config.showEmail
       ? `
           <div class="bd-form-group">
-            <label class="bd-label" for="email">Email${config.requireEmail ? ' *' : ''}</label>
-            <input type="email" id="email" class="bd-input" ${config.requireEmail ? 'required' : ''} placeholder="your@email.com" value="${escapeHtml(initialValues?.email || '')}" />
+            <label class="bd-label" for="email">${t().emailLabel}${config.requireEmail ? ' *' : ''}</label>
+            <input type="email" id="email" class="bd-input" ${config.requireEmail ? 'required' : ''} placeholder="${t().emailPlaceholder}" value="${escapeHtml(initialValues?.email || '')}" />
           </div>
         `
       : '';
 
     const modal = createModal(
       root,
-      'Send Feedback',
+      t().feedbackFormTitle,
       `
         <form id="feedback-form">
           <div class="bd-form-group">
-            <label class="bd-label">Category</label>
+            <label class="bd-label">${t().categoryLabel}</label>
             <div class="bd-category-selector" style="display: flex; gap: 8px; margin-top: 6px;">
               <label class="bd-category-option" style="flex: 1; display: flex; align-items: center; gap: 6px; padding: 8px 12px; border: var(--bd-border-style); border-radius: var(--bd-radius-sm); cursor: pointer; transition: all 0.15s ease;">
                 <input type="radio" name="category" value="bug" ${getCategoryChecked(initialValues, 'bug')} style="accent-color: var(--bd-primary);" />
-                <span style="font-size: 0.9rem;">🐛 Bug</span>
+                <span style="font-size: 0.9rem;">🐛 ${t().categoryBug}</span>
               </label>
               <label class="bd-category-option" style="flex: 1; display: flex; align-items: center; gap: 6px; padding: 8px 12px; border: var(--bd-border-style); border-radius: var(--bd-radius-sm); cursor: pointer; transition: all 0.15s ease;">
                 <input type="radio" name="category" value="feature" ${getCategoryChecked(initialValues, 'feature')} style="accent-color: var(--bd-primary);" />
-                <span style="font-size: 0.9rem;">✨ Feature</span>
+                <span style="font-size: 0.9rem;">✨ ${t().categoryFeature}</span>
               </label>
               <label class="bd-category-option" style="flex: 1; display: flex; align-items: center; gap: 6px; padding: 8px 12px; border: var(--bd-border-style); border-radius: var(--bd-radius-sm); cursor: pointer; transition: all 0.15s ease;">
                 <input type="radio" name="category" value="question" ${getCategoryChecked(initialValues, 'question')} style="accent-color: var(--bd-primary);" />
-                <span style="font-size: 0.9rem;">❓ Question</span>
+                <span style="font-size: 0.9rem;">❓ ${t().categoryQuestion}</span>
               </label>
             </div>
           </div>
           <div class="bd-form-group">
-            <label class="bd-label" for="title">Title *</label>
-            <input type="text" id="title" class="bd-input" required placeholder="Brief description of the issue or suggestion" value="${escapeHtml(initialValues?.title || '')}" />
+            <label class="bd-label" for="title">${t().titleLabel} *</label>
+            <input type="text" id="title" class="bd-input" required placeholder="${t().titlePlaceholder}" value="${escapeHtml(initialValues?.title || '')}" />
           </div>
           <div class="bd-form-group">
-            <label class="bd-label" for="description">Description</label>
-            <textarea id="description" class="bd-textarea" placeholder="Provide additional details, steps to reproduce, or context...">${escapeHtml(initialValues?.description || '')}</textarea>
+            <label class="bd-label" for="description">${t().descriptionLabel}</label>
+            <textarea id="description" class="bd-textarea" placeholder="${t().descriptionPlaceholder}">${escapeHtml(initialValues?.description || '')}</textarea>
           </div>
           ${nameFieldHtml}
           ${emailFieldHtml}
@@ -1390,8 +1392,8 @@ function showFeedbackFormWithScreenshotOption(
             ${getConsoleLogsFormControl(config, initialValues)}
           </div>
           <div class="bd-actions">
-            <button type="button" class="bd-btn bd-btn-secondary" data-action="cancel">Cancel</button>
-            <button type="submit" class="bd-btn bd-btn-primary" id="submit-btn">${config.screenshotMode === 'auto' ? 'Submit' : 'Continue'}</button>
+            <button type="button" class="bd-btn bd-btn-secondary" data-action="cancel">${t().cancel}</button>
+            <button type="submit" class="bd-btn bd-btn-primary" id="submit-btn">${config.screenshotMode === 'auto' ? t().submit : t().continueButton}</button>
           </div>
         </form>
       `
@@ -1491,10 +1493,7 @@ function showFeedbackFormWithScreenshotOption(
 
       const remainingSlots = MAX_UPLOAD_FILES - attachments.length;
       if (files.length > remainingSlots) {
-        showUploadError(
-          uploadError,
-          `Upload up to ${MAX_UPLOAD_FILES} files. Remove a file before adding another.`
-        );
+        showUploadError(uploadError, t().uploadTooMany(MAX_UPLOAD_FILES));
         return;
       }
 
@@ -1511,7 +1510,7 @@ function showFeedbackFormWithScreenshotOption(
         attachments = [...attachments, ...nextAttachments];
         rerenderUploads();
       } catch {
-        showUploadError(uploadError, 'Could not read that file. Try another one.');
+        showUploadError(uploadError, t().uploadReadError);
       }
     });
 
@@ -1522,14 +1521,14 @@ function showFeedbackFormWithScreenshotOption(
 function getUploadFormControl(): string {
   return `
     <div class="bd-upload-group">
-      <div class="bd-upload-row" aria-label="Uploads">
-        <button type="button" class="bd-btn bd-btn-secondary bd-upload-button" data-action="choose-uploads" aria-label="Upload files">
+      <div class="bd-upload-row" aria-label="${t().uploadsAriaLabel}">
+        <button type="button" class="bd-btn bd-btn-secondary bd-upload-button" data-action="choose-uploads" aria-label="${t().uploadFilesAriaLabel}">
           <svg class="bd-upload-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
             <path d="M8 11V3" />
             <path d="M4.5 6.5 8 3l3.5 3.5" />
             <path d="M3 12.5h10" />
           </svg>
-          Upload
+          ${t().uploadButton}
         </button>
       </div>
     </div>
@@ -1538,10 +1537,10 @@ function getUploadFormControl(): string {
 
 function validateUploadFile(file: File): string | null {
   if (!ACCEPTED_UPLOAD_TYPES.includes(file.type)) {
-    return 'That file type is not supported. Upload an image, PDF, or short video.';
+    return t().uploadUnsupportedType;
   }
   if (file.size > MAX_UPLOAD_SIZE_BYTES) {
-    return `File is too large. Upload files up to ${formatFileSize(MAX_UPLOAD_SIZE_BYTES)}.`;
+    return t().uploadTooLarge(formatFileSize(MAX_UPLOAD_SIZE_BYTES));
   }
   return null;
 }
@@ -1562,7 +1561,7 @@ function renderUploadList(
         <div class="bd-upload-item">
           <span class="bd-upload-item__name">${escapeHtml(attachment.name)}</span>
           <span class="bd-upload-item__meta">${formatFileSize(attachment.size)}</span>
-          <button type="button" class="bd-upload-remove" data-index="${index}" aria-label="Remove ${escapeHtml(attachment.name)}">&times;</button>
+          <button type="button" class="bd-upload-remove" data-index="${index}" aria-label="${t().removeAttachmentAriaLabel(escapeHtml(attachment.name))}">&times;</button>
         </div>
       `
     )
@@ -1607,13 +1606,10 @@ function getScreenshotFormControl(
   initialValues?: FeedbackFormResult | null
 ): string {
   if (config.screenshotMode === 'auto') {
-    const redactionNote =
-      getRedactionCount() > 0
-        ? ' Some fields this site marked private may be visually masked on supported pages, but unmarked sensitive information can still be included.'
-        : '';
+    const redactionNote = getRedactionCount() > 0 ? ` ${t().screenshotAutoRedactionNote}` : '';
     return `
       <p style="margin: 8px 0 0; color: var(--bd-text-secondary); font-size: 0.95rem;">
-        This site will attach a full-page screenshot when you submit without showing a preview. Review your page for sensitive information before sending.${redactionNote}
+        ${t().screenshotAutoNote}${redactionNote}
       </p>
     `;
   }
@@ -1621,7 +1617,7 @@ function getScreenshotFormControl(
   if (config.screenshotMode === 'required') {
     return `
       <p style="margin: 8px 0 0; color: var(--bd-text-secondary); font-size: 0.95rem;">
-        📸 A screenshot is required before submitting.
+        ${t().screenshotRequiredNote}
       </p>
     `;
   }
@@ -1634,7 +1630,7 @@ function getScreenshotFormControl(
     <div class="bd-screenshot-control">
       <input type="checkbox" id="include-screenshot" ${includeScreenshot ? 'checked' : ''} class="bd-checkbox" />
       <label for="include-screenshot" class="bd-checkbox-label">
-        📸 Include a screenshot
+        ${t().includeScreenshotLabel}
       </label>
     </div>
   `;
@@ -1650,7 +1646,7 @@ function getConsoleLogsFormControl(
     <div class="bd-form-group" style="display: flex; align-items: center; gap: 10px; margin-top: 8px;">
       <input type="checkbox" id="send-console-logs" ${sendConsoleLogs ? 'checked' : ''} style="width: 18px; height: 18px; accent-color: var(--bd-primary); cursor: pointer;" />
       <label for="send-console-logs" style="font-size: 0.95rem; color: var(--bd-text-secondary); cursor: pointer; user-select: none;">
-        Send Console Logs
+        ${t().sendConsoleLogsLabel}
       </label>
     </div>
   `;
@@ -1667,11 +1663,11 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
   // Show submitting modal with loading state
   const modal = createModal(
     root,
-    'Submitting...',
+    t().submittingTitle,
     `
       <div style="display: flex; flex-direction: column; align-items: center; padding: 20px;">
         <div class="bd-spinner bd-spinner--lg"></div>
-        <p class="bd-loading-text" style="margin-top: 12px;">Creating issue...</p>
+        <p class="bd-loading-text" style="margin-top: 12px;">${t().creatingIssue}</p>
       </div>
     `
   );
@@ -1730,12 +1726,7 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
     if (response.status === 429) {
       const retryAfter = response.headers.get('Retry-After');
       const minutes = retryAfter ? Math.ceil(parseInt(retryAfter, 10) / 60) : 15;
-      showSubmitError(
-        root,
-        config,
-        data,
-        `Too many submissions. Please try again in ${minutes} minute${minutes === 1 ? '' : 's'}.`
-      );
+      showSubmitError(root, config, data, t().rateLimited(minutes));
       return;
     }
 
@@ -1750,11 +1741,11 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
         config.issueLinkVisibility
       );
     } else {
-      showSubmitError(root, config, data, result.error || 'Failed to submit');
+      showSubmitError(root, config, data, result.error || t().submitFailedFallback);
     }
   } catch (_error) {
     modal.remove();
-    showSubmitError(root, config, data, 'Network error. Please check your connection.');
+    showSubmitError(root, config, data, t().networkError);
   }
 }
 
@@ -1766,7 +1757,7 @@ function showSubmitError(
 ) {
   const modal = createModal(
     root,
-    'Submission Failed',
+    t().submissionFailedTitle,
     `
       <div class="bd-error-message">
         <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
@@ -1775,8 +1766,8 @@ function showSubmitError(
         <span class="bd-error-message__text">${errorMessage}</span>
       </div>
       <div class="bd-actions">
-        <button class="bd-btn bd-btn-secondary" data-action="cancel">Cancel</button>
-        <button class="bd-btn bd-btn-primary" data-action="retry">Try Again</button>
+        <button class="bd-btn bd-btn-secondary" data-action="cancel">${t().cancel}</button>
+        <button class="bd-btn bd-btn-primary" data-action="retry">${t().tryAgain}</button>
       </div>
     `,
     true

--- a/src/widget/locales/en.ts
+++ b/src/widget/locales/en.ts
@@ -1,0 +1,127 @@
+import type { WidgetStrings } from '../i18n';
+
+export const en: WidgetStrings = {
+  // Trigger button & pull tab
+  triggerLabel: 'Feedback',
+  triggerAriaLabel: 'Report a bug or send feedback',
+  dismissButtonAriaLabel: 'Dismiss feedback button',
+  pullTabAriaLabel: 'Show feedback button',
+  dragHandleTitle: 'Drag feedback button',
+  // Install prompt
+  installRequiredTitle: 'Install Required',
+  connectionErrorTitle: 'Connection Error',
+  installRequiredMessage: 'BugDrop requires GitHub App installation to create issues.',
+  apiUnreachableMessage:
+    'Unable to reach BugDrop API. Check your network connection or script tag URL.',
+  installApp: 'Install App',
+  // Welcome screen
+  welcomeTitle: 'Share Your Feedback',
+  welcomeHeadline: 'Help us improve by sharing your thoughts',
+  welcomeBodyLine1: 'Report bugs, suggest features, or leave feedback.',
+  welcomeBodyLine2: 'You can optionally include annotated screenshots.',
+  getStarted: 'Get Started',
+  // Feedback form
+  feedbackFormTitle: 'Send Feedback',
+  categoryLabel: 'Category',
+  categoryBug: 'Bug',
+  categoryFeature: 'Feature',
+  categoryQuestion: 'Question',
+  nameLabel: 'Name',
+  namePlaceholder: 'Your name',
+  emailLabel: 'Email',
+  emailPlaceholder: 'your@email.com',
+  titleLabel: 'Title',
+  titlePlaceholder: 'Brief description of the issue or suggestion',
+  descriptionLabel: 'Description',
+  descriptionPlaceholder: 'Provide additional details, steps to reproduce, or context...',
+  screenshotAutoNote:
+    'This site will attach a full-page screenshot when you submit without showing a preview. Review your page for sensitive information before sending.',
+  screenshotAutoRedactionNote:
+    'Some fields this site marked private may be visually masked on supported pages, but unmarked sensitive information can still be included.',
+  screenshotRequiredNote: '📸 A screenshot is required before submitting.',
+  includeScreenshotLabel: '📸 Include a screenshot',
+  sendConsoleLogsLabel: 'Send Console Logs',
+  // Uploads
+  uploadsAriaLabel: 'Uploads',
+  uploadFilesAriaLabel: 'Upload files',
+  uploadButton: 'Upload',
+  uploadTooMany: (max: number) => `Upload up to ${max} files. Remove a file before adding another.`,
+  uploadUnsupportedType: 'That file type is not supported. Upload an image, PDF, or short video.',
+  uploadTooLarge: (maxSize: string) => `File is too large. Upload files up to ${maxSize}.`,
+  uploadReadError: 'Could not read that file. Try another one.',
+  removeAttachmentAriaLabel: (name: string) => `Remove ${name}`,
+  // Common buttons
+  cancel: 'Cancel',
+  continueButton: 'Continue',
+  submit: 'Submit',
+  // Submission
+  submittingTitle: 'Submitting...',
+  creatingIssue: 'Creating issue...',
+  rateLimited: (minutes: number) =>
+    `Too many submissions. Please try again in ${minutes} minute${minutes === 1 ? '' : 's'}.`,
+  submitFailedFallback: 'Failed to submit',
+  networkError: 'Network error. Please check your connection.',
+  submissionFailedTitle: 'Submission Failed',
+  tryAgain: 'Try Again',
+  // Success modal
+  successTitle: 'Feedback Submitted!',
+  issueCreated: (issueNumberHtml: string) => `Issue ${issueNumberHtml} has been created.`,
+  feedbackSubmittedMessage: 'Your feedback has been submitted successfully.',
+  viewOnGitHub: 'View on GitHub',
+  done: 'Done',
+  // Screenshot options
+  captureScreenshotTitle: 'Capture Screenshot',
+  chooseWhatToCapture: 'Choose what to capture:',
+  viewportRedactionWarning:
+    'Browser viewport capture cannot apply automatic private-field masks. Select Element to preserve automatic masking, or review and cover sensitive areas before sending.',
+  redactionReviewNote:
+    'This site marked some fields for redaction. Review the screenshot before sending.',
+  pageTooComplexViewportNote:
+    'This page is too complex for full-page or area capture. Capture the visible viewport or select a specific element instead.',
+  pageTooComplexElementNote:
+    'This page is too complex for full-page or area capture. Select a specific element instead.',
+  fullPage: 'Full Page',
+  captureViewport: 'Capture Viewport',
+  selectArea: 'Select Area',
+  selectElement: 'Select Element',
+  skipScreenshot: 'Skip Screenshot',
+  // Element & area pickers
+  areaPickerInstruction: 'Draw a selection around the area to capture',
+  areaPickerRedactionInstruction:
+    'Draw a selection around the area to capture. Marked private fields may be masked if included.',
+  elementPickerInstruction: 'Click any element to capture it',
+  elementPickerTouchInstruction: 'Tap any element to capture it',
+  escToCancel: 'ESC to cancel',
+  // Capture loading & failures
+  capturingTitle: 'Capturing...',
+  capturingScreenshot: 'Capturing screenshot...',
+  captureFailedTitle: 'Capture Failed',
+  captureFailedMessage:
+    'Failed to capture screenshot. The page may be too complex or browser restrictions may apply.',
+  chooseAnotherMethod: 'Choose Another Method',
+  maskFailureTitle: 'Privacy masking failed',
+  maskFailureMessage:
+    'Automatic redaction of private fields could not be applied. To protect your data, this screenshot was discarded. You can still submit feedback without one.',
+  continueWithoutScreenshot: 'Continue without screenshot',
+  // Annotation step
+  reviewScreenshotTitle: 'Review Screenshot',
+  viewportRedactionUnavailableNote:
+    'This browser viewport capture could not apply automatic private-field masks. Review and cover any sensitive areas before sending.',
+  redactionCountNote: (count: number) =>
+    `${count} private ${count === 1 ? 'item was' : 'items were'} marked for redaction in this screenshot. Review before sending.`,
+  redactionLimitationsNote:
+    'BugDrop only covered the measured marked boxes. It does not inspect pixels inside embedded or rendered content such as iframes, canvas, images, SVGs, videos, CSS backgrounds, or custom controls. Confirm the black box fully covers the sensitive region before sending, or retake after marking a larger wrapper.',
+  annotationInstruction:
+    'Check that no sensitive information is visible before sending. Cover sensitive areas before submitting. Redactions are baked into the uploaded image.',
+  selectedElementNote: (linkHtml: string) =>
+    `Need more surrounding context? Adjust ${linkHtml} on the BugDrop script tag.`,
+  toolDraw: 'Draw',
+  toolArrow: 'Arrow',
+  toolRectangle: 'Rectangle',
+  toolRedact: 'Redact',
+  undo: 'Undo',
+  retake: 'Retake',
+  submitFeedback: 'Submit Feedback',
+  // Capture timeout
+  captureTimeout: 'Screenshot capture timed out — the page may be too complex',
+};

--- a/src/widget/locales/nl.ts
+++ b/src/widget/locales/nl.ts
@@ -1,0 +1,133 @@
+import type { WidgetStrings } from '../i18n';
+
+export const nl: WidgetStrings = {
+  // Trigger button & pull tab
+  triggerLabel: 'Feedback',
+  triggerAriaLabel: 'Een fout melden of feedback versturen',
+  dismissButtonAriaLabel: 'Feedbackknop verbergen',
+  pullTabAriaLabel: 'Feedbackknop tonen',
+  dragHandleTitle: 'Feedbackknop verslepen',
+  // Install prompt
+  installRequiredTitle: 'Installatie vereist',
+  connectionErrorTitle: 'Verbindingsfout',
+  installRequiredMessage:
+    'BugDrop vereist installatie van de GitHub-app om issues te kunnen aanmaken.',
+  apiUnreachableMessage:
+    'Kan de BugDrop-API niet bereiken. Controleer uw netwerkverbinding of de URL van de scripttag.',
+  installApp: 'App installeren',
+  // Welcome screen
+  welcomeTitle: 'Deel uw feedback',
+  welcomeHeadline: 'Help ons verbeteren door uw mening te delen',
+  welcomeBodyLine1: 'Meld fouten, stel functies voor of laat feedback achter.',
+  welcomeBodyLine2: 'U kunt optioneel schermafbeeldingen met aantekeningen toevoegen.',
+  getStarted: 'Aan de slag',
+  // Feedback form
+  feedbackFormTitle: 'Feedback versturen',
+  categoryLabel: 'Categorie',
+  categoryBug: 'Fout',
+  categoryFeature: 'Suggestie',
+  categoryQuestion: 'Vraag',
+  nameLabel: 'Naam',
+  namePlaceholder: 'Uw naam',
+  emailLabel: 'E-mail',
+  emailPlaceholder: 'uw@email.nl',
+  titleLabel: 'Titel',
+  titlePlaceholder: 'Korte omschrijving van het probleem of de suggestie',
+  descriptionLabel: 'Omschrijving',
+  descriptionPlaceholder: 'Geef extra details, stappen om het te reproduceren of context...',
+  screenshotAutoNote:
+    'Deze site voegt bij het versturen automatisch een schermafbeelding van de volledige pagina toe, zonder voorbeeld. Controleer uw pagina op gevoelige informatie voordat u verstuurt.',
+  screenshotAutoRedactionNote:
+    'Sommige velden die deze site als privé heeft gemarkeerd, kunnen op ondersteunde pagina’s visueel worden gemaskeerd, maar niet-gemarkeerde gevoelige informatie kan nog steeds worden meegestuurd.',
+  screenshotRequiredNote: '📸 Een schermafbeelding is vereist voordat u kunt versturen.',
+  includeScreenshotLabel: '📸 Schermafbeelding toevoegen',
+  sendConsoleLogsLabel: 'Consolelogboeken meesturen',
+  // Uploads
+  uploadsAriaLabel: 'Uploads',
+  uploadFilesAriaLabel: 'Bestanden uploaden',
+  uploadButton: 'Uploaden',
+  uploadTooMany: (max: number) =>
+    `Upload maximaal ${max} bestanden. Verwijder een bestand voordat u er een toevoegt.`,
+  uploadUnsupportedType:
+    'Dat bestandstype wordt niet ondersteund. Upload een afbeelding, pdf of korte video.',
+  uploadTooLarge: (maxSize: string) => `Het bestand is te groot. Upload bestanden tot ${maxSize}.`,
+  uploadReadError: 'Kan dat bestand niet lezen. Probeer een ander bestand.',
+  removeAttachmentAriaLabel: (name: string) => `${name} verwijderen`,
+  // Common buttons
+  cancel: 'Annuleren',
+  continueButton: 'Doorgaan',
+  submit: 'Versturen',
+  // Submission
+  submittingTitle: 'Versturen...',
+  creatingIssue: 'Issue aanmaken...',
+  rateLimited: (minutes: number) =>
+    `Te veel inzendingen. Probeer het over ${minutes} ${minutes === 1 ? 'minuut' : 'minuten'} opnieuw.`,
+  submitFailedFallback: 'Versturen mislukt',
+  networkError: 'Netwerkfout. Controleer uw verbinding.',
+  submissionFailedTitle: 'Versturen mislukt',
+  tryAgain: 'Opnieuw proberen',
+  // Success modal
+  successTitle: 'Feedback verstuurd!',
+  issueCreated: (issueNumberHtml: string) => `Issue ${issueNumberHtml} is aangemaakt.`,
+  feedbackSubmittedMessage: 'Uw feedback is succesvol verstuurd.',
+  viewOnGitHub: 'Bekijken op GitHub',
+  done: 'Klaar',
+  // Screenshot options
+  captureScreenshotTitle: 'Schermafbeelding maken',
+  chooseWhatToCapture: 'Kies wat u wilt vastleggen:',
+  viewportRedactionWarning:
+    'Bij het vastleggen van het zichtbare deel via de browser kunnen privévelden niet automatisch worden gemaskeerd. Kies “Element selecteren” om automatische maskering te behouden, of controleer en dek gevoelige gebieden af voordat u verstuurt.',
+  redactionReviewNote:
+    'Deze site heeft enkele velden gemarkeerd voor redactie. Controleer de schermafbeelding voordat u verstuurt.',
+  pageTooComplexViewportNote:
+    'Deze pagina is te complex om volledig of per gebied vast te leggen. Leg het zichtbare deel vast of selecteer een specifiek element.',
+  pageTooComplexElementNote:
+    'Deze pagina is te complex om volledig of per gebied vast te leggen. Selecteer in plaats daarvan een specifiek element.',
+  fullPage: 'Volledige pagina',
+  captureViewport: 'Zichtbaar deel vastleggen',
+  selectArea: 'Gebied selecteren',
+  selectElement: 'Element selecteren',
+  skipScreenshot: 'Schermafbeelding overslaan',
+  // Element & area pickers
+  areaPickerInstruction: 'Trek een selectie rond het gebied dat u wilt vastleggen',
+  areaPickerRedactionInstruction:
+    'Trek een selectie rond het gebied dat u wilt vastleggen. Gemarkeerde privévelden kunnen worden gemaskeerd als ze binnen de selectie vallen.',
+  elementPickerInstruction: 'Klik op een element om het vast te leggen',
+  elementPickerTouchInstruction: 'Tik op een element om het vast te leggen',
+  escToCancel: 'ESC om te annuleren',
+  // Capture loading & failures
+  capturingTitle: 'Vastleggen...',
+  capturingScreenshot: 'Schermafbeelding wordt gemaakt...',
+  captureFailedTitle: 'Opname mislukt',
+  captureFailedMessage:
+    'Kan geen schermafbeelding maken. De pagina is mogelijk te complex of de browser staat dit niet toe.',
+  chooseAnotherMethod: 'Kies een andere methode',
+  maskFailureTitle: 'Privacymaskering mislukt',
+  maskFailureMessage:
+    'Automatische redactie van privévelden kon niet worden toegepast. Om uw gegevens te beschermen is deze schermafbeelding verwijderd. U kunt uw feedback nog steeds zonder schermafbeelding versturen.',
+  continueWithoutScreenshot: 'Doorgaan zonder schermafbeelding',
+  // Annotation step
+  reviewScreenshotTitle: 'Schermafbeelding controleren',
+  viewportRedactionUnavailableNote:
+    'Bij deze via de browser vastgelegde schermafbeelding konden privévelden niet automatisch worden gemaskeerd. Controleer en dek gevoelige gebieden af voordat u verstuurt.',
+  redactionCountNote: (count: number) =>
+    count === 1
+      ? '1 privé-item is gemarkeerd voor redactie in deze schermafbeelding. Controleer voordat u verstuurt.'
+      : `${count} privé-items zijn gemarkeerd voor redactie in deze schermafbeelding. Controleer voordat u verstuurt.`,
+  redactionLimitationsNote:
+    'BugDrop heeft alleen de gemeten gemarkeerde vakken afgedekt. Het inspecteert geen pixels binnen ingesloten of gerenderde inhoud zoals iframes, canvas, afbeeldingen, SVG’s, video’s, CSS-achtergronden of aangepaste elementen. Controleer of het zwarte vak het gevoelige gebied volledig bedekt voordat u verstuurt, of maak de afbeelding opnieuw nadat u een groter element hebt gemarkeerd.',
+  annotationInstruction:
+    'Controleer of er geen gevoelige informatie zichtbaar is voordat u verstuurt. Dek gevoelige gebieden af voordat u indient. Redacties worden permanent in de geüploade afbeelding verwerkt.',
+  selectedElementNote: (linkHtml: string) =>
+    `Meer omringende context nodig? Pas ${linkHtml} aan op de BugDrop-scripttag.`,
+  toolDraw: 'Tekenen',
+  toolArrow: 'Pijl',
+  toolRectangle: 'Rechthoek',
+  toolRedact: 'Redigeren',
+  undo: 'Ongedaan maken',
+  retake: 'Opnieuw maken',
+  submitFeedback: 'Feedback versturen',
+  // Capture timeout
+  captureTimeout:
+    'Het maken van de schermafbeelding duurde te lang — de pagina is mogelijk te complex',
+};

--- a/src/widget/locales/pl.ts
+++ b/src/widget/locales/pl.ts
@@ -1,0 +1,146 @@
+import type { WidgetStrings } from '../i18n';
+
+// Polish "few" plural form: 2-4, 22-24, 32-34, ... (but not 12-14).
+function isFew(count: number): boolean {
+  const mod10 = count % 10;
+  const mod100 = count % 100;
+  return mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14);
+}
+
+export const pl: WidgetStrings = {
+  // Trigger button & pull tab
+  triggerLabel: 'Opinia',
+  triggerAriaLabel: 'Zgłoś błąd lub wyślij opinię',
+  dismissButtonAriaLabel: 'Ukryj przycisk opinii',
+  pullTabAriaLabel: 'Pokaż przycisk opinii',
+  dragHandleTitle: 'Przeciągnij przycisk opinii',
+  // Install prompt
+  installRequiredTitle: 'Wymagana instalacja',
+  connectionErrorTitle: 'Błąd połączenia',
+  installRequiredMessage: 'BugDrop wymaga instalacji aplikacji GitHub, aby tworzyć zgłoszenia.',
+  apiUnreachableMessage:
+    'Nie można połączyć się z API BugDrop. Sprawdź połączenie sieciowe lub adres URL w tagu skryptu.',
+  installApp: 'Zainstaluj aplikację',
+  // Welcome screen
+  welcomeTitle: 'Podziel się opinią',
+  welcomeHeadline: 'Pomóż nam się rozwijać, dzieląc się swoimi uwagami',
+  welcomeBodyLine1: 'Zgłaszaj błędy, proponuj funkcje lub zostaw opinię.',
+  welcomeBodyLine2: 'Opcjonalnie możesz dołączyć zrzuty ekranu z adnotacjami.',
+  getStarted: 'Rozpocznij',
+  // Feedback form
+  feedbackFormTitle: 'Wyślij opinię',
+  categoryLabel: 'Kategoria',
+  categoryBug: 'Błąd',
+  categoryFeature: 'Propozycja',
+  categoryQuestion: 'Pytanie',
+  nameLabel: 'Imię i nazwisko',
+  namePlaceholder: 'Twoje imię i nazwisko',
+  emailLabel: 'E-mail',
+  emailPlaceholder: 'twoj@email.com',
+  titleLabel: 'Tytuł',
+  titlePlaceholder: 'Krótki opis problemu lub sugestii',
+  descriptionLabel: 'Opis',
+  descriptionPlaceholder: 'Podaj dodatkowe szczegóły, kroki do odtworzenia lub kontekst...',
+  screenshotAutoNote:
+    'Ta strona automatycznie dołączy zrzut całej strony podczas wysyłania, bez pokazywania podglądu. Przed wysłaniem sprawdź, czy strona nie zawiera poufnych informacji.',
+  screenshotAutoRedactionNote:
+    'Niektóre pola oznaczone przez tę stronę jako prywatne mogą zostać zamaskowane na obsługiwanych stronach, ale nieoznaczone poufne informacje nadal mogą zostać dołączone.',
+  screenshotRequiredNote: '📸 Zrzut ekranu jest wymagany przed wysłaniem.',
+  includeScreenshotLabel: '📸 Dołącz zrzut ekranu',
+  sendConsoleLogsLabel: 'Wyślij logi konsoli',
+  // Uploads
+  uploadsAriaLabel: 'Załączniki',
+  uploadFilesAriaLabel: 'Prześlij pliki',
+  uploadButton: 'Prześlij',
+  uploadTooMany: (max: number) =>
+    `Można przesłać maksymalnie ${max} ${isFew(max) ? 'pliki' : 'plików'}. Usuń plik, aby dodać kolejny.`,
+  uploadUnsupportedType:
+    'Ten typ pliku nie jest obsługiwany. Prześlij obraz, plik PDF lub krótki film.',
+  uploadTooLarge: (maxSize: string) =>
+    `Plik jest za duży. Prześlij pliki o rozmiarze do ${maxSize}.`,
+  uploadReadError: 'Nie udało się odczytać pliku. Spróbuj z innym.',
+  removeAttachmentAriaLabel: (name: string) => `Usuń ${name}`,
+  // Common buttons
+  cancel: 'Anuluj',
+  continueButton: 'Dalej',
+  submit: 'Wyślij',
+  // Submission
+  submittingTitle: 'Wysyłanie...',
+  creatingIssue: 'Tworzenie zgłoszenia...',
+  rateLimited: (minutes: number) =>
+    `Zbyt wiele zgłoszeń. Spróbuj ponownie za ${minutes} ${
+      minutes === 1 ? 'minutę' : isFew(minutes) ? 'minuty' : 'minut'
+    }.`,
+  submitFailedFallback: 'Nie udało się wysłać',
+  networkError: 'Błąd sieci. Sprawdź połączenie z internetem.',
+  submissionFailedTitle: 'Wysyłanie nie powiodło się',
+  tryAgain: 'Spróbuj ponownie',
+  // Success modal
+  successTitle: 'Opinia wysłana!',
+  issueCreated: (issueNumberHtml: string) => `Utworzono zgłoszenie ${issueNumberHtml}.`,
+  feedbackSubmittedMessage: 'Twoja opinia została pomyślnie wysłana.',
+  viewOnGitHub: 'Zobacz na GitHubie',
+  done: 'Gotowe',
+  // Screenshot options
+  captureScreenshotTitle: 'Zrób zrzut ekranu',
+  chooseWhatToCapture: 'Wybierz, co przechwycić:',
+  viewportRedactionWarning:
+    'Przechwytywanie widocznego obszaru przez przeglądarkę nie pozwala automatycznie zamaskować pól prywatnych. Wybierz „Zaznacz element”, aby zachować automatyczne maskowanie, albo sprawdź i zakryj poufne obszary przed wysłaniem.',
+  redactionReviewNote:
+    'Ta strona oznaczyła niektóre pola do zamazania. Sprawdź zrzut ekranu przed wysłaniem.',
+  pageTooComplexViewportNote:
+    'Ta strona jest zbyt złożona, aby przechwycić całą stronę lub zaznaczony obszar. Przechwyć widoczny obszar albo zaznacz konkretny element.',
+  pageTooComplexElementNote:
+    'Ta strona jest zbyt złożona, aby przechwycić całą stronę lub zaznaczony obszar. Zamiast tego zaznacz konkretny element.',
+  fullPage: 'Cała strona',
+  captureViewport: 'Przechwyć widoczny obszar',
+  selectArea: 'Zaznacz obszar',
+  selectElement: 'Zaznacz element',
+  skipScreenshot: 'Pomiń zrzut ekranu',
+  // Element & area pickers
+  areaPickerInstruction: 'Narysuj zaznaczenie wokół obszaru do przechwycenia',
+  areaPickerRedactionInstruction:
+    'Narysuj zaznaczenie wokół obszaru do przechwycenia. Pola oznaczone jako prywatne mogą zostać zamaskowane, jeśli znajdą się w zaznaczeniu.',
+  elementPickerInstruction: 'Kliknij dowolny element, aby go przechwycić',
+  elementPickerTouchInstruction: 'Dotknij dowolny element, aby go przechwycić',
+  escToCancel: 'ESC, aby anulować',
+  // Capture loading & failures
+  capturingTitle: 'Przechwytywanie...',
+  capturingScreenshot: 'Trwa przechwytywanie zrzutu ekranu...',
+  captureFailedTitle: 'Przechwytywanie nie powiodło się',
+  captureFailedMessage:
+    'Nie udało się przechwycić zrzutu ekranu. Strona może być zbyt złożona lub przeglądarka na to nie pozwala.',
+  chooseAnotherMethod: 'Wybierz inną metodę',
+  maskFailureTitle: 'Maskowanie prywatności nie powiodło się',
+  maskFailureMessage:
+    'Nie udało się automatycznie zamazać pól prywatnych. Aby chronić Twoje dane, ten zrzut ekranu został odrzucony. Nadal możesz wysłać opinię bez zrzutu ekranu.',
+  continueWithoutScreenshot: 'Kontynuuj bez zrzutu ekranu',
+  // Annotation step
+  reviewScreenshotTitle: 'Sprawdź zrzut ekranu',
+  viewportRedactionUnavailableNote:
+    'Na tym zrzucie przechwyconym przez przeglądarkę nie udało się automatycznie zamaskować pól prywatnych. Sprawdź i zakryj poufne obszary przed wysłaniem.',
+  redactionCountNote: (count: number) =>
+    `${count} ${
+      count === 1
+        ? 'prywatny element oznaczono'
+        : isFew(count)
+          ? 'prywatne elementy oznaczono'
+          : 'prywatnych elementów oznaczono'
+    } do zamazania na tym zrzucie ekranu. Sprawdź przed wysłaniem.`,
+  redactionLimitationsNote:
+    'BugDrop zakrywa tylko zmierzone, oznaczone obszary. Nie analizuje pikseli wewnątrz osadzonej lub renderowanej zawartości, takiej jak elementy iframe, canvas, obrazy, pliki SVG, filmy, tła CSS czy niestandardowe kontrolki. Przed wysłaniem upewnij się, że czarny prostokąt w pełni zakrywa poufny obszar, albo ponów zrzut po oznaczeniu większego elementu.',
+  annotationInstruction:
+    'Przed wysłaniem sprawdź, czy nie widać poufnych informacji. Zakryj poufne obszary przed przesłaniem. Zamazania są trwale zapisywane w przesyłanym obrazie.',
+  selectedElementNote: (linkHtml: string) =>
+    `Potrzebujesz więcej otaczającego kontekstu? Dostosuj ${linkHtml} w tagu skryptu BugDrop.`,
+  toolDraw: 'Rysuj',
+  toolArrow: 'Strzałka',
+  toolRectangle: 'Prostokąt',
+  toolRedact: 'Zamaż',
+  undo: 'Cofnij',
+  retake: 'Ponów zrzut',
+  submitFeedback: 'Wyślij opinię',
+  // Capture timeout
+  captureTimeout:
+    'Upłynął limit czasu przechwytywania zrzutu ekranu — strona może być zbyt złożona',
+};

--- a/src/widget/picker.ts
+++ b/src/widget/picker.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines, max-lines-per-function */
 import { resolvePickerStyle, type PickerStyle, type ResolvedPickerStyle } from './picker-style';
 import { getSelectionTarget } from './picker-target';
+import { t } from './i18n';
 
 export { resolvePickerStyle, type PickerStyle };
 
@@ -79,12 +80,12 @@ function createTooltip(
   `;
 
   if (!showInlineCancel) {
-    tooltip.textContent = 'Click any element to capture it (ESC to cancel)';
+    tooltip.textContent = `${t().elementPickerInstruction} (${t().escToCancel})`;
     return { tooltip, cancelButton: null };
   }
 
   const cancelButton = createCancelButton(style.accent);
-  tooltip.append('Tap any element to capture it (', cancelButton, ')');
+  tooltip.append(`${t().elementPickerTouchInstruction} (`, cancelButton, ')');
   return { tooltip, cancelButton };
 }
 
@@ -340,7 +341,7 @@ function createCancelButton(accent: string): HTMLButtonElement {
   const cancelButton = document.createElement('button');
   cancelButton.id = 'bugdrop-element-picker-cancel';
   cancelButton.type = 'button';
-  cancelButton.textContent = 'Cancel';
+  cancelButton.textContent = t().cancel;
   cancelButton.style.cssText = `
     align-items: center;
     appearance: none;

--- a/src/widget/screenshot-options.ts
+++ b/src/widget/screenshot-options.ts
@@ -5,6 +5,7 @@ import {
   isFullPageDisabled,
 } from './screenshot';
 import { createModal, redactionNoteHtml } from './ui';
+import { t } from './i18n';
 
 export type ScreenshotChoice =
   | { kind: 'skip' }
@@ -24,41 +25,35 @@ export function showScreenshotOptions(
 
   let redactionNote = '';
   if (nativeViewportAvailable) {
-    redactionNote = redactionNoteHtml(
-      'Browser viewport capture cannot apply automatic private-field masks. Select Element to preserve automatic masking, or review and cover sensitive areas before sending.'
-    );
+    redactionNote = redactionNoteHtml(t().viewportRedactionWarning);
   } else if (getRedactionCount() > 0) {
-    redactionNote = redactionNoteHtml(
-      'This site marked some fields for redaction. Review the screenshot before sending.'
-    );
+    redactionNote = redactionNoteHtml(t().redactionReviewNote);
   }
 
   return new Promise(resolve => {
     const complexNote = fullPageDisabled
-      ? `<p style="margin: 0 0 12px; padding: 8px 12px; background: var(--bd-bg-secondary, #f5f5f5); border-radius: 6px; font-size: 13px; color: var(--bd-text-secondary);">${nativeViewportAvailable ? 'This page is too complex for full-page or area capture. Capture the visible viewport or select a specific element instead.' : 'This page is too complex for full-page or area capture. Select a specific element instead.'}</p>`
+      ? `<p style="margin: 0 0 12px; padding: 8px 12px; background: var(--bd-bg-secondary, #f5f5f5); border-radius: 6px; font-size: 13px; color: var(--bd-text-secondary);">${nativeViewportAvailable ? t().pageTooComplexViewportNote : t().pageTooComplexElementNote}</p>`
       : '';
 
     let primaryCaptureButton = '';
     if (!fullPageDisabled) {
-      primaryCaptureButton =
-        '<button class="bd-btn bd-btn-primary" data-action="capture">Full Page</button>';
+      primaryCaptureButton = `<button class="bd-btn bd-btn-primary" data-action="capture">${t().fullPage}</button>`;
     } else if (nativeViewportAvailable) {
-      primaryCaptureButton =
-        '<button class="bd-btn bd-btn-primary" data-action="viewport">Capture Viewport</button>';
+      primaryCaptureButton = `<button class="bd-btn bd-btn-primary" data-action="viewport">${t().captureViewport}</button>`;
     }
 
     const modal = createModal(
       root,
-      'Capture Screenshot',
+      t().captureScreenshotTitle,
       `
-        <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">Choose what to capture:</p>
+        <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">${t().chooseWhatToCapture}</p>
         ${complexNote}
         ${redactionNote}
         <div class="bd-actions bd-screenshot-actions">
           ${primaryCaptureButton}
-          ${fullPageDisabled ? '' : '<button class="bd-btn bd-btn-secondary" data-action="area">Select Area</button>'}
-          <button class="bd-btn bd-btn-secondary" data-action="element">Select Element</button>
-          ${allowSkip ? '<button class="bd-btn bd-btn-quiet" data-action="skip">Skip Screenshot</button>' : ''}
+          ${fullPageDisabled ? '' : `<button class="bd-btn bd-btn-secondary" data-action="area">${t().selectArea}</button>`}
+          <button class="bd-btn bd-btn-secondary" data-action="element">${t().selectElement}</button>
+          ${allowSkip ? `<button class="bd-btn bd-btn-quiet" data-action="skip">${t().skipScreenshot}</button>` : ''}
         </div>
       `
     );

--- a/src/widget/screenshot-options.ts
+++ b/src/widget/screenshot-options.ts
@@ -5,7 +5,7 @@ import {
   isFullPageDisabled,
 } from './screenshot';
 import { createModal, redactionNoteHtml } from './ui';
-import { t } from './i18n';
+import { escapeWidgetText, t } from './i18n';
 
 export type ScreenshotChoice =
   | { kind: 'skip' }
@@ -32,28 +32,28 @@ export function showScreenshotOptions(
 
   return new Promise(resolve => {
     const complexNote = fullPageDisabled
-      ? `<p style="margin: 0 0 12px; padding: 8px 12px; background: var(--bd-bg-secondary, #f5f5f5); border-radius: 6px; font-size: 13px; color: var(--bd-text-secondary);">${nativeViewportAvailable ? t().pageTooComplexViewportNote : t().pageTooComplexElementNote}</p>`
+      ? `<p style="margin: 0 0 12px; padding: 8px 12px; background: var(--bd-bg-secondary, #f5f5f5); border-radius: 6px; font-size: 13px; color: var(--bd-text-secondary);">${nativeViewportAvailable ? escapeWidgetText(t().pageTooComplexViewportNote) : escapeWidgetText(t().pageTooComplexElementNote)}</p>`
       : '';
 
     let primaryCaptureButton = '';
     if (!fullPageDisabled) {
-      primaryCaptureButton = `<button class="bd-btn bd-btn-primary" data-action="capture">${t().fullPage}</button>`;
+      primaryCaptureButton = `<button class="bd-btn bd-btn-primary" data-action="capture">${escapeWidgetText(t().fullPage)}</button>`;
     } else if (nativeViewportAvailable) {
-      primaryCaptureButton = `<button class="bd-btn bd-btn-primary" data-action="viewport">${t().captureViewport}</button>`;
+      primaryCaptureButton = `<button class="bd-btn bd-btn-primary" data-action="viewport">${escapeWidgetText(t().captureViewport)}</button>`;
     }
 
     const modal = createModal(
       root,
       t().captureScreenshotTitle,
       `
-        <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">${t().chooseWhatToCapture}</p>
+        <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">${escapeWidgetText(t().chooseWhatToCapture)}</p>
         ${complexNote}
         ${redactionNote}
         <div class="bd-actions bd-screenshot-actions">
           ${primaryCaptureButton}
-          ${fullPageDisabled ? '' : `<button class="bd-btn bd-btn-secondary" data-action="area">${t().selectArea}</button>`}
-          <button class="bd-btn bd-btn-secondary" data-action="element">${t().selectElement}</button>
-          ${allowSkip ? `<button class="bd-btn bd-btn-quiet" data-action="skip">${t().skipScreenshot}</button>` : ''}
+          ${fullPageDisabled ? '' : `<button class="bd-btn bd-btn-secondary" data-action="area">${escapeWidgetText(t().selectArea)}</button>`}
+          <button class="bd-btn bd-btn-secondary" data-action="element">${escapeWidgetText(t().selectElement)}</button>
+          ${allowSkip ? `<button class="bd-btn bd-btn-quiet" data-action="skip">${escapeWidgetText(t().skipScreenshot)}</button>` : ''}
         </div>
       `
     );

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -6,6 +6,7 @@ import {
   sanitizeUrl,
 } from './sanitize';
 import { DEFAULT_ACCENT_COLOR, getAccentHoverColor } from '../defaults';
+import { t } from './i18n';
 
 declare const __BUGDROP_VERSION__: string;
 
@@ -1569,20 +1570,20 @@ export function showSuccessModal(
           <svg viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
             <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"/>
           </svg>
-          View on GitHub
+          ${t().viewOnGitHub}
         </a>`
         : '';
     const issueInfo =
       isPublic || (issueLinkVisibility === 'always' && shouldShowIssueLink)
         ? `
-        <p class="bd-success-issue">Issue <strong>#${issueNumber}</strong> has been created.</p>
+        <p class="bd-success-issue">${t().issueCreated(`<strong>#${issueNumber}</strong>`)}</p>
         ${issueLink}
       `
-        : `<p class="bd-success-issue">Your feedback has been submitted successfully.</p>`;
+        : `<p class="bd-success-issue">${t().feedbackSubmittedMessage}</p>`;
 
     const modal = createModal(
       container,
-      'Feedback Submitted!',
+      t().successTitle,
       `
         <div class="bd-success-content">
           <div class="bd-success-icon">
@@ -1594,7 +1595,7 @@ export function showSuccessModal(
           ${issueInfo}
         </div>
         <div class="bd-actions bd-success-actions">
-          <button class="bd-btn bd-btn-primary" data-action="done">Done</button>
+          <button class="bd-btn bd-btn-primary" data-action="done">${t().done}</button>
         </div>
         <div class="bd-powered-by">
           <a href="https://github.com/mean-weasel/bugdrop" target="_blank" rel="noopener noreferrer">Powered by BugDrop</a>

--- a/src/widget/ui.ts
+++ b/src/widget/ui.ts
@@ -6,7 +6,7 @@ import {
   sanitizeUrl,
 } from './sanitize';
 import { DEFAULT_ACCENT_COLOR, getAccentHoverColor } from '../defaults';
-import { t } from './i18n';
+import { escapeWidgetText, t } from './i18n';
 
 declare const __BUGDROP_VERSION__: string;
 
@@ -1367,7 +1367,7 @@ export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
 }
 
 export function redactionNoteHtml(message: string): string {
-  return `<p class="bd-redaction-note" style="margin: 0 0 12px; padding: 8px 12px; background: var(--bd-warning-bg, #fff8e1); border-radius: 6px; font-size: 13px; color: var(--bd-text-secondary);">${message}</p>`;
+  return `<p class="bd-redaction-note" style="margin: 0 0 12px; padding: 8px 12px; background: var(--bd-warning-bg, #fff8e1); border-radius: 6px; font-size: 13px; color: var(--bd-text-secondary);">${escapeHtml(message)}</p>`;
 }
 
 export function createModal(
@@ -1570,7 +1570,7 @@ export function showSuccessModal(
           <svg viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
             <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"/>
           </svg>
-          ${t().viewOnGitHub}
+          ${escapeWidgetText(t().viewOnGitHub)}
         </a>`
         : '';
     const issueInfo =
@@ -1579,7 +1579,7 @@ export function showSuccessModal(
         <p class="bd-success-issue">${t().issueCreated(`<strong>#${issueNumber}</strong>`)}</p>
         ${issueLink}
       `
-        : `<p class="bd-success-issue">${t().feedbackSubmittedMessage}</p>`;
+        : `<p class="bd-success-issue">${escapeWidgetText(t().feedbackSubmittedMessage)}</p>`;
 
     const modal = createModal(
       container,
@@ -1595,7 +1595,7 @@ export function showSuccessModal(
           ${issueInfo}
         </div>
         <div class="bd-actions bd-success-actions">
-          <button class="bd-btn bd-btn-primary" data-action="done">${t().done}</button>
+          <button class="bd-btn bd-btn-primary" data-action="done">${escapeWidgetText(t().done)}</button>
         </div>
         <div class="bd-powered-by">
           <a href="https://github.com/mean-weasel/bugdrop" target="_blank" rel="noopener noreferrer">Powered by BugDrop</a>

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { resolveLocale, setLocale, t } from '../src/widget/i18n';
+import { escapeWidgetText, resolveLocale, setLocale, t } from '../src/widget/i18n';
 import { en } from '../src/widget/locales/en';
 import { nl } from '../src/widget/locales/nl';
 import { pl } from '../src/widget/locales/pl';
@@ -68,6 +68,14 @@ describe('setLocale and t', () => {
   });
 });
 
+describe('escapeWidgetText', () => {
+  it('escapes translated text before insertion into HTML templates or attributes', () => {
+    expect(escapeWidgetText('Save "draft" & <retry>')).toBe(
+      'Save &quot;draft&quot; &amp; &lt;retry&gt;'
+    );
+  });
+});
+
 describe('locale dictionaries', () => {
   const enKeys = Object.keys(en).sort();
 
@@ -85,5 +93,32 @@ describe('locale dictionaries', () => {
     for (const key of enKeys) {
       expect(typeof dictionary[key as keyof typeof en]).toBe(typeof en[key as keyof typeof en]);
     }
+  });
+
+  it('preserves trusted HTML placeholders exactly once in rich messages', () => {
+    const issueLink = '<strong>#1</strong>';
+    const configLink = '<a href="#docs">data-element-context-max-area</a>';
+
+    expect(en.issueCreated(issueLink)).toBe(`Issue ${issueLink} has been created.`);
+    expect(nl.issueCreated(issueLink).match(/<strong>#1<\/strong>/g)).toHaveLength(1);
+    expect(pl.issueCreated(issueLink).match(/<strong>#1<\/strong>/g)).toHaveLength(1);
+
+    expect(en.selectedElementNote(configLink).match(/<a href="#docs">/g)).toHaveLength(1);
+    expect(nl.selectedElementNote(configLink).match(/<a href="#docs">/g)).toHaveLength(1);
+    expect(pl.selectedElementNote(configLink).match(/<a href="#docs">/g)).toHaveLength(1);
+  });
+
+  it('formats count-sensitive messages for singular and plural boundaries', () => {
+    expect(en.rateLimited(1)).toContain('1 minute.');
+    expect(en.rateLimited(2)).toContain('2 minutes.');
+
+    expect(nl.redactionCountNote(1)).toContain('1 privé-item');
+    expect(nl.redactionCountNote(2)).toContain('2 privé-items');
+
+    expect(pl.rateLimited(1)).toContain('1 minutę');
+    expect(pl.rateLimited(2)).toContain('2 minuty');
+    expect(pl.rateLimited(5)).toContain('5 minut');
+    expect(pl.rateLimited(12)).toContain('12 minut');
+    expect(pl.rateLimited(22)).toContain('22 minuty');
   });
 });

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveLocale, setLocale, t } from '../src/widget/i18n';
+import { en } from '../src/widget/locales/en';
+import { nl } from '../src/widget/locales/nl';
+import { pl } from '../src/widget/locales/pl';
+
+afterEach(() => {
+  setLocale('en');
+  vi.restoreAllMocks();
+});
+
+describe('resolveLocale', () => {
+  it('resolves exactly matching supported locales', () => {
+    expect(resolveLocale('en')).toBe('en');
+    expect(resolveLocale('nl')).toBe('nl');
+    expect(resolveLocale('pl')).toBe('pl');
+  });
+
+  it('resolves region subtags to the base language', () => {
+    expect(resolveLocale('nl-NL')).toBe('nl');
+    expect(resolveLocale('pl-PL')).toBe('pl');
+    expect(resolveLocale('en-GB')).toBe('en');
+  });
+
+  it('resolves underscore region formats to the base language', () => {
+    expect(resolveLocale('nl_NL')).toBe('nl');
+    expect(resolveLocale('pl_PL')).toBe('pl');
+  });
+
+  it('is case-insensitive', () => {
+    expect(resolveLocale('NL')).toBe('nl');
+    expect(resolveLocale('Pl-pl')).toBe('pl');
+    expect(resolveLocale('EN-us')).toBe('en');
+  });
+
+  it('falls back to English and warns for unsupported locales', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    expect(resolveLocale('de')).toBe('en');
+
+    expect(warn).toHaveBeenCalledWith(
+      '[BugDrop] Unsupported data-locale "de"; falling back to English.'
+    );
+  });
+
+  it('falls back to English without warning when no locale is provided', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    expect(resolveLocale(undefined)).toBe('en');
+    expect(resolveLocale(null)).toBe('en');
+    expect(resolveLocale('')).toBe('en');
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('setLocale and t', () => {
+  it('defaults to the English dictionary', () => {
+    expect(t()).toBe(en);
+  });
+
+  it('switches the active dictionary', () => {
+    setLocale('nl');
+    expect(t()).toBe(nl);
+
+    setLocale('pl');
+    expect(t()).toBe(pl);
+  });
+});
+
+describe('locale dictionaries', () => {
+  const enKeys = Object.keys(en).sort();
+
+  it.each([
+    ['nl', nl],
+    ['pl', pl],
+  ] as const)('%s has exactly the same keys as en', (_name, dictionary) => {
+    expect(Object.keys(dictionary).sort()).toEqual(enKeys);
+  });
+
+  it.each([
+    ['nl', nl],
+    ['pl', pl],
+  ] as const)('%s entries have the same type as their en counterparts', (_name, dictionary) => {
+    for (const key of enKeys) {
+      expect(typeof dictionary[key as keyof typeof en]).toBe(typeof en[key as keyof typeof en]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds multi-language support to the widget UI via a new `data-locale` script attribute. All user-facing strings - the feedback form, screenshot options, element/area pickers, annotation toolbar, capture-failure and success/error modals - now come from per-locale dictionaries. Ships English (default), Dutch, and Polish.

We run BugDrop self-hosted on a Dutch/Polish client-facing product, so the form language has to follow the page language. Hopefully useful to other non-English deployments too.

 ## How it works

 - `src/widget/i18n.ts` - `WidgetStrings` interface (92 keys; parameterized entries are typed functions, so no template-substitution engine), `resolveLocale()`, and `setLocale()`/`t()` module-level state (the widget is a per-page singleton).
 - `src/widget/locales/{en,nl,pl}.ts` - one dictionary per language. Dutch uses the formal "u" register; Polish uses impersonal/imperative forms with correct plural rules (e.g. minutę/minuty/minut).
 - Resolution order: `data-locale` → `<html lang>` → `en`. Matching is case-insensitive and accepts region subtags in BCP 47 and underscore formats (`nl-NL`, `nl_NL`, `NL` → `nl`). Unsupported values fall back to English with a console warning, mirroring the `data-theme` validation style.
 - `setLocale(config.locale)` runs during init, before any UI is built.

 ## Compatibility

 - **English output is byte-identical** to the previous hardcoded strings - existing tests that assert English text pass unchanged, and English users see zero difference.
 - No public API changes. An explicit `data-label` still overrides the (now localized) default trigger label.
 - Untranslated by design: "Powered by BugDrop" and the version badge (brand), developer console diagnostics, `[redacted]` console-log markers (data, not UI).
 - Bundle grows by the two extra dictionaries (a few KB minified). Lazy-loading locales was considered and rejected: the widget is deliberately a single synchronous file, and the dictionaries are small.

 ## Tests

 - `test/i18n.test.ts` — locale resolution (exact / region subtag in both formats / case-insensitivity / unknown → `en` + warning / missing → `en`), `setLocale`/`t()` round-trip, and a key-set + value-type parity check between `en` and each translation so dictionaries can't silently drift.
 - `e2e/locale.spec.ts` — opens the widget with `?locale=…` (the `/test/` harness now forwards a `locale` param to `data-locale`) and asserts the translated welcome title through the shadow DOM: default English, `nl`, `pl`, `nl-NL` subtag, and unsupported-locale fallback + console warning.

 ## Docs

 - README: `data-locale` row in the Widget Options table.
 - `docs/website/configuration.mdx`: attribute row plus a "Language Options" section covering resolution order, region-subtag handling, the fallback warning, and how to contribute a new language (add `src/widget/locales/<code>.ts`, register it in `i18n.ts` — the parity test enforces completeness).

 ## Checklist

 - [x] Tests added for new functionality (unit + E2E)
 - [x] `make check` green (lint, format, typecheck, knip)
 - [x] Unit tests: 335/335 passing
 - [x] `npm run build:widget` succeeds; bundle verified to contain all three locales
 - [x] Docs updated (README + configuration page)
 - [x] Focused: i18n only, no backend/worker changes