### PR TITLE
fix: allow Deckchecker Vercel candidate origins

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,59 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      - name: Deploy restricted hosted Worker
+        run: npx wrangler deploy --env personal
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Verify Deckchecker candidate CORS policy
+        run: |
+          WORKER_URL="https://bugdrop-personal.neonwatty.workers.dev/api/feedback"
+          ALLOWED_ORIGIN="https://deckchecker-o04ghwyay-jermwatts-projects.vercel.app"
+          REJECTED_ORIGIN="https://deckchecker-o04ghwyay-jermwatts-projects.vercel.app.evil.test"
+
+          for attempt in $(seq 1 30); do
+            if ! allowed_headers="$(curl -sS --connect-timeout 5 --max-time 15 -D - -o /dev/null -X OPTIONS "$WORKER_URL" -H "Origin: $ALLOWED_ORIGIN" -H 'Access-Control-Request-Method: POST' -H 'Access-Control-Request-Headers: content-type, authorization' | tr -d '\r')"; then
+              allowed_headers=""
+            fi
+            allowed_status="$(printf '%s\n' "$allowed_headers" | awk 'NR == 1 { print $2 }')"
+            allowed_header="$(printf '%s\n' "$allowed_headers" | awk -F ': ' 'tolower($1) == "access-control-allow-origin" { print $2 }')"
+            if [ "$allowed_status" = "204" ] && [ "$allowed_header" = "$ALLOWED_ORIGIN" ]; then
+              break
+            fi
+            echo "Attempt $attempt/30 did not serve the expected policy; retrying"
+            if [ "$attempt" = "30" ]; then
+              echo "Restricted hosted Worker did not serve the expected CORS policy"
+              exit 1
+            fi
+            sleep 5
+          done
+
+          test "$allowed_status" = "204"
+          test "$allowed_header" = "$ALLOWED_ORIGIN"
+          printf '%s\n' "$allowed_headers" | awk -F ': ' 'tolower($1) == "access-control-allow-methods" { print $2 }' | grep -q 'POST'
+          printf '%s\n' "$allowed_headers" | awk -F ': ' 'tolower($1) == "access-control-allow-headers" { print $2 }' | grep -q 'Content-Type'
+          printf '%s\n' "$allowed_headers" | awk -F ': ' 'tolower($1) == "access-control-allow-headers" { print $2 }' | grep -q 'Authorization'
+
+          for exact_origin in \
+            "https://bugdrop-personal.neonwatty.workers.dev" \
+            "https://bleepthat.sh" \
+            "https://preview.bleepthat.sh" \
+            "https://seatify.app" \
+            "https://preview.seatify.app" \
+            "https://deckchecker.app" \
+            "https://origin.deckchecker.app" \
+            "https://preview.deckchecker.app"; do
+            exact_headers="$(curl -sSf --connect-timeout 5 --max-time 15 -D - -o /dev/null -X OPTIONS "$WORKER_URL" -H "Origin: $exact_origin" -H 'Access-Control-Request-Method: POST' -H 'Access-Control-Request-Headers: content-type, authorization' | tr -d '\r')"
+            test "$(printf '%s\n' "$exact_headers" | awk 'NR == 1 { print $2 }')" = "204"
+            test "$(printf '%s\n' "$exact_headers" | awk -F ': ' 'tolower($1) == "access-control-allow-origin" { print $2 }')" = "$exact_origin"
+          done
+
+          rejected_headers="$(curl -sSf --connect-timeout 5 --max-time 15 -D - -o /dev/null -X OPTIONS "$WORKER_URL" -H "Origin: $REJECTED_ORIGIN" -H 'Access-Control-Request-Method: POST' -H 'Access-Control-Request-Headers: content-type, authorization' | tr -d '\r')"
+          test "$(printf '%s\n' "$rejected_headers" | awk 'NR == 1 { print $2 }')" = "204"
+          test -z "$(printf '%s\n' "$rejected_headers" | awk -F ': ' 'tolower($1) == "access-control-allow-origin" { print $2 }')"
+
   live-production-tests:
     name: Live Production Tests
     needs: [deploy]

