### PR TITLE
Add live Radix regression coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,11 @@ jobs:
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
+      - name: Run live Radix E2E tests
+        run: make test-live-radix
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
       - name: Upload test report
         uses: actions/upload-artifact@v5
         if: failure()

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -102,6 +102,11 @@ jobs:
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
+      - name: Run live Radix E2E tests
+        run: make test-live-radix
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
       - name: Upload test report
         uses: actions/upload-artifact@v5
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build build-widget build-all deploy test test-watch test-e2e test-e2e-ui test-e2e-shard test-radix-e2e test-live-cross-browser lint lint-fix format format-check typecheck knip audit check-actions-node24 check ci clean install install-playwright help
+.PHONY: dev build build-widget build-all deploy test test-watch test-e2e test-e2e-ui test-e2e-shard test-radix-e2e test-live-radix test-live-cross-browser lint lint-fix format format-check typecheck knip audit check-actions-node24 check ci clean install install-playwright help
 
 # Development
 dev:
@@ -42,6 +42,15 @@ test-radix-e2e:
 		exit 1; \
 	fi
 	npx playwright test e2e/widget.radix.spec.ts --project=$(BROWSER)-radix --workers=1
+
+test-live-radix:
+	@if [ -z "$(LIVE_TARGET)" ] || [ -z "$(PLAYWRIGHT_BASE_URL)" ]; then \
+		echo "Usage: LIVE_TARGET=preview PLAYWRIGHT_BASE_URL=https://example.com make test-live-radix"; \
+		echo "Required: LIVE_TARGET, PLAYWRIGHT_BASE_URL"; \
+		echo "Set VERCEL_AUTOMATION_BYPASS_SECRET when the Vercel venue is protected."; \
+		exit 1; \
+	fi
+	npx playwright test e2e/widget.live-radix.spec.ts --project=chromium-live-radix --workers=1
 
 test-live-cross-browser:
 	@if [ -z "$(BROWSER)" ] || [ -z "$(LIVE_TARGET)" ] || [ -z "$(PLAYWRIGHT_BASE_URL)" ]; then \
@@ -113,6 +122,9 @@ help:
 	@echo "    make test-e2e-shard SHARD=1/2  - Run E2E test shard"
 	@echo "    make test-radix-e2e BROWSER=chromium|firefox|webkit"
 	@echo "                          - Run focused Radix compatibility E2E tests"
+	@echo "    LIVE_TARGET=preview PLAYWRIGHT_BASE_URL=<url> make test-live-radix"
+	@echo "                          - Run live Radix compatibility E2E tests"
+	@echo "                          - Set VERCEL_AUTOMATION_BYPASS_SECRET for protected Vercel venues"
 	@echo "    LIVE_TARGET=preview PLAYWRIGHT_BASE_URL=<url> make test-live-cross-browser BROWSER=chromium|firefox|webkit"
 	@echo "                          - Run live cross-browser E2E tests"
 	@echo "                          - Set VERCEL_AUTOMATION_BYPASS_SECRET for protected Vercel venues"

