### PR TITLE
docs: mention locale setup in installation guide

### DIFF
--- a/docs/website/installation.mdx
+++ b/docs/website/installation.mdx
@@ -65,9 +65,13 @@ You can add data attributes to customize the widget's appearance and behavior:
   data-theme="dark"
   data-position="bottom-left"
   data-color="#6366f1"
+  data-locale="nl"
   data-welcome="We'd love your feedback!"
 ></script>
 ```
+
+Set `data-locale` to choose the widget language explicitly, or omit it to let
+BugDrop infer the language from your page's `<html lang>` attribute.
 
 See the [Configuration](/docs/configuration) and [Styling](/docs/styling) docs for all available attributes.
 


### PR DESCRIPTION
## Summary
- add `data-locale` to the customized installation example
- mention that BugDrop can infer locale from the page `<html lang>` attribute

## Validation
- `npm run format:check -- docs/website/installation.mdx`
- `git diff --check origin/main...HEAD`

## Follow-up
- investigate the post-merge docs sync failure separately; the failure looked like a `bugdrop-web` checkout credential issue.