--- a/e2e/api.spec.ts
+++ b/e2e/api.spec.ts
@@ -134,4 +134,48 @@ test.describe('CORS', () => {
     expect(response.headers()['access-control-allow-origin']).toBe('*');
     expect(response.headers()['access-control-allow-methods']).toContain('POST');
   });
+
+  test('allows an unaliased Deckchecker candidate preflight', async ({ request }) => {
+    const origin = 'https://deckchecker-o04ghwyay-jermwatts-projects.vercel.app';
+    const response = await request.fetch('/api/feedback', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: origin,
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'content-type, authorization',
+      },
+    });
+
+    expect(response.status()).toBe(204);
+    expect(response.headers()['access-control-allow-origin']).toBe(origin);
+    expect(response.headers()['access-control-allow-methods']).toContain('POST');
+    expect(response.headers()['access-control-allow-headers']).toContain('Content-Type');
+    expect(response.headers()['access-control-allow-headers']).toContain('Authorization');
+  });
+
+  test('rejects Deckchecker candidate lookalikes and unrelated Vercel projects', async ({
+    request,
+  }) => {
+    const rejectedOrigins = [
+      'https://deckchecker-o04ghwyay-jermwatts-projects.vercel.app.evil.test',
+      'http://deckchecker-o04ghwyay-jermwatts-projects.vercel.app',
+      'https://evil.test@deckchecker-o04ghwyay-jermwatts-projects.vercel.app',
+      'https://other-o04ghwyay-jermwatts-projects.vercel.app',
+      'https://arbitrary-project.vercel.app',
+    ];
+
+    for (const origin of rejectedOrigins) {
+      const response = await request.fetch('/api/feedback', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: origin,
+          'Access-Control-Request-Method': 'POST',
+          'Access-Control-Request-Headers': 'content-type, authorization',
+        },
+      });
+
+      expect(response.status()).toBe(204);
+      expect(response.headers()['access-control-allow-origin']).toBeUndefined();
+    }
+  });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -83,7 +83,8 @@ export default defineConfig({
   webServer: process.env.LIVE_TARGET
     ? undefined
     : {
-        command: 'BUGDROP_TEST_HOOKS=1 npm run build:widget && npm run dev',
+        command:
+          'BUGDROP_TEST_HOOKS=1 npm run build:widget && npm run dev -- --var ALLOWED_ORIGINS:https://deckchecker.app,https://preview.deckchecker.app --var ALLOW_DECKCHECKER_VERCEL_CANDIDATES:true',
         url: 'http://localhost:8787',
         reuseExistingServer: !process.env.CI,
         timeout: 120 * 1000,

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -49,6 +49,8 @@ const ALLOWED_ATTACHMENT_TYPES = new Set([
 const MAX_CONSOLE_LOG_ENTRIES = 50;
 const MAX_CONSOLE_LOG_BODY_CHARS = 12_000;
 const MAX_CONSOLE_LOG_MESSAGE_CHARS = 1_000;
+const DECKCHECKER_VERCEL_CANDIDATE_ORIGIN =
+  /^https:\/\/deckchecker-[a-z0-9]{9}-jermwatts-projects\.vercel\.app$/;
 // GitHub enforces a 50-char limit on label names; keep validation in lockstep
 // so over-long configured labels surface as a clear local warning rather than
 // going out, getting rejected, and triggering the GitHub-error fallback path.
@@ -74,7 +76,14 @@ api.use('*', async (c, next) => {
       // Wildcard allows all
       if (originList.includes('*')) return origin;
       // Check if origin is in whitelist
-      return originList.includes(origin) ? origin : null;
+      if (originList.includes(origin)) return origin;
+      if (
+        c.env.ALLOW_DECKCHECKER_VERCEL_CANDIDATES === 'true' &&
+        DECKCHECKER_VERCEL_CANDIDATE_ORIGIN.test(origin)
+      ) {
+        return origin;
+      }
+      return null;
     },
     allowMethods: ['GET', 'POST', 'OPTIONS'],
     allowHeaders: ['Content-Type', 'Authorization'],

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface Env {
   // Variables (from wrangler.toml)
   ENVIRONMENT: string;
   ALLOWED_ORIGINS: string; // Comma-separated list of allowed origins, or "*" for dev
+  ALLOW_DECKCHECKER_VERCEL_CANDIDATES?: string; // Hosted Deckchecker deployment origins
   GITHUB_APP_NAME: string; // Your GitHub App name for install URL
   MAX_SCREENSHOT_SIZE_MB: string; // Max screenshot size in MB (default: 5)
   CATEGORY_LABELS?: string; // Optional JSON category-label mapping keyed by repo or "*"

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1965,5 +1965,82 @@ describe('API Routes', () => {
       expect(res.headers.get('access-control-allow-origin')).toBe('*');
       expect(res.headers.get('access-control-allow-methods')).toContain('POST');
     });
+
+    it.each([
+      'https://deckchecker.app',
+      'https://preview.deckchecker.app',
+      'https://deckchecker-o04ghwyay-jermwatts-projects.vercel.app',
+      'https://deckchecker-123abcxyz-jermwatts-projects.vercel.app',
+    ])('allows configured and candidate Deckchecker origin %s', async origin => {
+      const req = new Request('http://localhost/feedback', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: origin,
+          'Access-Control-Request-Method': 'POST',
+          'Access-Control-Request-Headers': 'content-type, authorization',
+        },
+      });
+      const res = await app.fetch(req, {
+        ...mockEnv,
+        ALLOWED_ORIGINS: 'https://deckchecker.app,https://preview.deckchecker.app',
+        ALLOW_DECKCHECKER_VERCEL_CANDIDATES: 'true',
+      });
+
+      expect(res.status).toBe(204);
+      expect(res.headers.get('access-control-allow-origin')).toBe(origin);
+      expect(res.headers.get('access-control-allow-methods')).toContain('POST');
+      expect(res.headers.get('access-control-allow-headers')).toContain('Content-Type');
+      expect(res.headers.get('access-control-allow-headers')).toContain('Authorization');
+    });
+
+    it.each([
+      'https://deckchecker-o04ghwyay-jermwatts-projects.vercel.app.evil.test',
+      'https://deckchecker-o04ghwyay-jermwatts-projects-vercel.app',
+      'https://deckchecker-o04ghwyay-other-projects.vercel.app',
+      'https://deckchecker-o04ghwyay-jermwatts-projects.vercel.app@evil.test',
+      'https://evil.test@deckchecker-o04ghwyay-jermwatts-projects.vercel.app',
+      'http://deckchecker-o04ghwyay-jermwatts-projects.vercel.app',
+      'https://deckchecker-o04ghwya-jermwatts-projects.vercel.app',
+      'https://deckchecker-o04ghwyay0-jermwatts-projects.vercel.app',
+      'https://deckchecker-git-main-jermwatts-projects.vercel.app',
+      'https://other-o04ghwyay-jermwatts-projects.vercel.app',
+      'https://arbitrary-project.vercel.app',
+    ])('rejects adversarial Deckchecker lookalike origin %s', async origin => {
+      const req = new Request('http://localhost/feedback', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: origin,
+          'Access-Control-Request-Method': 'POST',
+          'Access-Control-Request-Headers': 'content-type, authorization',
+        },
+      });
+      const res = await app.fetch(req, {
+        ...mockEnv,
+        ALLOWED_ORIGINS: 'https://deckchecker.app,https://preview.deckchecker.app',
+        ALLOW_DECKCHECKER_VERCEL_CANDIDATES: 'true',
+      });
+
+      expect(res.status).toBe(204);
+      expect(res.headers.get('access-control-allow-origin')).toBeNull();
+    });
+
+    it('keeps Deckchecker candidate matching disabled unless explicitly configured', async () => {
+      const origin = 'https://deckchecker-o04ghwyay-jermwatts-projects.vercel.app';
+      const req = new Request('http://localhost/feedback', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: origin,
+          'Access-Control-Request-Method': 'POST',
+          'Access-Control-Request-Headers': 'content-type, authorization',
+        },
+      });
+      const res = await app.fetch(req, {
+        ...mockEnv,
+        ALLOWED_ORIGINS: 'https://deckchecker.app',
+      });
+
+      expect(res.status).toBe(204);
+      expect(res.headers.get('access-control-allow-origin')).toBeNull();
+    });
   });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -40,6 +40,20 @@ preview_id = "ff8f3809037d4403befd09369a9f7e36"
 # AUTH_TOKEN_SECRET  # Optional: set to require signed host-app auth tokens for /feedback
 # BUGDROP_BOARD_TOKEN_SECRET  # Optional: enables /board embedded demo token signing
 