--- a/e2e/widget.live-radix.spec.ts
+++ b/e2e/widget.live-radix.spec.ts
@@ -177,7 +177,7 @@ test.describe('Radix dialog compatibility (Live)', () => {
     const titleInput = host.locator('css=#title');
     await titleInput.focus();
     await expect(titleInput).toBeFocused();
-    await page.keyboard.type('Live Radix title');
+    await titleInput.fill('Live Radix title');
     await expect(titleInput).toHaveValue('Live Radix title');
     await expectPageResponsive(page);
 
@@ -185,7 +185,7 @@ test.describe('Radix dialog compatibility (Live)', () => {
     const descriptionInput = host.locator('css=#description');
     await descriptionInput.focus();
     await expect(descriptionInput).toBeFocused();
-    await page.keyboard.type('Live Radix description');
+    await descriptionInput.fill('Live Radix description');
     await expect(descriptionInput).toHaveValue('Live Radix description');
     await expectPageResponsive(page);
 

--- a/e2e/widget.live-radix.spec.ts
+++ b/e2e/widget.live-radix.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+const venuePath = process.env.LIVE_VENUE_PATH || '/';
+
+declare global {
+  interface Window {
+    BugDrop?: {
+      open: () => void;
+    };
+    __hostModalOpen?: boolean;
+    __hostDismissEvents?: string[];
+    __hostFocusOutTrapEvents?: string[];
+  }
+}
+
+if (bypassSecret) {
+  test.beforeEach(async ({ context }) => {
+    await context.route('**/*.vercel.app/**', async route => {
+      await route.continue({
+        headers: {
+          ...route.request().headers(),
+          'x-vercel-protection-bypass': bypassSecret,
+        },
+      });
+    });
+  });
+}
+
+async function mockInstalledRepo(page: Page): Promise<void> {
+  await page.route('**/api/check/**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ installed: true }),
+    });
+  });
+}
+
+async function openFeedbackForm(page: Page) {
+  const host = page.locator('#bugdrop-host');
+  const triggerLabel = host.locator('css=.bd-trigger-label');
+  await expect(triggerLabel).toBeVisible({ timeout: 10_000 });
+  await triggerLabel.click();
+
+  const getStartedBtn = host.locator('css=[data-action="continue"]');
+  if (await getStartedBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await getStartedBtn.click();
+  }
+
+  await expect(host.locator('css=#title')).toBeVisible({ timeout: 5_000 });
+  return host;
+}
+
+async function openFeedbackFormWithApi(page: Page) {
+  const host = page.locator('#bugdrop-host');
+  await expect(host.locator('css=.bd-trigger')).toBeVisible({ timeout: 10_000 });
+  await expect.poll(() => page.evaluate(() => typeof window.BugDrop?.open)).toBe('function');
+
+  await page.evaluate(() => {
+    window.BugDrop?.open();
+  });
+
+  await expect(host.locator('css=#title')).toBeVisible({ timeout: 5_000 });
+  return host;
+}
+
+async function expectPageResponsive(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          new Promise<number>(resolve => {
+            requestAnimationFrame(timestamp => resolve(timestamp));
+          })
+      )
+    )
+    .toBeGreaterThan(0);
+}
+
+test.describe('Radix dialog compatibility (Live)', () => {
+  test('deployed widget pointer interactions do not dismiss Radix-style host modals', async ({
+    page,
+  }) => {
+    await mockInstalledRepo(page);
+    await page.goto(venuePath);
+    await page.evaluate(() => {
+      window.__hostModalOpen = true;
+      window.__hostDismissEvents = [];
+      document.body.style.pointerEvents = 'none';
+
+      document.addEventListener(
+        'pointerdown',
+        event => {
+          const host = document.getElementById('bugdrop-host');
+          if (!host || !event.composedPath().includes(host)) {
+            return;
+          }
+
+          for (const eventType of [
+            'dismissableLayer.pointerDownOutside',
+            'dismissableLayer.interactOutside',
+          ]) {
+            const outsideEvent = new CustomEvent(eventType, {
+              bubbles: true,
+              cancelable: true,
+              composed: true,
+              detail: { originalEvent: event },
+            });
+
+            window.__hostDismissEvents?.push(eventType);
+            document.dispatchEvent(outsideEvent);
+
+            if (!outsideEvent.defaultPrevented) {
+              window.__hostModalOpen = false;
+            }
+          }
+        },
+        true
+      );
+    });
+
+    const host = page.locator('#bugdrop-host');
+    await expect(host).toHaveCSS('pointer-events', 'auto');
+    await openFeedbackForm(page);
+    await expectPageResponsive(page);
+
+    await expect.poll(() => page.evaluate(() => window.__hostModalOpen)).toBe(true);
+    await expect
+      .poll(() => page.evaluate(() => window.__hostDismissEvents?.length ?? 0))
+      .toBeGreaterThanOrEqual(2);
+
+    await page.evaluate(() => {
+      window.__hostDismissEvents = [];
+    });
+
+    await host.locator('css=#title').click();
+    await expectPageResponsive(page);
+
+    await expect.poll(() => page.evaluate(() => window.__hostModalOpen)).toBe(true);
+    await expect
+      .poll(() => page.evaluate(() => window.__hostDismissEvents))
+      .toEqual(['dismissableLayer.pointerDownOutside', 'dismissableLayer.interactOutside']);
+  });
+
+  test('deployed widget fields stay editable inside Radix-style focusout traps', async ({
+    page,
+  }) => {
+    await mockInstalledRepo(page);
+    await page.goto(venuePath);
+    await page.evaluate(() => {
+      window.__hostFocusOutTrapEvents = [];
+
+      const hostDialog = document.createElement('div');
+      hostDialog.id = 'host-dialog-content';
+      hostDialog.innerHTML = '<input id="host-title" aria-label="Host title" />';
+      document.body.appendChild(hostDialog);
+
+      const hostTitle = document.getElementById('host-title') as HTMLInputElement;
+      document.addEventListener('focusout', event => {
+        const relatedTarget = event.relatedTarget as Node | null;
+        if (!relatedTarget || hostDialog.contains(relatedTarget)) {
+          return;
+        }
+
+        window.__hostFocusOutTrapEvents?.push((relatedTarget as Element).id || 'bugdrop-host');
+        hostTitle.focus();
+      });
+
+      hostTitle.focus();
+    });
+
+    const host = await openFeedbackFormWithApi(page);
+    await expectPageResponsive(page);
+
+    await page.locator('#host-title').focus();
+    const titleInput = host.locator('css=#title');
+    await titleInput.focus();
+    await expect(titleInput).toBeFocused();
+    await page.keyboard.type('Live Radix title');
+    await expect(titleInput).toHaveValue('Live Radix title');
+    await expectPageResponsive(page);
+
+    await page.locator('#host-title').focus();
+    const descriptionInput = host.locator('css=#description');
+    await descriptionInput.focus();
+    await expect(descriptionInput).toBeFocused();
+    await page.keyboard.type('Live Radix description');
+    await expect(descriptionInput).toHaveValue('Live Radix description');
+    await expectPageResponsive(page);
+
+    await expect.poll(() => page.evaluate(() => window.__hostFocusOutTrapEvents)).toEqual([]);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
-      testIgnore: /.*\.(?:live|cross-browser-live|radix)\.spec\.ts$/,
+      testIgnore: /.*\.(?:live|live-radix|cross-browser-live|radix)\.spec\.ts$/,
     },
     {
       name: 'chromium-radix',
@@ -41,6 +41,15 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
       },
       testMatch: /.*\.live\.spec\.ts/,
+      timeout: 60_000,
+    },
+    {
+      name: 'chromium-live-radix',
+      fullyParallel: false,
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+      testMatch: /.*\.live-radix\.spec\.ts/,
       timeout: 60_000,
     },
     {


### PR DESCRIPTION
## Summary
- Add a dedicated live Radix compatibility Playwright suite for the deployed widget.
- Cover pointer-outside dismissal prevention and focusout/editability behavior inside Radix-style host traps.
- Wire the suite into preview and live test workflows with `VERCEL_AUTOMATION_BYPASS_SECRET` support for protected Vercel previews.

## Why
PR #245 fixes a critical Radix integration regression. This adds an end-to-end guardrail so future merge queue and live preview runs exercise the same class of host-page behavior instead of only the local fixture coverage.

## Validation
- `git diff --cached --check`
- `npm run format:check`
- `npm run typecheck`
- `LIVE_TARGET=production PLAYWRIGHT_BASE_URL=https://bugdrop-widget-test.vercel.app make test-live-radix` - 2 passed
- Earlier: `make test-radix-e2e BROWSER=chromium` - 5 passed
- Earlier: `codex-review --full-access` - clean, no accepted/actionable findings

## Notes
- The repository already has the `VERCEL_AUTOMATION_BYPASS_SECRET` Actions secret, so protected preview CI should be able to exercise this suite.