### PR TITLE
ci: skip expensive checks for docs-only pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,92 @@ jobs:
   check:
     name: Lint, Typecheck, Knip, Audit
     runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+    outputs:
+      full_ci: ${{ steps.scope.outputs.full_ci }}
+      diff_base: ${{ steps.scope.outputs.diff_base }}
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Verify previous full CI succeeded
+        id: previous-ci
+        if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+        uses: actions/github-script@v8
+        with:
+          result-encoding: string
+          script: |
+            const expected = [
+              'Lint, Typecheck, Knip, Audit',
+              'Unit Tests & Build',
+              'E2E Tests (Shard 1/2)',
+              'E2E Tests (Shard 2/2)',
+              'Radix Cross-Browser E2E (chromium)',
+              'Radix Cross-Browser E2E (firefox)',
+              'Radix Cross-Browser E2E (webkit)',
+            ];
+            const { data } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.before,
+              filter: 'latest',
+              per_page: 100,
+            });
+            const expectedNames = new Set(expected);
+            const suites = new Map();
+            for (const run of data.check_runs) {
+              if (
+                run.app?.slug !== 'github-actions' ||
+                !expectedNames.has(run.name) ||
+                !run.check_suite?.id
+              ) {
+                continue;
+              }
+              const suite = suites.get(run.check_suite.id) ?? {
+                runs: new Map(),
+              };
+              const current = suite.runs.get(run.name);
+              if (!current || run.id > current.id) {
+                suite.runs.set(run.name, run);
+              }
+              suites.set(run.check_suite.id, suite);
+            }
+            const gateName = 'Lint, Typecheck, Knip, Audit';
+            const latestSuite = [...suites.values()]
+              .filter((suite) => suite.runs.has(gateName))
+              .sort(
+                (left, right) =>
+                  right.runs.get(gateName).id - left.runs.get(gateName).id,
+              )[0];
+            const passed = expected.every(
+              (name) => latestSuite?.runs.get(name)?.conclusion === 'success',
+            );
+            core.info(
+              passed
+                ? 'All reusable checks passed on the previous SHA.'
+                : 'Previous checks are missing, pending, or unsuccessful; full CI is required.',
+            );
+            return passed;
+
+      - name: Determine CI scope
+        id: scope
+        shell: bash
+        env:
+          PR_ACTION: ${{ github.event.action }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          scripts/ci-scope.sh \
+            "$GITHUB_EVENT_NAME" \
+            "$PR_ACTION" \
+            "$PR_BASE_SHA" \
+            "$PR_HEAD_SHA" \
+            "$PR_BEFORE_SHA" \
+            "${{ steps.previous-ci.outputs.result }}"
 
       - uses: actions/setup-node@v5
         with:
@@ -21,16 +103,40 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
+        if: steps.scope.outputs.full_ci != 'false'
         run: make install
 
       - name: Run checks (lint, typecheck, knip, audit)
+        if: steps.scope.outputs.full_ci != 'false'
         run: make check
+
+      - name: Check changed documentation formatting
+        if: steps.scope.outputs.full_ci == 'false'
+        shell: bash
+        env:
+          DIFF_BASE_SHA: ${{ steps.scope.outputs.diff_base }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          format_files=()
+          while IFS= read -r -d '' path; do
+            format_files+=("$path")
+          done < <(
+            scripts/changed-docs.sh "$DIFF_BASE_SHA" "$PR_HEAD_SHA"
+          )
+          if (( ${#format_files[@]} > 0 )); then
+            printf '%s\0' "${format_files[@]}" |
+              xargs -0 npx --yes prettier@3.8.1 --check --ignore-unknown --
+          else
+            echo 'No remaining documentation files require formatting.'
+          fi
 
   # Unit tests and build
   test:
     name: Unit Tests & Build
     runs-on: ubuntu-latest
     needs: check
+    # Keep the required check visible as skipped for docs-only pull requests.
+    if: needs.check.outputs.full_ci != 'false'
     steps:
       - uses: actions/checkout@v5
 
@@ -58,24 +164,36 @@ jobs:
       matrix:
         shard: [1, 2]
     steps:
+      # These no-op matrix jobs preserve the two exact required check names. A job-level
+      # condition is evaluated before matrix expansion and would collapse them into one.
+      - name: Skip expensive E2E for documentation-only changes
+        if: needs.check.outputs.full_ci == 'false'
+        run: echo 'Documentation-only change; required E2E context satisfied without browser tests.'
+
       - uses: actions/checkout@v5
+        if: needs.check.outputs.full_ci != 'false'
 
       - uses: actions/setup-node@v5
+        if: needs.check.outputs.full_ci != 'false'
         with:
           node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
+        if: needs.check.outputs.full_ci != 'false'
         run: make install
 
       - name: Build widget
+        if: needs.check.outputs.full_ci != 'false'
         run: make build-widget
 
       - name: Get Playwright version
+        if: needs.check.outputs.full_ci != 'false'
         id: pw-version
         run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
+        if: needs.check.outputs.full_ci != 'false'
         id: pw-cache
         uses: actions/cache@v5
         with:
@@ -84,22 +202,23 @@ jobs:
 
       - name: Install Playwright browsers
         timeout-minutes: 5
-        if: steps.pw-cache.outputs.cache-hit != 'true'
+        if: needs.check.outputs.full_ci != 'false' && steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Install Playwright system deps
         timeout-minutes: 5
-        if: steps.pw-cache.outputs.cache-hit == 'true'
+        if: needs.check.outputs.full_ci != 'false' && steps.pw-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
 
       - name: Run E2E Tests (Shard ${{ matrix.shard }}/2)
+        if: needs.check.outputs.full_ci != 'false'
         run: make test-e2e-shard SHARD=${{ matrix.shard }}/2
         env:
           CI: true
 
       - name: Upload E2E Report
         uses: actions/upload-artifact@v5
-        if: failure()
+        if: needs.check.outputs.full_ci != 'false' && failure()
         with:
           name: playwright-report-shard-${{ matrix.shard }}
           path: playwright-report/
@@ -110,6 +229,7 @@ jobs:
     name: Radix Cross-Browser E2E (${{ matrix.browser }})
     runs-on: ubuntu-latest
     needs: check
+    if: needs.check.outputs.full_ci != 'false'
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build build-widget build-all deploy test test-watch test-e2e test-e2e-ui test-e2e-shard test-radix-e2e test-live-radix test-live-cross-browser lint lint-fix format format-check typecheck knip audit check-actions-node24 check ci clean install install-playwright help
+.PHONY: dev build build-widget build-all deploy test test-watch test-e2e test-e2e-ui test-e2e-shard test-radix-e2e test-live-radix test-live-cross-browser lint lint-fix format format-check typecheck knip audit check-actions-node24 check-ci-scope check-ci-workflow check ci clean install install-playwright help
 
 # Development
 dev:
@@ -86,8 +86,14 @@ knip:
 check-actions-node24:
 	npm run check:actions-node24
 
+check-ci-scope:
+	bash test/ci-scope.test.sh
+
+check-ci-workflow:
+	bash test/ci-workflow-contract.test.sh
+
 # Combined Commands
-check: lint format-check typecheck knip audit check-actions-node24
+check: lint format-check typecheck knip audit check-actions-node24 check-ci-scope check-ci-workflow
 	@echo "✓ All checks passed"
 
 ci: check test build-all test-e2e

--- a/scripts/changed-docs.sh
+++ b/scripts/changed-docs.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+base_sha=${1:?Usage: changed-docs.sh <base-sha> <head-sha>}
+head_sha=${2:?Usage: changed-docs.sh <base-sha> <head-sha>}
+
+while IFS= read -r -d '' path; do
+  [[ -f "$path" ]] && printf '%s\0' "$path"
+done < <(git diff --no-renames --name-only -z "$base_sha" "$head_sha")

--- a/scripts/ci-scope.sh
+++ b/scripts/ci-scope.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+event_name=${1:?Usage: ci-scope.sh <event-name> <action> <base-sha> <head-sha> <before-sha> <previous-ci-passed>}
+action=${2:-}
+base_sha=${3:-}
+head_sha=${4:-}
+before_sha=${5:-}
+previous_ci_passed=${6:-false}
+
+full_ci=true
+diff_base=''
+reason="${event_name} events always run full CI"
+
+commit_exists() {
+  [[ -n "$1" ]] && git cat-file -e "$1^{commit}" 2>/dev/null
+}
+
+if [[ "$event_name" == 'pull_request' ]]; then
+  if ! commit_exists "$base_sha" || ! commit_exists "$head_sha"; then
+    reason='pull request refs are unavailable; running full CI fail-safe'
+  else
+    if [[ "$action" == 'synchronize' ]]; then
+      if ! commit_exists "$before_sha" || ! git merge-base --is-ancestor "$before_sha" "$head_sha"; then
+        reason='push delta is unavailable or non-fast-forward; running full CI fail-safe'
+      else
+        diff_base=$before_sha
+      fi
+    else
+      diff_base=$(git merge-base "$base_sha" "$head_sha" 2>/dev/null || true)
+      if [[ -z "$diff_base" ]]; then
+        reason='pull request merge base is unavailable; running full CI fail-safe'
+      fi
+    fi
+
+    if [[ -n "$diff_base" ]]; then
+      changed_files=()
+      while IFS= read -r -d '' path; do
+        changed_files+=("$path")
+      done < <(git diff --no-renames --name-only -z "$diff_base" "$head_sha")
+
+      if [[ ${#changed_files[@]} -eq 0 ]]; then
+        reason='no changed files were detected; running full CI fail-safe'
+      else
+        full_ci=false
+        reason='the latest change contains documentation only'
+
+        for path in "${changed_files[@]}"; do
+          case "$path" in
+            AGENTS.md | CHANGELOG.md | CLAUDE.md | CONTRIBUTING.md | LICENSE | PRIVACY.md | README.md | SECURITY.md | SELF_HOSTING.md | TERMS.md | docs/*)
+              ;;
+            *)
+              full_ci=true
+              reason="${path} requires full CI"
+              break
+              ;;
+          esac
+        done
+
+        if [[ "$action" == 'synchronize' && "$full_ci" == 'false' && "$previous_ci_passed" != 'true' ]]; then
+          full_ci=true
+          reason='previous full CI is missing or unsuccessful; running full CI fail-safe'
+        fi
+      fi
+    fi
+  fi
+fi
+
+echo "full_ci=${full_ci}"
+echo "diff_base=${diff_base}"
+echo "CI scope: ${reason}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "full_ci=${full_ci}" >> "$GITHUB_OUTPUT"
+  echo "diff_base=${diff_base}" >> "$GITHUB_OUTPUT"
+fi

--- a/test/ci-scope.test.sh
+++ b/test/ci-scope.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+scope_script="$repo_root/scripts/ci-scope.sh"
+changed_docs_script="$repo_root/scripts/changed-docs.sh"
+test_repo=$(mktemp -d /tmp/bugdrop-ci-scope-test.XXXXXX)
+trap 'rm -rf "$test_repo"' EXIT
+
+git -C "$test_repo" init --quiet
+git -C "$test_repo" config user.name 'CI Scope Test'
+git -C "$test_repo" config user.email 'ci-scope@example.com'
+
+mkdir -p "$test_repo/src" "$test_repo/docs"
+printf '# Project\n' > "$test_repo/README.md"
+printf 'export const value = 1;\n' > "$test_repo/src/app.ts"
+git -C "$test_repo" add .
+git -C "$test_repo" commit --quiet -m 'initial'
+base_sha=$(git -C "$test_repo" rev-parse HEAD)
+
+printf 'export const value = 2;\n' > "$test_repo/src/app.ts"
+git -C "$test_repo" commit --quiet -am 'source change'
+source_head=$(git -C "$test_repo" rev-parse HEAD)
+
+printf '\nMore documentation.\n' >> "$test_repo/README.md"
+git -C "$test_repo" commit --quiet -am 'docs follow-up'
+docs_head=$(git -C "$test_repo" rev-parse HEAD)
+
+assert_scope() {
+  local expected=$1
+  shift
+
+  local output_file="$test_repo/.git/github-output"
+  : > "$output_file"
+  (
+    cd "$test_repo"
+    GITHUB_OUTPUT="$output_file" "$scope_script" "$@" >/dev/null
+  )
+
+  if ! grep -qx "full_ci=${expected}" "$output_file"; then
+    echo "Expected full_ci=${expected} for: $*" >&2
+    cat "$output_file" >&2
+    return 1
+  fi
+}
+
+# The motivating case: a docs-only push after a previously tested source change.
+assert_scope false pull_request synchronize "$base_sha" "$docs_head" "$source_head" true
+# A docs-only follow-up must not conceal failures from the preceding source SHA.
+assert_scope true pull_request synchronize "$base_sha" "$docs_head" "$source_head" false
+# Opening or reopening the same aggregate PR still validates its source changes.
+assert_scope true pull_request opened "$base_sha" "$docs_head" ''
+
+printf '# Guide\n' > "$test_repo/docs/guide with spaces.md"
+git -C "$test_repo" add .
+git -C "$test_repo" commit --quiet -m 'add spaced docs path'
+spaced_docs_head=$(git -C "$test_repo" rev-parse HEAD)
+assert_scope false pull_request synchronize "$base_sha" "$spaced_docs_head" "$docs_head" true
+
+format_files=()
+while IFS= read -r -d '' path; do
+  format_files+=("$path")
+done < <(
+  cd "$test_repo"
+  "$changed_docs_script" "$docs_head" "$spaced_docs_head"
+)
+[[ ${#format_files[@]} -eq 1 && "${format_files[0]}" == 'docs/guide with spaces.md' ]]
+
+rm "$test_repo/README.md"
+git -C "$test_repo" add -u
+git -C "$test_repo" commit --quiet -m 'delete docs'
+deleted_docs_head=$(git -C "$test_repo" rev-parse HEAD)
+assert_scope false pull_request synchronize "$base_sha" "$deleted_docs_head" "$spaced_docs_head" true
+
+format_files=()
+while IFS= read -r -d '' path; do
+  format_files+=("$path")
+done < <(
+  cd "$test_repo"
+  "$changed_docs_script" "$spaced_docs_head" "$deleted_docs_head"
+)
+[[ ${#format_files[@]} -eq 0 ]]
+
+printf 'export const value = 3;\n' > "$test_repo/src/app.ts"
+git -C "$test_repo" commit --quiet -am 'mixed source follow-up'
+mixed_head=$(git -C "$test_repo" rev-parse HEAD)
+assert_scope true pull_request synchronize "$base_sha" "$mixed_head" "$deleted_docs_head"
+assert_scope true pull_request synchronize "$base_sha" "$mixed_head" "$mixed_head"
+
+git -C "$test_repo" switch --quiet -c rewritten "$base_sha"
+printf '\nRewritten documentation.\n' >> "$test_repo/README.md"
+git -C "$test_repo" commit --quiet -am 'rewritten docs'
+rewritten_head=$(git -C "$test_repo" rev-parse HEAD)
+assert_scope true pull_request synchronize "$base_sha" "$rewritten_head" "$mixed_head"
+
+git -C "$test_repo" switch --quiet -c code-to-docs "$base_sha"
+mkdir -p "$test_repo/docs"
+git -C "$test_repo" mv src/app.ts docs/app.ts
+git -C "$test_repo" commit --quiet -m 'move code into docs'
+code_to_docs_head=$(git -C "$test_repo" rev-parse HEAD)
+assert_scope true pull_request synchronize "$base_sha" "$code_to_docs_head" "$base_sha"
+
+git -C "$test_repo" switch --quiet -c behind-docs "$base_sha"
+printf '\nDocs from a branch behind the base tip.\n' >> "$test_repo/README.md"
+git -C "$test_repo" commit --quiet -am 'docs from behind base'
+behind_docs_head=$(git -C "$test_repo" rev-parse HEAD)
+assert_scope false pull_request opened "$source_head" "$behind_docs_head" ''
+
+assert_scope true merge_group '' '' '' ''
+
+echo 'CI scope checks passed'

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+workflow="$repo_root/.github/workflows/ci.yml"
+
+# GitHub renders the matrix expression; this shell test must match it literally.
+# shellcheck disable=SC2016
+required_contexts=(
+  'Lint, Typecheck, Knip, Audit'
+  'Unit Tests & Build'
+  'E2E Tests (Shard ${{ matrix.shard }}/2)'
+  'Deploy Preview'
+  'Live Preview Tests'
+)
+
+for context in "${required_contexts[@]}"; do
+  grep -Fq "name: $context" "$workflow" || {
+    echo "Missing required check context: $context" >&2
+    exit 1
+  }
+done
+
+e2e_block=$(sed -n '/^  e2e:/,/^  radix-e2e:/p' "$workflow")
+if grep -Eq '^    if:' <<< "$e2e_block"; then
+  echo 'The required E2E matrix must not use a job-level condition.' >&2
+  exit 1
+fi
+
+grep -Fq 'shard: [1, 2]' <<< "$e2e_block"
+grep -Fq 'Skip expensive E2E for documentation-only changes' <<< "$e2e_block"
+grep -Fq 'Verify previous full CI succeeded' "$workflow"
+grep -Fq 'steps.previous-ci.outputs.result' "$workflow"
+grep -Fq "run.app?.slug !== 'github-actions'" "$workflow"
+grep -Fq 'suites.get(run.check_suite.id)' "$workflow"
+grep -Fq "const gateName = 'Lint, Typecheck, Knip, Audit'" "$workflow"
+grep -Fq 'right.runs.get(gateName).id' "$workflow"
+grep -Fq 'latestSuite?.runs.get(name)?.conclusion' "$workflow"
+
+echo 'CI workflow contract checks passed'


### PR DESCRIPTION
## Summary

- classify `synchronize` events from the previous PR head to the new head, so a docs-only follow-up does not repeat expensive checks that already passed
- reuse prior results only when the newest GitHub Actions CI suite has successful lint, unit/build, both required E2E shards, and all three Radix browser jobs
- keep the existing required check names visible while docs-only pushes run a lightweight formatting check and no-op E2E matrix jobs

## Safety model

- opened and reopened PRs inspect the aggregate branch diff from the merge base
- source changes, mixed changes, source-to-docs renames, missing refs, force pushes, pending/failed prior CI, and every merge-queue run execute full CI
- check runs are isolated by suite and the newest suite is selected by its lint gate, preventing older reruns from masking a newer failure

## Validation

- `make check`
- `shellcheck scripts/ci-scope.sh scripts/changed-docs.sh test/ci-scope.test.sh test/ci-workflow-contract.test.sh`
- `actionlint -ignore SC2086 .github/workflows/ci.yml`
- three pre-PR reviews: workflow correctness, test coverage, and simplification