+# Restricted hosted Worker for exact-origin clients; this reviewed config is the source of truth.
+# Deckchecker additionally needs its project-specific unaliased Vercel candidates below.
+[env.personal]
+name = "bugdrop-personal"
+workers_dev = true
+routes = []
+
+[env.personal.vars]
+ENVIRONMENT = "production"
+ALLOWED_ORIGINS = "https://bugdrop-personal.neonwatty.workers.dev,https://bleepthat.sh,https://preview.bleepthat.sh,https://seatify.app,https://preview.seatify.app,https://deckchecker.app,https://origin.deckchecker.app,https://preview.deckchecker.app"
+ALLOW_DECKCHECKER_VERCEL_CANDIDATES = "true"
+GITHUB_APP_NAME = "mean-weasel-bugdrop-personal"
+MAX_SCREENSHOT_SIZE_MB = "5"
+
 # Preview environment for live E2E tests (deployed in merge queue)
 [env.preview]
 name = "bugdrop-preview"


### PR DESCRIPTION
## Summary

- allow only HTTPS Deckchecker candidate deployment origins matching the observed deckchecker-<9 lowercase alphanumeric>-jermwatts-projects.vercel.app form
- keep the matcher disabled by default and preserve every exact bugdrop-personal origin in reviewed Wrangler config
- deploy bugdrop-personal through the normal main-branch workflow and verify the real POST /api/feedback preflight contract, preserved origins, and a suffix attack

