### PR TITLE
docs: add showcase CTA to installation docs

### DIFF
--- a/docs/website/installation.mdx
+++ b/docs/website/installation.mdx
@@ -179,3 +179,4 @@ You can also test by clicking the bug button and submitting a test report. Check
 - [Style the widget](/docs/styling) to match your site's design
 - [Use the JavaScript API](/docs/javascript-api) for advanced integrations
 - [Pin to a specific version](/docs/version-pinning) for production stability
+- [Share your setup](https://bugdrop.dev/showcase) on the opt-in BugDrop showcase


### PR DESCRIPTION
## Summary
- add a short opt-in showcase CTA to the installation docs Next Steps

## Verification
- `git diff --check`
- `npx prettier --check docs/website/installation.mdx`
- `curl -fsSI https://bugdrop.dev/showcase` returned HTTP 200
- pre-push hook ran `npm run typecheck` successfully

## Burden of proof
Strongest realistic failure mode: the docs add a broken CTA link or malformed MDX. Verified the MDX formatting with Prettier and confirmed the target showcase URL responds with HTTP 200.