### PR TITLE
fix: prevent focusout replay recursion in radix dialog compatibility

### DIFF
--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -29,6 +29,7 @@ import {
   startConsoleLogCapture,
   type ConsoleLogEntry,
 } from './console-logs';
+import { installRadixDialogCompatibility } from './radix-compat';
 import { resolveAccentColor } from '../defaults';
 
 type FeedbackCategory = 'bug' | 'feature' | 'question';
@@ -761,96 +762,6 @@ function createPullTab(root: HTMLElement, config: WidgetConfig): HTMLElement {
   root.appendChild(tab);
   _pullTab = tab;
   return tab;
-}
-
-function installRadixDialogCompatibility(host: HTMLElement): void {
-  const preventBugDropDismissal = (event: Event) => {
-    if (isBugDropInteraction(host, event)) {
-      event.preventDefault();
-    }
-  };
-  const keepBugDropFocus = (event: Event) => {
-    if (isBugDropFocusEvent(host, event)) {
-      if (event.type === 'focusin') {
-        event.stopImmediatePropagation();
-        return;
-      }
-
-      if (event.type === 'focusout') {
-        replayHostFocusOut(event);
-        event.stopImmediatePropagation();
-        return;
-      }
-
-      event.stopImmediatePropagation();
-    }
-  };
-
-  for (const eventType of [
-    'dismissableLayer.pointerDownOutside',
-    'dismissableLayer.interactOutside',
-  ] as const) {
-    document.addEventListener(eventType, preventBugDropDismissal, true);
-  }
-  window.addEventListener('focusin', keepBugDropFocus, true);
-  window.addEventListener('focusout', keepBugDropFocus, true);
-}
-
-function isBugDropInteraction(host: HTMLElement, event: Event): boolean {
-  const originalEvent = (event as CustomEvent<{ originalEvent?: Event }>).detail?.originalEvent;
-  const path =
-    typeof originalEvent?.composedPath === 'function'
-      ? originalEvent.composedPath()
-      : typeof event.composedPath === 'function'
-        ? event.composedPath()
-        : [];
-
-  if (path.includes(host)) {
-    return true;
-  }
-
-  return (originalEvent?.target ?? event.target) === host;
-}
-
-function isBugDropFocusEvent(host: HTMLElement, event: Event): boolean {
-  if (!(event instanceof FocusEvent)) {
-    return isBugDropInteraction(host, event);
-  }
-
-  if (event.type === 'focusin') {
-    return isBugDropInteraction(host, event);
-  }
-
-  if (event.type !== 'focusout') {
-    return false;
-  }
-
-  const nextFocusedNode = event.relatedTarget;
-  const nextFocusIsBugDrop =
-    nextFocusedNode === host ||
-    (nextFocusedNode instanceof Node && (host.shadowRoot?.contains(nextFocusedNode) ?? false));
-  return nextFocusIsBugDrop && !isBugDropInteraction(host, event);
-}
-
-function replayHostFocusOut(event: Event): void {
-  const path = typeof event.composedPath === 'function' ? event.composedPath() : [];
-  for (const node of path) {
-    if (!(node instanceof HTMLElement)) {
-      continue;
-    }
-
-    node.dispatchEvent(
-      new FocusEvent('focusout', {
-        bubbles: false,
-        composed: false,
-        relatedTarget: event instanceof FocusEvent ? event.relatedTarget : null,
-      })
-    );
-
-    if (node === document.body) {
-      break;
-    }
-  }
 }
 
 function initWidget(config: WidgetConfig) {

--- a/src/widget/radix-compat.ts
+++ b/src/widget/radix-compat.ts
@@ -1,0 +1,110 @@
+/*
+ * Compatibility layer for host pages built on Radix-style dismissable layers
+ * (and other focus-scope libraries): stops the host page from treating
+ * interaction with the BugDrop shadow DOM as an "outside" interaction that
+ * would dismiss its own dialogs or yank focus back.
+ */
+
+export function installRadixDialogCompatibility(host: HTMLElement): void {
+  // Guards replayHostFocusOut: the synthetic focusout events it dispatches
+  // propagate a capture phase from window and would re-enter keepBugDropFocus
+  // with the same in-widget relatedTarget, replaying forever (stack overflow).
+  let replayingFocusOut = false;
+
+  const preventBugDropDismissal = (event: Event) => {
+    if (isBugDropInteraction(host, event)) {
+      event.preventDefault();
+    }
+  };
+  const keepBugDropFocus = (event: Event) => {
+    if (replayingFocusOut) {
+      return;
+    }
+
+    if (isBugDropFocusEvent(host, event)) {
+      if (event.type === 'focusin') {
+        event.stopImmediatePropagation();
+        return;
+      }
+
+      if (event.type === 'focusout') {
+        replayingFocusOut = true;
+        try {
+          replayHostFocusOut(event);
+        } finally {
+          replayingFocusOut = false;
+        }
+        event.stopImmediatePropagation();
+        return;
+      }
+
+      event.stopImmediatePropagation();
+    }
+  };
+
+  for (const eventType of [
+    'dismissableLayer.pointerDownOutside',
+    'dismissableLayer.interactOutside',
+  ] as const) {
+    document.addEventListener(eventType, preventBugDropDismissal, true);
+  }
+  window.addEventListener('focusin', keepBugDropFocus, true);
+  window.addEventListener('focusout', keepBugDropFocus, true);
+}
+
+function isBugDropInteraction(host: HTMLElement, event: Event): boolean {
+  const originalEvent = (event as CustomEvent<{ originalEvent?: Event }>).detail?.originalEvent;
+  const path =
+    typeof originalEvent?.composedPath === 'function'
+      ? originalEvent.composedPath()
+      : typeof event.composedPath === 'function'
+        ? event.composedPath()
+        : [];
+
+  if (path.includes(host)) {
+    return true;
+  }
+
+  return (originalEvent?.target ?? event.target) === host;
+}
+
+function isBugDropFocusEvent(host: HTMLElement, event: Event): boolean {
+  if (!(event instanceof FocusEvent)) {
+    return isBugDropInteraction(host, event);
+  }
+
+  if (event.type === 'focusin') {
+    return isBugDropInteraction(host, event);
+  }
+
+  if (event.type !== 'focusout') {
+    return false;
+  }
+
+  const nextFocusedNode = event.relatedTarget;
+  const nextFocusIsBugDrop =
+    nextFocusedNode === host ||
+    (nextFocusedNode instanceof Node && (host.shadowRoot?.contains(nextFocusedNode) ?? false));
+  return nextFocusIsBugDrop && !isBugDropInteraction(host, event);
+}
+
+function replayHostFocusOut(event: Event): void {
+  const path = typeof event.composedPath === 'function' ? event.composedPath() : [];
+  for (const node of path) {
+    if (!(node instanceof HTMLElement)) {
+      continue;
+    }
+
+    node.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: false,
+        composed: false,
+        relatedTarget: event instanceof FocusEvent ? event.relatedTarget : null,
+      })
+    );
+
+    if (node === document.body) {
+      break;
+    }
+  }
+}

