### PR TITLE
fix: align centered selected-element screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,60 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
 
 See [full documentation](https://bugdrop.dev/docs/configuration) for all options including styling, submitter info, and dismissible button.
 
+## Test a Local Widget on a Live Site
+
+Build the widget and start the local server:
+
+```bash
+npm run build:widget && npm run dev
+```
+
+Then open the live site, open the browser console, and paste the script below. Change the
+`script.dataset.repo` value if the site should use a different repository.
+
+```js
+(() => {
+  const localBase = 'http://127.0.0.1:8787';
+
+  // Local development normally has no GitHub App credentials, so allow the
+  // widget to open while leaving every other request unchanged.
+  window.__bugdropRealFetch ??= window.fetch.bind(window);
+  window.fetch = (input, options) => {
+    if (String(input).startsWith(`${localBase}/api/check/`)) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ installed: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    }
+
+    return window.__bugdropRealFetch(input, options);
+  };
+
+  document.querySelector('#bugdrop-host')?.remove();
+  delete window.BugDrop;
+
+  document
+    .querySelectorAll('script[data-bugdrop-local-test="true"]')
+    .forEach(script => script.remove());
+
+  const script = document.createElement('script');
+  script.src = `${localBase}/widget.js`;
+  script.dataset.repo = 'owner/repo';
+  script.dataset.welcome = 'never';
+  script.dataset.theme = 'light';
+  script.dataset.bugdropLocalTest = 'true';
+  script.onload = () => window.BugDrop?.open();
+  document.body.appendChild(script);
+})();
+```
+
+This is intended for testing the widget and screenshot flow only. Submitting feedback still
+requires valid GitHub App credentials on the local server. If Chrome asks whether the page may
+access devices or services on the local network, allow it so the page can load `widget.js`. Reload
+the live page after testing to restore its original widget and `fetch` implementation.
+
 ## Documentation
 
 - [Full Documentation](https://bugdrop.dev/docs)

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -4060,6 +4060,118 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     expect(targetInfo.className).toContain('dot');
     expect(targetInfo.width).toBeLessThanOrEqual(selectedBox!.width + 1);
     expect(targetInfo.height).toBeLessThanOrEqual(selectedBox!.height + 1);
+
+    const captureOpts = await page.evaluate(() => window.__captureOpts);
+    expect(captureOpts?.style).toBeUndefined();
+  });
+
+  test('real element capture keeps a centered target aligned to the full image width', async ({
+    page,
+  }) => {
+    await page.goto('/test/annotation-style.html?elementContextMaxArea=1.5');
+    await page.evaluate(() => {
+      const context = document.createElement('section');
+      context.id = 'centered-capture-context';
+      context.style.cssText =
+        'width: 400px; height: 200px; margin: 0 auto; background: rgb(239, 68, 68); display: grid; place-items: center;';
+
+      const target = document.createElement('button');
+      target.id = 'centered-capture-fixture';
+      target.textContent = 'Pick';
+      target.style.cssText = 'width: 40px; height: 40px;';
+      context.appendChild(target);
+      document.body.prepend(context);
+    });
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="element"]').click();
+    await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
+    const selected = page.locator('#centered-capture-fixture');
+    const selectedBox = await selected.boundingBox();
+    expect(selectedBox).toBeTruthy();
+
+    const targetX = selectedBox!.x + selectedBox!.width / 2;
+    const targetY = selectedBox!.y + selectedBox!.height / 2;
+    await page.mouse.move(targetX, targetY);
+    await page.mouse.click(targetX, targetY);
+
+    const canvas = host.locator('css=#annotation-canvas canvas');
+    await expect(canvas).toBeVisible({ timeout: 30000 });
+    const bounds = await canvas.evaluate(node => {
+      const source = node as HTMLCanvasElement;
+      const context = source.getContext('2d');
+      if (!context) throw new Error('Missing canvas context');
+
+      const data = context.getImageData(0, 0, source.width, source.height).data;
+      const red = { minX: source.width, maxX: -1 };
+      const accent = { minX: source.width, maxX: -1, minY: source.height, maxY: -1 };
+
+      for (let y = 0; y < source.height; y++) {
+        for (let x = 0; x < source.width; x++) {
+          const offset = (y * source.width + x) * 4;
+          const r = data[offset];
+          const g = data[offset + 1];
+          const b = data[offset + 2];
+          const a = data[offset + 3];
+          if (a > 200 && r > 220 && g < 100 && b < 100) {
+            red.minX = Math.min(red.minX, x);
+            red.maxX = Math.max(red.maxX, x);
+          }
+          if (a > 200 && r > 240 && g > 130 && g < 190 && b > 70 && b < 130) {
+            accent.minX = Math.min(accent.minX, x);
+            accent.maxX = Math.max(accent.maxX, x);
+            accent.minY = Math.min(accent.minY, y);
+            accent.maxY = Math.max(accent.maxY, y);
+          }
+        }
+      }
+
+      return { width: source.width, height: source.height, red, accent };
+    });
+
+    expect(bounds.width).toBe(400);
+    expect(bounds.height).toBe(200);
+    expect(bounds.red.minX).toBeLessThanOrEqual(2);
+    expect(bounds.red.maxX).toBeGreaterThanOrEqual(bounds.width - 3);
+
+    const expectedHighlightX = (bounds.width - selectedBox!.width) / 2;
+    const expectedHighlightY = (bounds.height - selectedBox!.height) / 2;
+    expect(Math.abs(bounds.accent.minX - expectedHighlightX)).toBeLessThanOrEqual(8);
+    expect(
+      Math.abs(bounds.accent.maxX - (expectedHighlightX + selectedBox!.width))
+    ).toBeLessThanOrEqual(8);
+    expect(Math.abs(bounds.accent.minY - expectedHighlightY)).toBeLessThanOrEqual(8);
+    expect(
+      Math.abs(bounds.accent.maxY - (expectedHighlightY + selectedBox!.height))
+    ).toBeLessThanOrEqual(8);
+  });
+
+  test('element capture preserves vertical root margins while removing horizontal margins', async ({
+    page,
+  }) => {
+    await mockHtmlToImage(page, targetSpyToPng());
+    await page.goto('/test/?elementContextMaxArea=0');
+    await page.evaluate(() => {
+      const target = document.createElement('div');
+      target.id = 'vertical-margin-capture-fixture';
+      target.style.cssText = 'width: 400px; height: 200px; margin: 20px auto 30px;';
+      document.body.prepend(target);
+    });
+
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="element"]').click();
+    await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible({ timeout: 5000 });
+    const selected = page.locator('#vertical-margin-capture-fixture');
+    const selectedBox = await selected.boundingBox();
+    expect(selectedBox).toBeTruthy();
+    await page.mouse.click(
+      selectedBox!.x + selectedBox!.width / 2,
+      selectedBox!.y + selectedBox!.height / 2
+    );
+
+    await expect(host.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+    const captureOpts = await page.evaluate(() => window.__captureOpts);
+    expect(captureOpts?.style).toEqual({ margin: '20px 0px 30px 0px' });
   });
 
   test('element picker selects nearest clickable ancestor from nested content', async ({

--- a/src/widget/screenshot.ts
+++ b/src/widget/screenshot.ts
@@ -98,6 +98,7 @@ export async function captureScreenshot(
       : null;
 
   const pixelRatio = captureOptions.pixelRatio ?? getPixelRatio(isFullPage, screenshotScale);
+  const elementStyle = element ? window.getComputedStyle(element) : null;
 
   const toPng = getToPng();
   const opts: HtmlToImageOptions = {
@@ -105,6 +106,11 @@ export async function captureScreenshot(
     imagePlaceholder: TRANSPARENT_IMAGE_PLACEHOLDER,
     pixelRatio,
     filter: shouldIncludeCaptureNode,
+    // Root margins position an element in its parent, but html-to-image copies them inside its
+    // border-box crop. Preserve computed vertical margins; clear horizontal margins to stop drift.
+    ...(elementStyle && (elementStyle.marginLeft !== '0px' || elementStyle.marginRight !== '0px')
+      ? { style: { margin: `${elementStyle.marginTop} 0px ${elementStyle.marginBottom} 0px` } }
+      : {}),
   };
 
   const redactionSnapshot = createRedactionSnapshot(target);


### PR DESCRIPTION
Closes #252

## What changed

Selected-element screenshots now treat the captured element's border box as the horizontal image origin, including when the live layout centers that element with automatic margins. Vertical margins and descendant layout remain unchanged.

## Why

`html-to-image` measures the screenshot from the element's border box, which excludes outer margins, but then copies the resolved page-relative margins into its clone. Removing only the cloned root's horizontal margins corrects that mismatch without changing the live page.

Clearing all four margins also fixed the visible offset, but changed root/child vertical margin behavior in a controlled fixture. The narrower correction therefore preserves computed top and bottom margins and leaves full-page and selected-area captures untouched.

## Risks we're accepting

Vertical root-margin offsets remain outside this change because correcting them safely requires a separate decision about margin collapsing. Element captures that relied on the previous horizontal blank space and clipping will change, but that output contradicts the documented tight-capture behavior.

---

## Test plan

- [x] `npm run validate` — lint, formatting, type checks, and 340 unit tests passed.
- [x] Built the widget with test hooks and ran the three focused margin/context tests.
- [x] Ran 11 selected-element and masking browser tests.
- [x] Ran 15 full-page and selected-area browser tests.
- [x] Loaded the local widget on the Secunda production page and verified the 1,280px "Cars in Stock" capture was centered and unclipped.
