### PR TITLE
feat: add German (de) locale for widget UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
 | ------------------------------- | ---------------------------------------------------- | --------------------- |
 | `data-repo`                     | `owner/repo`                                         | **required**          |
 | `data-theme`                    | `light`, `dark`, `auto`                              | `auto`                |
-| `data-locale`                   | `en`, `nl`, `pl` (region subtags accepted)           | `<html lang>` or `en` |
+| `data-locale`                   | `de`, `en`, `nl`, `pl` (region subtags accepted)     | `<html lang>` or `en` |
 | `data-position`                 | `bottom-right`, `bottom-left`                        | `bottom-right`        |
 | `data-color`                    | Accent color for buttons/highlights (e.g. `#FF6B35`) | `#14b8a6` (teal)      |
 | `data-label`                    | Any string                                           | localized label       |

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -10,7 +10,7 @@ These attributes control the fundamental behavior of the widget.
 |-----------|---------|-------------|
 | `data-repo` | **(required)** | GitHub repository in `owner/repo` format |
 | `data-theme` | `"auto"` | Widget theme: `"light"`, `"dark"`, or `"auto"` |
-| `data-locale` | `<html lang>` or `"en"` | UI language: `"en"`, `"nl"`, or `"pl"` |
+| `data-locale` | `<html lang>` or `"en"` | UI language: `"de"`, `"en"`, `"nl"`, or `"pl"` |
 | `data-position` | `"bottom-right"` | Button position: `"bottom-right"` or `"bottom-left"` |
 | `data-color` | `"#14b8a6"` | Primary accent color (any CSS color value) |
 | `data-icon` | *(default bug icon)* | Custom icon: URL to an image, `"none"` to hide, or omit for default |
@@ -62,7 +62,8 @@ The `data-theme` attribute controls the overall color scheme of the widget:
 The `data-locale` attribute controls BugDrop's built-in widget UI text -- the
 feedback form, screenshot flow, annotation tools, and most success/error messages.
 Brand attribution, custom labels, and server-provided error text may remain as
-provided. Supported locales: **`en`** (English), **`nl`** (Dutch), **`pl`** (Polish).
+provided. Supported locales: **`de`** (German), **`en`** (English), **`nl`** (Dutch),
+**`pl`** (Polish).
 
 Resolution order:
 