--- a/test/radix-compat.test.ts
+++ b/test/radix-compat.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { installRadixDialogCompatibility } from '../src/widget/radix-compat';
+
+function setup() {
+  const host = document.createElement('div');
+  host.id = 'bugdrop-host';
+  host.attachShadow({ mode: 'open' });
+  document.body.appendChild(host);
+
+  const pageButton = document.createElement('button');
+  document.body.appendChild(pageButton);
+
+  installRadixDialogCompatibility(host);
+  return { host, pageButton };
+}
+
+describe('installRadixDialogCompatibility', () => {
+  it('replays focusout exactly once per element when focus moves into the widget', () => {
+    const { host, pageButton } = setup();
+
+    const buttonEvents: Event[] = [];
+    const bodyEvents: Event[] = [];
+    pageButton.addEventListener('focusout', e => buttonEvents.push(e));
+    document.body.addEventListener('focusout', e => bodyEvents.push(e));
+
+    // Browser-style focusout: focus leaves a page element for the widget; the
+    // relatedTarget is retargeted to the shadow host. The compat layer swallows
+    // the original event and replays a non-composed focusout along the path.
+    // The replayed events re-enter the same window capture listener with the
+    // in-widget relatedTarget — without a re-entrancy guard the listener
+    // replays them again, recursing until the stack overflows.
+    pageButton.dispatchEvent(
+      new FocusEvent('focusout', { bubbles: true, composed: true, relatedTarget: host })
+    );
+
+    expect(buttonEvents).toHaveLength(1);
+    expect(buttonEvents[0].bubbles).toBe(false);
+    expect(bodyEvents).toHaveLength(1);
+  });
+
+  it('leaves focusout between page elements untouched', () => {
+    const { pageButton } = setup();
+
+    const other = document.createElement('input');
+    document.body.appendChild(other);
+
+    const received: Event[] = [];
+    pageButton.addEventListener('focusout', e => received.push(e));
+
+    pageButton.dispatchEvent(
+      new FocusEvent('focusout', { bubbles: true, composed: true, relatedTarget: other })
+    );
+
+    expect(received).toHaveLength(1);
+    expect(received[0].bubbles).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The Radix dialog compatibility layer added in 81226c0 (v1.51.2) can crash the host page with `RangeError: Maximum call stack size exceeded` as soon as focus moves from a page element into the widget - e.g. the first click into the form's Title field - and again when the widget closes.

## Root cause

`keepBugDropFocus` is a capture-phase `focusout` listener on `window`. When it matches (focus leaving the page for the widget), it calls `replayHostFocusOut`, which re-dispatches synthetic non-composed `focusout` events along the original event's path. Each synthetic dispatch runs its own capture phase from `window` down, so it re-enters `keepBugDropFocus`; the synthetic event carries the same in-widget `relatedTarget`, so `isBugDropFocusEvent` matches again and the listener replays again - unbounded synchronous recursion until the stack overflows. No Radix on the page is required; it reproduces on a bare HTML page.

Minimal repro against the current published widget (count the re-entries):

  ```html
  <button id="page-btn">page button</button>
  <script src="https://bugdrop.neonwatty.workers.dev/widget.js" data-repo="owner/repo"></script>
  <script>
    let n = 0;
    window.addEventListener('focusout', () => n++, true); // registered before? register first to count
    document.getElementById('page-btn').dispatchEvent(
      new FocusEvent('focusout', { bubbles: true, composed: true,
        relatedTarget: document.getElementById('bugdrop-host') })
    );
    // n ends up at ~950 (stack limit) instead of the expected handful;
    // a real trusted focus change into the widget triggers the same storm.
  </script>
```

## Fix

A re-entrancy guard: while replayHostFocusOut is dispatching, the listener ignores incoming focus events. The replay still delivers exactly one focusout per host element (the behavior 81226c0 introduced for Radix focus scopes) - it just no longer feeds back into itself.

To make this unit-testable without executing the widget's init side effects, the compatibility block moved verbatim from src/widget/index.ts into src/widget/radix-compat.ts (only installRadixDialogCompatibility is exported); the guard is the only behavioral change.

## Testing

- test/radix-compat.test.ts (jsdom): focus moving into the widget replays focusout exactly once per element (this test stack-overflows without the into the widget previously produced ~950 nested capture-listener invocations; with the fix it produces the expected 3 (original + one replay per element).
  - make check and the full unit suite (325/325) pass; npm run build:widget succeeds.

## Checklist

  - [x] Failing test written first, fix verified against it
  - [x] make check green (lint, format, typecheck, knip)
  - [x] Unit tests pass
  - [x] Focused: one fix, no unrelated changes
  - [x] No user-facing/API changes (no docs needed)
