### PR TITLE
feat: multi-tenant single-script embed (HubSpot-style loader + per-tenant config)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -58,3 +58,7 @@ YOUR_PRIVATE_KEY_CONTENT_HERE
 # e2e/multi-tenant.spec.ts (contract docs/plans/multi-tenant-embed.md, card M1-04);
 # that suite skips itself when this is unset, so it is optional for a normal `npm run dev`.
 # ADMIN_TOKEN=replace-with-a-long-random-secret
+
+# Key-encryption key for per-tenant widget-auth secrets (contract D5/M2-01).
+# 32 random bytes, base64: `openssl rand -base64 32`
+# BUGDROP_KEK=replace-with-32-bytes-base64

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -51,3 +51,10 @@ YOUR_PRIVATE_KEY_CONTENT_HERE
 
 # RATE_LIMIT is intentionally not configured here.
 # Local development runs with ENVIRONMENT=development and can work without a KV namespace.
+
+# Optional: Bearer secret protecting the tenant admin API (/api/admin/tenants/*).
+# Missing this secret makes every admin route fail loud with 503 (never silently open).
+# Required locally to run the multi-tenant admin-seeded E2E coverage in
+# e2e/multi-tenant.spec.ts (contract docs/plans/multi-tenant-embed.md, card M1-04);
+# that suite skips itself when this is unset, so it is optional for a normal `npm run dev`.
+# ADMIN_TOKEN=replace-with-a-long-random-secret

--- a/README.md
+++ b/README.md
@@ -37,6 +37,147 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
 
 > **Security note:** BugDrop is not a spam or malware filtering service. Treat feedback and screenshots as unauthenticated user-generated content. Exclude `bugdrop-screenshots` from CI/deploy workflows, and self-host behind your own WAF/CAPTCHA/content controls for stricter environments.
 
+## Multi-tenant hosted embed
+
+If you self-host a BugDrop Worker for multiple customers or sites, you can serve a
+single-script "loader" per tenant instead of hand-writing `data-*` attributes on
+every page. This is an operator feature (opt-in, requires your own Worker
+deployment) — the public `bugdrop.neonwatty.workers.dev` service above is unaffected
+and the legacy `/widget.js` embed keeps working exactly as documented, byte for byte.
+
+```html
+<script src="https://<worker-host>/t/{tenantKey}.js" async></script>
+```
+
+A **tenant** is one customer of your hosted instance: a target repo, an origin
+allowlist, a theme, behavior flags, and a rate-limit tier, stored server-side and
+managed by you (the operator) through an admin API. The loader at `/t/{tenantKey}.js`
+renders a tiny bootstrap script that injects the widget core
+(`/widget.v1.js`) with the tenant's config baked in as `data-*` attributes — same
+widget bootstrap, same theming pipeline, zero per-site configuration for the
+customer.
+
+An unknown or paused tenant key still returns `200` with a body that only does
+`console.warn(...)`, so a bad key never shows up as a broken script tag on the
+customer's page.
+
+### TenantConfig v1 reference
+
+| Field                     | Type                   | Notes                                                                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`                 | `1`                    | Fixed.                                                                                                                                                                                                                                                                                                                                                                                          |
+| `key`                     | `string`               | Tenant slug, `^[a-z0-9](?:[a-z0-9-]{1,30}[a-z0-9])$`. Public — appears in the loader URL. Not a secret; origin checks are the security boundary, not the key.                                                                                                                                                                                                                                   |
+| `name`                    | `string`               | Display name, 1-100 chars.                                                                                                                                                                                                                                                                                                                                                                      |
+| `repo`                    | `string`               | `owner/repo`. Authoritative: any `repo` a client sends is validated against this and rejected with `400` on mismatch.                                                                                                                                                                                                                                                                           |
+| `origins`                 | `string[]`             | Exact-match web origins (e.g. `https://app.example.com`). `https://` required, except `http://localhost[:port]`. No paths, no wildcards. Requests with an `Origin` header outside this list get `403`; requests without an `Origin` header (curl, server-to-server) are allowed, matching the legacy embed.                                                                                     |
+| `status`                  | `"active" \| "paused"` | A paused tenant gets a warn-only loader and `403` on feedback/check.                                                                                                                                                                                                                                                                                                                            |
+| `theme.*`                 | see below              | Maps 1:1 to the existing `data-*` theming attributes.                                                                                                                                                                                                                                                                                                                                           |
+| `behavior.*`              | see below              | Maps 1:1 to the existing `data-*` behavior attributes.                                                                                                                                                                                                                                                                                                                                          |
+| `rate.perIp`              | `number`               | Overrides the default 20 requests / 15 min per IP.                                                                                                                                                                                                                                                                                                                                              |
+| `rate.perRepo`            | `number`               | Overrides the default 50 requests / 60 min per repo. Tenant rate buckets never share counters with the legacy global limits or with other tenants.                                                                                                                                                                                                                                              |
+| `authTokenSecretEnc`      | `string`               | Server-managed: an AES-256-GCM envelope (`v1.<iv>.<ciphertext>`, KEK from the `BUGDROP_KEK` Workers Secret) storing a per-tenant widget-auth secret. Don't set this field directly in admin requests: send plaintext via the write-only `authTokenSecret` field instead (see Admin API below); the server wraps it before storing and never returns the plaintext or the envelope in responses. |
+| `createdAt` / `updatedAt` | `string`               | ISO 8601, set by the server; ignored/overwritten if sent.                                                                                                                                                                                                                                                                                                                                       |
+
+`theme` fields (all optional): `color`, `bg`, `text`, `font`, `radius`, `borderWidth`,
+`borderColor`, `shadow` (`none`/`soft`/`hard`), `icon`, `label`,
+`position` (`bottom-right`/`bottom-left`), `mode` (`light`/`dark`/`auto`) — these map
+to `data-color`, `data-bg`, `data-text`, `data-font`, `data-radius`,
+`data-border-width`, `data-border-color`, `data-shadow`, `data-icon`, `data-label`,
+`data-position`, `data-theme` respectively.
+
+`behavior` fields (all optional): `locale`, `showName`, `requireName`, `showEmail`,
+`requireEmail`, `screenshot` (`optional`/`auto`/`required`), `welcome`
+(`once`/`always`/`never`), `showIssueLink` (`public`/`always`/`never`),
+`sendConsoleLogs`, `buttonDismissible`, `dismissDuration` (days), `showRestore`,
+`categoryLabels` (JSON) — same mapping pattern to their `data-*` equivalents.
+
+Unknown fields at any level are rejected (fail-loud on typos).
+
+### Admin API
+
+Full CRUD lives under `/api/admin/tenants`, protected by a Bearer token compared
+timing-safe against the `ADMIN_TOKEN` Workers Secret. There is no CORS allowance on
+this surface — same-origin/curl only. If `ADMIN_TOKEN` (or the `TENANTS` KV binding)
+is missing, every admin route fails loud with `503` rather than opening up.
+
+To set or rotate a tenant's optional widget-auth secret, send plaintext through the
+write-only `authTokenSecret` field (16-256 chars, or `authTokenSecret: null` to
+clear it). The server wraps it into the `authTokenSecretEnc` envelope with
+`BUGDROP_KEK` before storing it; the plaintext is never persisted, logged, or
+echoed back. Admin responses never include the envelope either — they report
+`hasAuthTokenSecret: true|false` instead.
+
+```bash
+# Create a tenant
+curl -X POST https://<worker-host>/api/admin/tenants \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "acme",
+    "name": "Acme Corp",
+    "repo": "acme-corp/website",
+    "origins": ["https://acme.example.com"],
+    "status": "active",
+    "theme": { "color": "#6366f1", "position": "bottom-left" }
+  }'
+
+# List tenants (key + name only)
+curl https://<worker-host>/api/admin/tenants \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+
+# Get a tenant
+curl https://<worker-host>/api/admin/tenants/acme \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+
+# Update a tenant (full object; createdAt is preserved, updatedAt is refreshed).
+# Omitting authTokenSecret keeps the existing one, if any; pass null to clear it.
+curl -X PUT https://<worker-host>/api/admin/tenants/acme \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "Acme Corp", "repo": "acme-corp/website", "origins": ["https://acme.example.com"], "status": "paused" }'
+
+# Set/rotate the tenant's widget-auth secret
+curl -X PUT https://<worker-host>/api/admin/tenants/acme \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "Acme Corp", "repo": "acme-corp/website", "origins": ["https://acme.example.com"], "status": "active", "authTokenSecret": "a-long-random-shared-secret" }'
+
+# Delete a tenant
+curl -X DELETE https://<worker-host>/api/admin/tenants/acme \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+### Enabling multi-tenant mode on your own deployment
+
+Multi-tenant embed is opt-in and dormant unless you configure it:
+
+1. Create the KV namespace: `wrangler kv namespace create bugdrop-tenants`, then
+   replace the placeholder `id` under the `TENANTS` binding in `wrangler.toml`
+   with the real namespace id.
+2. Set the admin secret: `wrangler secret put ADMIN_TOKEN` (a long random value —
+   this is the Bearer token for `/api/admin/tenants`).
+3. If you plan to set per-tenant widget-auth secrets (`authTokenSecret` above),
+   set `wrangler secret put BUGDROP_KEK` to a random 32-byte key, base64 or
+   base64url encoded. Without it, tenants that don't use `authTokenSecret` are
+   unaffected; a create/update that does set it fails with `500` until the key
+   is configured (fail-loud by design, never silently unencrypted).
+4. Create tenants via the admin API above, then hand each customer their
+   `/t/{tenantKey}.js` snippet.
+
+Without the `TENANTS` binding, the admin routes return `503`, `/t/*.js` serves the
+warn-only body, and everything else (legacy `/widget.js` + `/api`) is unaffected.
+
+### SRI (Subresource Integrity)
+
+The tenant loader does **not** support SRI. Its body changes whenever you edit a
+tenant's config, and the widget core it injects rolls forward on minor releases —
+the same trade-off every vendor loader makes (HubSpot, Intercom, Sentry): the trust
+anchor is the serving origin over HTTPS, not a content hash. If you need SRI, use the
+legacy embed instead: pin an exact widget version
+(`https://<worker-host>/widget.v1.X.Y.js`) and hand-write the `data-*` attributes
+yourself, with a matching `integrity` attribute on the `<script>` tag. That gets you
+SRI at the cost of losing centrally managed config.
+
 ## Features
 
 - 🔒 **Privacy masking** — tag sensitive elements with `data-bugdrop-mask` and BugDrop visually covers them in supported screenshot modes before submission. Passwords and credit-card inputs are masked automatically.

--- a/docs/plans/multi-tenant-embed.md
+++ b/docs/plans/multi-tenant-embed.md
@@ -1,6 +1,7 @@
 # Multi-Tenant Embed Contract (single-script loader, per-tenant config)
 
-Status: DRAFT under execution on branch `feat/multitenant-embed`.
+Status: M0, M1 and M2 executed on branch `feat/multitenant-embed` (PR #251).
+Remaining: operator instance provisioning (owner-only, post-merge).
 Amendments discovered during implementation are recorded inline under "Amendments".
 
 ## Nature of this document
@@ -276,6 +277,18 @@ tests incl. new ones). No file over ESLint limits.
   secrets remain M2 (D5).
 - 2026-07-12: D10 clarified in code: paused tenants also get the 200 warn-only
   loader body (the D4 403 applies to API traffic, not the loader).
+- 2026-07-12 (M2-01): per-tenant secrets land as a write-only admin field
+  `authTokenSecret` (16..256 chars; `null` clears; PUT without it inherits the
+  stored envelope) wrapped into `authTokenSecretEnc` (`v1.<iv>.<ciphertext>`
+  AES-256-GCM, KEK `BUGDROP_KEK`). Admin responses mask the envelope and expose
+  `hasAuthTokenSecret` instead. A tenant WITH its own secret requires a `bd1.`
+  token signed with THAT secret (global `AUTH_TOKEN_SECRET*` tokens are
+  rejected for it); a tenant WITHOUT one keeps global-secret parity. KEK
+  missing/invalid while a tenant has an envelope = 500, never a silent skip.
+- 2026-07-12 (M2-01, known limitation): `AUTH_TOKEN_REQUIRED_FOR_CHECK` still
+  validates `/api/t/{key}/check` against the GLOBAL secrets (the gate lives
+  inside the shared handler); tenants with their own secret are incompatible
+  with that flag until the check gate is generalized.
 - 2026-07-12 (review pass 2): `/api/admin` is now mounted BEFORE `/api` in
   src/index.ts (tenantApi stays first). Same textual-overlap leak as the
   tenantApi/api mount-order note: api's global wildcard `'*'` CORS middleware

--- a/docs/plans/multi-tenant-embed.md
+++ b/docs/plans/multi-tenant-embed.md
@@ -1,0 +1,268 @@
+# Multi-Tenant Embed Contract (single-script loader, per-tenant config)
+
+Status: DRAFT under execution on branch `feat/multitenant-embed`.
+Amendments discovered during implementation are recorded inline under "Amendments".
+
+## Nature of this document
+
+This is an execution contract, not a discussion document. Executor agents implement
+what is written here; they do not reopen decisions. If reality contradicts this
+document (an API does not exist, a test cannot pass as specified), the executor
+STOPS and reports; the contract is amended BEFORE code diverges from it.
+
+Required reading before taking any card: this file, `CLAUDE.md`, `src/routes/api.ts`,
+`src/widget/index.ts`, `src/widget/theme.ts`, `src/lib/authToken.ts`,
+`src/middleware/rateLimit.ts`, `wrangler.toml`.
+
+## Goal
+
+Today a site embeds BugDrop with a script tag plus up to ~30 `data-*` attributes,
+and the Worker has one global CORS list, one global auth secret, and hardcoded rate
+limits. The goal is a HubSpot-style embed: the customer pastes ONE script tag with a
+tenant key in the path and nothing else; all configuration (target repo, allowed
+origins, colors/theme, behavior, rate limits) lives server-side, per tenant, managed
+by the operator:
+
+```html
+<script src="https://<worker-host>/t/{tenantKey}.js" async></script>
+```
+
+## Vocabulary (use these terms literally)
+
+- **tenant**: one customer of a hosted BugDrop instance. Owns a target repo, an
+  origin allowlist, a theme, behavior flags, rate-limit tier.
+- **tenant key**: public slug identifying a tenant, appears in the loader URL path.
+  Not a secret (it is visible in page source), but unguessable enough to avoid
+  casual enumeration is not required; security comes from origin checks, not the key.
+- **loader**: the tiny server-rendered JS served at `/t/{key}.js`. Injects the
+  widget core with the tenant's config as `data-*` attributes.
+- **widget core**: the existing bundle `public/widget.v1.js` (unchanged bootstrap:
+  reads `document.currentScript.dataset`).
+- **legacy embed**: the current documented install (`/widget.js` + hand-written
+  `data-*`). MUST keep working unchanged.
+- **operator**: whoever hosts a BugDrop Worker deployment and administers tenants
+  (via admin API). Tenant data lives in the operator's KV, never in this repo.
+
+## Facts (measured; do not re-derive)
+
+- Widget config is read exclusively from `script.dataset` in
+  `src/widget/index.ts` (~lines 369-476); `apiUrl` is derived from `script.src`
+  by replacing `/widget(.vX[.Y[.Z]])?.js` with `/api`.
+- All theming is applied client-side as CSS custom properties in
+  `src/widget/theme.ts` (`--bd-*`), driven by `data-color`, `data-bg`, `data-text`,
+  `data-font`, `data-radius`, `data-border-width`, `data-border-color`,
+  `data-shadow`, `data-theme`.
+- CORS: single global `ALLOWED_ORIGINS` var (comma list or `*`), exact string
+  match, in `src/routes/api.ts`.
+- Rate limits hardcoded in `src/routes/api.ts`: 20 req/15 min per IP,
+  50 req/h per repo, via KV binding `RATE_LIMIT` (`src/middleware/rateLimit.ts`).
+- Widget auth token `bd1.<payload>.<sig>` (HMAC) verified against global
+  `AUTH_TOKEN_SECRET` (+`AUTH_TOKEN_ADDITIONAL_SECRETS`) in `src/lib/authToken.ts`.
+- GitHub App is global to the Worker (one App ID + private key); a tenant's repo
+  must have the App installed, same as today.
+- ESLint warns at >300 lines/file, >150 lines/function. Conventional commits
+  enforced by commitlint. Unit = Vitest in `test/`, E2E = Playwright in `e2e/`
+  against `wrangler dev` on :8787 (widget must be rebuilt first).
+
+## Frozen design decisions
+
+- **D1 Loader shape**: `/t/{key}.js` is rendered by the Worker (Hono route), NOT a
+  static asset. It contains: double-injection guard, the tenant's config baked in
+  as a data-attribute map, creation of a classic `<script>` pointing at
+  `/widget.v1.js` (major-pinned) on the same origin, plus `data-tenant={key}`.
+  Rationale: reuses the entire tested dataset config surface and theming pipeline;
+  zero rewrite of the widget bootstrap; HubSpot path-param pattern. Rejected
+  alternative: settings-JSON fetch + `window` config object (would fork the
+  bootstrap and double the test surface for no user-visible gain).
+- **D2 Tenant registry**: KV namespace binding `TENANTS` (resource name
+  `bugdrop-tenants`), key `tenant:{key}`, value = `TenantConfig` JSON (schema
+  below). Point reads at the edge with `cacheTtl: 60`. Rejected alternative: D1 —
+  no relational queries needed; a config blob per key is exactly KV's shape.
+- **D3 Additive only**: legacy embed, legacy routes, global CORS/rate/auth behavior
+  stay byte-for-byte compatible. All tenant enforcement lives under the new
+  namespaced router `/api/t/{key}/*`. All 340 existing unit tests and all existing
+  E2E specs must keep passing without modification (fixing a test is allowed only
+  if the test itself asserted nothing about legacy behavior; otherwise STOP).
+- **D4 Server-side authority**: for tenant traffic, `tenant.repo` and
+  `tenant.origins` are authoritative. The client-supplied repo must equal
+  `tenant.repo` (else 400). Requests with an Origin header not in
+  `tenant.origins` are rejected 403 (requests without Origin — curl,
+  server-to-server — are allowed, matching legacy semantics). A paused tenant
+  returns 403 for feedback/check and a no-op loader.
+- **D5 Per-tenant widget-auth secret (optional field, M2)**: stored encrypted
+  (AES-256-GCM envelope; KEK from Workers Secret `BUGDROP_KEK`; plaintext only in
+  memory during verification; never logged). Absent field = tenant does not use
+  widget auth tokens. Fail-loud: envelope present but KEK missing = 500, not skip.
+- **D6 Admin surface**: REST CRUD under `/api/admin/tenants`, protected by Bearer
+  token compared timing-safe against Workers Secret `ADMIN_TOKEN`; no CORS
+  allowance (same-origin/curl only), no dashboard UI in this round. Full CRUD from
+  day one: list, get, create, update, delete.
+- **D7 Validation**: manual typed validators following existing repo conventions
+  (`sanitizeCssColor`, `parseCategoryLabels`); no new runtime dependencies.
+  Zod was considered and rejected: the repo validates by hand consistently.
+- **D8 Naming**: new cloud resources are prefixed `bugdrop-` (`bugdrop-tenants`);
+  new secrets are `BUGDROP_KEK`, `ADMIN_TOKEN`. Dev values go in `.dev.vars`
+  (gitignored), never in code or in `wrangler.toml` `[vars]`.
+- **D9 Loader caching**: `Content-Type: application/javascript; charset=utf-8`,
+  `Cache-Control: public, max-age=300`. Config changes propagate within
+  5 min + KV cacheTtl; acceptable for theming/config. No ETag machinery in v1.
+- **D11 No Subresource Integrity on the loader (deliberate)**: SRI requires a
+  fixed hash; the loader body changes whenever the operator edits the tenant's
+  config, and the widget core it injects rolls forward on minor releases. This is
+  the same trade-off every vendor loader makes (HubSpot, Intercom, Sentry): the
+  trust anchor is the serving origin (operator's Worker over HTTPS), not a hash.
+  Customers who want SRI can instead pin an exact version
+  (`/widget.v1.X.Y.js` + hand-written data-attrs, legacy embed) at the cost of
+  losing central config. Document this in M2-02.
+- **D10 Unknown tenant**: `/t/{key}.js` for a missing key returns HTTP 200 with a
+  JS body that only `console.warn('[BugDrop] unknown tenant key: …')`. 200, not
+  404, so the page never sees a script error; the warn is the debugging surface.
+
+## TenantConfig v1 (FROZEN by card M0-01; changes require contract amendment)
+
+```ts
+interface TenantConfig {
+  version: 1;
+  key: string; // ^[a-z0-9](?:[a-z0-9-]{1,30}[a-z0-9])$
+  name: string; // display name, 1..100 chars
+  repo: string; // "owner/repo", same validation as data-repo today
+  origins: string[]; // exact-match web origins, e.g. "https://app.example.com";
+  // https required except http://localhost[:port]; no paths, no wildcards in v1
+  status: 'active' | 'paused';
+  theme?: {
+    color?: string; // -> data-color (sanitizeCssColor rules)
+    bg?: string; // -> data-bg
+    text?: string; // -> data-text
+    font?: string; // -> data-font
+    radius?: string; // -> data-radius
+    borderWidth?: string; // -> data-border-width
+    borderColor?: string; // -> data-border-color
+    shadow?: 'none' | 'soft' | 'hard'; // -> data-shadow
+    icon?: string; // -> data-icon (URL or "none")
+    label?: string; // -> data-label
+    position?: 'bottom-right' | 'bottom-left'; // -> data-position
+    mode?: 'light' | 'dark' | 'auto'; // -> data-theme
+  };
+  behavior?: {
+    locale?: string; // -> data-locale
+    showName?: boolean; // -> data-show-name
+    requireName?: boolean; // -> data-require-name
+    showEmail?: boolean; // -> data-show-email
+    requireEmail?: boolean; // -> data-require-email
+    screenshot?: 'optional' | 'auto' | 'required'; // -> data-screenshot
+    welcome?: 'once' | 'always' | 'never'; // -> data-welcome
+    showIssueLink?: 'public' | 'always' | 'never'; // -> data-show-issue-link
+    sendConsoleLogs?: boolean; // -> data-send-console-logs
+    buttonDismissible?: boolean; // -> data-button-dismissible
+    dismissDuration?: number; // -> data-dismiss-duration (days)
+    showRestore?: boolean; // -> data-show-restore
+    categoryLabels?: Record<string, string | string[]>; // -> data-category-labels (JSON)
+  };
+  rate?: {
+    perIp?: number; // default 20 (per 15 min window, window fixed in v1)
+    perRepo?: number; // default 50 (per 60 min window, window fixed in v1)
+  };
+  authTokenSecretEnc?: string; // M2. AES-256-GCM envelope, base64url; see D5
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+}
+```
+
+Booleans/numbers are serialized into data-attributes as strings exactly the way the
+widget already parses them (`'true'`/`'false'`, decimal numbers). Unknown fields in
+stored JSON are rejected by the validator (fail-loud on typos).
+
+## Request flow (tenant traffic)
+
+1. Page loads `/t/acme.js` → loader injects
+   `<script src="/widget.v1.js" data-tenant="acme" data-repo="…" data-color="…" …>`.
+2. Widget boots exactly as today (dataset + currentScript). When `data-tenant` is
+   present, the derived `apiUrl` becomes `<origin>/api/t/{key}` instead of
+   `<origin>/api`.
+3. `GET /api/t/{key}/check/:owner/:repo` and `POST /api/t/{key}/feedback` run the
+   existing handlers wrapped with per-tenant enforcement: CORS against
+   `tenant.origins` (including preflight), repo pinning to `tenant.repo`,
+   rate limits from `tenant.rate` (KV key prefix `t:{key}:` so tenants never share
+   buckets), paused → 403.
+
+## Milestones and cards
+
+Execution: cards run strictly in the listed order, one agent per card, one
+conventional commit per card (message = card title). Calibration column = model
+tier for the executor agent.
+
+### M0 — Tenant foundation
+
+| #     | Card (commit title)                                             | Scope                                                                                                                                                                                                                                            | Exports (frozen interface)                                                                                        | Depends | Calibration |
+| ----- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- | ------- | ----------- |
+| M0-01 | `feat: add TenantConfig v1 types and validator` **(BLOCKER)**   | `src/lib/tenants.ts`: `TenantConfig` + sub-interfaces exactly as in this contract; `validateTenantConfig(input: unknown): { ok: true; value: TenantConfig } \| { ok: false; errors: string[] }`; `tenantToDataAttributes(t): Record<string,string>` (the loader's attr map, including `repo`). Unit tests in `test/tenants.test.ts` covering every field family, rejection of unknown fields, key/origin/repo formats. | `TenantConfig`, `validateTenantConfig`, `tenantToDataAttributes`                                                    | —       | Sonnet med  |
+| M0-02 | `feat: add KV tenant store`                                      | `src/lib/tenantStore.ts`: `getTenant(env, key)` (KV `TENANTS`, `cacheTtl: 60`, validates stored JSON, returns null on missing/invalid + `console.error` on invalid), `putTenant`, `deleteTenant`, `listTenants` (KV list by prefix `tenant:`, returns keys + names only). Add `TENANTS` binding to `src/types.ts` Env and `wrangler.toml` (all envs; use placeholder id + `# create: wrangler kv namespace create bugdrop-tenants` comment). Unit tests with a KV mock following existing test patterns. | `getTenant`, `putTenant`, `deleteTenant`, `listTenants`                                                             | M0-01   | Sonnet med  |
+| M0-03 | `feat: add tenant admin CRUD routes`                             | `src/routes/admin.ts` mounted at `/api/admin`: `GET /tenants`, `POST /tenants`, `GET /tenants/:key`, `PUT /tenants/:key`, `DELETE /tenants/:key`. Bearer auth: timing-safe comparison against `env.ADMIN_TOKEN` (reuse/extract the existing timing-safe compare if present in the codebase; else implement with `crypto.subtle` digest comparison). Missing `ADMIN_TOKEN` secret → all admin routes 503 (fail-loud, never open). POST/PUT validate via `validateTenantConfig`; server sets `createdAt`/`updatedAt`/`version`. Unit tests: authz (no token / wrong token / ok), full CRUD round-trip, validation errors 400. | Admin REST surface as described                                                                                    | M0-02   | Sonnet med  |
+
+**M0 acceptance gate**: `npm run validate` green (lint, format, typecheck, all unit
+tests incl. new ones). No file over ESLint limits.
+
+### M1 — Loader + per-tenant enforcement
+
+| #     | Card (commit title)                                        | Scope                                                                                                                                                                                                                                                                                                                                                                                     | Exports                                                     | Depends | Calibration |
+| ----- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ------- | ----------- |
+| M1-01 | `feat: serve tenant loader at /t/:key.js`                  | `src/routes/loader.ts` (mounted in `src/index.ts`): render the loader IIFE per D1/D9/D10. Attribute values embedded via `JSON.stringify` (XSS-safe by construction; no string concatenation of raw values into JS). Paused tenant → warn-only loader like D10. Unit tests: header values, guard present, attrs match `tenantToDataAttributes`, unknown/paused tenant bodies, script src is `/widget.v1.js` with `data-tenant`.                                                                             | Loader route                                                | M0      | Sonnet med  |
+| M1-02 | `feat: widget derives tenant-scoped apiUrl from data-tenant` | In `src/widget/index.ts` only: read `data-tenant`; when present and matching `^[a-z0-9-]{3,32}$`, apiUrl = existing derivation + `/t/{key}` (i.e. `<origin>/api/t/{key}`); include the raw key nowhere else. Minimal diff. Unit test in existing widget test file covering with/without/invalid `data-tenant`. Run `npm run build:widget` and confirm it builds.                                                                                                                                                | `data-tenant` contract                                      | M0-01   | Sonnet med  |
+| M1-03 | `feat: enforce per-tenant CORS, repo pinning and rate limits` | `src/routes/tenantApi.ts` mounted at `/api/t/:key` in `src/routes/api.ts` or `src/index.ts` (whichever keeps files under the 300-line limit): resolve tenant once per request (404 JSON if unknown, 403 if paused); CORS allowing exactly `tenant.origins` (handle preflight; if Hono's `cors()` origin callback cannot access route params in the installed version, implement a small explicit middleware — check `node_modules/hono` first, do not guess); requests with an Origin not in the allowlist → 403 (no-Origin requests allowed); then delegate to the SAME feedback/check handler logic used by the legacy routes (extract shared handlers if needed, without changing legacy route behavior), with: repo forced/validated to equal `tenant.repo` (mismatch → 400), rate limits from `tenant.rate` with KV key prefix `t:{key}:`. Unit tests: unknown/paused tenant, origin allowed/denied/absent, preflight, repo pinning, custom rate override applied. | `/api/t/{key}/check/...`, `/api/t/{key}/feedback`           | M0, M1-02 | Sonnet high |
+| M1-04 | `test: add multi-tenant embed E2E coverage`                | New `e2e/multi-tenant.spec.ts` following existing E2E conventions (fixtures, wrangler dev, built widget): seed a test tenant via the admin API (`ADMIN_TOKEN` from `.dev.vars`; add `.dev.vars.example` entry), load a page embedding `/t/<testkey>.js`, assert: widget button renders with the tenant's `theme.color`, feedback modal opens, submission path hits `/api/t/<testkey>/feedback` (route assertion via request interception or the dev-mode mock the existing E2E uses — follow the existing pattern for how feedback submission is asserted without hitting GitHub), a disallowed origin is rejected (API-level assertion with fetch + Origin header), legacy embed spec still passes untouched. | E2E proof of the whole flow                                 | M1-01..03 | Sonnet high |
+
+**M1 acceptance gate**: `npm run validate` green + `npm run build:widget` +
+`npx playwright test` green locally (both legacy and new specs).
+
+### M2 — Hardening + docs (after M1 gate)
+
+| #     | Card                                                        | Scope                                                                                                                                                                                     | Depends | Calibration |
+| ----- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ----------- |
+| M2-01 | `feat: per-tenant widget auth secret (envelope encryption)` | D5: `src/lib/envelope.ts` (AES-256-GCM wrap/unwrap, KEK `BUGDROP_KEK`, versioned prefix `v1.`), admin routes accept plaintext secret on create/update and store only the envelope; tenant API verifies `bd1.` tokens against the tenant secret when configured (falling back to global secrets for legacy routes only). Unit tests incl. round-trip and KEK-missing fail-loud. | M1      | Fable (security-critical review required) |
+| M2-02 | `docs: document single-script multi-tenant embed`           | README section + `docs/website` page if the site has an install page: one-line snippet, admin API usage (curl examples), TenantConfig reference table, migration note that legacy embed is unchanged.                                                                                                | M1      | Sonnet low  |
+
+## Hard rules for executor agents
+
+1. One card = one agent = one coherent conventional commit; commit message = card
+   title. Do not `git add -A`; stage only files your card touches.
+2. Never deploy. Never run `wrangler deploy` or touch CI workflows.
+3. Legacy behavior is untouchable: if an existing test needs modification to pass,
+   STOP and report instead.
+4. Interfaces in this contract are law (schema, route paths, function names,
+   binding names). Divergence requires amending this file BEFORE the code.
+5. No new npm dependencies. No secrets in code, `wrangler.toml` `[vars]`, tests,
+   or logs; dev secrets go in `.dev.vars` (+ `.dev.vars.example` placeholders).
+6. Respect ESLint limits (300-line files, 150-line functions); split files rather
+   than suppress warnings. Never weaken lint/type configs.
+7. After your card: run `npm run validate`; a widget card also runs
+   `npm run build:widget`. Report results honestly; a red gate = card not done.
+8. STOP conditions: same error 3 times → stop and report; implementation growing
+   past ~2x the card's scope → stop and report; ambiguity in the contract → stop
+   and ask, do not improvise.
+9. Card report format (final message): JSON
+   `{ card, status: 'done'|'blocked', filesTouched[], testsAdded, gate: {validate, build}, findings[], next_action }`.
+
+## Gates that survive all milestones
+
+- The pre-PR review gate from `CLAUDE.md` (pr-review-toolkit agents) runs before
+  the PR is opened; findings are addressed first.
+- Burden Of Proof (`CLAUDE.md`): before declaring the feature complete, actively
+  try to disprove it (e.g. cross-tenant request with a valid foreign origin, repo
+  spoof attempt, cache poisoning of the loader) and attach the evidence.
+- Operator deployment (KV namespace creation, `ADMIN_TOKEN`/`BUGDROP_KEK` secrets,
+  real tenant records) is NEVER part of this branch; it happens on the operator's
+  account, manually, after merge.
+
+## Decisions only the owner can take (open)
+
+- Whether to upstream this PR to `mean-weasel/bugdrop` as-is or keep it on a fork
+  for the operator instance first.
+- Tenant key format for real customers (readable slug like `acme` vs random
+  suffix like `acme-8f3k`).
+- Whether M2-01 (per-tenant auth secrets) is needed before the first real tenant
+  or can wait.
+- Custom domain / hosting account for the operator instance.
+
+## Amendments
+
+- (none yet)

--- a/docs/plans/multi-tenant-embed.md
+++ b/docs/plans/multi-tenant-embed.md
@@ -265,4 +265,14 @@ tests incl. new ones). No file over ESLint limits.
 
 ## Amendments
 
-- (none yet)
+- 2026-07-12 (review pass): the loader emits the widget script src as an ABSOLUTE
+  URL on the Worker's own origin (derived from the request URL). A relative
+  `/widget.v1.js` would resolve against the customer's domain, since the loader
+  executes on their page; local E2E masked this because the test page is served
+  from the same origin as the Worker.
+- 2026-07-12 (review pass): tenant `/feedback` also runs the legacy
+  `requireBugDropFeedbackAuthToken` middleware (global `AUTH_TOKEN_SECRET*`), so
+  configuring widget-auth on an instance protects tenant routes too. Per-tenant
+  secrets remain M2 (D5).
+- 2026-07-12: D10 clarified in code: paused tenants also get the 200 warn-only
+  loader body (the D4 403 applies to API traffic, not the loader).

--- a/docs/plans/multi-tenant-embed.md
+++ b/docs/plans/multi-tenant-embed.md
@@ -276,3 +276,27 @@ tests incl. new ones). No file over ESLint limits.
   secrets remain M2 (D5).
 - 2026-07-12: D10 clarified in code: paused tenants also get the 200 warn-only
   loader body (the D4 403 applies to API traffic, not the loader).
+- 2026-07-12 (review pass 2): `/api/admin` is now mounted BEFORE `/api` in
+  src/index.ts (tenantApi stays first). Same textual-overlap leak as the
+  tenantApi/api mount-order note: api's global wildcard `'*'` CORS middleware
+  would otherwise also apply to admin traffic, contradicting D6 (admin has no
+  CORS allowance at all).
+- 2026-07-12 (review pass 2): tenant `/feedback` middleware order now mirrors
+  legacy exactly — IP rate limit runs BEFORE auth, so a flood of requests
+  carrying invalid/missing bd1. tokens still consumes IP quota instead of
+  bypassing rate limiting; repo-match and repo rate limit run after auth, same
+  as before.
+- 2026-07-12 (review pass 2): `TENANTS` is now an OPTIONAL Env binding
+  (src/types.ts). Multitenant is an opt-in operator feature: absent, admin
+  routes 503, the loader is warn-only, and tenant lookups return null/empty.
+  The preview environment in wrangler.toml no longer declares a TENANTS
+  binding at all (a real `wrangler deploy` rejects the placeholder id).
+- 2026-07-12 (review pass 2): `authTokenSecretEnc` removed from TenantConfig
+  v1 and its validator until M2 envelope encryption (D5) actually lands;
+  presence of the field is rejected with an explicit
+  "not supported yet (M2 envelope encryption)" error rather than a generic
+  unknown-field message.
+- 2026-07-12 (review pass 2): rate limiting's fixed-window counter is now a
+  single shared core, `applyFixedWindowLimit` (src/middleware/rateLimit.ts),
+  used by both the legacy `rateLimit()`/`rateLimitByRepo()` and the tenant-scoped
+  limiters in src/routes/tenantApi.ts, with no observable change to either.

--- a/docs/website/installation.mdx
+++ b/docs/website/installation.mdx
@@ -177,6 +177,25 @@ If you see any errors, check that:
 
 You can also test by clicking the bug button and submitting a test report. Check your GitHub repository's Issues tab to confirm it was created successfully.
 
+## Multi-tenant hosted embed (self-hosted operators)
+
+If you run your own BugDrop Worker for multiple customers or sites, you can skip
+hand-written `data-*` attributes entirely and give each customer a single script
+tag with a tenant key in the path:
+
+```html
+<script src="https://<your-worker-host>/t/{tenantKey}.js" async></script>
+```
+
+Configuration (target repo, allowed origins, theme, behavior, rate limits) is
+managed server-side per tenant through an admin API, so each customer only ever
+pastes one line. This is an operator feature for self-hosted deployments; it does
+not apply to the public BugDrop service used above, and the standard install in
+Step 2 keeps working unchanged either way.
+
+See the [Multi-tenant hosted embed section of the README](https://github.com/mean-weasel/bugdrop#multi-tenant-hosted-embed)
+for the full TenantConfig reference, admin API examples, and setup steps.
+
 ## Next Steps
 
 - [Configure the widget](/docs/configuration) with custom attributes

--- a/e2e/multi-tenant.spec.ts
+++ b/e2e/multi-tenant.spec.ts
@@ -1,0 +1,277 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test, expect, type Page, type APIRequestContext } from '@playwright/test';
+
+/**
+ * E2E coverage for the multi-tenant embed loader (`/t/:key.js`) and the per-tenant
+ * API enforcement layer (`/api/t/:key/*`) — contract docs/plans/multi-tenant-embed.md,
+ * card M1-04.
+ *
+ * The admin-seeded tests below create/delete a real tenant through the admin CRUD API
+ * (src/routes/admin.ts) against the running `wrangler dev` server, so they need the
+ * same ADMIN_TOKEN the dev server was started with. That value lives in the
+ * developer's local, gitignored `.dev.vars` (see `.dev.vars.example`) — it is read
+ * straight from disk here instead of requiring a second, easy-to-forget copy in the
+ * shell environment. CI runs `wrangler dev` with no `.dev.vars` at all, so
+ * ADMIN_TOKEN is unset there and every admin-seeded test skips itself (mirroring how
+ * GitHub-credential-dependent assertions already degrade gracefully elsewhere in this
+ * suite, e.g. e2e/api.spec.ts's `expect([403, 500])`), while the legacy-embed
+ * regression guard below still runs unconditionally.
+ */
+function readAdminTokenFromDevVars(): string | undefined {
+  let content: string;
+  try {
+    content = readFileSync(join(process.cwd(), '.dev.vars'), 'utf8');
+  } catch {
+    return undefined;
+  }
+  const match = content.match(/^ADMIN_TOKEN\s*=\s*(.+?)\s*$/m);
+  if (!match) return undefined;
+  const value = match[1].trim().replace(/^['"]|['"]$/g, '');
+  return value.length > 0 ? value : undefined;
+}
+
+const ADMIN_TOKEN = readAdminTokenFromDevVars();
+const TEST_THEME_COLOR = '#2563eb';
+
+function randomSuffix(): string {
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function randomTenantKey(): string {
+  return `e2e-${randomSuffix()}`;
+}
+
+function randomRepo(): string {
+  return `bugdrop-e2e/${randomSuffix()}`;
+}
+
+function requireBaseUrl(baseURL: string | undefined): string {
+  if (!baseURL) {
+    throw new Error('playwright.config baseURL is required for multi-tenant E2E coverage');
+  }
+  return new URL(baseURL).origin;
+}
+
+interface TenantSeed {
+  key: string;
+  repo: string;
+  origins: string[];
+  theme?: Record<string, unknown>;
+}
+
+async function createTenant(request: APIRequestContext, seed: TenantSeed): Promise<void> {
+  const res = await request.post('/api/admin/tenants', {
+    headers: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+    data: {
+      key: seed.key,
+      name: `E2E tenant ${seed.key}`,
+      repo: seed.repo,
+      origins: seed.origins,
+      status: 'active',
+      ...(seed.theme ? { theme: seed.theme } : {}),
+    },
+  });
+  expect(res.ok(), `create tenant failed: ${res.status()} ${await res.text()}`).toBeTruthy();
+}
+
+async function deleteTenant(request: APIRequestContext, key: string): Promise<void> {
+  await request.delete(`/api/admin/tenants/${key}`, {
+    headers: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+  });
+}
+
+/**
+ * Navigates to a same-origin document with no widget pre-loaded, then injects the
+ * tenant loader script (`/t/{key}.js`) exactly as a customer's page tag would —
+ * proving the loader (not a hand-written data-tenant fixture) drives the boot.
+ */
+async function loadTenantEmbed(page: Page, key: string): Promise<void> {
+  await page.goto('/api/health');
+  await page.setContent('<!DOCTYPE html><html><head></head><body></body></html>');
+  await page.addScriptTag({ url: `/t/${key}.js` });
+}
+
+function widgetHost(page: Page) {
+  return page.locator('#bugdrop-host');
+}
+
+function widgetTrigger(page: Page) {
+  return widgetHost(page).locator('css=.bd-trigger');
+}
+
+function rootPrimaryColor(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const host = document.getElementById('bugdrop-host');
+    const root = host?.shadowRoot?.querySelector('.bd-root') as HTMLElement | null;
+    return root?.style.getPropertyValue('--bd-primary') ?? '';
+  });
+}
+
+test.describe('Multi-tenant embed (M1-04)', () => {
+  test.beforeEach(() => {
+    test.skip(
+      !ADMIN_TOKEN,
+      'ADMIN_TOKEN not set in .dev.vars — see .dev.vars.example to enable multi-tenant admin-seeded E2E coverage locally.'
+    );
+  });
+
+  test('widget renders the tenant theme color and opens the feedback modal', async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    const key = randomTenantKey();
+    const origin = requireBaseUrl(baseURL);
+    await createTenant(request, {
+      key,
+      repo: randomRepo(),
+      origins: [origin],
+      theme: { color: TEST_THEME_COLOR },
+    });
+
+    try {
+      await loadTenantEmbed(page, key);
+
+      const trigger = widgetTrigger(page);
+      await expect(trigger).toBeVisible({ timeout: 5000 });
+      expect(await rootPrimaryColor(page)).toBe(TEST_THEME_COLOR);
+
+      await trigger.click();
+      await expect(widgetHost(page).locator('css=.bd-modal')).toBeVisible({ timeout: 5000 });
+    } finally {
+      await deleteTenant(request, key);
+    }
+  });
+
+  test('feedback submission POSTs to the tenant-scoped endpoint and succeeds', async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    const key = randomTenantKey();
+    const repo = randomRepo();
+    const origin = requireBaseUrl(baseURL);
+    await createTenant(request, { key, repo, origins: [origin] });
+
+    try {
+      const payloads: Array<Record<string, unknown>> = [];
+      await page.route(`**/api/t/${key}/check/**`, route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ installed: true }),
+        })
+      );
+      await page.route(`**/api/t/${key}/feedback`, async route => {
+        payloads.push(route.request().postDataJSON());
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, issueNumber: 1, issueUrl: '#', isPublic: false }),
+        });
+      });
+
+      await loadTenantEmbed(page, key);
+      const host = widgetHost(page);
+      const trigger = widgetTrigger(page);
+      await expect(trigger).toBeVisible({ timeout: 5000 });
+      await trigger.click();
+
+      const getStartedBtn = host.locator('css=[data-action="continue"]');
+      await expect(getStartedBtn).toBeVisible({ timeout: 5000 });
+      await getStartedBtn.click();
+
+      await host.locator('css=#title').fill('Multi-tenant E2E feedback');
+      await host.locator('css=#include-screenshot').uncheck();
+      await host.locator('css=#submit-btn').click();
+
+      await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0].repo).toBe(repo);
+    } finally {
+      await deleteTenant(request, key);
+    }
+  });
+
+  test('a disallowed Origin is rejected 403; the tenant origin reaches the real handler', async ({
+    request,
+  }) => {
+    // Deliberately NOT baseURL's own origin: wrangler dev's local proxy rewrites an
+    // incoming Origin header that literally matches its own bind address
+    // (http://localhost:8787) to the zone_name from wrangler.toml's `routes` before
+    // the Worker ever sees it — a dev-only quirk, verified by hand against the real
+    // server, unrelated to src/routes/tenantApi.ts's origin check. An arbitrary
+    // synthetic origin sidesteps that rewrite and still exercises the same
+    // `tenant.origins.includes(origin)` code path faithfully.
+    const allowedOrigin = 'https://allowed.bugdrop-e2e.test';
+    const key = randomTenantKey();
+    const repo = randomRepo();
+    await createTenant(request, { key, repo, origins: [allowedOrigin] });
+
+    try {
+      const denied = await request.post(`/api/t/${key}/feedback`, {
+        headers: { Origin: 'https://evil.example.test', 'Content-Type': 'application/json' },
+        data: { repo, title: 'should be rejected' },
+      });
+      expect(denied.status()).toBe(403);
+      const deniedBody = await denied.json();
+      expect(deniedBody.error).toContain('Origin not allowed');
+
+      // Same tenant, allowed Origin, deliberately invalid body (missing required
+      // fields): a 400 (not 403/CORS-blocked) proves this request cleared the origin
+      // gate and reached handleFeedbackRequest's own validation.
+      const allowed = await request.post(`/api/t/${key}/feedback`, {
+        headers: { Origin: allowedOrigin, 'Content-Type': 'application/json' },
+        data: {},
+      });
+      expect(allowed.status()).toBe(400);
+    } finally {
+      await deleteTenant(request, key);
+    }
+  });
+});
+
+test.describe('Legacy embed regression guard (M1-04)', () => {
+  // Runs unconditionally (no ADMIN_TOKEN needed): proves the new /api/t/:key mount
+  // (registered before /api in src/index.ts, see the mount-order note atop
+  // src/routes/tenantApi.ts) did not change where the legacy embed's feedback
+  // submission lands.
+  test('legacy embed (no data-tenant) still posts to /api/feedback, not a tenant-scoped path', async ({
+    page,
+  }) => {
+    const requestPaths: string[] = [];
+    await page.route('**/feedback', async route => {
+      requestPaths.push(new URL(route.request().url()).pathname);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, issueNumber: 1, issueUrl: '#', isPublic: false }),
+      });
+    });
+    await page.route('**/api/check**', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      })
+    );
+
+    await page.goto('/test/');
+    const scriptTag = page.locator('script[src="/widget.js"]');
+    await expect(scriptTag).toBeAttached();
+    expect(
+      await scriptTag.evaluate(el => (el as HTMLScriptElement).dataset.tenant)
+    ).toBeUndefined();
+
+    const host = widgetHost(page);
+    await widgetTrigger(page).click();
+    await host.locator('css=[data-action="continue"]').click();
+    await host.locator('css=#title').fill('Legacy embed regression guard');
+    await host.locator('css=#include-screenshot').uncheck();
+    await host.locator('css=#submit-btn').click();
+
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+    expect(requestPaths).toEqual(['/api/feedback']);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5818,9 +5818,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.29",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.29.tgz",
+      "integrity": "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { logger } from 'hono/logger';
 import type { Env } from './types';
 import api from './routes/api';
 import admin from './routes/admin';