## Root cause

Deckchecker loads bugdrop-personal, whose production exact allowlist did not include unaliased Vercel candidate hosts. The normal release workflow deployed only the public bugdrop Worker, so Worker code and reviewed personal deployment configuration were both required.

## Validation

- red: legitimate candidate unit cases returned no Access-Control-Allow-Origin; wildcard-backed E2E accepted the suffix lookalike
- green: 16 focused unit preflight cases and 2 focused E2E cases
- make check
- 356/356 unit tests
- 13/13 API E2E tests
- full Chromium E2E completed once at 229/229; a later full run hit the known unrelated modal-resize timing test, reproduced as retry-pass under CI policy
- wrangler deploy --env personal --dry-run
- three independent pre-PR review passes, with follow-up reviews after fixes

## Production safety

- no production wildcard
- matcher requires explicit ALLOW_DECKCHECKER_VERCEL_CANDIDATES=true
- anchored exact scheme/project/team/hostname shape
- rejects wrong scheme, userinfo, wrong token length, suffix attacks, aliases, arbitrary Vercel apps, and other projects
- deployment poll is transport-failure tolerant and time-bounded

## Rollback

Rollback bugdrop-personal to Cloudflare Worker version 8a349d67-bab8-48dc-994e-24313f5f196b, then revert this PR if live verification fails.