--- a/e2e/locale.spec.ts
+++ b/e2e/locale.spec.ts
@@ -4,6 +4,7 @@ import { test, expect, type Page } from '@playwright/test';
 // rendered localized UI through the widget shadow DOM.
 
 const WELCOME_TITLES = {
+  de: 'Teilen Sie Ihr Feedback',
   en: 'Share Your Feedback',
   nl: 'Deel uw feedback',
   pl: 'Podziel się opinią',
@@ -58,6 +59,11 @@ test.describe('Widget localization', () => {
   test('defaults to English without data-locale', async ({ page }) => {
     await openWidget(page);
     await expect(modalTitle(page)).toHaveText(WELCOME_TITLES.en);
+  });
+
+  test('data-locale="de" renders the German UI', async ({ page }) => {
+    await openWidget(page, { locale: 'de' });
+    await expect(modalTitle(page)).toHaveText(WELCOME_TITLES.de);
   });
 
   test('data-locale="nl" renders the Dutch UI', async ({ page }) => {

--- a/src/widget/i18n.ts
+++ b/src/widget/i18n.ts
@@ -1,3 +1,4 @@
+import { de } from './locales/de';
 import { en } from './locales/en';
 import { nl } from './locales/nl';
 import { pl } from './locales/pl';
@@ -115,7 +116,7 @@ export interface WidgetStrings {
   captureTimeout: string;
 }
 
-const DICTIONARIES = { en, nl, pl } satisfies Record<string, WidgetStrings>;
+const DICTIONARIES = { en, de, nl, pl } satisfies Record<string, WidgetStrings>;
 
 export type SupportedLocale = keyof typeof DICTIONARIES;
 

--- a/src/widget/locales/de.ts
+++ b/src/widget/locales/de.ts
@@ -1,0 +1,135 @@
+import type { WidgetStrings } from '../i18n';
+
+export const de: WidgetStrings = {
+  // Trigger button & pull tab
+  triggerLabel: 'Feedback',
+  triggerAriaLabel: 'Fehler melden oder Feedback senden',
+  dismissButtonAriaLabel: 'Feedback-Button ausblenden',
+  pullTabAriaLabel: 'Feedback-Button anzeigen',
+  dragHandleTitle: 'Feedback-Button verschieben',
+  // Install prompt
+  installRequiredTitle: 'Installation erforderlich',
+  connectionErrorTitle: 'Verbindungsfehler',
+  installRequiredMessage:
+    'BugDrop benötigt die Installation der GitHub-App, um Issues zu erstellen.',
+  apiUnreachableMessage:
+    'Die BugDrop-API ist nicht erreichbar. Überprüfen Sie Ihre Netzwerkverbindung oder die URL des Script-Tags.',
+  installApp: 'App installieren',
+  // Welcome screen
+  welcomeTitle: 'Teilen Sie Ihr Feedback',
+  welcomeHeadline: 'Helfen Sie uns, besser zu werden, indem Sie Ihre Meinung teilen',
+  welcomeBodyLine1:
+    'Melden Sie Fehler, schlagen Sie Funktionen vor oder hinterlassen Sie Feedback.',
+  welcomeBodyLine2: 'Sie können optional kommentierte Screenshots hinzufügen.',
+  getStarted: 'Los geht’s',
+  // Feedback form
+  feedbackFormTitle: 'Feedback senden',
+  categoryLabel: 'Kategorie',
+  categoryBug: 'Fehler',
+  categoryFeature: 'Funktion',
+  categoryQuestion: 'Frage',
+  nameLabel: 'Name',
+  namePlaceholder: 'Ihr Name',
+  emailLabel: 'E-Mail',
+  emailPlaceholder: 'ihre@email.de',
+  titleLabel: 'Titel',
+  titlePlaceholder: 'Kurze Beschreibung des Problems oder Vorschlags',
+  descriptionLabel: 'Beschreibung',
+  descriptionPlaceholder: 'Geben Sie weitere Details, Schritte zur Reproduktion oder Kontext an...',
+  screenshotAutoNote:
+    'Diese Website hängt beim Absenden automatisch einen Screenshot der gesamten Seite an, ohne eine Vorschau anzuzeigen. Überprüfen Sie Ihre Seite vor dem Senden auf sensible Informationen.',
+  screenshotAutoRedactionNote:
+    'Einige von dieser Website als privat markierte Felder können auf unterstützten Seiten optisch maskiert werden, nicht markierte sensible Informationen können jedoch weiterhin enthalten sein.',
+  screenshotRequiredNote: '📸 Vor dem Absenden ist ein Screenshot erforderlich.',
+  includeScreenshotLabel: '📸 Screenshot hinzufügen',
+  sendConsoleLogsLabel: 'Konsolenprotokolle mitsenden',
+  // Uploads
+  uploadsAriaLabel: 'Uploads',
+  uploadFilesAriaLabel: 'Dateien hochladen',
+  uploadButton: 'Hochladen',
+  uploadTooMany: (max: number) =>
+    `Laden Sie bis zu ${max} Dateien hoch. Entfernen Sie eine Datei, bevor Sie eine weitere hinzufügen.`,
+  uploadUnsupportedType:
+    'Dieser Dateityp wird nicht unterstützt. Laden Sie ein Bild, ein PDF oder ein kurzes Video hoch.',
+  uploadTooLarge: (maxSize: string) =>
+    `Die Datei ist zu groß. Laden Sie Dateien bis zu ${maxSize} hoch.`,
+  uploadReadError: 'Diese Datei konnte nicht gelesen werden. Versuchen Sie es mit einer anderen.',
+  removeAttachmentAriaLabel: (name: string) => `${name} entfernen`,
+  // Common buttons
+  cancel: 'Abbrechen',
+  continueButton: 'Weiter',
+  submit: 'Absenden',
+  // Submission
+  submittingTitle: 'Wird gesendet...',
+  creatingIssue: 'Issue wird erstellt...',
+  rateLimited: (minutes: number) =>
+    `Zu viele Übermittlungen. Bitte versuchen Sie es in ${minutes} Minute${minutes === 1 ? '' : 'n'} erneut.`,
+  submitFailedFallback: 'Senden fehlgeschlagen',
+  networkError: 'Netzwerkfehler. Bitte überprüfen Sie Ihre Verbindung.',
+  submissionFailedTitle: 'Senden fehlgeschlagen',
+  tryAgain: 'Erneut versuchen',
+  // Success modal
+  successTitle: 'Feedback gesendet!',
+  issueCreated: (issueNumberHtml: string) => `Issue ${issueNumberHtml} wurde erstellt.`,
+  feedbackSubmittedMessage: 'Ihr Feedback wurde erfolgreich gesendet.',
+  viewOnGitHub: 'Auf GitHub ansehen',
+  done: 'Fertig',
+  // Screenshot options
+  captureScreenshotTitle: 'Screenshot erstellen',
+  chooseWhatToCapture: 'Wählen Sie aus, was erfasst werden soll:',
+  viewportRedactionWarning:
+    'Bei der Erfassung des sichtbaren Bereichs über den Browser können private Felder nicht automatisch maskiert werden. Wählen Sie „Element auswählen“, um die automatische Maskierung beizubehalten, oder überprüfen und verdecken Sie sensible Bereiche vor dem Senden.',
+  redactionReviewNote:
+    'Diese Website hat einige Felder zur Schwärzung markiert. Überprüfen Sie den Screenshot vor dem Senden.',
+  pageTooComplexViewportNote:
+    'Diese Seite ist zu komplex für eine vollständige Erfassung oder eine Bereichserfassung. Erfassen Sie stattdessen den sichtbaren Bereich oder wählen Sie ein bestimmtes Element aus.',
+  pageTooComplexElementNote:
+    'Diese Seite ist zu komplex für eine vollständige Erfassung oder eine Bereichserfassung. Wählen Sie stattdessen ein bestimmtes Element aus.',
+  fullPage: 'Ganze Seite',
+  captureViewport: 'Sichtbaren Bereich erfassen',
+  selectArea: 'Bereich auswählen',
+  selectElement: 'Element auswählen',
+  skipScreenshot: 'Screenshot überspringen',
+  // Element & area pickers
+  areaPickerInstruction: 'Ziehen Sie eine Auswahl um den zu erfassenden Bereich',
+  areaPickerRedactionInstruction:
+    'Ziehen Sie eine Auswahl um den zu erfassenden Bereich. Markierte private Felder können maskiert werden, wenn sie darin enthalten sind.',
+  elementPickerInstruction: 'Klicken Sie auf ein beliebiges Element, um es zu erfassen',
+  elementPickerTouchInstruction: 'Tippen Sie auf ein beliebiges Element, um es zu erfassen',
+  escToCancel: 'ESC zum Abbrechen',
+  // Capture loading & failures
+  capturingTitle: 'Wird erfasst...',
+  capturingScreenshot: 'Screenshot wird erfasst...',
+  captureFailedTitle: 'Erfassung fehlgeschlagen',
+  captureFailedMessage:
+    'Der Screenshot konnte nicht erfasst werden. Die Seite ist möglicherweise zu komplex, oder Browsereinschränkungen greifen.',
+  chooseAnotherMethod: 'Andere Methode wählen',
+  maskFailureTitle: 'Datenschutz-Maskierung fehlgeschlagen',
+  maskFailureMessage:
+    'Die automatische Schwärzung privater Felder konnte nicht angewendet werden. Zum Schutz Ihrer Daten wurde dieser Screenshot verworfen. Sie können Ihr Feedback weiterhin ohne Screenshot senden.',
+  continueWithoutScreenshot: 'Ohne Screenshot fortfahren',
+  // Annotation step
+  reviewScreenshotTitle: 'Screenshot überprüfen',
+  viewportRedactionUnavailableNote:
+    'Bei diesem über den Browser erfassten sichtbaren Bereich konnten private Felder nicht automatisch maskiert werden. Überprüfen und verdecken Sie sensible Bereiche vor dem Senden.',
+  redactionCountNote: (count: number) =>
+    count === 1
+      ? `${count} privates Element wurde zur Schwärzung in diesem Screenshot markiert. Überprüfen Sie ihn vor dem Senden.`
+      : `${count} private Elemente wurden zur Schwärzung in diesem Screenshot markiert. Überprüfen Sie ihn vor dem Senden.`,
+  redactionLimitationsNote:
+    'BugDrop hat nur die gemessenen markierten Bereiche abgedeckt. Es untersucht keine Pixel innerhalb eingebetteter oder gerenderter Inhalte wie iFrames, Canvas, Bildern, SVGs, Videos, CSS-Hintergründen oder benutzerdefinierten Steuerelementen. Stellen Sie vor dem Senden sicher, dass das schwarze Feld den sensiblen Bereich vollständig abdeckt, oder nehmen Sie den Screenshot nach Markierung eines größeren Bereichs erneut auf.',
+  annotationInstruction:
+    'Stellen Sie vor dem Senden sicher, dass keine sensiblen Informationen sichtbar sind. Verdecken Sie sensible Bereiche vor dem Absenden. Schwärzungen werden dauerhaft in das hochgeladene Bild eingebettet.',
+  selectedElementNote: (linkHtml: string) =>
+    `Benötigen Sie mehr umgebenden Kontext? Passen Sie ${linkHtml} im BugDrop-Script-Tag an.`,
+  toolDraw: 'Zeichnen',
+  toolArrow: 'Pfeil',
+  toolRectangle: 'Rechteck',
+  toolRedact: 'Schwärzen',
+  undo: 'Rückgängig',
+  retake: 'Erneut aufnehmen',
+  submitFeedback: 'Feedback senden',
+  // Capture timeout
+  captureTimeout:
+    'Zeitüberschreitung bei der Screenshot-Erfassung — die Seite ist möglicherweise zu komplex',
+};

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { escapeWidgetText, resolveLocale, setLocale, t } from '../src/widget/i18n';
+import { de } from '../src/widget/locales/de';
 import { en } from '../src/widget/locales/en';
 import { nl } from '../src/widget/locales/nl';
 import { pl } from '../src/widget/locales/pl';
@@ -12,17 +13,20 @@ afterEach(() => {
 describe('resolveLocale', () => {
   it('resolves exactly matching supported locales', () => {
     expect(resolveLocale('en')).toBe('en');
+    expect(resolveLocale('de')).toBe('de');
     expect(resolveLocale('nl')).toBe('nl');
     expect(resolveLocale('pl')).toBe('pl');
   });
 
   it('resolves region subtags to the base language', () => {
+    expect(resolveLocale('de-DE')).toBe('de');
     expect(resolveLocale('nl-NL')).toBe('nl');
     expect(resolveLocale('pl-PL')).toBe('pl');
     expect(resolveLocale('en-GB')).toBe('en');
   });
 
   it('resolves underscore region formats to the base language', () => {
+    expect(resolveLocale('de_DE')).toBe('de');
     expect(resolveLocale('nl_NL')).toBe('nl');
     expect(resolveLocale('pl_PL')).toBe('pl');
   });
@@ -31,15 +35,16 @@ describe('resolveLocale', () => {
     expect(resolveLocale('NL')).toBe('nl');
     expect(resolveLocale('Pl-pl')).toBe('pl');
     expect(resolveLocale('EN-us')).toBe('en');
+    expect(resolveLocale('DE-de')).toBe('de');
   });
 
   it('falls back to English and warns for unsupported locales', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-    expect(resolveLocale('de')).toBe('en');
+    expect(resolveLocale('fr')).toBe('en');
 
     expect(warn).toHaveBeenCalledWith(
-      '[BugDrop] Unsupported data-locale "de"; falling back to English.'
+      '[BugDrop] Unsupported data-locale "fr"; falling back to English.'
     );
   });
 
@@ -60,6 +65,9 @@ describe('setLocale and t', () => {
   });
 
   it('switches the active dictionary', () => {
+    setLocale('de');
+    expect(t()).toBe(de);
+
     setLocale('nl');
     expect(t()).toBe(nl);
 
@@ -80,6 +88,7 @@ describe('locale dictionaries', () => {
   const enKeys = Object.keys(en).sort();
 
   it.each([
+    ['de', de],
     ['nl', nl],
     ['pl', pl],
   ] as const)('%s has exactly the same keys as en', (_name, dictionary) => {
@@ -87,6 +96,7 @@ describe('locale dictionaries', () => {
   });
 
   it.each([
+    ['de', de],
     ['nl', nl],
     ['pl', pl],
   ] as const)('%s entries have the same type as their en counterparts', (_name, dictionary) => {
@@ -100,10 +110,12 @@ describe('locale dictionaries', () => {
     const configLink = '<a href="#docs">data-element-context-max-area</a>';
 
     expect(en.issueCreated(issueLink)).toBe(`Issue ${issueLink} has been created.`);
+    expect(de.issueCreated(issueLink).match(/<strong>#1<\/strong>/g)).toHaveLength(1);
     expect(nl.issueCreated(issueLink).match(/<strong>#1<\/strong>/g)).toHaveLength(1);
     expect(pl.issueCreated(issueLink).match(/<strong>#1<\/strong>/g)).toHaveLength(1);
 
     expect(en.selectedElementNote(configLink).match(/<a href="#docs">/g)).toHaveLength(1);
+    expect(de.selectedElementNote(configLink).match(/<a href="#docs">/g)).toHaveLength(1);
     expect(nl.selectedElementNote(configLink).match(/<a href="#docs">/g)).toHaveLength(1);
     expect(pl.selectedElementNote(configLink).match(/<a href="#docs">/g)).toHaveLength(1);
   });
@@ -111,6 +123,12 @@ describe('locale dictionaries', () => {
   it('formats count-sensitive messages for singular and plural boundaries', () => {
     expect(en.rateLimited(1)).toContain('1 minute.');
     expect(en.rateLimited(2)).toContain('2 minutes.');
+
+    expect(de.rateLimited(1)).toContain('1 Minute ');
+    expect(de.rateLimited(2)).toContain('2 Minuten ');
+
+    expect(de.redactionCountNote(1)).toContain('1 privates Element');
+    expect(de.redactionCountNote(2)).toContain('2 private Elemente');
 
     expect(nl.redactionCountNote(1)).toContain('1 privé-item');
     expect(nl.redactionCountNote(2)).toContain('2 privé-items');


### PR DESCRIPTION
Hi! 
First off, really nice work on BugDrop, the whole flow from client annotation straight to a GitHub Issue is exactly what freelancers like me have been missing. I very impresssed by the system and it`s very easy istall und so it fits perfect in my development pipeline.
I've been dealing with the "client sends a screenshot with a red circle in Mattermost" problem for years, and this solves it in the cleanest way I've seen so far, no per-seat pricing, self-hostable, actually open source.

This PR adds a German (de) locale for the widget UI, translating all strings in WidgetStrings following the same structure as en.ts. A lot of German-speaking freelancers and agencies (myself included) work with clients who are far more comfortable giving feedback in their native language, so I think this would be a genuinely useful addition for the DACH region.

Happy to adjust tone or wording if you'd prefer something more formal/informal, or if any strings need rework. Thanks again for building and open-sourcing this, hope it keeps growing, because it deserves it!