+import loader from './routes/loader';
 import { createBoardDogfoodToken } from './lib/boardDogfood';
 
 const app = new Hono<{ Bindings: Env }>();
@@ -47,6 +48,7 @@ app.use('*', logger());
 // Mount API routes
 app.route('/api', api);
 app.route('/api/admin', admin);
+app.route('/t', loader);
 
 export function isWeakAuthTokenSecret(secret?: string): boolean {
   return typeof secret === 'string' && secret.length > 0 && secret.length < 32;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import type { Env } from './types';
 import api from './routes/api';
 import admin from './routes/admin';
 import loader from './routes/loader';
+import tenantApi from './routes/tenantApi';
 import { createBoardDogfoodToken } from './lib/boardDogfood';
 
 const app = new Hono<{ Bindings: Env }>();
@@ -45,7 +46,12 @@ app.use('*', async (c, next) => {
 // Request logging
 app.use('*', logger());
 
-// Mount API routes
+// Mount API routes. tenantApi is mounted BEFORE api on purpose: both prefixes
+// (/api/t/:key and /api) overlap textually, and api's own wildcard '*' CORS
+// middleware would otherwise also match tenant traffic if api were registered
+// first (verified against the installed Hono version — see the mount-order note
+// atop src/routes/tenantApi.ts).
+app.route('/api/t/:key', tenantApi);
 app.route('/api', api);
 app.route('/api/admin', admin);
 app.route('/t', loader);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { logger } from 'hono/logger';
 import type { Env } from './types';
 import api from './routes/api';
+import admin from './routes/admin';
 import { createBoardDogfoodToken } from './lib/boardDogfood';
 
 const app = new Hono<{ Bindings: Env }>();
@@ -45,6 +46,7 @@ app.use('*', logger());
 
 // Mount API routes
 app.route('/api', api);
+app.route('/api/admin', admin);
 
 export function isWeakAuthTokenSecret(secret?: string): boolean {
   return typeof secret === 'string' && secret.length > 0 && secret.length < 32;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,14 +46,18 @@ app.use('*', async (c, next) => {
 // Request logging
 app.use('*', logger());
 
-// Mount API routes. tenantApi is mounted BEFORE api on purpose: both prefixes
-// (/api/t/:key and /api) overlap textually, and api's own wildcard '*' CORS
-// middleware would otherwise also match tenant traffic if api were registered
-// first (verified against the installed Hono version — see the mount-order note
-// atop src/routes/tenantApi.ts).
+// Mount API routes. tenantApi AND admin are both mounted BEFORE api on
+// purpose: all three prefixes (/api/t/:key, /api/admin, /api) overlap
+// textually, and api's own wildcard '*' CORS middleware would otherwise also
+// match tenant AND admin traffic if api were registered first (verified
+// against the installed Hono version — see the mount-order note atop
+// src/routes/tenantApi.ts). Admin must never receive CORS headers at all
+// (contract docs/plans/multi-tenant-embed.md, decision D6: same-origin/curl
+// only, no CORS allowance) — mounting it after api would leak api's global
+// ALLOWED_ORIGINS wildcard onto the admin surface.
 app.route('/api/t/:key', tenantApi);
-app.route('/api', api);
 app.route('/api/admin', admin);
+app.route('/api', api);
 app.route('/t', loader);
 
 export function isWeakAuthTokenSecret(secret?: string): boolean {

--- a/src/lib/authToken.ts
+++ b/src/lib/authToken.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from './timingSafeEqual';
+
 interface BugDropAuthTokenPayload {
   iss?: string;
   aud?: string;
@@ -108,17 +110,6 @@ function isPayload(value: unknown): value is BugDropAuthTokenPayload {
     (payload.origin === undefined || typeof payload.origin === 'string') &&
     (payload.nbf === undefined || typeof payload.nbf === 'number')
   );
-}
-
-function timingSafeEqual(left: string, right: string): boolean {
-  const leftBytes = new TextEncoder().encode(left);
-  const rightBytes = new TextEncoder().encode(right);
-  let diff = leftBytes.length ^ rightBytes.length;
-  const max = Math.max(leftBytes.length, rightBytes.length);
-  for (let index = 0; index < max; index++) {
-    diff |= (leftBytes[index] ?? 0) ^ (rightBytes[index] ?? 0);
-  }
-  return diff === 0;
 }
 
 function base64UrlEncodeString(value: string): string {

--- a/src/lib/envelope.ts
+++ b/src/lib/envelope.ts
@@ -1,0 +1,78 @@
+// AES-256-GCM envelope encryption for per-tenant secrets — contract
+// docs/plans/multi-tenant-embed.md, decision D5 (card M2-01). Envelope format:
+// `v1.<iv_b64url>.<ciphertext_b64url>` (ciphertext includes the GCM tag). The KEK
+// comes from the Workers Secret BUGDROP_KEK (base64 or base64url, 32 bytes decoded)
+// and is fail-loud by design: a missing or malformed KEK throws instead of silently
+// skipping encryption. Plaintext secrets must only ever live in memory — never in
+// KV, logs, or responses.
+
+const ENVELOPE_VERSION = 'v1';
+const ENVELOPE_PATTERN = /^v1\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+const IV_BYTES = 12;
+const KEK_BYTES = 32;
+
+export function isEnvelope(value: string): boolean {
+  return ENVELOPE_PATTERN.test(value);
+}
+
+export async function wrapSecret(plaintext: string, kekB64: string | undefined): Promise<string> {
+  const key = await importKek(kekB64);
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    new TextEncoder().encode(plaintext)
+  );
+  return `${ENVELOPE_VERSION}.${base64UrlEncode(iv)}.${base64UrlEncode(new Uint8Array(ciphertext))}`;
+}
+
+export async function unwrapSecret(envelope: string, kekB64: string | undefined): Promise<string> {
+  if (!isEnvelope(envelope)) {
+    throw new Error('Malformed secret envelope');
+  }
+  const key = await importKek(kekB64);
+  const [, ivB64, ciphertextB64] = envelope.split('.');
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: base64UrlDecode(ivB64 ?? '') },
+    key,
+    base64UrlDecode(ciphertextB64 ?? '')
+  );
+  return new TextDecoder().decode(plaintext);
+}
+
+async function importKek(kekB64: string | undefined): Promise<CryptoKey> {
+  if (!kekB64) {
+    throw new Error('BUGDROP_KEK is not configured');
+  }
+  let raw: Uint8Array;
+  try {
+    raw = base64UrlDecode(kekB64.trim().replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, ''));
+  } catch {
+    throw new Error('BUGDROP_KEK is not valid base64');
+  }
+  if (raw.length !== KEK_BYTES) {
+    throw new Error(`BUGDROP_KEK must decode to ${KEK_BYTES} bytes, got ${raw.length}`);
+  }
+  return crypto.subtle.importKey('raw', raw as BufferSource, { name: 'AES-GCM' }, false, [
+    'encrypt',
+    'decrypt',
+  ]);
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlDecode(value: string): Uint8Array {
+  const padded = value.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/src/lib/tenantFieldValidators.ts
+++ b/src/lib/tenantFieldValidators.ts
@@ -1,0 +1,272 @@
+// Field-level validators for TenantConfig v1 sub-objects (theme/behavior/rate).
+// Split out of tenants.ts to respect the repo's 300-line-per-file ESLint limit.
+// Schema is FROZEN by contract docs/plans/multi-tenant-embed.md (card M0-01).
+
+import type { TenantBehaviorConfig, TenantRateConfig, TenantThemeConfig } from './tenantTypes';
+
+const SHADOW_VALUES = new Set(['none', 'soft', 'hard']);
+const POSITION_VALUES = new Set(['bottom-right', 'bottom-left']);
+const THEME_MODE_VALUES = new Set(['light', 'dark', 'auto']);
+const SCREENSHOT_VALUES = new Set(['optional', 'auto', 'required']);
+const WELCOME_VALUES = new Set(['once', 'always', 'never']);
+const SHOW_ISSUE_LINK_VALUES = new Set(['public', 'always', 'never']);
+
+export const THEME_FIELDS = new Set([
+  'color',
+  'bg',
+  'text',
+  'font',
+  'radius',
+  'borderWidth',
+  'borderColor',
+  'shadow',
+  'icon',
+  'label',
+  'position',
+  'mode',
+]);
+
+export const BEHAVIOR_FIELDS = new Set([
+  'locale',
+  'showName',
+  'requireName',
+  'showEmail',
+  'requireEmail',
+  'screenshot',
+  'welcome',
+  'showIssueLink',
+  'sendConsoleLogs',
+  'buttonDismissible',
+  'dismissDuration',
+  'showRestore',
+  'categoryLabels',
+]);
+
+export const RATE_FIELDS = new Set(['perIp', 'perRepo']);
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function checkUnknownFields(
+  obj: Record<string, unknown>,
+  allowed: Set<string>,
+  pathPrefix: string,
+  errors: string[]
+): void {
+  for (const field of Object.keys(obj)) {
+    if (!allowed.has(field)) {
+      errors.push(`Unknown field "${pathPrefix}${field}"`);
+    }
+  }
+}
+
+export function isValidOrigin(value: string): boolean {
+  if (value.includes('*')) return false;
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  // No paths, no query, no hash, no trailing slash beyond the origin itself.
+  if (url.pathname !== '/' && url.pathname !== '') return false;
+  if (url.search !== '' || url.hash !== '') return false;
+  if (`${url.protocol}//${url.host}` !== value) return false;
+
+  if (url.protocol === 'https:') return true;
+  if (url.protocol === 'http:' && url.hostname === 'localhost') return true;
+  return false;
+}
+
+export function validateTheme(input: unknown, errors: string[]): TenantThemeConfig | undefined {
+  if (input === undefined) return undefined;
+  if (!isPlainObject(input)) {
+    errors.push('theme must be an object');
+    return undefined;
+  }
+  checkUnknownFields(input, THEME_FIELDS, 'theme.', errors);
+
+  const theme: TenantThemeConfig = {};
+  const stringFields: Array<keyof TenantThemeConfig> = [
+    'color',
+    'bg',
+    'text',
+    'font',
+    'radius',
+    'borderWidth',
+    'borderColor',
+    'icon',
+    'label',
+  ];
+  for (const field of stringFields) {
+    const value = input[field];
+    if (value === undefined) continue;
+    if (typeof value !== 'string') {
+      errors.push(`theme.${field} must be a string`);
+      continue;
+    }
+    (theme[field] as string) = value;
+  }
+
+  if (input.shadow !== undefined) {
+    if (typeof input.shadow !== 'string' || !SHADOW_VALUES.has(input.shadow)) {
+      errors.push('theme.shadow must be one of "none", "soft", "hard"');
+    } else {
+      theme.shadow = input.shadow as TenantThemeConfig['shadow'];
+    }
+  }
+
+  if (input.position !== undefined) {
+    if (typeof input.position !== 'string' || !POSITION_VALUES.has(input.position)) {
+      errors.push('theme.position must be one of "bottom-right", "bottom-left"');
+    } else {
+      theme.position = input.position as TenantThemeConfig['position'];
+    }
+  }
+
+  if (input.mode !== undefined) {
+    if (typeof input.mode !== 'string' || !THEME_MODE_VALUES.has(input.mode)) {
+      errors.push('theme.mode must be one of "light", "dark", "auto"');
+    } else {
+      theme.mode = input.mode as TenantThemeConfig['mode'];
+    }
+  }
+
+  return theme;
+}
+
+function validateCategoryLabels(
+  input: unknown,
+  errors: string[]
+): Record<string, string | string[]> | undefined {
+  if (!isPlainObject(input)) {
+    errors.push('behavior.categoryLabels must be an object');
+    return undefined;
+  }
+  const result: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value === 'string') {
+      result[key] = value;
+    } else if (Array.isArray(value) && value.every(v => typeof v === 'string')) {
+      result[key] = value as string[];
+    } else {
+      errors.push(`behavior.categoryLabels.${key} must be a string or array of strings`);
+    }
+  }
+  return result;
+}
+
+export function validateBehavior(
+  input: unknown,
+  errors: string[]
+): TenantBehaviorConfig | undefined {
+  if (input === undefined) return undefined;
+  if (!isPlainObject(input)) {
+    errors.push('behavior must be an object');
+    return undefined;
+  }
+  checkUnknownFields(input, BEHAVIOR_FIELDS, 'behavior.', errors);
+
+  const behavior: TenantBehaviorConfig = {};
+
+  if (input.locale !== undefined) {
+    if (typeof input.locale !== 'string') {
+      errors.push('behavior.locale must be a string');
+    } else {
+      behavior.locale = input.locale;
+    }
+  }
+
+  const boolFields: Array<keyof TenantBehaviorConfig> = [
+    'showName',
+    'requireName',
+    'showEmail',
+    'requireEmail',
+    'sendConsoleLogs',
+    'buttonDismissible',
+    'showRestore',
+  ];
+  for (const field of boolFields) {
+    const value = input[field];
+    if (value === undefined) continue;
+    if (typeof value !== 'boolean') {
+      errors.push(`behavior.${field} must be a boolean`);
+      continue;
+    }
+    (behavior[field] as boolean) = value;
+  }
+
+  if (input.screenshot !== undefined) {
+    if (typeof input.screenshot !== 'string' || !SCREENSHOT_VALUES.has(input.screenshot)) {
+      errors.push('behavior.screenshot must be one of "optional", "auto", "required"');
+    } else {
+      behavior.screenshot = input.screenshot as TenantBehaviorConfig['screenshot'];
+    }
+  }
+
+  if (input.welcome !== undefined) {
+    if (typeof input.welcome !== 'string' || !WELCOME_VALUES.has(input.welcome)) {
+      errors.push('behavior.welcome must be one of "once", "always", "never"');
+    } else {
+      behavior.welcome = input.welcome as TenantBehaviorConfig['welcome'];
+    }
+  }
+
+  if (input.showIssueLink !== undefined) {
+    if (
+      typeof input.showIssueLink !== 'string' ||
+      !SHOW_ISSUE_LINK_VALUES.has(input.showIssueLink)
+    ) {
+      errors.push('behavior.showIssueLink must be one of "public", "always", "never"');
+    } else {
+      behavior.showIssueLink = input.showIssueLink as TenantBehaviorConfig['showIssueLink'];
+    }
+  }
+
+  if (input.dismissDuration !== undefined) {
+    if (
+      typeof input.dismissDuration !== 'number' ||
+      !Number.isFinite(input.dismissDuration) ||
+      input.dismissDuration <= 0
+    ) {
+      errors.push('behavior.dismissDuration must be a positive number');
+    } else {
+      behavior.dismissDuration = input.dismissDuration;
+    }
+  }
+
+  if (input.categoryLabels !== undefined) {
+    const labels = validateCategoryLabels(input.categoryLabels, errors);
+    if (labels) behavior.categoryLabels = labels;
+  }
+
+  return behavior;
+}
+
+export function validateRate(input: unknown, errors: string[]): TenantRateConfig | undefined {
+  if (input === undefined) return undefined;
+  if (!isPlainObject(input)) {
+    errors.push('rate must be an object');
+    return undefined;
+  }
+  checkUnknownFields(input, RATE_FIELDS, 'rate.', errors);
+
+  const rate: TenantRateConfig = {};
+  for (const field of ['perIp', 'perRepo'] as const) {
+    const value = input[field];
+    if (value === undefined) continue;
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+      errors.push(`rate.${field} must be a positive number`);
+      continue;
+    }
+    rate[field] = value;
+  }
+
+  return rate;
+}

--- a/src/lib/tenantStore.ts
+++ b/src/lib/tenantStore.ts
@@ -1,0 +1,85 @@
+// KV-backed tenant registry — frozen by contract docs/plans/multi-tenant-embed.md (card
+// M0-02, decision D2). Point reads use cacheTtl: 60 at the edge; writes/deletes are
+// immediate. Stored JSON is always re-validated against TenantConfig v1 on read so a
+// corrupted/legacy record fails loud instead of being trusted blindly.
+
+import { validateTenantConfig, type TenantConfig } from './tenants';
+import type { Env } from '../types';
+
+const TENANT_KEY_PREFIX = 'tenant:';
+
+function storageKey(key: string): string {
+  return `${TENANT_KEY_PREFIX}${key}`;
+}
+
+/**
+ * Reads and validates a tenant config from KV. Returns null when the key is
+ * missing, or when the stored JSON is not valid JSON or fails TenantConfig v1
+ * validation (logging the failure so a corrupted record is debuggable).
+ */
+export async function getTenant(env: Env, key: string): Promise<TenantConfig | null> {
+  const raw = await env.TENANTS.get(storageKey(key), { cacheTtl: 60 });
+  if (raw === null) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    console.error(`[tenantStore] invalid JSON stored for tenant "${key}":`, error);
+    return null;
+  }
+
+  const result = validateTenantConfig(parsed);
+  if (!result.ok) {
+    console.error(
+      `[tenantStore] stored config for tenant "${key}" failed validation:`,
+      result.errors
+    );
+    return null;
+  }
+
+  return result.value;
+}
+
+/**
+ * Writes a validated tenant config to KV. Callers are responsible for
+ * validating with `validateTenantConfig` before calling this (e.g. the admin
+ * routes), so this function trusts its input's shape.
+ */
+export async function putTenant(env: Env, tenant: TenantConfig): Promise<void> {
+  await env.TENANTS.put(storageKey(tenant.key), JSON.stringify(tenant));
+}
+
+/**
+ * Deletes a tenant config from KV. No-op if the key does not exist.
+ */
+export async function deleteTenant(env: Env, key: string): Promise<void> {
+  await env.TENANTS.delete(storageKey(key));
+}
+
+export interface TenantListEntry {
+  key: string;
+  name: string;
+}
+
+/**
+ * Lists tenants by the `tenant:` key prefix, returning only key + name (not
+ * full config) per D6's admin list surface. Skips entries that fail to parse
+ * or validate, logging each so a corrupted record doesn't break the listing.
+ */
+export async function listTenants(env: Env): Promise<TenantListEntry[]> {
+  const listed = await env.TENANTS.list({ prefix: TENANT_KEY_PREFIX });
+  const entries: TenantListEntry[] = [];
+
+  for (const item of listed.keys) {
+    const key = item.name.slice(TENANT_KEY_PREFIX.length);
+    const tenant = await getTenant(env, key);
+    if (tenant) {
+      entries.push({ key: tenant.key, name: tenant.name });
+    }
+  }
+
+  return entries;
+}

--- a/src/lib/tenantStore.ts
+++ b/src/lib/tenantStore.ts
@@ -15,9 +15,13 @@ function storageKey(key: string): string {
 /**
  * Reads and validates a tenant config from KV. Returns null when the key is
  * missing, or when the stored JSON is not valid JSON or fails TenantConfig v1
- * validation (logging the failure so a corrupted record is debuggable).
+ * validation (logging the failure so a corrupted record is debuggable). Also
+ * returns null when the TENANTS binding itself is absent (multitenant is an
+ * opt-in operator feature; see src/types.ts).
  */
 export async function getTenant(env: Env, key: string): Promise<TenantConfig | null> {
+  if (!env.TENANTS) return null;
+
   const raw = await env.TENANTS.get(storageKey(key), { cacheTtl: 60 });
   if (raw === null) {
     return null;
@@ -46,16 +50,21 @@ export async function getTenant(env: Env, key: string): Promise<TenantConfig | n
 /**
  * Writes a validated tenant config to KV. Callers are responsible for
  * validating with `validateTenantConfig` before calling this (e.g. the admin
- * routes), so this function trusts its input's shape.
+ * routes), so this function trusts its input's shape. Throws when the
+ * TENANTS binding is absent — writes must fail loud, never silently no-op.
  */
 export async function putTenant(env: Env, tenant: TenantConfig): Promise<void> {
+  if (!env.TENANTS) throw new Error('TENANTS KV binding is not configured');
   await env.TENANTS.put(storageKey(tenant.key), JSON.stringify(tenant));
 }
 
 /**
- * Deletes a tenant config from KV. No-op if the key does not exist.
+ * Deletes a tenant config from KV. No-op if the key does not exist. Throws
+ * when the TENANTS binding is absent — deletes must fail loud, never
+ * silently no-op.
  */
 export async function deleteTenant(env: Env, key: string): Promise<void> {
+  if (!env.TENANTS) throw new Error('TENANTS KV binding is not configured');
   await env.TENANTS.delete(storageKey(key));
 }
 
@@ -68,18 +77,18 @@ export interface TenantListEntry {
  * Lists tenants by the `tenant:` key prefix, returning only key + name (not
  * full config) per D6's admin list surface. Skips entries that fail to parse
  * or validate, logging each so a corrupted record doesn't break the listing.
+ * Returns an empty list when the TENANTS binding is absent. Fetches entries
+ * in parallel rather than sequentially awaiting each in a loop.
  */
 export async function listTenants(env: Env): Promise<TenantListEntry[]> {
+  if (!env.TENANTS) return [];
+
   const listed = await env.TENANTS.list({ prefix: TENANT_KEY_PREFIX });
-  const entries: TenantListEntry[] = [];
+  const tenants = await Promise.all(
+    listed.keys.map(item => getTenant(env, item.name.slice(TENANT_KEY_PREFIX.length)))
+  );
 
-  for (const item of listed.keys) {
-    const key = item.name.slice(TENANT_KEY_PREFIX.length);
-    const tenant = await getTenant(env, key);
-    if (tenant) {
-      entries.push({ key: tenant.key, name: tenant.name });
-    }
-  }
-
-  return entries;
+  return tenants
+    .filter((tenant): tenant is TenantConfig => tenant !== null)
+    .map(tenant => ({ key: tenant.key, name: tenant.name }));
 }

--- a/src/lib/tenantTypes.ts
+++ b/src/lib/tenantTypes.ts
@@ -48,8 +48,9 @@ export interface TenantConfig {
   theme?: TenantThemeConfig;
   behavior?: TenantBehaviorConfig;
   rate?: TenantRateConfig;
-  // authTokenSecretEnc intentionally omitted: not supported until M2 envelope
-  // encryption lands (D5). validateTenantConfig rejects the field explicitly.
+  // AES-256-GCM envelope (`v1.<iv>.<ciphertext>`, KEK = BUGDROP_KEK, D5/M2-01).
+  // Never contains plaintext; admin responses mask it (hasAuthTokenSecret).
+  authTokenSecretEnc?: string;
   createdAt: string; // ISO 8601
   updatedAt: string; // ISO 8601
 }

--- a/src/lib/tenantTypes.ts
+++ b/src/lib/tenantTypes.ts
@@ -1,0 +1,54 @@
+// TenantConfig v1 types — FROZEN by contract docs/plans/multi-tenant-embed.md (card M0-01).
+// Split into its own module (no logic) so both tenants.ts and tenantFieldValidators.ts
+// can depend on the shapes without forming an import cycle.
+
+export interface TenantThemeConfig {
+  color?: string; // -> data-color (sanitizeCssColor rules)
+  bg?: string; // -> data-bg
+  text?: string; // -> data-text
+  font?: string; // -> data-font
+  radius?: string; // -> data-radius
+  borderWidth?: string; // -> data-border-width
+  borderColor?: string; // -> data-border-color
+  shadow?: 'none' | 'soft' | 'hard'; // -> data-shadow
+  icon?: string; // -> data-icon (URL or "none")
+  label?: string; // -> data-label
+  position?: 'bottom-right' | 'bottom-left'; // -> data-position
+  mode?: 'light' | 'dark' | 'auto'; // -> data-theme
+}
+
+export interface TenantBehaviorConfig {
+  locale?: string; // -> data-locale
+  showName?: boolean; // -> data-show-name
+  requireName?: boolean; // -> data-require-name
+  showEmail?: boolean; // -> data-show-email
+  requireEmail?: boolean; // -> data-require-email
+  screenshot?: 'optional' | 'auto' | 'required'; // -> data-screenshot
+  welcome?: 'once' | 'always' | 'never'; // -> data-welcome
+  showIssueLink?: 'public' | 'always' | 'never'; // -> data-show-issue-link
+  sendConsoleLogs?: boolean; // -> data-send-console-logs
+  buttonDismissible?: boolean; // -> data-button-dismissible
+  dismissDuration?: number; // -> data-dismiss-duration (days)
+  showRestore?: boolean; // -> data-show-restore
+  categoryLabels?: Record<string, string | string[]>; // -> data-category-labels (JSON)
+}
+
+export interface TenantRateConfig {
+  perIp?: number; // default 20 (per 15 min window, window fixed in v1)
+  perRepo?: number; // default 50 (per 60 min window, window fixed in v1)
+}
+
+export interface TenantConfig {
+  version: 1;
+  key: string; // ^[a-z0-9](?:[a-z0-9-]{1,30}[a-z0-9])$
+  name: string; // display name, 1..100 chars
+  repo: string; // "owner/repo", same validation as data-repo today
+  origins: string[]; // exact-match web origins
+  status: 'active' | 'paused';
+  theme?: TenantThemeConfig;
+  behavior?: TenantBehaviorConfig;
+  rate?: TenantRateConfig;
+  authTokenSecretEnc?: string; // M2. AES-256-GCM envelope, base64url; see D5
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+}

--- a/src/lib/tenantTypes.ts
+++ b/src/lib/tenantTypes.ts
@@ -48,7 +48,8 @@ export interface TenantConfig {
   theme?: TenantThemeConfig;
   behavior?: TenantBehaviorConfig;
   rate?: TenantRateConfig;
-  authTokenSecretEnc?: string; // M2. AES-256-GCM envelope, base64url; see D5
+  // authTokenSecretEnc intentionally omitted: not supported until M2 envelope
+  // encryption lands (D5). validateTenantConfig rejects the field explicitly.
   createdAt: string; // ISO 8601
   updatedAt: string; // ISO 8601
 }

--- a/src/lib/tenants.ts
+++ b/src/lib/tenants.ts
@@ -1,0 +1,191 @@
+// TenantConfig v1 — FROZEN by contract docs/plans/multi-tenant-embed.md (card M0-01).
+// Any field/shape change requires amending that contract before touching this file.
+
+import {
+  checkUnknownFields,
+  isNonEmptyString,
+  isPlainObject,
+  isValidOrigin,
+  validateBehavior,
+  validateRate,
+  validateTheme,
+} from './tenantFieldValidators';
+import type { TenantConfig } from './tenantTypes';
+
+export type {
+  TenantBehaviorConfig,
+  TenantConfig,
+  TenantRateConfig,
+  TenantThemeConfig,
+} from './tenantTypes';
+
+export type ValidateTenantConfigResult =
+  | { ok: true; value: TenantConfig }
+  | { ok: false; errors: string[] };
+
+const KEY_PATTERN = /^[a-z0-9](?:[a-z0-9-]{1,30}[a-z0-9])$/;
+const REPO_PATTERN = /^[^/\s]+\/[^/\s]+$/;
+const ISO_8601_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const STATUS_VALUES = new Set(['active', 'paused']);
+
+const TOP_LEVEL_FIELDS = new Set([
+  'version',
+  'key',
+  'name',
+  'repo',
+  'origins',
+  'status',
+  'theme',
+  'behavior',
+  'rate',
+  'authTokenSecretEnc',
+  'createdAt',
+  'updatedAt',
+]);
+
+/**
+ * Validates an unknown value against the frozen TenantConfig v1 schema.
+ * Rejects unknown fields at every level (fail-loud on typos).
+ */
+export function validateTenantConfig(input: unknown): ValidateTenantConfigResult {
+  const errors: string[] = [];
+
+  if (!isPlainObject(input)) {
+    return { ok: false, errors: ['TenantConfig must be an object'] };
+  }
+
+  checkUnknownFields(input, TOP_LEVEL_FIELDS, '', errors);
+
+  if (input.version !== 1) {
+    errors.push('version must be 1');
+  }
+
+  if (!isNonEmptyString(input.key) || !KEY_PATTERN.test(input.key)) {
+    errors.push('key must match ^[a-z0-9](?:[a-z0-9-]{1,30}[a-z0-9])$');
+  }
+
+  if (!isNonEmptyString(input.name) || input.name.length > 100) {
+    errors.push('name must be a non-empty string of at most 100 characters');
+  }
+
+  if (!isNonEmptyString(input.repo) || !REPO_PATTERN.test(input.repo)) {
+    errors.push('repo must be in "owner/repo" format');
+  }
+
+  if (
+    !Array.isArray(input.origins) ||
+    input.origins.length === 0 ||
+    !input.origins.every(origin => typeof origin === 'string')
+  ) {
+    errors.push('origins must be a non-empty array of strings');
+  } else {
+    for (const origin of input.origins as string[]) {
+      if (!isValidOrigin(origin)) {
+        errors.push(
+          `origins entry "${origin}" must be an https:// origin (or http://localhost) with no path`
+        );
+      }
+    }
+  }
+
+  if (typeof input.status !== 'string' || !STATUS_VALUES.has(input.status)) {
+    errors.push('status must be "active" or "paused"');
+  }
+
+  const theme = validateTheme(input.theme, errors);
+  const behavior = validateBehavior(input.behavior, errors);
+  const rate = validateRate(input.rate, errors);
+
+  if (input.authTokenSecretEnc !== undefined && typeof input.authTokenSecretEnc !== 'string') {
+    errors.push('authTokenSecretEnc must be a string');
+  }
+
+  if (!isNonEmptyString(input.createdAt) || !ISO_8601_PATTERN.test(input.createdAt)) {
+    errors.push('createdAt must be an ISO 8601 string');
+  }
+
+  if (!isNonEmptyString(input.updatedAt) || !ISO_8601_PATTERN.test(input.updatedAt)) {
+    errors.push('updatedAt must be an ISO 8601 string');
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  const value: TenantConfig = {
+    version: 1,
+    key: input.key as string,
+    name: input.name as string,
+    repo: input.repo as string,
+    origins: input.origins as string[],
+    status: input.status as TenantConfig['status'],
+    createdAt: input.createdAt as string,
+    updatedAt: input.updatedAt as string,
+  };
+  if (theme && Object.keys(theme).length > 0) value.theme = theme;
+  if (behavior && Object.keys(behavior).length > 0) value.behavior = behavior;
+  if (rate && Object.keys(rate).length > 0) value.rate = rate;
+  if (typeof input.authTokenSecretEnc === 'string') {
+    value.authTokenSecretEnc = input.authTokenSecretEnc;
+  }
+
+  return { ok: true, value };
+}
+
+/**
+ * Maps a validated TenantConfig to the data-attribute map the loader injects
+ * into the widget core `<script>` tag (per D1). Booleans/numbers are
+ * serialized as strings exactly the way the widget already parses them.
+ */
+export function tenantToDataAttributes(tenant: TenantConfig): Record<string, string> {
+  const attrs: Record<string, string> = {
+    repo: tenant.repo,
+  };
+
+  const theme = tenant.theme;
+  if (theme) {
+    if (theme.color !== undefined) attrs.color = theme.color;
+    if (theme.bg !== undefined) attrs.bg = theme.bg;
+    if (theme.text !== undefined) attrs.text = theme.text;
+    if (theme.font !== undefined) attrs.font = theme.font;
+    if (theme.radius !== undefined) attrs.radius = theme.radius;
+    if (theme.borderWidth !== undefined) attrs['border-width'] = theme.borderWidth;
+    if (theme.borderColor !== undefined) attrs['border-color'] = theme.borderColor;
+    if (theme.shadow !== undefined) attrs.shadow = theme.shadow;
+    if (theme.icon !== undefined) attrs.icon = theme.icon;
+    if (theme.label !== undefined) attrs.label = theme.label;
+    if (theme.position !== undefined) attrs.position = theme.position;
+    if (theme.mode !== undefined) attrs.theme = theme.mode;
+  }
+
+  const behavior = tenant.behavior;
+  if (behavior) {
+    if (behavior.locale !== undefined) attrs.locale = behavior.locale;
+    if (behavior.showName !== undefined) attrs['show-name'] = String(behavior.showName);
+    if (behavior.requireName !== undefined) attrs['require-name'] = String(behavior.requireName);
+    if (behavior.showEmail !== undefined) attrs['show-email'] = String(behavior.showEmail);
+    if (behavior.requireEmail !== undefined) {
+      attrs['require-email'] = String(behavior.requireEmail);
+    }
+    if (behavior.screenshot !== undefined) attrs.screenshot = behavior.screenshot;
+    if (behavior.welcome !== undefined) attrs.welcome = behavior.welcome;
+    if (behavior.showIssueLink !== undefined) {
+      attrs['show-issue-link'] = behavior.showIssueLink;
+    }
+    if (behavior.sendConsoleLogs !== undefined) {
+      attrs['send-console-logs'] = String(behavior.sendConsoleLogs);
+    }
+    if (behavior.buttonDismissible !== undefined) {
+      attrs['button-dismissible'] = String(behavior.buttonDismissible);
+    }
+    if (behavior.dismissDuration !== undefined) {
+      attrs['dismiss-duration'] = String(behavior.dismissDuration);
+    }
+    if (behavior.showRestore !== undefined) attrs['show-restore'] = String(behavior.showRestore);
+    if (behavior.categoryLabels !== undefined) {
+      attrs['category-labels'] = JSON.stringify(behavior.categoryLabels);
+    }
+  }
+
+  return attrs;
+}

--- a/src/lib/tenants.ts
+++ b/src/lib/tenants.ts
@@ -28,6 +28,9 @@ const REPO_PATTERN = /^[^/\s]+\/[^/\s]+$/;
 const ISO_8601_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 const STATUS_VALUES = new Set(['active', 'paused']);
 
+// authTokenSecretEnc is deliberately NOT in this set: it is rejected with an
+// explicit error below (M2, D5) rather than falling into the generic
+// "Unknown field" case, so operators get a clear "not yet supported" message.
 const TOP_LEVEL_FIELDS = new Set([
   'version',
   'key',
@@ -38,7 +41,6 @@ const TOP_LEVEL_FIELDS = new Set([
   'theme',
   'behavior',
   'rate',
-  'authTokenSecretEnc',
   'createdAt',
   'updatedAt',
 ]);
@@ -54,7 +56,14 @@ export function validateTenantConfig(input: unknown): ValidateTenantConfigResult
     return { ok: false, errors: ['TenantConfig must be an object'] };
   }
 
-  checkUnknownFields(input, TOP_LEVEL_FIELDS, '', errors);
+  // Reject authTokenSecretEnc explicitly (M2, D5) before the generic unknown-field
+  // scan, so it never gets folded into a plain "Unknown field" error and its
+  // presence doesn't also trigger that generic message.
+  const { authTokenSecretEnc, ...knownShapeInput } = input;
+  if (authTokenSecretEnc !== undefined) {
+    errors.push('authTokenSecretEnc is not supported yet (M2 envelope encryption)');
+  }
+  checkUnknownFields(knownShapeInput, TOP_LEVEL_FIELDS, '', errors);
 
   if (input.version !== 1) {
     errors.push('version must be 1');
@@ -96,10 +105,6 @@ export function validateTenantConfig(input: unknown): ValidateTenantConfigResult
   const behavior = validateBehavior(input.behavior, errors);
   const rate = validateRate(input.rate, errors);
 
-  if (input.authTokenSecretEnc !== undefined && typeof input.authTokenSecretEnc !== 'string') {
-    errors.push('authTokenSecretEnc must be a string');
-  }
-
   if (!isNonEmptyString(input.createdAt) || !ISO_8601_PATTERN.test(input.createdAt)) {
     errors.push('createdAt must be an ISO 8601 string');
   }
@@ -125,9 +130,6 @@ export function validateTenantConfig(input: unknown): ValidateTenantConfigResult
   if (theme && Object.keys(theme).length > 0) value.theme = theme;
   if (behavior && Object.keys(behavior).length > 0) value.behavior = behavior;
   if (rate && Object.keys(rate).length > 0) value.rate = rate;
-  if (typeof input.authTokenSecretEnc === 'string') {
-    value.authTokenSecretEnc = input.authTokenSecretEnc;
-  }
 
   return { ok: true, value };
 }

--- a/src/lib/tenants.ts
+++ b/src/lib/tenants.ts
@@ -10,6 +10,7 @@ import {
   validateRate,
   validateTheme,
 } from './tenantFieldValidators';
+import { isEnvelope } from './envelope';
 import type { TenantConfig } from './tenantTypes';
 
 export type {
@@ -28,9 +29,6 @@ const REPO_PATTERN = /^[^/\s]+\/[^/\s]+$/;
 const ISO_8601_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 const STATUS_VALUES = new Set(['active', 'paused']);
 
-// authTokenSecretEnc is deliberately NOT in this set: it is rejected with an
-// explicit error below (M2, D5) rather than falling into the generic
-// "Unknown field" case, so operators get a clear "not yet supported" message.
 const TOP_LEVEL_FIELDS = new Set([
   'version',
   'key',
@@ -41,6 +39,7 @@ const TOP_LEVEL_FIELDS = new Set([
   'theme',
   'behavior',
   'rate',
+  'authTokenSecretEnc',
   'createdAt',
   'updatedAt',
 ]);
@@ -56,14 +55,17 @@ export function validateTenantConfig(input: unknown): ValidateTenantConfigResult
     return { ok: false, errors: ['TenantConfig must be an object'] };
   }
 
-  // Reject authTokenSecretEnc explicitly (M2, D5) before the generic unknown-field
-  // scan, so it never gets folded into a plain "Unknown field" error and its
-  // presence doesn't also trigger that generic message.
-  const { authTokenSecretEnc, ...knownShapeInput } = input;
-  if (authTokenSecretEnc !== undefined) {
-    errors.push('authTokenSecretEnc is not supported yet (M2 envelope encryption)');
+  checkUnknownFields(input, TOP_LEVEL_FIELDS, '', errors);
+
+  // D5/M2-01: only a versioned AES-GCM envelope shape is storable — a raw
+  // plaintext secret in this field would silently sit unencrypted in KV.
+  if (input.authTokenSecretEnc !== undefined) {
+    if (typeof input.authTokenSecretEnc !== 'string' || !isEnvelope(input.authTokenSecretEnc)) {
+      errors.push(
+        'authTokenSecretEnc must be a v1 AES-GCM envelope (use the write-only authTokenSecret admin field to set it)'
+      );
+    }
   }
-  checkUnknownFields(knownShapeInput, TOP_LEVEL_FIELDS, '', errors);
 
   if (input.version !== 1) {
     errors.push('version must be 1');
@@ -130,6 +132,9 @@ export function validateTenantConfig(input: unknown): ValidateTenantConfigResult
   if (theme && Object.keys(theme).length > 0) value.theme = theme;
   if (behavior && Object.keys(behavior).length > 0) value.behavior = behavior;
   if (rate && Object.keys(rate).length > 0) value.rate = rate;
+  if (input.authTokenSecretEnc !== undefined) {
+    value.authTokenSecretEnc = input.authTokenSecretEnc as string;
+  }
 
   return { ok: true, value };
 }

--- a/src/lib/timingSafeEqual.ts
+++ b/src/lib/timingSafeEqual.ts
@@ -1,0 +1,13 @@
+// Shared constant-time string comparison. Extracted from src/lib/authToken.ts so
+// other callers needing timing-safe secret comparison (e.g. admin Bearer-token
+// auth) reuse the same implementation instead of writing a new one.
+export function timingSafeEqual(left: string, right: string): boolean {
+  const leftBytes = new TextEncoder().encode(left);
+  const rightBytes = new TextEncoder().encode(right);
+  let diff = leftBytes.length ^ rightBytes.length;
+  const max = Math.max(leftBytes.length, rightBytes.length);
+  for (let index = 0; index < max; index++) {
+    diff |= (leftBytes[index] ?? 0) ^ (rightBytes[index] ?? 0);
+  }
+  return diff === 0;
+}

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -8,9 +8,13 @@ interface RateLimitConfig {
 }
 
 /**
- * Extract client IP from Cloudflare headers
+ * Extract client IP from Cloudflare headers. Exported so tenant-scoped rate limiting
+ * (src/routes/tenantApi.ts, contract docs/plans/multi-tenant-embed.md card M1-03) can
+ * reuse the same client-IP resolution without duplicating it. Generic over the Hono
+ * env so it accepts a Context typed with any Variables shape (e.g. tenantApi's), not
+ * just this file's own Bindings-only Context type.
  */
-function getClientIp(c: Context<{ Bindings: Env }>): string {
+export function getClientIp<E extends { Bindings: Env }>(c: Context<E>): string {
   return (
     c.req.header('cf-connecting-ip') ||
     c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -22,6 +22,44 @@ export function getClientIp<E extends { Bindings: Env }>(c: Context<E>): string 
   );
 }
 
+export interface FixedWindowLimitParams {
+  key: string; // base bucket key, WITHOUT the window suffix (this appends it)
+  windowMs: number;
+  maxRequests: number;
+}
+
+export interface FixedWindowLimitResult {
+  limited: boolean;
+  retryAfter: number; // seconds; always populated, even when not limited
+  remaining: number; // 0 when limited
+}
+
+/**
+ * Fixed-window counter core shared by rateLimit()/rateLimitByRepo() below and
+ * by the tenant-scoped rate limiting in src/routes/tenantApi.ts (contract
+ * docs/plans/multi-tenant-embed.md, card M1-03 / review-pass-2 FIX 6): get the
+ * current count for the window, and if under the limit, increment with a TTL
+ * matching the window. Callers own KV-unconfigured/dev-environment skips and
+ * error handling — this function assumes `kv` is present and lets KV errors
+ * propagate.
+ */
+export async function applyFixedWindowLimit(
+  kv: KVNamespace,
+  { key, windowMs, maxRequests }: FixedWindowLimitParams
+): Promise<FixedWindowLimitResult> {
+  const windowStart = Math.floor(Date.now() / windowMs);
+  const windowKey = `${key}:${windowStart}`;
+  const retryAfter = Math.ceil(windowMs / 1000);
+
+  const currentCount = parseInt((await kv.get(windowKey)) || '0', 10);
+  if (currentCount >= maxRequests) {
+    return { limited: true, retryAfter, remaining: 0 };
+  }
+
+  await kv.put(windowKey, String(currentCount + 1), { expirationTtl: retryAfter });
+  return { limited: false, retryAfter, remaining: maxRequests - currentCount - 1 };
+}
+
 /**
  * Create a rate limiting middleware for IP-based limiting
  */
@@ -37,32 +75,28 @@ export function rateLimit(config: RateLimitConfig) {
     }
 
     const clientIp = getClientIp(c);
-    const windowStart = Math.floor(Date.now() / windowMs);
-    const key = `${keyPrefix}:${clientIp}:${windowStart}`;
 
     try {
-      // Get current count
-      const currentCount = parseInt((await kv.get(key)) || '0', 10);
+      const result = await applyFixedWindowLimit(kv, {
+        key: `${keyPrefix}:${clientIp}`,
+        windowMs,
+        maxRequests,
+      });
 
-      if (currentCount >= maxRequests) {
-        const retryAfter = Math.ceil(windowMs / 1000);
+      if (result.limited) {
         return c.json(
           {
             error: 'Too many requests. Please try again later.',
-            retryAfter,
+            retryAfter: result.retryAfter,
           },
           429,
-          { 'Retry-After': String(retryAfter) }
+          { 'Retry-After': String(result.retryAfter) }
         );
       }
 
-      // Increment count with TTL
-      const ttlSeconds = Math.ceil(windowMs / 1000);
-      await kv.put(key, String(currentCount + 1), { expirationTtl: ttlSeconds });
-
       // Add rate limit headers
       c.header('X-RateLimit-Limit', String(maxRequests));
-      c.header('X-RateLimit-Remaining', String(maxRequests - currentCount - 1));
+      c.header('X-RateLimit-Remaining', String(result.remaining));
 
       return next();
     } catch (error) {
@@ -101,14 +135,13 @@ export function rateLimitByRepo(config: Omit<RateLimitConfig, 'keyPrefix'>) {
         return next(); // Will fail validation in the route handler
       }
 
-      const windowMs = config.windowMs;
-      const maxRequests = config.maxRequests;
-      const windowStart = Math.floor(Date.now() / windowMs);
-      const key = `repo:${repo}:${windowStart}`;
+      const result = await applyFixedWindowLimit(kv, {
+        key: `repo:${repo}`,
+        windowMs: config.windowMs,
+        maxRequests: config.maxRequests,
+      });
 
-      const currentCount = parseInt((await kv.get(key)) || '0', 10);
-
-      if (currentCount >= maxRequests) {
+      if (result.limited) {
         return c.json(
           {
             error:
@@ -117,10 +150,6 @@ export function rateLimitByRepo(config: Omit<RateLimitConfig, 'keyPrefix'>) {
           429
         );
       }
-
-      await kv.put(key, String(currentCount + 1), {
-        expirationTtl: Math.ceil(windowMs / 1000),
-      });
 
       return next();
     } catch {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -5,8 +5,9 @@
 
 import { Hono } from 'hono';
 import type { Env } from '../types';
+import { wrapSecret } from '../lib/envelope';
 import { deleteTenant, getTenant, listTenants, putTenant } from '../lib/tenantStore';
-import { validateTenantConfig } from '../lib/tenants';
+import { validateTenantConfig, type TenantConfig } from '../lib/tenants';
 import { isPlainObject } from '../lib/tenantFieldValidators';
 import { timingSafeEqual } from '../lib/timingSafeEqual';
 
@@ -40,7 +41,7 @@ admin.get('/tenants/:key', async c => {
   if (!tenant) {
     return c.json({ error: 'Tenant not found' }, 404);
   }
-  return c.json(tenant);
+  return c.json(maskTenant(tenant));
 });
 
 admin.post('/tenants', async c => {
@@ -54,15 +55,19 @@ admin.post('/tenants', async c => {
     return c.json({ error: 'Tenant already exists' }, 409);
   }
 
+  const record = asRecord(body.value);
+  const secretError = await absorbWriteOnlySecret(record, c.env);
+  if (secretError) return secretError;
+
   const now = new Date().toISOString();
-  const candidate = { ...asRecord(body.value), version: 1, createdAt: now, updatedAt: now };
+  const candidate = { ...record, version: 1, createdAt: now, updatedAt: now };
   const result = validateTenantConfig(candidate);
   if (!result.ok) {
     return c.json({ errors: result.errors }, 400);
   }
 
   await putTenant(c.env, result.value);
-  return c.json(result.value, 201);
+  return c.json(maskTenant(result.value), 201);
 });
 
 admin.put('/tenants/:key', async c => {
@@ -82,6 +87,19 @@ admin.put('/tenants/:key', async c => {
     return c.json({ errors: ['body key must match the :key path parameter'] }, 400);
   }
 
+  // A PUT that neither rotates (authTokenSecret) nor clears (authTokenSecret:
+  // null) the secret inherits the stored envelope — otherwise every unrelated
+  // config update would silently drop the tenant's widget-auth.
+  if (
+    record.authTokenSecret === undefined &&
+    record.authTokenSecretEnc === undefined &&
+    existing.authTokenSecretEnc !== undefined
+  ) {
+    record.authTokenSecretEnc = existing.authTokenSecretEnc;
+  }
+  const secretError = await absorbWriteOnlySecret(record, c.env);
+  if (secretError) return secretError;
+
   const candidate = {
     ...record,
     key,
@@ -95,7 +113,7 @@ admin.put('/tenants/:key', async c => {
   }
 
   await putTenant(c.env, result.value);
-  return c.json(result.value, 200);
+  return c.json(maskTenant(result.value), 200);
 });
 
 admin.delete('/tenants/:key', async c => {
@@ -111,6 +129,51 @@ admin.delete('/tenants/:key', async c => {
 
 function asRecord(value: unknown): Record<string, unknown> {
   return isPlainObject(value) ? value : {};
+}
+
+/**
+ * Consumes the write-only `authTokenSecret` field (D5/M2-01): plaintext arrives
+ * only in the request body, is wrapped with BUGDROP_KEK into
+ * `authTokenSecretEnc`, and never reaches KV, logs, or responses.
+ * `authTokenSecret: null` clears the stored envelope. Returns an error Response
+ * or null on success; mutates `record` in place.
+ */
+async function absorbWriteOnlySecret(
+  record: Record<string, unknown>,
+  env: Env
+): Promise<Response | null> {
+  if (!('authTokenSecret' in record)) return null;
+
+  const secret = record.authTokenSecret;
+  delete record.authTokenSecret;
+
+  if (secret === null) {
+    delete record.authTokenSecretEnc;
+    return null;
+  }
+  if (typeof secret !== 'string' || secret.length < 16 || secret.length > 256) {
+    return Response.json(
+      { errors: ['authTokenSecret must be a string of 16 to 256 characters (or null to clear)'] },
+      { status: 400 }
+    );
+  }
+  try {
+    record.authTokenSecretEnc = await wrapSecret(secret, env.BUGDROP_KEK);
+    return null;
+  } catch (error) {
+    // Fail-loud per D5: never store the tenant without the requested encryption.
+    console.error(
+      '[admin] cannot wrap tenant auth secret:',
+      error instanceof Error ? error.message : String(error)
+    );
+    return Response.json({ error: 'BUGDROP_KEK is not configured or invalid' }, { status: 500 });
+  }
+}
+
+/** Admin responses never expose the envelope — only whether a secret exists. */
+function maskTenant(tenant: TenantConfig): Record<string, unknown> {
+  const { authTokenSecretEnc, ...rest } = tenant;
+  return { ...rest, hasAuthTokenSecret: authTokenSecretEnc !== undefined };
 }
 
 async function parseJsonBody(

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,0 +1,126 @@
+// Tenant admin CRUD — frozen by contract docs/plans/multi-tenant-embed.md (card
+// M0-03, decision D6). Mounted at /api/admin. Bearer-token protected, no CORS
+// allowance (same-origin/curl only). Missing ADMIN_TOKEN secret fails loud (503
+// on every route) rather than silently opening the surface.
+
+import { Hono } from 'hono';
+import type { Env } from '../types';
+import { deleteTenant, getTenant, listTenants, putTenant } from '../lib/tenantStore';
+import { validateTenantConfig } from '../lib/tenants';
+import { timingSafeEqual } from '../lib/timingSafeEqual';
+
+const admin = new Hono<{ Bindings: Env }>();
+
+admin.use('*', async (c, next) => {
+  const adminToken = c.env.ADMIN_TOKEN;
+  if (!adminToken) {
+    return c.json({ error: 'Admin API is not configured' }, 503);
+  }
+
+  const authHeader = c.req.header('Authorization') ?? '';
+  const [scheme, token] = authHeader.split(' ');
+  if (scheme !== 'Bearer' || !token || !timingSafeEqual(token, adminToken)) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  return next();
+});
+
+admin.get('/tenants', async c => {
+  const entries = await listTenants(c.env);
+  return c.json({ tenants: entries });
+});
+
+admin.get('/tenants/:key', async c => {
+  const tenant = await getTenant(c.env, c.req.param('key'));
+  if (!tenant) {
+    return c.json({ error: 'Tenant not found' }, 404);
+  }
+  return c.json(tenant);
+});
+
+admin.post('/tenants', async c => {
+  const body = await parseJsonBody(c.req.raw);
+  if (!body.ok) {
+    return c.json({ errors: [body.error] }, 400);
+  }
+
+  const key = isPlainObject(body.value) ? body.value.key : undefined;
+  if (typeof key === 'string' && (await getTenant(c.env, key))) {
+    return c.json({ error: 'Tenant already exists' }, 409);
+  }
+
+  const now = new Date().toISOString();
+  const candidate = { ...asRecord(body.value), version: 1, createdAt: now, updatedAt: now };
+  const result = validateTenantConfig(candidate);
+  if (!result.ok) {
+    return c.json({ errors: result.errors }, 400);
+  }
+
+  await putTenant(c.env, result.value);
+  return c.json(result.value, 201);
+});
+
+admin.put('/tenants/:key', async c => {
+  const key = c.req.param('key');
+  const existing = await getTenant(c.env, key);
+  if (!existing) {
+    return c.json({ error: 'Tenant not found' }, 404);
+  }
+
+  const body = await parseJsonBody(c.req.raw);
+  if (!body.ok) {
+    return c.json({ errors: [body.error] }, 400);
+  }
+
+  const record = asRecord(body.value);
+  if (record.key !== undefined && record.key !== key) {
+    return c.json({ errors: ['body key must match the :key path parameter'] }, 400);
+  }
+
+  const candidate = {
+    ...record,
+    key,
+    version: 1,
+    createdAt: existing.createdAt,
+    updatedAt: new Date().toISOString(),
+  };
+  const result = validateTenantConfig(candidate);
+  if (!result.ok) {
+    return c.json({ errors: result.errors }, 400);
+  }
+
+  await putTenant(c.env, result.value);
+  return c.json(result.value, 200);
+});
+
+admin.delete('/tenants/:key', async c => {
+  const key = c.req.param('key');
+  const existing = await getTenant(c.env, key);
+  if (!existing) {
+    return c.json({ error: 'Tenant not found' }, 404);
+  }
+
+  await deleteTenant(c.env, key);
+  return c.body(null, 204);
+});
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return isPlainObject(value) ? value : {};
+}
+
+async function parseJsonBody(
+  req: Request
+): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
+  try {
+    return { ok: true, value: await req.json() };
+  } catch {
+    return { ok: false, error: 'Request body must be valid JSON' };
+  }
+}
+
+export default admin;

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -7,6 +7,7 @@ import { Hono } from 'hono';
 import type { Env } from '../types';
 import { deleteTenant, getTenant, listTenants, putTenant } from '../lib/tenantStore';
 import { validateTenantConfig } from '../lib/tenants';
+import { isPlainObject } from '../lib/tenantFieldValidators';
 import { timingSafeEqual } from '../lib/timingSafeEqual';
 
 const admin = new Hono<{ Bindings: Env }>();
@@ -15,6 +16,9 @@ admin.use('*', async (c, next) => {
   const adminToken = c.env.ADMIN_TOKEN;
   if (!adminToken) {
     return c.json({ error: 'Admin API is not configured' }, 503);
+  }
+  if (!c.env.TENANTS) {
+    return c.json({ error: 'Tenant storage is not configured' }, 503);
   }
 
   const authHeader = c.req.header('Authorization') ?? '';
@@ -104,10 +108,6 @@ admin.delete('/tenants/:key', async c => {
   await deleteTenant(c.env, key);
   return c.body(null, 204);
 });
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 function asRecord(value: unknown): Record<string, unknown> {
   return isPlainObject(value) ? value : {};

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -301,7 +301,12 @@ export async function handleFeedbackRequest(c: Context<ApiEnv>): Promise<Respons
   }
 }
 
-async function requireBugDropFeedbackAuthToken(
+/**
+ * Also reused by src/routes/tenantApi.ts so tenant-scoped feedback enforces the
+ * same globally-configured widget-auth secrets as this legacy route (contract
+ * docs/plans/multi-tenant-embed.md; per-tenant secrets arrive with D5/M2).
+ */
+export async function requireBugDropFeedbackAuthToken(
   c: Context<ApiEnv>,
   next: Next
 ): Promise<Response | void> {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -20,10 +20,10 @@ import { rateLimit, rateLimitByRepo } from '../middleware/rateLimit';
 import { resolveAccentColor } from '../defaults';
 import { verifyBugDropAuthToken } from '../lib/authToken';
 
-type ApiVariables = {
+export type ApiVariables = {
   feedbackPayload?: FeedbackPayload;
 };
-type ApiEnv = { Bindings: Env; Variables: ApiVariables };
+export type ApiEnv = { Bindings: Env; Variables: ApiVariables };
 
 const api = new Hono<ApiEnv>();
 
@@ -115,7 +115,14 @@ api.get('/health', c => {
 });
 
 // Check if app is installed on repo
-api.get('/check/:owner/:repo', async c => {
+api.get('/check/:owner/:repo', handleCheckRequest);
+
+/**
+ * Shared /check/:owner/:repo logic, reused verbatim by the tenant-scoped routes in
+ * src/routes/tenantApi.ts (contract docs/plans/multi-tenant-embed.md, card M1-03) so
+ * tenant traffic runs through the exact same installation-check behavior as legacy.
+ */
+export async function handleCheckRequest(c: Context<ApiEnv>): Promise<Response> {
   const { owner, repo } = c.req.param();
   const fullRepo = `${owner}/${repo}`;
 
@@ -131,10 +138,17 @@ api.get('/check/:owner/:repo', async c => {
     repo: fullRepo,
     appName: c.env.GITHUB_APP_NAME || undefined,
   });
-});
+}
 
 // Submit feedback
-api.post('/feedback', async c => {
+api.post('/feedback', handleFeedbackRequest);
+
+/**
+ * Shared /feedback logic, reused verbatim by the tenant-scoped routes in
+ * src/routes/tenantApi.ts (contract docs/plans/multi-tenant-embed.md, card M1-03) so
+ * tenant traffic runs through the exact same issue-creation behavior as legacy.
+ */
+export async function handleFeedbackRequest(c: Context<ApiEnv>): Promise<Response> {
   // Parse payload
   let payload: FeedbackPayload;
   try {
@@ -285,7 +299,7 @@ api.post('/feedback', async c => {
       500
     );
   }
-});
+}
 
 async function requireBugDropFeedbackAuthToken(
   c: Context<ApiEnv>,

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -326,7 +326,8 @@ export async function requireBugDropFeedbackAuthToken(
   return next();
 }
 
-function getBearerToken(value: string | undefined): string | undefined {
+/** Also reused by src/routes/tenantApi.ts for per-tenant token verification (D5). */
+export function getBearerToken(value: string | undefined): string | undefined {
   return value?.match(/^Bearer\s+(.+)$/i)?.[1];
 }
 

--- a/src/routes/loader.ts
+++ b/src/routes/loader.ts
@@ -1,0 +1,75 @@
+// Tenant loader — frozen by contract docs/plans/multi-tenant-embed.md (card M1-01,
+// decisions D1/D9/D10/D11). Serves the tiny bootstrap JS at /t/:key.js: a
+// double-injection guard, the tenant's config baked in as data-attributes (via
+// JSON.stringify — no string concatenation of raw values into JS), and a classic
+// <script> pointing at the major-pinned widget core (/widget.v1.js). Unknown or
+// paused tenants get a 200 warn-only body (D10) so the host page never sees a
+// script error.
+
+import { Hono } from 'hono';
+import type { Env } from '../types';
+import { getTenant } from '../lib/tenantStore';
+import { tenantToDataAttributes } from '../lib/tenants';
+
+const loader = new Hono<{ Bindings: Env }>();
+
+const LOADER_HEADERS = {
+  'Content-Type': 'application/javascript; charset=utf-8',
+  'Cache-Control': 'public, max-age=300',
+};
+
+loader.get('/:file{[a-z0-9-]+\\.js}', async c => {
+  const key = c.req.param('file').replace(/\.js$/, '');
+  const tenant = await getTenant(c.env, key);
+
+  if (!tenant) {
+    return c.body(warnOnlyScript(`unknown tenant key: ${key}`), 200, LOADER_HEADERS);
+  }
+
+  if (tenant.status === 'paused') {
+    return c.body(warnOnlyScript(`tenant is paused: ${key}`), 200, LOADER_HEADERS);
+  }
+
+  const attrs = tenantToDataAttributes(tenant);
+  return c.body(loaderScript(key, attrs), 200, LOADER_HEADERS);
+});
+
+/**
+ * Renders the warn-only loader body for an unknown or paused tenant (D10/D4):
+ * a single `console.warn`, no widget injected, still 200 so the host page
+ * never sees a script error.
+ */
+function warnOnlyScript(message: string): string {
+  return `(function () { console.warn(${JSON.stringify(`[BugDrop] ${message}`)}); })();`;
+}
+
+/**
+ * Renders the loader IIFE (D1): a double-injection guard keyed on the tenant
+ * key, then a classic <script src="/widget.v1.js"> carrying the tenant's
+ * config as data-* attributes plus data-tenant. Every dynamic value is
+ * embedded via JSON.stringify so it is XSS-safe by construction.
+ */
+function loaderScript(key: string, attrs: Record<string, string>): string {
+  const guardKey = `__bugdropLoaded_${key}`;
+  return [
+    '(function () {',
+    `  var GUARD = ${JSON.stringify(guardKey)};`,
+    '  if (window[GUARD]) return;',
+    '  window[GUARD] = true;',
+    `  var TENANT_KEY = ${JSON.stringify(key)};`,
+    `  var ATTRS = ${JSON.stringify(attrs)};`,
+    '  var s = document.createElement("script");',
+    '  s.src = "/widget.v1.js";',
+    '  s.async = true;',
+    '  s.setAttribute("data-tenant", TENANT_KEY);',
+    '  for (var k in ATTRS) {',
+    '    if (Object.prototype.hasOwnProperty.call(ATTRS, k)) {',
+    '      s.setAttribute("data-" + k, ATTRS[k]);',
+    '    }',
+    '  }',
+    '  document.head.appendChild(s);',
+    '})();',
+  ].join('\n');
+}
+
+export default loader;

--- a/src/routes/loader.ts
+++ b/src/routes/loader.ts
@@ -31,7 +31,10 @@ loader.get('/:file{[a-z0-9-]+\\.js}', async c => {
   }
 
   const attrs = tenantToDataAttributes(tenant);
-  return c.body(loaderScript(key, attrs), 200, LOADER_HEADERS);
+  // Absolute URL: the loader executes on the customer's origin, so a relative
+  // src would resolve against their site instead of this Worker.
+  const widgetUrl = `${new URL(c.req.url).origin}/widget.v1.js`;
+  return c.body(loaderScript(key, attrs, widgetUrl), 200, LOADER_HEADERS);
 });
 
 /**
@@ -49,7 +52,7 @@ function warnOnlyScript(message: string): string {
  * config as data-* attributes plus data-tenant. Every dynamic value is
  * embedded via JSON.stringify so it is XSS-safe by construction.
  */
-function loaderScript(key: string, attrs: Record<string, string>): string {
+function loaderScript(key: string, attrs: Record<string, string>, widgetUrl: string): string {
   const guardKey = `__bugdropLoaded_${key}`;
   return [
     '(function () {',
@@ -59,7 +62,7 @@ function loaderScript(key: string, attrs: Record<string, string>): string {
     `  var TENANT_KEY = ${JSON.stringify(key)};`,
     `  var ATTRS = ${JSON.stringify(attrs)};`,
     '  var s = document.createElement("script");',
-    '  s.src = "/widget.v1.js";',
+    `  s.src = ${JSON.stringify(widgetUrl)};`,
     '  s.async = true;',
     '  s.setAttribute("data-tenant", TENANT_KEY);',
     '  for (var k in ATTRS) {',

--- a/src/routes/loader.ts
+++ b/src/routes/loader.ts
@@ -20,6 +20,11 @@ const LOADER_HEADERS = {
 
 loader.get('/:file{[a-z0-9-]+\\.js}', async c => {
   const key = c.req.param('file').replace(/\.js$/, '');
+
+  if (!c.env.TENANTS) {
+    return c.body(warnOnlyScript('tenant storage is not configured'), 200, LOADER_HEADERS);
+  }
+
   const tenant = await getTenant(c.env, key);
 
   if (!tenant) {

--- a/src/routes/tenantApi.ts
+++ b/src/routes/tenantApi.ts
@@ -1,0 +1,189 @@
+// Per-tenant enforcement layer — contract docs/plans/multi-tenant-embed.md (card
+// M1-03, decision D4). Mounted at /api/t/:key. Resolves the tenant once per request
+// (404 unknown, 403 paused), enforces CORS against exactly `tenant.origins` (including
+// preflight; a present-but-disallowed Origin is rejected 403 outright, not just left
+// for the browser to block client-side — no-Origin requests such as curl or
+// server-to-server calls are allowed, matching legacy semantics), pins the repo to
+// `tenant.repo` (mismatch -> 400), and rate-limits with a `t:{key}:` KV prefix so
+// tenant traffic never shares a bucket with another tenant or with the legacy global
+// routes. All business logic is delegated to the exact same
+// handleCheckRequest/handleFeedbackRequest used by the legacy /api routes.
+//
+// Mount order note (verified against the installed Hono version, see
+// node_modules/hono): when two sub-apps are mounted with `app.route()` on prefixes
+// that overlap textually (`/api` and `/api/t/:key`), a wildcard `'*'` middleware
+// registered inside the FIRST-mounted sub-app also matches requests under the
+// second prefix. Mounting this router before `api` in src/index.ts keeps the legacy
+// global CORS middleware (global ALLOWED_ORIGINS) from running on tenant traffic.
+
+import { Hono, type Context, type Next } from 'hono';
+import { cors } from 'hono/cors';
+import type { Env } from '../types';
+import { getTenant } from '../lib/tenantStore';
+import type { TenantConfig } from '../lib/tenants';
+import { getClientIp } from '../middleware/rateLimit';
+import { handleCheckRequest, handleFeedbackRequest, type ApiEnv } from './api';
+
+type TenantApiVariables = { tenant: TenantConfig };
+type TenantApiEnv = { Bindings: Env; Variables: TenantApiVariables };
+
+const DEFAULT_IP_WINDOW_MS = 15 * 60 * 1000; // matches legacy /api/feedback IP window
+const DEFAULT_IP_MAX_REQUESTS = 20;
+const DEFAULT_REPO_WINDOW_MS = 60 * 60 * 1000; // matches legacy /api/feedback repo window
+const DEFAULT_REPO_MAX_REQUESTS = 50;
+
+const tenantApi = new Hono<TenantApiEnv>();
+
+// Resolve the tenant once per request; downstream middleware/handlers read it via
+// c.get('tenant'). D10's warn-only loader body is a loader-route concern only — API
+// traffic for an unknown/paused tenant gets a plain JSON error (D4).
+tenantApi.use('*', async (c, next) => {
+  const key = c.req.param('key');
+  const tenant = key ? await getTenant(c.env, key) : null;
+
+  if (!tenant) {
+    return c.json({ error: 'Unknown tenant' }, 404);
+  }
+  if (tenant.status === 'paused') {
+    return c.json({ error: 'Tenant is paused' }, 403);
+  }
+
+  c.set('tenant', tenant);
+  return next();
+});
+
+// Explicit origin allowlist enforcement (D4): a present-but-disallowed Origin is
+// rejected 403 outright, including on preflight, rather than left for the browser to
+// block client-side after a response with no CORS header. An absent Origin (curl,
+// server-to-server) is allowed through, matching legacy semantics.
+tenantApi.use('*', async (c, next) => {
+  const origin = c.req.header('Origin');
+  const tenant = c.get('tenant');
+  if (origin && !tenant.origins.includes(origin)) {
+    return c.json({ error: 'Origin not allowed for this tenant' }, 403);
+  }
+  return next();
+});
+
+// CORS headers + preflight handling for whatever Origin survived the guard above (an
+// allowed origin, or none). Every value this ever sees has already been validated
+// against tenant.origins, so it only needs to echo it back (or fall back to '*' for
+// no-Origin requests, matching the legacy /api CORS middleware's behavior).
+tenantApi.use('*', async (c, next) => {
+  const corsMiddleware = cors({
+    origin: origin => origin || '*',
+    allowMethods: ['GET', 'POST', 'OPTIONS'],
+    allowHeaders: ['Content-Type', 'Authorization'],
+  });
+  return corsMiddleware(c, next);
+});
+
+tenantApi.get('/check/:owner/:repo', async c => {
+  const tenant = c.get('tenant');
+  const { owner, repo } = c.req.param();
+  if (`${owner}/${repo}` !== tenant.repo) {
+    return c.json({ error: 'Repository does not match tenant configuration' }, 400);
+  }
+  return handleCheckRequest(asApiContext(c));
+});
+
+tenantApi.use('/feedback', requireTenantRepoMatch);
+tenantApi.use('/feedback', tenantIpRateLimit);
+tenantApi.use('/feedback', tenantRepoRateLimit);
+tenantApi.post('/feedback', async c => handleFeedbackRequest(asApiContext(c)));
+
+/**
+ * Rejects a /feedback submission whose body repo does not match tenant.repo (D4).
+ * Mirrors the clone-then-parse pattern used by the legacy
+ * requireBugDropFeedbackAuthToken middleware so the body can still be read once more
+ * downstream: on invalid JSON here, this simply lets handleFeedbackRequest return its
+ * own "Invalid JSON" response instead of failing early with an unrelated error.
+ */
+async function requireTenantRepoMatch(
+  c: Context<TenantApiEnv>,
+  next: Next
+): Promise<Response | void> {
+  const tenant = c.get('tenant');
+  try {
+    const payload = (await c.req.raw.clone().json()) as { repo?: unknown };
+    if (typeof payload.repo === 'string' && payload.repo !== tenant.repo) {
+      return c.json({ error: 'Repository does not match tenant configuration' }, 400);
+    }
+  } catch {
+    // Let handleFeedbackRequest return its own "Invalid JSON" response.
+  }
+  return next();
+}
+
+async function tenantIpRateLimit(c: Context<TenantApiEnv>, next: Next): Promise<Response | void> {
+  const tenant = c.get('tenant');
+  return enforceTenantRateLimit(c, next, {
+    windowMs: DEFAULT_IP_WINDOW_MS,
+    maxRequests: tenant.rate?.perIp ?? DEFAULT_IP_MAX_REQUESTS,
+    bucketKey: `t:${tenant.key}:ip:${getClientIp(c)}`,
+  });
+}
+
+async function tenantRepoRateLimit(c: Context<TenantApiEnv>, next: Next): Promise<Response | void> {
+  const tenant = c.get('tenant');
+  return enforceTenantRateLimit(c, next, {
+    windowMs: DEFAULT_REPO_WINDOW_MS,
+    maxRequests: tenant.rate?.perRepo ?? DEFAULT_REPO_MAX_REQUESTS,
+    bucketKey: `t:${tenant.key}:repo:${tenant.repo}`,
+  });
+}
+
+interface RateLimitBucket {
+  windowMs: number;
+  maxRequests: number;
+  bucketKey: string;
+}
+
+/**
+ * Fixed-window counter identical in shape to src/middleware/rateLimit.ts, but keyed
+ * under the tenant-scoped bucket built by the callers above (`t:{key}:...`) so tenant
+ * traffic never shares a bucket with another tenant or with the legacy global routes.
+ * Skips (allows through) when KV is unconfigured or in development, matching legacy.
+ */
+async function enforceTenantRateLimit(
+  c: Context<TenantApiEnv>,
+  next: Next,
+  { windowMs, maxRequests, bucketKey }: RateLimitBucket
+): Promise<Response | void> {
+  const kv = c.env.RATE_LIMIT;
+  if (!kv || c.env.ENVIRONMENT === 'development') return next();
+
+  const windowStart = Math.floor(Date.now() / windowMs);
+  const key = `${bucketKey}:${windowStart}`;
+
+  try {
+    const currentCount = parseInt((await kv.get(key)) || '0', 10);
+    if (currentCount >= maxRequests) {
+      const retryAfter = Math.ceil(windowMs / 1000);
+      return c.json({ error: 'Too many requests. Please try again later.', retryAfter }, 429, {
+        'Retry-After': String(retryAfter),
+      });
+    }
+
+    await kv.put(key, String(currentCount + 1), { expirationTtl: Math.ceil(windowMs / 1000) });
+    return next();
+  } catch (error) {
+    console.error('[tenantApi] rate limit KV error:', error);
+    return next();
+  }
+}
+
+/**
+ * The shared handlers are typed against api.ts's ApiEnv (Variables: { feedbackPayload
+ * }). This router's own Context carries a different Variables shape (Variables:
+ * { tenant }), and it never sets feedbackPayload — handleFeedbackRequest already
+ * falls back to re-parsing the body itself (`c.get('feedbackPayload') ??
+ * await c.req.json()`) when it is absent, so this cast changes no behavior; it only
+ * satisfies TypeScript across the two Hono apps' distinct Variables types.
+ */
+function asApiContext(c: Context<TenantApiEnv>): Context<ApiEnv> {
+  return c as unknown as Context<ApiEnv>;
+}
+
+export default tenantApi;
+export type { TenantApiEnv };

--- a/src/routes/tenantApi.ts
+++ b/src/routes/tenantApi.ts
@@ -23,11 +23,14 @@ import { getTenant } from '../lib/tenantStore';
 import type { TenantConfig } from '../lib/tenants';
 import { applyFixedWindowLimit, getClientIp } from '../middleware/rateLimit';
 import {
+  getBearerToken,
   handleCheckRequest,
   handleFeedbackRequest,
   requireBugDropFeedbackAuthToken,
   type ApiEnv,
 } from './api';
+import { verifyBugDropAuthToken } from '../lib/authToken';
+import { unwrapSecret } from '../lib/envelope';
 
 type TenantApiVariables = { tenant: TenantConfig; feedbackPayload?: FeedbackPayload };
 type TenantApiEnv = { Bindings: Env; Variables: TenantApiVariables };
@@ -101,10 +104,55 @@ tenantApi.get('/check/:owner/:repo', async c => {
 // configured (see requireTenantRepoMatch's own comment, FIX 3). The repo rate limit
 // runs last, same relative position as legacy's rateLimitByRepo.
 tenantApi.use('/feedback', tenantIpRateLimit);
-tenantApi.use('/feedback', (c, next) => requireBugDropFeedbackAuthToken(asApiContext(c), next));
+tenantApi.use('/feedback', requireTenantWidgetAuth);
 tenantApi.use('/feedback', requireTenantRepoMatch);
 tenantApi.use('/feedback', tenantRepoRateLimit);
 tenantApi.post('/feedback', async c => handleFeedbackRequest(asApiContext(c)));
+
+/**
+ * Widget-auth for tenant feedback (D5/M2-01). A tenant WITH its own secret
+ * (authTokenSecretEnc) must present a bd1. token signed with THAT secret and
+ * pinned to tenant.repo — global AUTH_TOKEN_SECRET* tokens do not apply to it.
+ * A tenant WITHOUT its own secret keeps parity with the legacy route: the
+ * globally-configured secrets are enforced when present (M1 amendment).
+ * Fail-loud per D5: an envelope that cannot be unwrapped (missing/invalid
+ * BUGDROP_KEK, corrupt envelope) is a 500, never a silent skip.
+ */
+async function requireTenantWidgetAuth(
+  c: Context<TenantApiEnv>,
+  next: Next
+): Promise<Response | void> {
+  const tenant = c.get('tenant');
+  if (!tenant.authTokenSecretEnc) {
+    return requireBugDropFeedbackAuthToken(asApiContext(c), next);
+  }
+
+  let secret: string;
+  try {
+    secret = await unwrapSecret(tenant.authTokenSecretEnc, c.env.BUGDROP_KEK);
+  } catch (error) {
+    console.error(
+      '[tenantApi] cannot unwrap tenant auth secret:',
+      error instanceof Error ? error.message : String(error)
+    );
+    return c.json({ error: 'Tenant widget auth is misconfigured' }, 500);
+  }
+
+  try {
+    await verifyBugDropAuthToken(getBearerToken(c.req.header('Authorization')), {
+      secret,
+      repo: tenant.repo,
+    });
+  } catch (error) {
+    console.warn('[tenantApi] rejected tenant auth token', {
+      tenant: tenant.key,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    return c.json({ error: 'BugDrop auth token required' }, 401);
+  }
+
+  return next();
+}
 
 /**
  * Rejects a /feedback submission whose body repo does not match tenant.repo (D4).

--- a/src/routes/tenantApi.ts
+++ b/src/routes/tenantApi.ts
@@ -22,7 +22,12 @@ import type { Env } from '../types';
 import { getTenant } from '../lib/tenantStore';
 import type { TenantConfig } from '../lib/tenants';
 import { getClientIp } from '../middleware/rateLimit';
-import { handleCheckRequest, handleFeedbackRequest, type ApiEnv } from './api';
+import {
+  handleCheckRequest,
+  handleFeedbackRequest,
+  requireBugDropFeedbackAuthToken,
+  type ApiEnv,
+} from './api';
 
 type TenantApiVariables = { tenant: TenantConfig };
 type TenantApiEnv = { Bindings: Env; Variables: TenantApiVariables };
@@ -87,6 +92,11 @@ tenantApi.get('/check/:owner/:repo', async c => {
   return handleCheckRequest(asApiContext(c));
 });
 
+// Parity with legacy /api/feedback: when the operator configures global widget-auth
+// secrets (AUTH_TOKEN_SECRET*), tenant traffic must present the same bd1. token —
+// otherwise this route would silently bypass a protection the legacy route enforces.
+// Per-tenant secrets arrive with D5/M2.
+tenantApi.use('/feedback', (c, next) => requireBugDropFeedbackAuthToken(asApiContext(c), next));
 tenantApi.use('/feedback', requireTenantRepoMatch);
 tenantApi.use('/feedback', tenantIpRateLimit);
 tenantApi.use('/feedback', tenantRepoRateLimit);

--- a/src/routes/tenantApi.ts
+++ b/src/routes/tenantApi.ts
@@ -18,10 +18,10 @@
 
 import { Hono, type Context, type Next } from 'hono';
 import { cors } from 'hono/cors';
-import type { Env } from '../types';
+import type { Env, FeedbackPayload } from '../types';
 import { getTenant } from '../lib/tenantStore';
 import type { TenantConfig } from '../lib/tenants';
-import { getClientIp } from '../middleware/rateLimit';
+import { applyFixedWindowLimit, getClientIp } from '../middleware/rateLimit';
 import {
   handleCheckRequest,
   handleFeedbackRequest,
@@ -29,7 +29,7 @@ import {
   type ApiEnv,
 } from './api';
 
-type TenantApiVariables = { tenant: TenantConfig };
+type TenantApiVariables = { tenant: TenantConfig; feedbackPayload?: FeedbackPayload };
 type TenantApiEnv = { Bindings: Env; Variables: TenantApiVariables };
 
 const DEFAULT_IP_WINDOW_MS = 15 * 60 * 1000; // matches legacy /api/feedback IP window
@@ -92,22 +92,30 @@ tenantApi.get('/check/:owner/:repo', async c => {
   return handleCheckRequest(asApiContext(c));
 });
 
-// Parity with legacy /api/feedback: when the operator configures global widget-auth
-// secrets (AUTH_TOKEN_SECRET*), tenant traffic must present the same bd1. token —
-// otherwise this route would silently bypass a protection the legacy route enforces.
-// Per-tenant secrets arrive with D5/M2.
+// Middleware order mirrors the legacy /api/feedback chain exactly (src/routes/api.ts):
+// IP rate limit -> auth -> repo rate limit. The IP limit runs FIRST, before auth, so a
+// flood of requests carrying invalid/missing bd1. tokens still consumes IP quota
+// instead of bypassing rate limiting entirely (an attacker retrying bad tokens would
+// otherwise never hit a bucket). requireTenantRepoMatch runs right after auth because
+// it needs the parsed body, which auth already parsed and cached when secrets are
+// configured (see requireTenantRepoMatch's own comment, FIX 3). The repo rate limit
+// runs last, same relative position as legacy's rateLimitByRepo.
+tenantApi.use('/feedback', tenantIpRateLimit);
 tenantApi.use('/feedback', (c, next) => requireBugDropFeedbackAuthToken(asApiContext(c), next));
 tenantApi.use('/feedback', requireTenantRepoMatch);
-tenantApi.use('/feedback', tenantIpRateLimit);
 tenantApi.use('/feedback', tenantRepoRateLimit);
 tenantApi.post('/feedback', async c => handleFeedbackRequest(asApiContext(c)));
 
 /**
  * Rejects a /feedback submission whose body repo does not match tenant.repo (D4).
- * Mirrors the clone-then-parse pattern used by the legacy
- * requireBugDropFeedbackAuthToken middleware so the body can still be read once more
- * downstream: on invalid JSON here, this simply lets handleFeedbackRequest return its
- * own "Invalid JSON" response instead of failing early with an unrelated error.
+ * Reuses the body already parsed and cached by requireBugDropFeedbackAuthToken
+ * (c.get('feedbackPayload')) when present — that middleware only sets it when
+ * widget-auth secrets are configured, in which case it already consumed the one
+ * read of a non-cloned body via c.req.raw.clone().json(). Falls back to its own
+ * clone-then-parse (mirroring the same pattern) only when that cache is absent,
+ * so the body is never parsed from the same non-cloned stream twice. On invalid
+ * JSON this simply lets handleFeedbackRequest return its own "Invalid JSON"
+ * response instead of failing early with an unrelated error.
  */
 async function requireTenantRepoMatch(
   c: Context<TenantApiEnv>,
@@ -115,7 +123,8 @@ async function requireTenantRepoMatch(
 ): Promise<Response | void> {
   const tenant = c.get('tenant');
   try {
-    const payload = (await c.req.raw.clone().json()) as { repo?: unknown };
+    const payload: { repo?: unknown } =
+      c.get('feedbackPayload') ?? ((await c.req.raw.clone().json()) as { repo?: unknown });
     if (typeof payload.repo === 'string' && payload.repo !== tenant.repo) {
       return c.json({ error: 'Repository does not match tenant configuration' }, 400);
     }
@@ -125,57 +134,69 @@ async function requireTenantRepoMatch(
   return next();
 }
 
-async function tenantIpRateLimit(c: Context<TenantApiEnv>, next: Next): Promise<Response | void> {
-  const tenant = c.get('tenant');
-  return enforceTenantRateLimit(c, next, {
-    windowMs: DEFAULT_IP_WINDOW_MS,
-    maxRequests: tenant.rate?.perIp ?? DEFAULT_IP_MAX_REQUESTS,
-    bucketKey: `t:${tenant.key}:ip:${getClientIp(c)}`,
-  });
-}
-
-async function tenantRepoRateLimit(c: Context<TenantApiEnv>, next: Next): Promise<Response | void> {
-  const tenant = c.get('tenant');
-  return enforceTenantRateLimit(c, next, {
-    windowMs: DEFAULT_REPO_WINDOW_MS,
-    maxRequests: tenant.rate?.perRepo ?? DEFAULT_REPO_MAX_REQUESTS,
-    bucketKey: `t:${tenant.key}:repo:${tenant.repo}`,
-  });
-}
-
-interface RateLimitBucket {
-  windowMs: number;
-  maxRequests: number;
-  bucketKey: string;
-}
-
 /**
- * Fixed-window counter identical in shape to src/middleware/rateLimit.ts, but keyed
- * under the tenant-scoped bucket built by the callers above (`t:{key}:...`) so tenant
- * traffic never shares a bucket with another tenant or with the legacy global routes.
- * Skips (allows through) when KV is unconfigured or in development, matching legacy.
+ * Parity with legacy /api/feedback's IP limiter (rateLimit() in
+ * src/middleware/rateLimit.ts): same window/default, same X-RateLimit-* headers on
+ * success, keyed under `t:{key}:ip:...` (review pass 2, FIX 6) so tenant traffic
+ * never shares a bucket with another tenant or the legacy global routes.
  */
-async function enforceTenantRateLimit(
-  c: Context<TenantApiEnv>,
-  next: Next,
-  { windowMs, maxRequests, bucketKey }: RateLimitBucket
-): Promise<Response | void> {
+async function tenantIpRateLimit(c: Context<TenantApiEnv>, next: Next): Promise<Response | void> {
   const kv = c.env.RATE_LIMIT;
   if (!kv || c.env.ENVIRONMENT === 'development') return next();
 
-  const windowStart = Math.floor(Date.now() / windowMs);
-  const key = `${bucketKey}:${windowStart}`;
+  const tenant = c.get('tenant');
+  const maxRequests = tenant.rate?.perIp ?? DEFAULT_IP_MAX_REQUESTS;
 
   try {
-    const currentCount = parseInt((await kv.get(key)) || '0', 10);
-    if (currentCount >= maxRequests) {
-      const retryAfter = Math.ceil(windowMs / 1000);
-      return c.json({ error: 'Too many requests. Please try again later.', retryAfter }, 429, {
-        'Retry-After': String(retryAfter),
-      });
+    const result = await applyFixedWindowLimit(kv, {
+      key: `t:${tenant.key}:ip:${getClientIp(c)}`,
+      windowMs: DEFAULT_IP_WINDOW_MS,
+      maxRequests,
+    });
+
+    if (result.limited) {
+      return c.json(
+        { error: 'Too many requests. Please try again later.', retryAfter: result.retryAfter },
+        429,
+        { 'Retry-After': String(result.retryAfter) }
+      );
     }
 
-    await kv.put(key, String(currentCount + 1), { expirationTtl: Math.ceil(windowMs / 1000) });
+    c.header('X-RateLimit-Limit', String(maxRequests));
+    c.header('X-RateLimit-Remaining', String(result.remaining));
+    return next();
+  } catch (error) {
+    console.error('[tenantApi] rate limit KV error:', error);
+    return next();
+  }
+}
+
+/**
+ * Parity with legacy /api/feedback's repo limiter (rateLimitByRepo()), keyed under
+ * `t:{key}:repo:...` (review pass 2, FIX 6) so tenant traffic never shares a bucket
+ * with another tenant or the legacy global routes.
+ */
+async function tenantRepoRateLimit(c: Context<TenantApiEnv>, next: Next): Promise<Response | void> {
+  const kv = c.env.RATE_LIMIT;
+  if (!kv || c.env.ENVIRONMENT === 'development') return next();
+
+  const tenant = c.get('tenant');
+
+  try {
+    const result = await applyFixedWindowLimit(kv, {
+      key: `t:${tenant.key}:repo:${tenant.repo}`,
+      windowMs: DEFAULT_REPO_WINDOW_MS,
+      maxRequests: tenant.rate?.perRepo ?? DEFAULT_REPO_MAX_REQUESTS,
+    });
+
+    if (result.limited) {
+      return c.json(
+        { error: 'Too many requests. Please try again later.', retryAfter: result.retryAfter },
+        429,
+        { 'Retry-After': String(result.retryAfter) }
+      );
+    }
+
     return next();
   } catch (error) {
     console.error('[tenantApi] rate limit KV error:', error);
@@ -185,11 +206,11 @@ async function enforceTenantRateLimit(
 
 /**
  * The shared handlers are typed against api.ts's ApiEnv (Variables: { feedbackPayload
- * }). This router's own Context carries a different Variables shape (Variables:
- * { tenant }), and it never sets feedbackPayload — handleFeedbackRequest already
- * falls back to re-parsing the body itself (`c.get('feedbackPayload') ??
- * await c.req.json()`) when it is absent, so this cast changes no behavior; it only
- * satisfies TypeScript across the two Hono apps' distinct Variables types.
+ * }). This router's own Context carries a superset Variables shape (Variables:
+ * { tenant, feedbackPayload }), and setting/getting feedbackPayload through either
+ * typed view reads/writes the same underlying Hono context object, so this cast
+ * changes no runtime behavior; it only satisfies TypeScript across the two Hono
+ * apps' distinct Variables types.
  */
 function asApiContext(c: Context<TenantApiEnv>): Context<ApiEnv> {
   return c as unknown as Context<ApiEnv>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface Env {
   // Bindings
   ASSETS: Fetcher;
   RATE_LIMIT?: KVNamespace; // Optional: for rate limiting (create with wrangler kv:namespace create RATE_LIMIT)
+  TENANTS: KVNamespace; // Tenant registry (create with: wrangler kv namespace create bugdrop-tenants)
 }
 
 export type FeedbackCategory = 'bug' | 'feature' | 'question';

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface Env {
   BUGDROP_BOARD_TOKEN_AUDIENCE?: string; // Optional override for board token audience
   BUGDROP_BOARD_TOKEN_ISSUER?: string; // Optional override for board token issuer
   ADMIN_TOKEN?: string; // Optional Bearer secret protecting /api/admin/* tenant CRUD
+  BUGDROP_KEK?: string; // Optional 32-byte base64 KEK wrapping per-tenant auth secrets (D5)
 
   // Bindings
   ASSETS: Fetcher;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,12 @@ export interface Env {
   // Bindings
   ASSETS: Fetcher;
   RATE_LIMIT?: KVNamespace; // Optional: for rate limiting (create with wrangler kv:namespace create RATE_LIMIT)
-  TENANTS: KVNamespace; // Tenant registry (create with: wrangler kv namespace create bugdrop-tenants)
+  // Optional: tenant registry (create with: wrangler kv namespace create bugdrop-tenants).
+  // Multitenant embed is opt-in for the operator — when this binding is absent,
+  // the multitenant feature (admin CRUD, /t/:key loader, /api/t/:key routes) is
+  // dormant: admin routes 503, the loader warn-only no-ops, tenant lookups
+  // return null/empty. Legacy /widget.js + /api are unaffected either way.
+  TENANTS?: KVNamespace;
 }
 
 export type FeedbackCategory = 'bug' | 'feature' | 'question';

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface Env {
   BUGDROP_BOARD_APP_ID?: string; // Optional hosted beta app claim for the demo board token
   BUGDROP_BOARD_TOKEN_AUDIENCE?: string; // Optional override for board token audience
   BUGDROP_BOARD_TOKEN_ISSUER?: string; // Optional override for board token issuer
+  ADMIN_TOKEN?: string; // Optional Bearer secret protecting /api/admin/* tenant CRUD
 
   // Bindings
   ASSETS: Fetcher;

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -416,9 +416,17 @@ if (rawShowIssueLink && rawShowIssueLink !== 'public' && rawShowIssueLink !== is
     `[BugDrop] Invalid data-show-issue-link "${rawShowIssueLink}". Expected "public", "always", or "never".`
   );
 }
+const rawTenant = script?.dataset.tenant;
+const tenantKey = rawTenant && /^[a-z0-9-]{3,32}$/.test(rawTenant) ? rawTenant : undefined;
+if (rawTenant && !tenantKey) {
+  console.warn(
+    `[BugDrop] Invalid data-tenant "${rawTenant}". Expected 3-32 chars of lowercase letters, digits, or hyphens.`
+  );
+}
+const baseApiUrl = script?.src.replace(/\/widget(?:\.v[\d.]+)?\.js$/, '/api') || '';
 const config: WidgetConfig = {
   repo: script?.dataset.repo || '',
-  apiUrl: script?.src.replace(/\/widget(?:\.v[\d.]+)?\.js$/, '/api') || '',
+  apiUrl: baseApiUrl && tenantKey ? `${baseApiUrl}/t/${tenantKey}` : baseApiUrl,
   authTokenProvider: resolveAuthTokenProvider(script?.dataset.authTokenProvider),
   position: rawPosition === 'bottom-left' ? 'bottom-left' : 'bottom-right',
   theme: isValidTheme(rawTheme) ? rawTheme : 'auto', // Default to auto-detection

--- a/test/admin.test.ts
+++ b/test/admin.test.ts
@@ -221,4 +221,86 @@ describe('admin routes', () => {
       expect(res.status).toBe(400);
     });
   });
+
+  describe('write-only authTokenSecret (D5/M2-01)', () => {
+    const KEK = Buffer.alloc(32, 3).toString('base64');
+
+    it('wraps the plaintext into an envelope, stores it, and masks responses', async () => {
+      const kekEnv = { ...env, BUGDROP_KEK: KEK } as Env;
+      const res = await admin.fetch(
+        req('/tenants', {
+          method: 'POST',
+          body: JSON.stringify(validTenantInput({ authTokenSecret: 'my-plaintext-widget-secret' })),
+        }),
+        kekEnv
+      );
+      expect(res.status).toBe(201);
+      const created = (await res.json()) as Record<string, unknown>;
+      expect(created.hasAuthTokenSecret).toBe(true);
+      expect(created.authTokenSecretEnc).toBeUndefined();
+      expect(JSON.stringify(created)).not.toContain('my-plaintext-widget-secret');
+
+      const stored = JSON.parse(store.get('tenant:acme') ?? '{}') as Record<string, unknown>;
+      expect(String(stored.authTokenSecretEnc)).toMatch(/^v1\./);
+      expect(JSON.stringify(stored)).not.toContain('my-plaintext-widget-secret');
+    });
+
+    it('fails loud with 500 when BUGDROP_KEK is missing', async () => {
+      const res = await admin.fetch(
+        req('/tenants', {
+          method: 'POST',
+          body: JSON.stringify(validTenantInput({ authTokenSecret: 'my-plaintext-widget-secret' })),
+        }),
+        env
+      );
+      expect(res.status).toBe(500);
+      expect(store.has('tenant:acme')).toBe(false);
+    });
+
+    it('rejects a too-short secret with 400', async () => {
+      const kekEnv = { ...env, BUGDROP_KEK: KEK } as Env;
+      const res = await admin.fetch(
+        req('/tenants', {
+          method: 'POST',
+          body: JSON.stringify(validTenantInput({ authTokenSecret: 'short' })),
+        }),
+        kekEnv
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('PUT without the secret fields inherits the stored envelope; null clears it', async () => {
+      const kekEnv = { ...env, BUGDROP_KEK: KEK } as Env;
+      await admin.fetch(
+        req('/tenants', {
+          method: 'POST',
+          body: JSON.stringify(validTenantInput({ authTokenSecret: 'my-plaintext-widget-secret' })),
+        }),
+        kekEnv
+      );
+
+      const update = await admin.fetch(
+        req('/tenants/acme', {
+          method: 'PUT',
+          body: JSON.stringify(validTenantInput({ name: 'Renamed' })),
+        }),
+        kekEnv
+      );
+      expect(update.status).toBe(200);
+      let stored = JSON.parse(store.get('tenant:acme') ?? '{}') as Record<string, unknown>;
+      expect(String(stored.authTokenSecretEnc)).toMatch(/^v1\./);
+
+      const clear = await admin.fetch(
+        req('/tenants/acme', {
+          method: 'PUT',
+          body: JSON.stringify(validTenantInput({ authTokenSecret: null })),
+        }),
+        kekEnv
+      );
+      expect(clear.status).toBe(200);
+      stored = JSON.parse(store.get('tenant:acme') ?? '{}') as Record<string, unknown>;
+      expect(stored.authTokenSecretEnc).toBeUndefined();
+      expect((await clear.json()).hasAuthTokenSecret).toBe(false);
+    });
+  });
 });

--- a/test/admin.test.ts
+++ b/test/admin.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import admin from '../src/routes/admin';
+import type { Env } from '../src/types';
+import type { TenantConfig } from '../src/lib/tenants';
+
+function validTenantInput(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    key: 'acme',
+    name: 'Acme Corp',
+    repo: 'acme/widget',
+    origins: ['https://app.acme.com'],
+    status: 'active',
+    ...overrides,
+  };
+}
+
+function storedTenant(overrides: Partial<TenantConfig> = {}): TenantConfig {
+  return {
+    version: 1,
+    key: 'acme',
+    name: 'Acme Corp',
+    repo: 'acme/widget',
+    origins: ['https://app.acme.com'],
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('admin routes', () => {
+  let mockKv: {
+    get: (key: string) => Promise<string | null>;
+    put: (key: string, value: string) => Promise<void>;
+    delete: (key: string) => Promise<void>;
+    list: (opts: { prefix: string }) => Promise<{
+      keys: { name: string }[];
+      list_complete: boolean;
+      cursor: string;
+    }>;
+  };
+  let store: Map<string, string>;
+  let env: Env;
+
+  beforeEach(() => {
+    store = new Map();
+    mockKv = {
+      get: async key => store.get(key) ?? null,
+      put: async (key, value) => {
+        store.set(key, value);
+      },
+      delete: async key => {
+        store.delete(key);
+      },
+      list: async ({ prefix }) => ({
+        keys: [...store.keys()].filter(k => k.startsWith(prefix)).map(name => ({ name })),
+        list_complete: true,
+        cursor: '',
+      }),
+    };
+    env = {
+      TENANTS: mockKv as unknown as KVNamespace,
+      GITHUB_APP_ID: 'test',
+      GITHUB_PRIVATE_KEY: 'test',
+      ENVIRONMENT: 'test',
+      ALLOWED_ORIGINS: '*',
+      GITHUB_APP_NAME: 'test',
+      MAX_SCREENSHOT_SIZE_MB: '5',
+      ASSETS: {} as Fetcher,
+      ADMIN_TOKEN: 'super-secret-admin-token',
+    } as Env;
+  });
+
+  function req(
+    path: string,
+    init: RequestInit = {},
+    token: string | null | undefined = env.ADMIN_TOKEN
+  ): Request {
+    const headers = new Headers(init.headers);
+    if (token) headers.set('Authorization', `Bearer ${token}`);
+    if (init.body) headers.set('Content-Type', 'application/json');
+    return new Request(`http://localhost${path}`, { ...init, headers });
+  }
+
+  describe('authz', () => {
+    it('returns 503 on every route when ADMIN_TOKEN is not configured', async () => {
+      const noTokenEnv = { ...env, ADMIN_TOKEN: undefined };
+      const res = await admin.fetch(req('/tenants', {}, null), noTokenEnv);
+      expect(res.status).toBe(503);
+    });
+
+    it('returns 401 when no Authorization header is sent', async () => {
+      const res = await admin.fetch(req('/tenants', {}, null), env);
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 when the token is wrong', async () => {
+      const res = await admin.fetch(req('/tenants', {}, 'wrong-token'), env);
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 200 when the token is correct', async () => {
+      const res = await admin.fetch(req('/tenants'), env);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('CRUD round-trip', () => {
+    it('creates, reads, updates, lists and deletes a tenant', async () => {
+      const createRes = await admin.fetch(
+        req('/tenants', { method: 'POST', body: JSON.stringify(validTenantInput()) }),
+        env
+      );
+      expect(createRes.status).toBe(201);
+      const created = (await createRes.json()) as TenantConfig;
+      expect(created.key).toBe('acme');
+      expect(created.version).toBe(1);
+      expect(created.createdAt).toBeTruthy();
+      expect(created.updatedAt).toBe(created.createdAt);
+
+      const getRes = await admin.fetch(req('/tenants/acme'), env);
+      expect(getRes.status).toBe(200);
+      expect(await getRes.json()).toEqual(created);
+
+      const listRes = await admin.fetch(req('/tenants'), env);
+      expect(listRes.status).toBe(200);
+      expect(await listRes.json()).toEqual({ tenants: [{ key: 'acme', name: 'Acme Corp' }] });
+
+      const putRes = await admin.fetch(
+        req('/tenants/acme', {
+          method: 'PUT',
+          body: JSON.stringify(validTenantInput({ name: 'Acme Corp Updated' })),
+        }),
+        env
+      );
+      expect(putRes.status).toBe(200);
+      const updated = (await putRes.json()) as TenantConfig;
+      expect(updated.name).toBe('Acme Corp Updated');
+      expect(updated.createdAt).toBe(created.createdAt);
+
+      const deleteRes = await admin.fetch(req('/tenants/acme', { method: 'DELETE' }), env);
+      expect(deleteRes.status).toBe(204);
+
+      const getAfterDeleteRes = await admin.fetch(req('/tenants/acme'), env);
+      expect(getAfterDeleteRes.status).toBe(404);
+    });
+
+    it('returns 404 for GET on an unknown tenant', async () => {
+      const res = await admin.fetch(req('/tenants/ghost'), env);
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for PUT on an unknown tenant', async () => {
+      const res = await admin.fetch(
+        req('/tenants/ghost', { method: 'PUT', body: JSON.stringify(validTenantInput()) }),
+        env
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for DELETE on an unknown tenant', async () => {
+      const res = await admin.fetch(req('/tenants/ghost', { method: 'DELETE' }), env);
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 409 when creating a tenant whose key already exists', async () => {
+      await store.set('tenant:acme', JSON.stringify(storedTenant()));
+
+      const res = await admin.fetch(
+        req('/tenants', { method: 'POST', body: JSON.stringify(validTenantInput()) }),
+        env
+      );
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe('validation errors', () => {
+    it('returns 400 with errors for an invalid POST body', async () => {
+      const res = await admin.fetch(
+        req('/tenants', { method: 'POST', body: JSON.stringify({ key: 'acme' }) }),
+        env
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { errors: string[] };
+      expect(body.errors.length).toBeGreaterThan(0);
+    });
+
+    it('returns 400 for malformed JSON', async () => {
+      const res = await admin.fetch(req('/tenants', { method: 'POST', body: '{not json' }), env);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when PUT body key does not match the path key', async () => {
+      store.set('tenant:acme', JSON.stringify(storedTenant()));
+
+      const res = await admin.fetch(
+        req('/tenants/acme', {
+          method: 'PUT',
+          body: JSON.stringify(validTenantInput({ key: 'other' })),
+        }),
+        env
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects unknown fields', async () => {
+      const res = await admin.fetch(
+        req('/tenants', {
+          method: 'POST',
+          body: JSON.stringify(validTenantInput({ notARealField: true })),
+        }),
+        env
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/test/admin.test.ts
+++ b/test/admin.test.ts
@@ -103,6 +103,13 @@ describe('admin routes', () => {
       const res = await admin.fetch(req('/tenants'), env);
       expect(res.status).toBe(200);
     });
+
+    it('returns 503 when the TENANTS binding is not configured (FIX 4)', async () => {
+      const { TENANTS: _unused, ...envWithoutTenants } = env;
+      const res = await admin.fetch(req('/tenants'), envWithoutTenants as Env);
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: 'Tenant storage is not configured' });
+    });
   });
 
   describe('CRUD round-trip', () => {

--- a/test/adminMountIsolation.test.ts
+++ b/test/adminMountIsolation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import app from '../src/index';
+import type { Env } from '../src/types';
+
+// Regression coverage for review-pass-2 FIX 1: admin must be mounted before the
+// legacy api router so api's global wildcard '*' CORS middleware (which honors
+// ALLOWED_ORIGINS, including "*") never applies to /api/admin traffic (D6: admin
+// has no CORS allowance at all, same-origin/curl only).
+describe('admin mount isolation from global CORS (FIX 1)', () => {
+  let store: Map<string, string>;
+  let env: Env;
+
+  beforeEach(() => {
+    store = new Map();
+    const mockKv = {
+      get: async (key: string) => store.get(key) ?? null,
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+      delete: async (key: string) => {
+        store.delete(key);
+      },
+      list: async ({ prefix }: { prefix: string }) => ({
+        keys: [...store.keys()].filter(k => k.startsWith(prefix)).map(name => ({ name })),
+        list_complete: true,
+        cursor: '',
+      }),
+    };
+    env = {
+      TENANTS: mockKv as unknown as KVNamespace,
+      GITHUB_APP_ID: 'test',
+      GITHUB_PRIVATE_KEY: 'test',
+      ENVIRONMENT: 'test',
+      ALLOWED_ORIGINS: '*',
+      GITHUB_APP_NAME: 'test',
+      MAX_SCREENSHOT_SIZE_MB: '5',
+      ASSETS: {} as Fetcher,
+      ADMIN_TOKEN: 'super-secret-admin-token',
+    } as Env;
+  });
+
+  it('never sends Access-Control-Allow-Origin for admin traffic, even with a hostile Origin and ALLOWED_ORIGINS "*"', async () => {
+    const req = new Request('http://localhost/api/admin/tenants', {
+      headers: { Origin: 'https://evil.example' },
+    });
+    const res = await app.fetch(req, env);
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    expect([401, 503]).toContain(res.status);
+  });
+
+  it('returns 200 with no CORS header for a correctly authorized admin request', async () => {
+    const req = new Request('http://localhost/api/admin/tenants', {
+      headers: {
+        Origin: 'https://evil.example',
+        Authorization: `Bearer ${env.ADMIN_TOKEN}`,
+      },
+    });
+    const res = await app.fetch(req, env);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+  });
+});

--- a/test/envelope.test.ts
+++ b/test/envelope.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { isEnvelope, unwrapSecret, wrapSecret } from '../src/lib/envelope';
+
+// 32 zero bytes, base64 — deterministic test KEK, never a real one.
+const KEK = Buffer.alloc(32, 0).toString('base64');
+const OTHER_KEK = Buffer.alloc(32, 7).toString('base64');
+
+describe('secret envelope (D5/M2-01)', () => {
+  it('round-trips a secret through wrap/unwrap', async () => {
+    const envelope = await wrapSecret('super-secret-value', KEK);
+    expect(isEnvelope(envelope)).toBe(true);
+    expect(envelope.startsWith('v1.')).toBe(true);
+    expect(envelope).not.toContain('super-secret-value');
+    expect(await unwrapSecret(envelope, KEK)).toBe('super-secret-value');
+  });
+
+  it('produces a distinct envelope per wrap (random IV)', async () => {
+    const a = await wrapSecret('same-plaintext-here', KEK);
+    const b = await wrapSecret('same-plaintext-here', KEK);
+    expect(a).not.toBe(b);
+  });
+
+  it('accepts a base64url KEK too', async () => {
+    const urlSafe = KEK.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const envelope = await wrapSecret('secret', urlSafe);
+    expect(await unwrapSecret(envelope, KEK)).toBe('secret');
+  });
+
+  it('fails loud when the KEK is missing', async () => {
+    await expect(wrapSecret('secret', undefined)).rejects.toThrow('BUGDROP_KEK is not configured');
+    await expect(unwrapSecret('v1.aaaa.bbbb', undefined)).rejects.toThrow(
+      'BUGDROP_KEK is not configured'
+    );
+  });
+
+  it('fails loud when the KEK has the wrong length', async () => {
+    const short = Buffer.alloc(16, 0).toString('base64');
+    await expect(wrapSecret('secret', short)).rejects.toThrow('must decode to 32 bytes');
+  });
+
+  it('rejects a malformed envelope', async () => {
+    await expect(unwrapSecret('not-an-envelope', KEK)).rejects.toThrow('Malformed secret envelope');
+    await expect(unwrapSecret('v2.aaaa.bbbb', KEK)).rejects.toThrow('Malformed secret envelope');
+  });
+
+  it('rejects an envelope wrapped with a different KEK', async () => {
+    const envelope = await wrapSecret('secret', KEK);
+    await expect(unwrapSecret(envelope, OTHER_KEK)).rejects.toThrow();
+  });
+
+  it('isEnvelope matches only the v1 shape', () => {
+    expect(isEnvelope('v1.abc-_123.def-_456')).toBe(true);
+    expect(isEnvelope('v1.only-one-part')).toBe(false);
+    expect(isEnvelope('plaintext')).toBe(false);
+    expect(isEnvelope('v1.has.three.parts')).toBe(false);
+  });
+});

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import loader from '../src/routes/loader';
+import { tenantToDataAttributes, type TenantConfig } from '../src/lib/tenants';
+import type { Env } from '../src/types';
+
+function storedTenant(overrides: Partial<TenantConfig> = {}): TenantConfig {
+  return {
+    version: 1,
+    key: 'acme',
+    name: 'Acme Corp',
+    repo: 'acme/widget',
+    origins: ['https://app.acme.com'],
+    status: 'active',
+    theme: { color: '#111827', position: 'bottom-left' },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('loader route', () => {
+  let store: Map<string, string>;
+  let env: Env;
+
+  beforeEach(() => {
+    store = new Map();
+    const mockKv = {
+      get: async (key: string) => store.get(key) ?? null,
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+      delete: async (key: string) => {
+        store.delete(key);
+      },
+      list: async ({ prefix }: { prefix: string }) => ({
+        keys: [...store.keys()].filter(k => k.startsWith(prefix)).map(name => ({ name })),
+        list_complete: true,
+        cursor: '',
+      }),
+    };
+    env = {
+      TENANTS: mockKv as unknown as KVNamespace,
+      GITHUB_APP_ID: 'test',
+      GITHUB_PRIVATE_KEY: 'test',
+      ENVIRONMENT: 'test',
+      ALLOWED_ORIGINS: '*',
+      GITHUB_APP_NAME: 'test',
+      MAX_SCREENSHOT_SIZE_MB: '5',
+      ASSETS: {} as Fetcher,
+    } as Env;
+  });
+
+  async function putTenant(tenant: TenantConfig): Promise<void> {
+    store.set(`tenant:${tenant.key}`, JSON.stringify(tenant));
+  }
+
+  function req(path: string): Request {
+    return new Request(`http://localhost${path}`);
+  }
+
+  it('serves the correct headers (D9)', async () => {
+    await putTenant(storedTenant());
+    const res = await loader.fetch(req('/acme.js'), env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/javascript; charset=utf-8');
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=300');
+  });
+
+  it('includes a double-injection guard keyed on the tenant key', async () => {
+    await putTenant(storedTenant());
+    const body = await (await loader.fetch(req('/acme.js'), env)).text();
+    expect(body).toContain('__bugdropLoaded_acme');
+    expect(body).toContain('if (window[GUARD]) return;');
+    expect(body).toContain('window[GUARD] = true;');
+  });
+
+  it('points the injected script at /widget.v1.js with data-tenant', async () => {
+    await putTenant(storedTenant());
+    const body = await (await loader.fetch(req('/acme.js'), env)).text();
+    expect(body).toContain('s.src = "/widget.v1.js";');
+    expect(body).toContain('s.setAttribute("data-tenant", TENANT_KEY);');
+    expect(body).toContain('var TENANT_KEY = "acme";');
+  });
+
+  it('embeds an attribute map matching tenantToDataAttributes, via JSON.stringify', async () => {
+    const tenant = storedTenant();
+    await putTenant(tenant);
+    const body = await (await loader.fetch(req('/acme.js'), env)).text();
+    const expectedAttrs = tenantToDataAttributes(tenant);
+    expect(body).toContain(`var ATTRS = ${JSON.stringify(expectedAttrs)};`);
+  });
+
+  it('returns a 200 warn-only body for an unknown tenant (D10)', async () => {
+    const res = await loader.fetch(req('/ghost.js'), env);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('console.warn(');
+    expect(body).toContain('unknown tenant key: ghost');
+    expect(body).not.toContain('widget.v1.js');
+  });
+
+  it('returns a 200 warn-only body for a paused tenant (D4/D10)', async () => {
+    await putTenant(storedTenant({ status: 'paused' }));
+    const res = await loader.fetch(req('/acme.js'), env);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('console.warn(');
+    expect(body).toContain('tenant is paused: acme');
+    expect(body).not.toContain('widget.v1.js');
+  });
+
+  it('still applies the loader headers on unknown/paused responses', async () => {
+    const res = await loader.fetch(req('/ghost.js'), env);
+    expect(res.headers.get('Content-Type')).toBe('application/javascript; charset=utf-8');
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=300');
+  });
+});

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -74,10 +74,12 @@ describe('loader route', () => {
     expect(body).toContain('window[GUARD] = true;');
   });
 
-  it('points the injected script at /widget.v1.js with data-tenant', async () => {
+  it('points the injected script at the absolute widget URL with data-tenant', async () => {
     await putTenant(storedTenant());
     const body = await (await loader.fetch(req('/acme.js'), env)).text();
-    expect(body).toContain('s.src = "/widget.v1.js";');
+    // Absolute, on the Worker's own origin: the loader runs on the customer's
+    // page, where a relative src would resolve against their domain.
+    expect(body).toContain('s.src = "http://localhost/widget.v1.js";');
     expect(body).toContain('s.setAttribute("data-tenant", TENANT_KEY);');
     expect(body).toContain('var TENANT_KEY = "acme";');
   });

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -116,4 +116,16 @@ describe('loader route', () => {
     expect(res.headers.get('Content-Type')).toBe('application/javascript; charset=utf-8');
     expect(res.headers.get('Cache-Control')).toBe('public, max-age=300');
   });
+
+  it('returns a 200 warn-only body when the TENANTS binding is not configured (FIX 4)', async () => {
+    await putTenant(storedTenant());
+    const { TENANTS: _unused, ...envWithoutTenants } = env;
+    const res = await loader.fetch(req('/acme.js'), envWithoutTenants as Env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/javascript; charset=utf-8');
+    const body = await res.text();
+    expect(body).toContain('console.warn(');
+    expect(body).toContain('tenant storage is not configured');
+    expect(body).not.toContain('widget.v1.js');
+  });
 });

--- a/test/tenantApi.test.ts
+++ b/test/tenantApi.test.ts
@@ -1,0 +1,364 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { Env } from '../src/types';
+import type { TenantConfig } from '../src/lib/tenants';
+
+// Mock GitHub API functions the same way test/api.test.ts does, so
+// handleCheckRequest/handleFeedbackRequest (reused verbatim from src/routes/api.ts)
+// exercise this test's fakes instead of hitting the network.
+const mockGetInstallationToken = vi.fn();
+const mockCreateIssue = vi.fn();
+const mockUploadScreenshotAsAsset = vi.fn();
+const mockUploadAttachmentAsAsset = vi.fn();
+const mockIsRepoPublic = vi.fn();
+
+vi.mock('../src/lib/github', () => ({
+  getInstallationToken: (...args: unknown[]) => mockGetInstallationToken(...args),
+  createIssue: (...args: unknown[]) => mockCreateIssue(...args),
+  uploadScreenshotAsAsset: (...args: unknown[]) => mockUploadScreenshotAsAsset(...args),
+  uploadAttachmentAsAsset: (...args: unknown[]) => mockUploadAttachmentAsAsset(...args),
+  isRepoPublic: (...args: unknown[]) => mockIsRepoPublic(...args),
+  GitHubLabelError: class extends Error {},
+}));
+
+function storedTenant(overrides: Partial<TenantConfig> = {}): TenantConfig {
+  return {
+    version: 1,
+    key: 'acme',
+    name: 'Acme Corp',
+    repo: 'acme/widget',
+    origins: ['https://app.acme.com'],
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('tenant API routes', () => {
+  let tenantStore: Map<string, string>;
+  let rateLimitStore: Map<string, string>;
+  let env: Env;
+  let app: Hono;
+
+  beforeEach(async () => {
+    mockGetInstallationToken.mockReset();
+    mockCreateIssue.mockReset();
+    mockUploadScreenshotAsAsset.mockReset();
+    mockUploadAttachmentAsAsset.mockReset();
+    mockIsRepoPublic.mockReset();
+    mockGetInstallationToken.mockResolvedValue('test-token');
+    mockCreateIssue.mockResolvedValue({
+      number: 42,
+      html_url: 'https://github.com/acme/widget/issues/42',
+    });
+    mockIsRepoPublic.mockResolvedValue(true);
+
+    tenantStore = new Map();
+    rateLimitStore = new Map();
+
+    const tenantsKv = {
+      get: async (key: string) => tenantStore.get(key) ?? null,
+      put: async (key: string, value: string) => {
+        tenantStore.set(key, value);
+      },
+      delete: async (key: string) => {
+        tenantStore.delete(key);
+      },
+      list: async ({ prefix }: { prefix: string }) => ({
+        keys: [...tenantStore.keys()].filter(k => k.startsWith(prefix)).map(name => ({ name })),
+        list_complete: true,
+        cursor: '',
+      }),
+    };
+
+    const rateLimitKv = {
+      get: async (key: string) => rateLimitStore.get(key) ?? null,
+      put: async (key: string, value: string) => {
+        rateLimitStore.set(key, value);
+      },
+    };
+
+    env = {
+      TENANTS: tenantsKv as unknown as KVNamespace,
+      RATE_LIMIT: rateLimitKv as unknown as KVNamespace,
+      GITHUB_APP_ID: 'test',
+      GITHUB_PRIVATE_KEY: 'test',
+      ENVIRONMENT: 'test',
+      ALLOWED_ORIGINS: '*',
+      GITHUB_APP_NAME: 'test',
+      MAX_SCREENSHOT_SIZE_MB: '5',
+      ASSETS: {} as Fetcher,
+    } as Env;
+
+    // Mirrors the production mount shape (src/index.ts): tenantApi's own routes
+    // don't include :key, it comes from the mount prefix.
+    const { default: tenantApi } = await import('../src/routes/tenantApi');
+    app = new Hono();
+    app.route('/api/t/:key', tenantApi);
+  });
+
+  async function putTenant(tenant: TenantConfig): Promise<void> {
+    tenantStore.set(`tenant:${tenant.key}`, JSON.stringify(tenant));
+  }
+
+  describe('tenant resolution', () => {
+    it('returns 404 for an unknown tenant key', async () => {
+      const res = await app.fetch(
+        new Request('http://localhost/api/t/ghost/check/acme/widget'),
+        env
+      );
+      const data = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(data).toEqual({ error: 'Unknown tenant' });
+    });
+
+    it('returns 403 for a paused tenant', async () => {
+      await putTenant(storedTenant({ status: 'paused' }));
+      const res = await app.fetch(
+        new Request('http://localhost/api/t/acme/check/acme/widget'),
+        env
+      );
+      const data = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(data).toEqual({ error: 'Tenant is paused' });
+    });
+  });
+
+  describe('origin enforcement (D4)', () => {
+    it('allows a request whose Origin is in tenant.origins', async () => {
+      await putTenant(storedTenant());
+      const req = new Request('http://localhost/api/t/acme/check/acme/widget', {
+        headers: { Origin: 'https://app.acme.com' },
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('access-control-allow-origin')).toBe('https://app.acme.com');
+    });
+
+    it('rejects a request whose Origin is not in tenant.origins with 403', async () => {
+      await putTenant(storedTenant());
+      const req = new Request('http://localhost/api/t/acme/check/acme/widget', {
+        headers: { Origin: 'https://evil.example.com' },
+      });
+      const res = await app.fetch(req, env);
+      const data = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(data).toEqual({ error: 'Origin not allowed for this tenant' });
+      expect(mockGetInstallationToken).not.toHaveBeenCalled();
+    });
+
+    it("rejects a request using a DIFFERENT tenant's valid origin (cross-tenant spoof)", async () => {
+      await putTenant(storedTenant({ key: 'acme', origins: ['https://app.acme.com'] }));
+      await putTenant(
+        storedTenant({ key: 'other', repo: 'other/widget', origins: ['https://app.other.com'] })
+      );
+
+      const req = new Request('http://localhost/api/t/acme/check/acme/widget', {
+        headers: { Origin: 'https://app.other.com' },
+      });
+      const res = await app.fetch(req, env);
+      const data = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(data).toEqual({ error: 'Origin not allowed for this tenant' });
+    });
+
+    it('allows a request with no Origin header (curl, server-to-server)', async () => {
+      await putTenant(storedTenant());
+      const req = new Request('http://localhost/api/t/acme/check/acme/widget');
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('handles a CORS preflight for an allowed origin', async () => {
+      await putTenant(storedTenant());
+      const req = new Request('http://localhost/api/t/acme/feedback', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://app.acme.com',
+          'Access-Control-Request-Method': 'POST',
+        },
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(204);
+      expect(res.headers.get('access-control-allow-origin')).toBe('https://app.acme.com');
+      expect(res.headers.get('access-control-allow-methods')).toContain('POST');
+    });
+
+    it('rejects a CORS preflight for a disallowed origin with 403', async () => {
+      await putTenant(storedTenant());
+      const req = new Request('http://localhost/api/t/acme/feedback', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://evil.example.com',
+          'Access-Control-Request-Method': 'POST',
+        },
+      });
+      const res = await app.fetch(req, env);
+
+      expect(res.status).toBe(403);
+      expect(res.headers.get('access-control-allow-origin')).toBeNull();
+    });
+  });
+
+  describe('repo pinning (D4)', () => {
+    it('rejects /check for a repo that does not match tenant.repo', async () => {
+      await putTenant(storedTenant());
+      const req = new Request('http://localhost/api/t/acme/check/someone/else');
+      const res = await app.fetch(req, env);
+      const data = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(data).toEqual({ error: 'Repository does not match tenant configuration' });
+      expect(mockGetInstallationToken).not.toHaveBeenCalled();
+    });
+
+    it('allows /check for the tenant-pinned repo and delegates to the shared handler', async () => {
+      await putTenant(storedTenant());
+      const req = new Request('http://localhost/api/t/acme/check/acme/widget');
+      const res = await app.fetch(req, env);
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data).toEqual({ installed: true, repo: 'acme/widget', appName: 'test' });
+      expect(mockGetInstallationToken).toHaveBeenCalledWith(env, 'acme', 'widget');
+    });
+
+    it('rejects /feedback whose body repo does not match tenant.repo with 400', async () => {
+      await putTenant(storedTenant());
+      const req = new Request('http://localhost/api/t/acme/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ repo: 'someone/else', title: 'Test' }),
+      });
+      const res = await app.fetch(req, env);
+      const data = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(data).toEqual({ error: 'Repository does not match tenant configuration' });
+      expect(mockCreateIssue).not.toHaveBeenCalled();
+    });
+
+    it('creates the issue via the shared handler when /feedback repo matches tenant.repo', async () => {
+      await putTenant(storedTenant());
+      const req = new Request('http://localhost/api/t/acme/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          repo: 'acme/widget',
+          title: 'Test feedback',
+          description: 'via tenant route',
+          metadata: {
+            url: 'http://localhost:3000',
+            userAgent: 'Mozilla/5.0',
+            viewport: { width: 1920, height: 1080 },
+            timestamp: '2025-01-15T12:00:00Z',
+          },
+        }),
+      });
+      const res = await app.fetch(req, env);
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data).toMatchObject({ success: true, issueNumber: 42 });
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        'test-token',
+        'acme',
+        'widget',
+        'Test feedback',
+        expect.any(String),
+        expect.any(Array)
+      );
+    });
+  });
+
+  describe('rate limiting (t:{key}: prefix, tenant.rate override)', () => {
+    const validPayload = {
+      repo: 'acme/widget',
+      title: 'Test feedback',
+      metadata: {
+        url: 'http://localhost:3000',
+        userAgent: 'Mozilla/5.0',
+        viewport: { width: 1920, height: 1080 },
+        timestamp: '2025-01-15T12:00:00Z',
+      },
+    };
+
+    function feedbackRequest(): Request {
+      return new Request('http://localhost/api/t/acme/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'cf-connecting-ip': '203.0.113.10' },
+        body: JSON.stringify(validPayload),
+      });
+    }
+
+    it('keys the IP rate-limit bucket with the t:{key}: prefix', async () => {
+      await putTenant(storedTenant());
+      await app.fetch(feedbackRequest(), env);
+
+      const ipKeys = [...rateLimitStore.keys()].filter(k => k.startsWith('t:acme:ip:'));
+      expect(ipKeys.length).toBeGreaterThan(0);
+    });
+
+    it('keys the repo rate-limit bucket with the t:{key}: prefix', async () => {
+      await putTenant(storedTenant());
+      await app.fetch(feedbackRequest(), env);
+
+      const repoKeys = [...rateLimitStore.keys()].filter(k => k.startsWith('t:acme:repo:'));
+      expect(repoKeys.length).toBeGreaterThan(0);
+    });
+
+    it('applies the default per-IP limit (20) when tenant.rate is not set', async () => {
+      await putTenant(storedTenant());
+      const req = feedbackRequest();
+      // Pre-seed the bucket at the default limit.
+      const windowStart = Math.floor(Date.now() / (15 * 60 * 1000));
+      rateLimitStore.set(`t:acme:ip:203.0.113.10:${windowStart}`, '20');
+
+      const res = await app.fetch(req, env);
+      const data = await res.json();
+
+      expect(res.status).toBe(429);
+      expect(data.error).toBe('Too many requests. Please try again later.');
+      expect(mockCreateIssue).not.toHaveBeenCalled();
+    });
+
+    it('applies a custom tenant.rate.perIp override instead of the default', async () => {
+      await putTenant(storedTenant({ rate: { perIp: 2 } }));
+      const windowStart = Math.floor(Date.now() / (15 * 60 * 1000));
+      rateLimitStore.set(`t:acme:ip:203.0.113.10:${windowStart}`, '2');
+
+      const res = await app.fetch(feedbackRequest(), env);
+      const data = await res.json();
+
+      expect(res.status).toBe(429);
+      expect(data.error).toBe('Too many requests. Please try again later.');
+    });
+
+    it('does not share a rate-limit bucket across two different tenants', async () => {
+      await putTenant(storedTenant({ key: 'acme', origins: ['https://app.acme.com'] }));
+      await putTenant(
+        storedTenant({ key: 'other', repo: 'other/widget', origins: ['https://app.other.com'] })
+      );
+
+      const windowStart = Math.floor(Date.now() / (15 * 60 * 1000));
+      rateLimitStore.set(`t:acme:ip:203.0.113.10:${windowStart}`, '20');
+
+      const otherReq = new Request('http://localhost/api/t/other/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'cf-connecting-ip': '203.0.113.10' },
+        body: JSON.stringify({ ...validPayload, repo: 'other/widget' }),
+      });
+      const res = await app.fetch(otherReq, env);
+
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/test/tenantApi.test.ts
+++ b/test/tenantApi.test.ts
@@ -279,6 +279,53 @@ describe('tenant API routes', () => {
     });
   });
 
+  describe('widget-auth parity with legacy /api/feedback', () => {
+    const feedbackBody = JSON.stringify({
+      repo: 'acme/widget',
+      title: 'Test feedback',
+      description: 'via tenant route',
+      metadata: {
+        url: 'http://localhost:3000',
+        userAgent: 'Mozilla/5.0',
+        viewport: { width: 1920, height: 1080 },
+        timestamp: '2025-01-15T12:00:00Z',
+      },
+    });
+
+    it('rejects /feedback without a bd1. token when AUTH_TOKEN_SECRET is configured', async () => {
+      await putTenant(storedTenant());
+      const req = new Request('http://localhost/api/t/acme/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: feedbackBody,
+      });
+      const res = await app.fetch(req, { ...env, AUTH_TOKEN_SECRET: 'tenant-parity-secret' });
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: 'BugDrop auth token required' });
+      expect(mockCreateIssue).not.toHaveBeenCalled();
+    });
+
+    it('accepts /feedback with a valid bd1. token when AUTH_TOKEN_SECRET is configured', async () => {
+      await putTenant(storedTenant());
+      const { createBugDropAuthTokenForTest } = await import('../src/lib/authToken');
+      const now = Math.floor(Date.now() / 1000);
+      const token = await createBugDropAuthTokenForTest(
+        { sub: 'user-1', repo: 'acme/widget', iat: now, exp: now + 300, jti: 'jti-1' },
+        'tenant-parity-secret'
+      );
+      const req = new Request('http://localhost/api/t/acme/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: feedbackBody,
+      });
+      const res = await app.fetch(req, { ...env, AUTH_TOKEN_SECRET: 'tenant-parity-secret' });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ success: true, issueNumber: 42 });
+    });
+  });
+
   describe('rate limiting (t:{key}: prefix, tenant.rate override)', () => {
     const validPayload = {
       repo: 'acme/widget',

--- a/test/tenantApi.test.ts
+++ b/test/tenantApi.test.ts
@@ -408,4 +408,72 @@ describe('tenant API routes', () => {
       expect(res.status).toBe(200);
     });
   });
+
+  describe('IP rate limit runs before auth (FIX 2)', () => {
+    const feedbackBody = JSON.stringify({
+      repo: 'acme/widget',
+      title: 'Test feedback',
+      metadata: {
+        url: 'http://localhost:3000',
+        userAgent: 'Mozilla/5.0',
+        viewport: { width: 1920, height: 1080 },
+        timestamp: '2025-01-15T12:00:00Z',
+      },
+    });
+
+    function invalidTokenRequest(): Request {
+      return new Request('http://localhost/api/t/acme/feedback', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'cf-connecting-ip': '203.0.113.20',
+          Authorization: 'Bearer not-a-real-token',
+        },
+        body: feedbackBody,
+      });
+    }
+
+    it('increments the t:{key}:ip: counter even when the request is rejected for an invalid token (401)', async () => {
+      await putTenant(storedTenant());
+      const res = await app.fetch(invalidTokenRequest(), {
+        ...env,
+        ENVIRONMENT: 'production',
+        AUTH_TOKEN_SECRET: 'tenant-parity-secret',
+      });
+
+      expect(res.status).toBe(401);
+      const ipKeys = [...rateLimitStore.keys()].filter(k =>
+        k.startsWith('t:acme:ip:203.0.113.20:')
+      );
+      expect(ipKeys.length).toBe(1);
+      expect(rateLimitStore.get(ipKeys[0]!)).toBe('1');
+    });
+
+    it('returns 429 (not 401) when the IP bucket is already at the limit, even with an invalid token', async () => {
+      await putTenant(storedTenant());
+      const windowStart = Math.floor(Date.now() / (15 * 60 * 1000));
+      rateLimitStore.set(`t:acme:ip:203.0.113.20:${windowStart}`, '20');
+
+      const res = await app.fetch(invalidTokenRequest(), {
+        ...env,
+        ENVIRONMENT: 'production',
+        AUTH_TOKEN_SECRET: 'tenant-parity-secret',
+      });
+
+      expect(res.status).toBe(429);
+      expect(mockCreateIssue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('TENANTS binding absent (FIX 4)', () => {
+    it('returns 404 (unknown tenant) when the TENANTS binding is not configured', async () => {
+      const { TENANTS: _unused, ...envWithoutTenants } = env;
+      const req = new Request('http://localhost/api/t/acme/check/acme/widget');
+      const res = await app.fetch(req, envWithoutTenants as Env);
+      const data = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(data).toEqual({ error: 'Unknown tenant' });
+    });
+  });
 });

--- a/test/tenantApi.test.ts
+++ b/test/tenantApi.test.ts
@@ -326,6 +326,76 @@ describe('tenant API routes', () => {
     });
   });
 
+  describe('per-tenant widget-auth secret (D5/M2-01)', () => {
+    const KEK = Buffer.alloc(32, 5).toString('base64');
+    const feedbackBody = JSON.stringify({
+      repo: 'acme/widget',
+      title: 'Test feedback',
+      description: 'via tenant route',
+      metadata: {
+        url: 'http://localhost:3000',
+        userAgent: 'Mozilla/5.0',
+        viewport: { width: 1920, height: 1080 },
+        timestamp: '2025-01-15T12:00:00Z',
+      },
+    });
+
+    async function seedTenantWithSecret(secret: string): Promise<void> {
+      const { wrapSecret } = await import('../src/lib/envelope');
+      await putTenant(
+        storedTenant({ authTokenSecretEnc: await wrapSecret(secret, KEK) } as Partial<TenantConfig>)
+      );
+    }
+
+    async function mintToken(secret: string, repo = 'acme/widget'): Promise<string> {
+      const { createBugDropAuthTokenForTest } = await import('../src/lib/authToken');
+      const now = Math.floor(Date.now() / 1000);
+      return createBugDropAuthTokenForTest(
+        { sub: 'user-1', repo, iat: now, exp: now + 300, jti: 'jti-t' },
+        secret
+      );
+    }
+
+    function post(token?: string): Request {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (token) headers.Authorization = `Bearer ${token}`;
+      return new Request('http://localhost/api/t/acme/feedback', {
+        method: 'POST',
+        headers,
+        body: feedbackBody,
+      });
+    }
+
+    it('requires a token signed with the tenant secret', async () => {
+      await seedTenantWithSecret('tenant-own-secret-value');
+      const kekEnv = { ...env, BUGDROP_KEK: KEK } as Env;
+
+      expect((await app.fetch(post(), kekEnv)).status).toBe(401);
+      const ok = await app.fetch(post(await mintToken('tenant-own-secret-value')), kekEnv);
+      expect(ok.status).toBe(200);
+    });
+
+    it('rejects a token signed with the GLOBAL secret when the tenant has its own', async () => {
+      await seedTenantWithSecret('tenant-own-secret-value');
+      const kekEnv = {
+        ...env,
+        BUGDROP_KEK: KEK,
+        AUTH_TOKEN_SECRET: 'global-secret-value-here',
+      } as Env;
+
+      const res = await app.fetch(post(await mintToken('global-secret-value-here')), kekEnv);
+      expect(res.status).toBe(401);
+      expect(mockCreateIssue).not.toHaveBeenCalled();
+    });
+
+    it('fails loud with 500 when the tenant has a secret but BUGDROP_KEK is missing', async () => {
+      await seedTenantWithSecret('tenant-own-secret-value');
+      const res = await app.fetch(post(await mintToken('tenant-own-secret-value')), env);
+      expect(res.status).toBe(500);
+      expect(mockCreateIssue).not.toHaveBeenCalled();
+    });
+  });
+
   describe('rate limiting (t:{key}: prefix, tenant.rate override)', () => {
     const validPayload = {
       repo: 'acme/widget',

--- a/test/tenantStore.test.ts
+++ b/test/tenantStore.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { deleteTenant, getTenant, listTenants, putTenant } from '../src/lib/tenantStore';
+import type { TenantConfig } from '../src/lib/tenants';
+import type { Env } from '../src/types';
+
+function validTenant(overrides: Partial<TenantConfig> = {}): TenantConfig {
+  return {
+    version: 1,
+    key: 'acme',
+    name: 'Acme Corp',
+    repo: 'acme/widget',
+    origins: ['https://app.acme.com'],
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('tenantStore', () => {
+  let mockKv: {
+    get: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    list: ReturnType<typeof vi.fn>;
+  };
+  let env: Env;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockKv = {
+      get: vi.fn().mockResolvedValue(null),
+      put: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockResolvedValue({ keys: [], list_complete: true, cursor: '' }),
+    };
+    env = {
+      TENANTS: mockKv as unknown as KVNamespace,
+      GITHUB_APP_ID: 'test',
+      GITHUB_PRIVATE_KEY: 'test',
+      ENVIRONMENT: 'test',
+      ALLOWED_ORIGINS: '*',
+      GITHUB_APP_NAME: 'test',
+      MAX_SCREENSHOT_SIZE_MB: '5',
+      ASSETS: {} as Fetcher,
+    } as Env;
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  describe('getTenant', () => {
+    it('returns null when the key is missing', async () => {
+      mockKv.get.mockResolvedValue(null);
+
+      const result = await getTenant(env, 'ghost');
+
+      expect(result).toBeNull();
+      expect(mockKv.get).toHaveBeenCalledWith('tenant:ghost', { cacheTtl: 60 });
+    });
+
+    it('returns the validated tenant when the stored JSON is valid', async () => {
+      const tenant = validTenant();
+      mockKv.get.mockResolvedValue(JSON.stringify(tenant));
+
+      const result = await getTenant(env, 'acme');
+
+      expect(result).toEqual(tenant);
+    });
+
+    it('returns null and logs when the stored value is not valid JSON', async () => {
+      mockKv.get.mockResolvedValue('not json{');
+
+      const result = await getTenant(env, 'acme');
+
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it('returns null and logs when the stored JSON fails TenantConfig validation', async () => {
+      mockKv.get.mockResolvedValue(JSON.stringify({ version: 1, key: 'acme' }));
+
+      const result = await getTenant(env, 'acme');
+
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it('reads with cacheTtl: 60', async () => {
+      mockKv.get.mockResolvedValue(JSON.stringify(validTenant()));
+
+      await getTenant(env, 'acme');
+
+      expect(mockKv.get).toHaveBeenCalledWith('tenant:acme', { cacheTtl: 60 });
+    });
+  });
+
+  describe('putTenant', () => {
+    it('writes the tenant under the tenant: prefix', async () => {
+      const tenant = validTenant();
+
+      await putTenant(env, tenant);
+
+      expect(mockKv.put).toHaveBeenCalledWith('tenant:acme', JSON.stringify(tenant));
+    });
+  });
+
+  describe('deleteTenant', () => {
+    it('deletes the tenant under the tenant: prefix', async () => {
+      await deleteTenant(env, 'acme');
+
+      expect(mockKv.delete).toHaveBeenCalledWith('tenant:acme');
+    });
+  });
+
+  describe('listTenants', () => {
+    it('lists keys and names by the tenant: prefix', async () => {
+      mockKv.list.mockResolvedValue({
+        keys: [{ name: 'tenant:acme' }, { name: 'tenant:beta' }],
+        list_complete: true,
+        cursor: '',
+      });
+      mockKv.get.mockImplementation(async (storageKey: string) => {
+        const key = storageKey.replace('tenant:', '');
+        return JSON.stringify(validTenant({ key, name: key.toUpperCase() }));
+      });
+
+      const result = await listTenants(env);
+
+      expect(mockKv.list).toHaveBeenCalledWith({ prefix: 'tenant:' });
+      expect(result).toEqual([
+        { key: 'acme', name: 'ACME' },
+        { key: 'beta', name: 'BETA' },
+      ]);
+    });
+
+    it('skips entries that fail validation', async () => {
+      mockKv.list.mockResolvedValue({
+        keys: [{ name: 'tenant:acme' }, { name: 'tenant:broken' }],
+        list_complete: true,
+        cursor: '',
+      });
+      mockKv.get.mockImplementation(async (storageKey: string) => {
+        if (storageKey === 'tenant:broken') {
+          return 'not json{';
+        }
+        return JSON.stringify(validTenant());
+      });
+
+      const result = await listTenants(env);
+
+      expect(result).toEqual([{ key: 'acme', name: 'Acme Corp' }]);
+    });
+
+    it('returns an empty list when there are no tenants', async () => {
+      const result = await listTenants(env);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/test/tenants.test.ts
+++ b/test/tenants.test.ts
@@ -207,14 +207,23 @@ describe('validateTenantConfig', () => {
     expect(validateTenantConfig(baseTenant({ rate: { perRepo: -5 } as never })).ok).toBe(false);
   });
 
-  it('rejects the presence of authTokenSecretEnc with an explicit not-yet-supported message', () => {
-    const result = validateTenantConfig(baseTenant({ authTokenSecretEnc: 'v1.abcdef' } as never));
+  it('accepts a v1 envelope in authTokenSecretEnc and carries it through', () => {
+    const result = validateTenantConfig(
+      baseTenant({ authTokenSecretEnc: 'v1.abc-123.def_456' } as never)
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.authTokenSecretEnc).toBe('v1.abc-123.def_456');
+    }
+  });
+
+  it('rejects a non-envelope authTokenSecretEnc (plaintext must never be storable)', () => {
+    const result = validateTenantConfig(
+      baseTenant({ authTokenSecretEnc: 'raw-plaintext-secret' } as never)
+    );
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.errors).toContain(
-        'authTokenSecretEnc is not supported yet (M2 envelope encryption)'
-      );
-      expect(result.errors.some(e => e.includes('Unknown field'))).toBe(false);
+      expect(result.errors.some(e => e.includes('v1 AES-GCM envelope'))).toBe(true);
     }
   });
 });

--- a/test/tenants.test.ts
+++ b/test/tenants.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from 'vitest';
+import {
+  tenantToDataAttributes,
+  validateTenantConfig,
+  type TenantConfig,
+} from '../src/lib/tenants';
+
+function baseTenant(overrides: Partial<TenantConfig> = {}): unknown {
+  return {
+    version: 1,
+    key: 'acme',
+    name: 'Acme Inc',
+    repo: 'acme/website',
+    origins: ['https://app.acme.com'],
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('validateTenantConfig', () => {
+  it('accepts a minimal valid tenant', () => {
+    const result = validateTenantConfig(baseTenant());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.key).toBe('acme');
+      expect(result.value.theme).toBeUndefined();
+    }
+  });
+
+  it('accepts a fully populated tenant covering every field family', () => {
+    const result = validateTenantConfig(
+      baseTenant({
+        origins: ['https://app.acme.com', 'http://localhost:3000'],
+        theme: {
+          color: '#2563eb',
+          bg: '#ffffff',
+          text: '#111111',
+          font: 'Inter, sans-serif',
+          radius: '8',
+          borderWidth: '1',
+          borderColor: '#e2e8f0',
+          shadow: 'soft',
+          icon: 'https://cdn.acme.com/icon.svg',
+          label: 'Feedback',
+          position: 'bottom-left',
+          mode: 'dark',
+        },
+        behavior: {
+          locale: 'en',
+          showName: true,
+          requireName: false,
+          showEmail: true,
+          requireEmail: false,
+          screenshot: 'auto',
+          welcome: 'always',
+          showIssueLink: 'always',
+          sendConsoleLogs: true,
+          buttonDismissible: true,
+          dismissDuration: 7,
+          showRestore: true,
+          categoryLabels: { bug: 'Bug', idea: ['Idea', 'Feature Request'] },
+        },
+        rate: { perIp: 10, perRepo: 100 },
+        authTokenSecretEnc: 'v1.abcdef',
+      })
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.theme?.color).toBe('#2563eb');
+      expect(result.value.behavior?.categoryLabels).toEqual({
+        bug: 'Bug',
+        idea: ['Idea', 'Feature Request'],
+      });
+      expect(result.value.rate).toEqual({ perIp: 10, perRepo: 100 });
+      expect(result.value.authTokenSecretEnc).toBe('v1.abcdef');
+    }
+  });
+
+  it('rejects non-object input', () => {
+    expect(validateTenantConfig(null).ok).toBe(false);
+    expect(validateTenantConfig('acme').ok).toBe(false);
+    expect(validateTenantConfig([]).ok).toBe(false);
+  });
+
+  it('rejects unknown top-level fields', () => {
+    const result = validateTenantConfig(baseTenant({ extra: 'nope' } as never));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some(e => e.includes('extra'))).toBe(true);
+    }
+  });
+
+  it('rejects unknown fields inside theme, behavior, and rate', () => {
+    const result = validateTenantConfig(
+      baseTenant({
+        theme: { bogus: 'x' } as never,
+        behavior: { bogus: 'x' } as never,
+        rate: { bogus: 1 } as never,
+      })
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some(e => e.includes('theme.bogus'))).toBe(true);
+      expect(result.errors.some(e => e.includes('behavior.bogus'))).toBe(true);
+      expect(result.errors.some(e => e.includes('rate.bogus'))).toBe(true);
+    }
+  });
+
+  it('rejects version other than 1', () => {
+    expect(validateTenantConfig(baseTenant({ version: 2 as never })).ok).toBe(false);
+    expect(validateTenantConfig(baseTenant({ version: undefined as never })).ok).toBe(false);
+  });
+
+  describe('key format', () => {
+    it.each(['acm', 'acme', 'acme-inc', 'a1b', 'abc-def-ghi'])('accepts %s', key => {
+      expect(validateTenantConfig(baseTenant({ key })).ok).toBe(true);
+    });
+
+    it.each([
+      'A', // too short, uppercase
+      'a', // too short
+      'ab', // too short (pattern [a-z0-9] + 1..30 + [a-z0-9] means min length 3)
+      '-abc', // cannot start with hyphen
+      'abc-', // cannot end with hyphen
+      'ABC', // uppercase not allowed
+      'ab_c', // underscore not allowed
+      '',
+    ])('rejects %s', key => {
+      const result = validateTenantConfig(baseTenant({ key }));
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('origins', () => {
+    it('accepts https origins and http://localhost with optional port', () => {
+      expect(validateTenantConfig(baseTenant({ origins: ['https://example.com'] })).ok).toBe(true);
+      expect(validateTenantConfig(baseTenant({ origins: ['http://localhost:5173'] })).ok).toBe(
+        true
+      );
+      expect(validateTenantConfig(baseTenant({ origins: ['http://localhost'] })).ok).toBe(true);
+    });
+
+    it('rejects plain http origins that are not localhost', () => {
+      expect(validateTenantConfig(baseTenant({ origins: ['http://example.com'] })).ok).toBe(false);
+    });
+
+    it('rejects origins with paths, query strings, or wildcards', () => {
+      expect(validateTenantConfig(baseTenant({ origins: ['https://example.com/app'] })).ok).toBe(
+        false
+      );
+      expect(validateTenantConfig(baseTenant({ origins: ['https://example.com?x=1'] })).ok).toBe(
+        false
+      );
+      expect(validateTenantConfig(baseTenant({ origins: ['https://*.example.com'] })).ok).toBe(
+        false
+      );
+    });
+
+    it('rejects an empty origins array', () => {
+      expect(validateTenantConfig(baseTenant({ origins: [] })).ok).toBe(false);
+    });
+  });
+
+  describe('repo format', () => {
+    it.each(['octocat/hello-world', 'acme/website'])('accepts %s', repo => {
+      expect(validateTenantConfig(baseTenant({ repo })).ok).toBe(true);
+    });
+
+    it.each(['', 'no-slash', 'a/b/c', '/repo', 'owner/'])('rejects %s', repo => {
+      expect(validateTenantConfig(baseTenant({ repo })).ok).toBe(false);
+    });
+  });
+
+  it('rejects an invalid status', () => {
+    expect(validateTenantConfig(baseTenant({ status: 'disabled' as never })).ok).toBe(false);
+  });
+
+  it('rejects malformed timestamps', () => {
+    expect(validateTenantConfig(baseTenant({ createdAt: 'not-a-date' })).ok).toBe(false);
+    expect(validateTenantConfig(baseTenant({ updatedAt: '2026-01-01' })).ok).toBe(false);
+  });
+
+  it('rejects wrong-typed theme enum values', () => {
+    expect(validateTenantConfig(baseTenant({ theme: { shadow: 'blurry' } as never })).ok).toBe(
+      false
+    );
+    expect(validateTenantConfig(baseTenant({ theme: { position: 'top' } as never })).ok).toBe(
+      false
+    );
+    expect(validateTenantConfig(baseTenant({ theme: { mode: 'sepia' } as never })).ok).toBe(false);
+  });
+
+  it('rejects wrong-typed behavior fields', () => {
+    expect(validateTenantConfig(baseTenant({ behavior: { showName: 'true' } as never })).ok).toBe(
+      false
+    );
+    expect(
+      validateTenantConfig(baseTenant({ behavior: { dismissDuration: -1 } as never })).ok
+    ).toBe(false);
+    expect(
+      validateTenantConfig(baseTenant({ behavior: { categoryLabels: { bug: 42 } } as never })).ok
+    ).toBe(false);
+  });
+
+  it('rejects wrong-typed rate fields', () => {
+    expect(validateTenantConfig(baseTenant({ rate: { perIp: 0 } as never })).ok).toBe(false);
+    expect(validateTenantConfig(baseTenant({ rate: { perRepo: -5 } as never })).ok).toBe(false);
+  });
+
+  it('rejects a non-string authTokenSecretEnc', () => {
+    expect(validateTenantConfig(baseTenant({ authTokenSecretEnc: 123 as never })).ok).toBe(false);
+  });
+});
+
+describe('tenantToDataAttributes', () => {
+  it('always includes repo', () => {
+    const result = validateTenantConfig(baseTenant());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(tenantToDataAttributes(result.value)).toEqual({ repo: 'acme/website' });
+  });
+
+  it('maps every theme field to its kebab-case data attribute', () => {
+    const result = validateTenantConfig(
+      baseTenant({
+        theme: {
+          color: '#2563eb',
+          bg: '#fff',
+          text: '#111',
+          font: 'Inter',
+          radius: '8',
+          borderWidth: '1',
+          borderColor: '#e2e8f0',
+          shadow: 'hard',
+          icon: 'none',
+          label: 'Feedback',
+          position: 'bottom-left',
+          mode: 'light',
+        },
+      })
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(tenantToDataAttributes(result.value)).toEqual({
+      repo: 'acme/website',
+      color: '#2563eb',
+      bg: '#fff',
+      text: '#111',
+      font: 'Inter',
+      radius: '8',
+      'border-width': '1',
+      'border-color': '#e2e8f0',
+      shadow: 'hard',
+      icon: 'none',
+      label: 'Feedback',
+      position: 'bottom-left',
+      theme: 'light',
+    });
+  });
+
+  it('maps every behavior field to its kebab-case data attribute, serializing booleans/numbers as strings', () => {
+    const result = validateTenantConfig(
+      baseTenant({
+        behavior: {
+          locale: 'pt',
+          showName: true,
+          requireName: false,
+          showEmail: true,
+          requireEmail: false,
+          screenshot: 'required',
+          welcome: 'never',
+          showIssueLink: 'never',
+          sendConsoleLogs: false,
+          buttonDismissible: true,
+          dismissDuration: 3,
+          showRestore: false,
+          categoryLabels: { bug: 'Bug' },
+        },
+      })
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(tenantToDataAttributes(result.value)).toEqual({
+      repo: 'acme/website',
+      locale: 'pt',
+      'show-name': 'true',
+      'require-name': 'false',
+      'show-email': 'true',
+      'require-email': 'false',
+      screenshot: 'required',
+      welcome: 'never',
+      'show-issue-link': 'never',
+      'send-console-logs': 'false',
+      'button-dismissible': 'true',
+      'dismiss-duration': '3',
+      'show-restore': 'false',
+      'category-labels': JSON.stringify({ bug: 'Bug' }),
+    });
+  });
+});

--- a/test/tenants.test.ts
+++ b/test/tenants.test.ts
@@ -63,7 +63,6 @@ describe('validateTenantConfig', () => {
           categoryLabels: { bug: 'Bug', idea: ['Idea', 'Feature Request'] },
         },
         rate: { perIp: 10, perRepo: 100 },
-        authTokenSecretEnc: 'v1.abcdef',
       })
     );
     expect(result.ok).toBe(true);
@@ -74,7 +73,6 @@ describe('validateTenantConfig', () => {
         idea: ['Idea', 'Feature Request'],
       });
       expect(result.value.rate).toEqual({ perIp: 10, perRepo: 100 });
-      expect(result.value.authTokenSecretEnc).toBe('v1.abcdef');
     }
   });
 
@@ -209,8 +207,15 @@ describe('validateTenantConfig', () => {
     expect(validateTenantConfig(baseTenant({ rate: { perRepo: -5 } as never })).ok).toBe(false);
   });
 
-  it('rejects a non-string authTokenSecretEnc', () => {
-    expect(validateTenantConfig(baseTenant({ authTokenSecretEnc: 123 as never })).ok).toBe(false);
+  it('rejects the presence of authTokenSecretEnc with an explicit not-yet-supported message', () => {
+    const result = validateTenantConfig(baseTenant({ authTokenSecretEnc: 'v1.abcdef' } as never));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain(
+        'authTokenSecretEnc is not supported yet (M2 envelope encryption)'
+      );
+      expect(result.errors.some(e => e.includes('Unknown field'))).toBe(false);
+    }
   });
 });
 

--- a/test/widgetApiUrl.test.ts
+++ b/test/widgetApiUrl.test.ts
@@ -47,3 +47,56 @@ describe('Widget apiUrl derivation', () => {
     expect(deriveApiUrl(url)).toBe(url);
   });
 });
+
+/**
+ * Tests for the widget's tenant-scoped apiUrl derivation from data-tenant.
+ *
+ * When data-tenant is present and matches ^[a-z0-9-]{3,32}$, the widget
+ * appends /t/{key} to the base apiUrl. Mirrors the logic in
+ * src/widget/index.ts.
+ */
+const tenantKeyPattern = /^[a-z0-9-]{3,32}$/;
+
+function deriveTenantApiUrl(scriptSrc: string, rawTenant: string | undefined): string {
+  const tenantKey = rawTenant && tenantKeyPattern.test(rawTenant) ? rawTenant : undefined;
+  const baseApiUrl = deriveApiUrl(scriptSrc);
+  return baseApiUrl && tenantKey ? `${baseApiUrl}/t/${tenantKey}` : baseApiUrl;
+}
+
+describe('Widget tenant-scoped apiUrl derivation', () => {
+  const base = 'https://bugdrop.neonwatty.workers.dev';
+  const scriptSrc = `${base}/widget.v1.js`;
+
+  it('leaves apiUrl unchanged when data-tenant is absent', () => {
+    expect(deriveTenantApiUrl(scriptSrc, undefined)).toBe(`${base}/api`);
+  });
+
+  it('appends /t/{key} when data-tenant is a valid key', () => {
+    expect(deriveTenantApiUrl(scriptSrc, 'acme')).toBe(`${base}/api/t/acme`);
+  });
+
+  it('accepts a key at the minimum length (3 chars)', () => {
+    expect(deriveTenantApiUrl(scriptSrc, 'abc')).toBe(`${base}/api/t/abc`);
+  });
+
+  it('accepts a key at the maximum length (32 chars)', () => {
+    const key = 'a'.repeat(32);
+    expect(deriveTenantApiUrl(scriptSrc, key)).toBe(`${base}/api/t/${key}`);
+  });
+
+  it('ignores an invalid data-tenant (too short)', () => {
+    expect(deriveTenantApiUrl(scriptSrc, 'ab')).toBe(`${base}/api`);
+  });
+
+  it('ignores an invalid data-tenant (too long)', () => {
+    expect(deriveTenantApiUrl(scriptSrc, 'a'.repeat(33))).toBe(`${base}/api`);
+  });
+
+  it('ignores an invalid data-tenant (uppercase letters)', () => {
+    expect(deriveTenantApiUrl(scriptSrc, 'Acme-Corp')).toBe(`${base}/api`);
+  });
+
+  it('ignores an invalid data-tenant (disallowed characters)', () => {
+    expect(deriveTenantApiUrl(scriptSrc, 'acme_corp')).toBe(`${base}/api`);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -34,6 +34,12 @@ binding = "RATE_LIMIT"
 id = "e6454ed79f514ed3a9e24eea99dd6cd3"
 preview_id = "ff8f3809037d4403befd09369a9f7e36"
 
+# Tenant registry KV namespace (multi-tenant embed, contract docs/plans/multi-tenant-embed.md)
+# create: wrangler kv namespace create bugdrop-tenants
+[[kv_namespaces]]
+binding = "TENANTS"
+id = "REPLACE_WITH_BUGDROP_TENANTS_NAMESPACE_ID"
+
 # Secrets (set with: wrangler secret put GITHUB_APP_ID)
 # GITHUB_APP_ID
 # GITHUB_PRIVATE_KEY
@@ -55,3 +61,9 @@ MAX_SCREENSHOT_SIZE_MB = "5"
 [[env.preview.kv_namespaces]]
 binding = "RATE_LIMIT"
 id = "cdb88fa95d6348d6ab84037751853d5d"
+
+# Tenant registry KV namespace (multi-tenant embed, contract docs/plans/multi-tenant-embed.md)
+# create: wrangler kv namespace create bugdrop-tenants --env preview
+[[env.preview.kv_namespaces]]
+binding = "TENANTS"
+id = "REPLACE_WITH_BUGDROP_TENANTS_PREVIEW_NAMESPACE_ID"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -34,8 +34,12 @@ binding = "RATE_LIMIT"
 id = "e6454ed79f514ed3a9e24eea99dd6cd3"
 preview_id = "ff8f3809037d4403befd09369a9f7e36"
 
-# Tenant registry KV namespace (multi-tenant embed, contract docs/plans/multi-tenant-embed.md)
-# create: wrangler kv namespace create bugdrop-tenants
+# Tenant registry KV namespace (multi-tenant embed, contract docs/plans/multi-tenant-embed.md).
+# Optional/opt-in: TENANTS is an optional Env binding (src/types.ts) — absent,
+# the multitenant feature (admin CRUD, /t/:key loader, /api/t/:key routes) stays
+# dormant and legacy /widget.js + /api are unaffected. The placeholder id below
+# only satisfies `wrangler dev` locally; the operator must replace it with a
+# real namespace id before deploying (wrangler kv namespace create bugdrop-tenants).
 [[kv_namespaces]]
 binding = "TENANTS"
 id = "REPLACE_WITH_BUGDROP_TENANTS_NAMESPACE_ID"
@@ -62,8 +66,6 @@ MAX_SCREENSHOT_SIZE_MB = "5"
 binding = "RATE_LIMIT"
 id = "cdb88fa95d6348d6ab84037751853d5d"
 
-# Tenant registry KV namespace (multi-tenant embed, contract docs/plans/multi-tenant-embed.md)
-# create: wrangler kv namespace create bugdrop-tenants --env preview
-[[env.preview.kv_namespaces]]
-binding = "TENANTS"
-id = "REPLACE_WITH_BUGDROP_TENANTS_PREVIEW_NAMESPACE_ID"
+# No TENANTS binding in preview: a real `wrangler deploy` rejects a placeholder
+# KV namespace id, and TENANTS is optional (src/types.ts) — its absence just
+# leaves the multitenant feature dormant for preview deploys/E2E.


### PR DESCRIPTION
## What

One-line embed for hosted BugDrop instances: `<script src="https://<worker-host>/t/{tenantKey}.js" async></script>`. All configuration (target repo, allowed origins, theme colors, behavior, rate limits) lives server-side per tenant, managed by the operator through an admin API. Fully additive: the legacy embed and routes are untouched (all pre-existing tests pass unmodified).

Design contract with frozen decisions, card-by-card execution log and amendments: `docs/plans/multi-tenant-embed.md`.

## How

- **Loader** (`/t/:key.js`): server-rendered IIFE with a double-injection guard that injects `widget.v1.js` (absolute URL on the Worker origin) with the tenant's config as the existing `data-*` attributes — reuses the tested dataset/theming surface, zero bootstrap rewrite. Unknown/paused tenant → 200 warn-only body.
- **Tenant registry**: optional KV binding `TENANTS` (`bugdrop-tenants`), `TenantConfig v1` validated by hand (repo convention, no new deps). Binding absent = feature dormant (admin 503, loader warn, tenant API 404) so existing deployments and the preview env are unaffected.
- **Per-tenant enforcement** (`/api/t/:key/*`): CORS against exactly `tenant.origins` (403 on disallowed Origin incl. preflight), repo pinned to `tenant.repo` (400 on mismatch), per-tenant rate limits (`t:{key}:` KV prefix) via the shared fixed-window core, widget-auth parity with the legacy route. Mounted before `/api` (and admin too) because Hono's overlapping-prefix wildcard middleware would otherwise leak the global CORS onto them (documented in-code, covered by a composed-app test).
- **Widget**: minimal change — `data-tenant` switches the derived apiUrl to `<origin>/api/t/{key}`.
- **Admin CRUD** (`/api/admin/tenants`): Bearer `ADMIN_TOKEN` (timing-safe), fail-loud 503 when unconfigured, no CORS exposure.
- **Security fix ride-along**: hono 4.12.23 → 4.12.29 (GHSA-88fw-hqm2-52qc, CORS credential reflection).

## Testing

- 443 unit tests green (`npm run validate`), including: cross-tenant origin spoof, repo spoof, preflight allow/deny, rate-limit ordering (429 before 401 on invalid-token flood), admin authz, composed-app CORS isolation, loader bodies.
- New Playwright spec `e2e/multi-tenant.spec.ts` (tenant seeded via admin API, themed button, submission path, disallowed origin) + legacy embed regression guard. Chromium suite verified locally; firefox/webkit/live projects rely on CI runners.
- Adversarial pass against `wrangler dev`: cross-tenant 403, repo spoof 400, unknown tenant 404, admin 401 with no CORS headers, legacy preflight unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)