### PR TITLE
test: add merge queue issue canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,40 +286,13 @@ jobs:
   deploy-preview:
     name: Deploy Preview
     runs-on: ubuntu-latest
-    needs: check
+    timeout-minutes: 45
+    needs: [check, test, e2e, radix-e2e]
     if: github.event_name == 'merge_group'
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: make install
-
-      - name: Build all
-        run: VERSION=$(git describe --tags --abbrev=0) make build-all
-
-      - name: Deploy to preview
-        run: npx wrangler deploy --env preview
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-  # Live E2E tests against real cross-origin deployment (merge queue only)
-  live-preview-tests:
-    name: Live Preview Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    needs: [deploy-preview]
-    if: github.event_name == 'merge_group'
-    env:
-      LIVE_TARGET: preview
-      PLAYWRIGHT_BASE_URL: https://bugdrop-widget-test-git-preview-jermwatts-projects.vercel.app
+    concurrency:
+      group: bugdrop-shared-preview
+      cancel-in-progress: false
+      queue: max
     steps:
       - uses: actions/checkout@v5
         with:
@@ -342,55 +315,69 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: pw-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+          key: pw-${{ runner.os }}-all-${{ steps.pw-version.outputs.version }}
 
       - name: Install Playwright browsers
-        timeout-minutes: 5
+        timeout-minutes: 10
         if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium firefox webkit
 
       - name: Install Playwright system deps
-        timeout-minutes: 5
+        timeout-minutes: 10
         if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
+        run: npx playwright install-deps chromium firefox webkit
 
-      - name: Wait for preview widget deployment
+      - name: Record canary identity
+        shell: bash
+        run: |
+          echo "BUGDROP_CANARY_MARKER=bugdrop-ci-canary:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "BUGDROP_CANARY_RESULT_FILE=test-results/issue-canary-result.json" >> "$GITHUB_ENV"
+          echo "EXPECTED_WORKER_SHA=${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "EXPECTED_WIDGET_ORIGIN=https://bugdrop-preview.neonwatty.workers.dev" >> "$GITHUB_ENV"
+          echo "LIVE_TARGET=preview" >> "$GITHUB_ENV"
+          echo "PLAYWRIGHT_BASE_URL=https://bugdrop-widget-test-git-preview-jermwatts-projects.vercel.app" >> "$GITHUB_ENV"
+
+      - name: Preflight stale canary cleanup
+        run: >-
+          node scripts/github-issue-canary.mjs preflight
+          --repo mean-weasel/bugdrop-widget-test
+          --prefix "[BugDrop CI canary]"
+        env:
+          BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
+
+      - name: Build all
+        run: VERSION=$(git describe --tags --abbrev=0) make build-all
+
+      - name: Record expected preview widget hash
+        run: echo "EXPECTED_WIDGET_SHA256=$(shasum -a 256 public/widget.js | awk '{print $1}')" >> "$GITHUB_ENV"
+
+      - name: Deploy to preview
+        run: npx wrangler deploy --env preview --var "BUILD_SHA:$GITHUB_SHA"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Wait for exact preview Worker
         run: |
           WORKER_URL="https://bugdrop-preview.neonwatty.workers.dev/api/health"
-          echo "Polling $WORKER_URL until ready..."
+          echo "Polling preview health for the expected environment and build SHA..."
           for i in $(seq 1 30); do
-            if curl -sfo /dev/null "$WORKER_URL"; then
-              echo "Preview worker ready after $((i * 10))s"
+            HEALTH=$(curl -sSf "$WORKER_URL" || true)
+            ENVIRONMENT=$(jq -r '.environment // empty' <<< "$HEALTH")
+            BUILD_SHA=$(jq -r '.buildSha // empty' <<< "$HEALTH")
+            if [ "$ENVIRONMENT" = "preview" ] && [ "$BUILD_SHA" = "$GITHUB_SHA" ]; then
+              echo "Preview worker matched the expected build after $((i * 10))s"
               exit 0
             fi
-            echo "Attempt $i/30 — not ready, waiting 10s..."
+            echo "Attempt $i/30 did not match the expected preview identity; waiting 10s..."
             sleep 10
           done
-          echo "Preview worker not ready after 300s"
+          echo "Preview worker did not report the expected environment and build SHA"
           exit 1
 
-      - name: Verify test venue is reachable
+      - name: Wait for exact preview widget asset
         run: |
-          VENUE_URL="${PLAYWRIGHT_BASE_URL}"
-          echo "Checking test venue at $VENUE_URL..."
-          BYPASS_ARGS=""
-          if [ -n "$VERCEL_AUTOMATION_BYPASS_SECRET" ]; then
-            BYPASS_ARGS="-H x-vercel-protection-bypass:${VERCEL_AUTOMATION_BYPASS_SECRET}"
-          fi
-          curl -sfo /dev/null $BYPASS_ARGS "$VENUE_URL" || (echo "Test venue unreachable at $VENUE_URL" && exit 1)
-          echo "Test venue reachable"
-        env:
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-
-      - name: Record expected preview widget asset
-        run: |
-          VERSION=$(git describe --tags --abbrev=0) npm run build:widget
-          echo "EXPECTED_WIDGET_ORIGIN=https://bugdrop-preview.neonwatty.workers.dev" >> "$GITHUB_ENV"
-          echo "EXPECTED_WIDGET_SHA256=$(shasum -a 256 public/widget.js | awk '{print $1}')" >> "$GITHUB_ENV"
-
-      - name: Wait for expected preview widget asset
-        run: |
-          WIDGET_URL="https://bugdrop-preview.neonwatty.workers.dev/widget.js"
+          WIDGET_URL="$EXPECTED_WIDGET_ORIGIN/widget.js"
           echo "Waiting for $WIDGET_URL to serve $EXPECTED_WIDGET_SHA256..."
           for i in $(seq 1 30); do
             ACTUAL_SHA="$(curl -sSf "$WIDGET_URL" | shasum -a 256 | awk '{print $1}')"
@@ -404,8 +391,22 @@ jobs:
           echo "Preview widget did not serve expected asset $EXPECTED_WIDGET_SHA256"
           exit 1
 
+      - name: Verify fixed preview venue
+        run: |
+          BYPASS_ARGS=()
+          if [ -n "$VERCEL_AUTOMATION_BYPASS_SECRET" ]; then
+            BYPASS_ARGS=(-H "x-vercel-protection-bypass:${VERCEL_AUTOMATION_BYPASS_SECRET}")
+          fi
+          HTML=$(curl -sSf "${BYPASS_ARGS[@]}" "$PLAYWRIGHT_BASE_URL")
+          grep -Fq "$EXPECTED_WIDGET_ORIGIN/widget.js" <<< "$HTML" || {
+            echo 'The fixed venue does not reference the expected preview widget.'
+            exit 1
+          }
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
       - name: Run live E2E tests
-        run: npx playwright test --project=chromium-live --workers=1
+        run: npx playwright test --project=chromium-live --workers=1 --retries=0
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
@@ -414,106 +415,74 @@ jobs:
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
-      - name: Upload test report
+      - name: Run Chromium live cross-browser smoke
+        run: make test-live-cross-browser BROWSER=chromium
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Run Firefox live cross-browser smoke
+        run: make test-live-cross-browser BROWSER=firefox
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Run WebKit live cross-browser smoke
+        run: make test-live-cross-browser BROWSER=webkit
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Run one real-Issue canary
+        run: npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --workers=1 --retries=0
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Verify canary Issue independently
+        run: >-
+          node scripts/github-issue-canary.mjs verify
+          --repo mean-weasel/bugdrop-widget-test
+          --marker "$BUGDROP_CANARY_MARKER"
+          --expected-sha "$GITHUB_SHA"
+          --result-file "$BUGDROP_CANARY_RESULT_FILE"
+        env:
+          BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
+
+      - name: Cleanup current canary marker
+        if: always()
+        run: >-
+          node scripts/github-issue-canary.mjs cleanup
+          --repo mean-weasel/bugdrop-widget-test
+          --marker "$BUGDROP_CANARY_MARKER"
+        env:
+          BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
+
+      - name: Final reserved-prefix sweep
+        if: always()
+        run: >-
+          node scripts/github-issue-canary.mjs sweep
+          --repo mean-weasel/bugdrop-widget-test
+          --prefix "[BugDrop CI canary]"
+        env:
+          BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
+
+      - name: Upload preview failure report
         uses: actions/upload-artifact@v5
         if: failure()
         with:
-          name: playwright-live-report
+          name: playwright-preview-critical-report
           path: playwright-report/
           retention-days: 7
 
-  # Cross-browser live smoke tests against real cross-origin deployment (merge queue only)
-  live-preview-cross-browser-tests:
-    name: Live Preview Cross-Browser (${{ matrix.browser }})
+  # Required-check bridge: fail closed if the merge-group critical section did not succeed.
+  live-preview-tests:
+    name: Live Preview Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     needs: [deploy-preview]
-    if: github.event_name == 'merge_group'
-    strategy:
-      fail-fast: false
-      matrix:
-        browser: [chromium, firefox, webkit]
-    env:
-      LIVE_TARGET: preview
-      PLAYWRIGHT_BASE_URL: https://bugdrop-widget-test-git-preview-jermwatts-projects.vercel.app
+    if: ${{ always() && github.event_name == 'merge_group' }}
     steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: make install
-
-      - name: Get Playwright version
-        id: pw-version
-        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browser
-        id: pw-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: pw-${{ runner.os }}-${{ matrix.browser }}-${{ steps.pw-version.outputs.version }}
-
-      - name: Install Playwright browser
-        timeout-minutes: 5
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps ${{ matrix.browser }}
-
-      - name: Install Playwright system deps
-        timeout-minutes: 5
-        if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps ${{ matrix.browser }}
-
-      - name: Verify test venue is reachable
+      - name: Require successful preview critical section
+        env:
+          CRITICAL_RESULT: ${{ needs.deploy-preview.result }}
         run: |
-          VENUE_URL="${PLAYWRIGHT_BASE_URL}"
-          echo "Checking test venue at $VENUE_URL..."
-          BYPASS_ARGS=""
-          if [ -n "$VERCEL_AUTOMATION_BYPASS_SECRET" ]; then
-            BYPASS_ARGS="-H x-vercel-protection-bypass:${VERCEL_AUTOMATION_BYPASS_SECRET}"
+          if [ "$CRITICAL_RESULT" != "success" ]; then
+            echo "Deploy Preview concluded $CRITICAL_RESULT; failing required status."
+            exit 1
           fi
-          curl -sfo /dev/null $BYPASS_ARGS "$VENUE_URL" || (echo "Test venue unreachable at $VENUE_URL" && exit 1)
-          echo "Test venue reachable"
-        env:
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-
-      - name: Record expected preview widget asset
-        run: |
-          VERSION=$(git describe --tags --abbrev=0) npm run build:widget
-          echo "EXPECTED_WIDGET_ORIGIN=https://bugdrop-preview.neonwatty.workers.dev" >> "$GITHUB_ENV"
-          echo "EXPECTED_WIDGET_SHA256=$(shasum -a 256 public/widget.js | awk '{print $1}')" >> "$GITHUB_ENV"
-
-      - name: Wait for expected preview widget asset
-        run: |
-          WIDGET_URL="https://bugdrop-preview.neonwatty.workers.dev/widget.js"
-          echo "Waiting for $WIDGET_URL to serve $EXPECTED_WIDGET_SHA256..."
-          for i in $(seq 1 30); do
-            ACTUAL_SHA="$(curl -sSf "$WIDGET_URL" | shasum -a 256 | awk '{print $1}')"
-            if [ "$ACTUAL_SHA" = "$EXPECTED_WIDGET_SHA256" ]; then
-              echo "Preview widget asset matched after $((i * 5))s"
-              exit 0
-            fi
-            echo "Attempt $i/30 served $ACTUAL_SHA; waiting 5s..."
-            sleep 5
-          done
-          echo "Preview widget did not serve expected asset $EXPECTED_WIDGET_SHA256"
-          exit 1
-
-      - name: Run cross-browser live smoke tests
-        run: npx playwright test e2e/widget.cross-browser-live.spec.ts --project=${{ matrix.browser }}-cross-browser-live --workers=1
-        env:
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-
-      - name: Upload cross-browser test report
-        uses: actions/upload-artifact@v5
-        if: failure()
-        with:
-          name: playwright-cross-browser-report-${{ matrix.browser }}
-          path: playwright-report/
-          retention-days: 7

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -15,6 +15,11 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+concurrency:
+  group: ${{ github.event_name == 'schedule' && 'bugdrop-shared-preview' || format('bugdrop-live-{0}-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: false
+  queue: max
+
 jobs:
   live-tests:
     name: Live E2E Tests
@@ -98,7 +103,7 @@ jobs:
           exit 1
 
       - name: Run live E2E tests
-        run: npx playwright test --project=chromium-live --workers=1
+        run: npx playwright test --project=chromium-live --workers=1 --retries=0
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
@@ -106,6 +111,15 @@ jobs:
         run: make test-live-radix
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Sweep stale merge-queue canaries
+        if: always() && github.event_name == 'schedule'
+        run: >-
+          node scripts/github-issue-canary.mjs sweep
+          --repo mean-weasel/bugdrop-widget-test
+          --prefix "[BugDrop CI canary]"
+        env:
+          BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
 
       - name: Upload test report
         uses: actions/upload-artifact@v5

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test-live-radix:
 		echo "Set VERCEL_AUTOMATION_BYPASS_SECRET when the Vercel venue is protected."; \
 		exit 1; \
 	fi
-	npx playwright test e2e/widget.live-radix.spec.ts --project=chromium-live-radix --workers=1
+	npx playwright test e2e/widget.live-radix.spec.ts --project=chromium-live-radix --workers=1 --retries=0
 
 test-live-cross-browser:
 	@if [ -z "$(BROWSER)" ] || [ -z "$(LIVE_TARGET)" ] || [ -z "$(PLAYWRIGHT_BASE_URL)" ]; then \
@@ -59,7 +59,7 @@ test-live-cross-browser:
 		echo "Set VERCEL_AUTOMATION_BYPASS_SECRET when the Vercel venue is protected."; \
 		exit 1; \
 	fi
-	npx playwright test e2e/widget.cross-browser-live.spec.ts --project=$(BROWSER)-cross-browser-live --workers=1
+	npx playwright test e2e/widget.cross-browser-live.spec.ts --project=$(BROWSER)-cross-browser-live --workers=1 --retries=0
 
 # Code Quality
 lint:

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ the live page after testing to restore its original widget and `fetch` implement
 - [JavaScript API](https://bugdrop.dev/docs/javascript-api)
 - [Version Pinning](https://bugdrop.dev/docs/version-pinning)
 - [CI Testing](https://bugdrop.dev/docs/ci-testing)
+- [Merge-queue Issue canary operations](docs/merge-queue-issue-canary.md)
 - [Security & Rate Limiting](https://bugdrop.dev/docs/security)
 - [Self-Hosting](https://bugdrop.dev/docs/self-hosting)
 - [FAQ](https://bugdrop.dev/docs/faq)

--- a/docs/goals/merge-queue-issue-canary/goal.md
+++ b/docs/goals/merge-queue-issue-canary/goal.md
@@ -1,0 +1,132 @@
+# Merge-Queue Real-Issue Canary
+
+## Objective
+
+Safely close the clearly attributable historical live-E2E Issues in
+`mean-weasel/bugdrop-widget-test`, then produce an implementation-ready, evidence-backed plan for a
+merge-group-only canary that creates, verifies, and closes exactly one real Issue through the
+deployed preview widget, preview Worker, and existing GitHub App.
+
+## Original Request
+
+> First clean up the old issues in the preview test repo, and then talk about implementing and an
+> implementation plan for this, using GoalBuddy prep to keep us on track with granular, grounded
+> tasks.
+
+## Intake Summary
+
+- Input shape: `existing_plan`
+- Audience: BugDrop maintainers and merge-queue operators
+- Authority: `approved`
+- Proof type: `artifact`
+- Completion proof: the exact historical CI-Issue population is closed without touching unrelated
+  Issues, and a reviewed implementation plan maps every canary requirement to current repository
+  files, workflow changes, tests, verification commands, rollback boundaries, and failure-mode
+  evidence.
+- Goal oracle: GitHub API readback shows zero open Issues with the exact legacy automated title and
+  unchanged nonmatching Issues; the final Judge accepts the plan only if it prevents leaked or
+  duplicate Issues and proves the actual feedback request was handled by the merge-group preview
+  widget and Worker.
+- Likely misfire: broadly closing human-created test Issues, treating a health response as Worker
+  SHA proof, relying on Playwright `afterAll` for cleanup, or beginning implementation before the
+  owner reviews the plan.
+- Blind spots considered: hard cancellation can bypass in-process cleanup; the shared preview mutex
+  must span deploy through cleanup; production scheduled live tests currently share the live spec;
+  the verification token must never create Issues or enter browser context; the referenced variants
+  design is currently untracked.
+- Existing plan facts: use `mean-weasel/bugdrop-widget-test`; merge-group-only; exact deployed widget
+  and Worker must match `github.sha`; use the legacy widget with screenshots disabled; require a real
+  Issue number and canonical URL; assert title, body, labels, attribution, and unique marker; disable
+  retries; close all marker matches after partial failure; serialize the shared preview; wait for all
+  local gates; add no storage/services; preserve behavior; do not implement configurable variants.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`Independent GitHub API readback proves the exact-title historical cleanup touched no unrelated
+Issue, and a final Judge can trace every proposed canary step from merge-group SHA and deployed
+assets through one real Issue to independently verified zero-leak cleanup.`
+
+The PM must keep comparing task receipts to this oracle. A plausible plan, a passing happy path, or
+an optimistic cleanup summary is insufficient. Completion requires direct GitHub readback plus a
+final Judge receipt recording `full_outcome_complete: true`.
+
+## Goal Kind
+
+`existing_plan`
+
+## Current Tranche
+
+This is a cleanup-and-planning tranche. Close only the exact legacy automated population, inspect
+the current live-test and CI architecture, make the key concurrency/SHA/cleanup decisions explicit,
+and produce a granular implementation plan. Do not implement the canary in this tranche; execution
+requires the owner's review of the plan.
+
+## Non-Negotiable Constraints
+
+- Close only open, non-pull-request Issues whose title is exactly `Live E2E test submission` in
+  `mean-weasel/bugdrop-widget-test`; do not close fuzzy matches or any other Issue.
+- Inventory and record the exact target numbers before mutation; after mutation, prove zero exact
+  matches remain open and that nonmatching Issues were not closed by this work.
+- Treat closure as recoverable but material; on ambiguous API failure, read back state before retry.
+- Do not expose any GitHub verification token to browser code, traces, Worker configuration, or Issue
+  creation.
+- Do not edit product, test, workflow, or configuration files during this tranche. The only planned
+  repository artifact beyond GoalBuddy control files is the implementation-plan document.
+- Preserve existing public behavior and use no new storage, queue, database, or backend service.
+- Keep the canary merge-group-only and keep configurable feedback variants out of scope.
+- Follow `AGENTS.md` and `CLAUDE.md`, including the burden-of-proof requirement.
+
+## Stop Rule
+
+Stop only after a final audit proves both outcomes of this tranche: the exact legacy population is
+closed without collateral mutation, and the implementation plan is grounded enough for an owner to
+approve or revise before code changes begin.
+
+Planning is completion for this explicitly plan-only tranche; canary implementation is intentionally
+deferred to a separately approved execution tranche.
+
+## Slice Sizing
+
+The cleanup is one bounded Worker package because its high mutation count shares one exact selection
+rule and one proof contract. Architecture discovery is one read-only Scout package. Plan authoring is
+one coherent Worker package after Judge validation, not a collection of tiny file-by-file tasks.
+
+## Board Health
+
+Machine truth lives in `docs/goals/merge-queue-issue-canary/state.yaml`. If the board looks stale or
+misleading, run:
+
+```bash
+node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.4.2/skills/goal-prep/scripts/check-goal-state.mjs docs/goals/merge-queue-issue-canary
+```
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/merge-queue-issue-canary/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts,
+verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/merge-queue-issue-canary/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter and the GoalBuddy execution contract.
+2. Read `state.yaml` and work only on its active task.
+3. Re-check the exact cleanup selection, authority, oracle, constraints, and likely misfire.
+4. Dispatch Scout, Judge, or Worker according to the task card and preserve one active task.
+5. Record a compact receipt with commands and direct evidence, then update the board.
+6. Continue through the plan-only tranche while safe work remains.
+7. Before ending, run the GoalBuddy `check-can-stop.mjs` gate.
+8. Finish only when the final Judge maps cleanup and plan evidence to the oracle and records
+   `full_outcome_complete: true`.

--- a/docs/goals/merge-queue-issue-canary/notes/T001-cleanup-evidence.md
+++ b/docs/goals/merge-queue-issue-canary/notes/T001-cleanup-evidence.md
@@ -1,0 +1,48 @@
+# T001 cleanup evidence
+
+## Selection contract
+
+- Repository: `mean-weasel/bugdrop-widget-test`
+- State: `open`
+- Pull requests: excluded (`pull_request` absent)
+- Title: byte-for-byte exactly `Live E2E test submission`
+- Mutation: close only the explicit Issue numbers in the reviewed inventory below, using
+  `state=closed` and `state_reason=not_planned`
+
+## Reviewed pre-mutation inventory
+
+- Target count: `332`
+- Target-number SHA-256:
+  `e776533febf29b36802889f7761bf1da1e0fba61922c62be8b85090cfece2f81`
+- Selector-invalid count: `0`
+- Nonmatching open Issue count: `119`
+- Nonmatching open Issue-number SHA-256:
+  `beebb8f75fb74bcc3c6a44f41796d4691dfecfd7fc26a925d5370f1cd1212945`
+
+Target Issue numbers:
+
+```text
+125,126,127,130,133,134,135,136,137,141,143,144,146,147,148,149,150,153,154,155,156,157,159,161,162,163,164,165,166,170,171,175,176,177,180,181,183,184,185,186,187,188,193,194,195,196,198,199,200,201,202,203,204,206,207,208,210,211,212,214,215,216,217,218,220,221,222,223,224,225,226,227,229,230,231,233,234,237,238,243,244,246,247,248,249,251,252,254,255,256,257,258,259,260,261,263,264,266,267,268,271,272,275,276,277,278,280,281,282,283,284,286,291,292,293,294,295,296,297,298,299,300,301,302,303,304,305,306,307,308,309,310,311,312,313,317,318,319,320,322,323,325,326,327,330,332,333,334,335,339,340,341,343,346,347,348,349,351,352,353,354,357,358,359,360,362,363,365,366,367,368,369,371,372,373,374,375,376,377,378,379,380,381,382,383,384,385,386,387,388,389,390,391,392,393,394,395,399,400,401,402,405,406,407,408,409,410,411,412,413,414,415,416,417,418,419,421,422,423,424,425,426,427,428,429,430,431,432,434,436,437,438,439,440,441,442,444,445,446,447,448,449,450,451,452,453,454,455,456,457,458,459,460,461,462,463,464,466,467,468,469,472,473,474,475,481,482,483,484,486,487,488,489,491,492,493,494,495,497,500,501,503,504,505,506,507,508,509,510,511,512,513,514,515,516,517,518,522,525,529,530,532,533,537,538,540,541,543,544,545,546,548,549,552,555,556,557,558,559,560,561,562,563,564,565,566,568,569,572,573,575,576
+```
+
+## Mutation result
+
+- Explicit close responses/readbacks accepted: `332/332`
+- Last target closed: `#576`
+- No response or readback returned a different Issue number, title, or final state.
+
+The first local loop invocation failed before any PATCH because zsh preserved the newline-delimited
+number set as one malformed URL argument. The guarded Bash rerun first reproduced both reviewed
+fingerprints and then performed the closures. The dedicated GoalBuddy Worker was interrupted after
+the execution contract's first wait timeout showed no external progress; the PM completed the task
+as deterministic fallback.
+
+## Independent post-mutation verification
+
+- Remaining open exact-title Issues: `0`
+- Historical exact-title Issues: `394 total`, `394 closed`, `0 nonclosed`
+- Nonmatching open Issue count: `119` before and `119` after
+- Nonmatching open Issue-number SHA-256:
+  `beebb8f75fb74bcc3c6a44f41796d4691dfecfd7fc26a925d5370f1cd1212945` before and after
+
+The unchanged nonmatching number set is the collateral-mutation proof for this task.

--- a/docs/goals/merge-queue-issue-canary/notes/T002-architecture-map.md
+++ b/docs/goals/merge-queue-issue-canary/notes/T002-architecture-map.md
@@ -1,0 +1,216 @@
+# T002 architecture map
+
+## Current workflow DAG
+
+The `CI` workflow runs on `pull_request` and `merge_group`.
+
+```text
+check
+├── test (unit + build)
+├── e2e (Chromium, two shards)
+├── radix-e2e (Chromium, Firefox, WebKit)
+└── deploy-preview (merge_group only)
+    ├── live-preview-tests (Chromium live + Chromium live Radix)
+    └── live-preview-cross-browser-tests (Chromium, Firefox, WebKit matrix)
+```
+
+Evidence:
+
+- `.github/workflows/ci.yml:133-155`: unit tests and full build need only `check`.
+- `.github/workflows/ci.yml:157-218`: both local Chromium E2E shards need only `check`.
+- `.github/workflows/ci.yml:227-275`: the local Radix browser matrix needs only `check`.
+- `.github/workflows/ci.yml:285-311`: `deploy-preview` also needs only `check`, so preview
+  deployment can begin before unit, build, local E2E, or Radix results exist.
+- `.github/workflows/ci.yml:313-423`: the main live preview job needs only deployment.
+- `.github/workflows/ci.yml:425-519`: the cross-browser live matrix also needs only deployment.
+- The active GitHub ruleset requires Lint/Check, Unit, both local Chromium E2E shards, Deploy
+  Preview, and Live Preview Tests. It does not require the local Radix matrix or live cross-browser
+  matrix, although those jobs still run.
+
+The implementation must decide whether "all local unit/E2E gates" includes the Radix browser matrix.
+Repository guidance and the existing PR-reuse check treat the Radix matrix as part of the reusable
+local checks, so the conservative dependency is `check`, `test`, `e2e`, and `radix-e2e` before any
+preview deployment.
+
+## Shared-preview replacement surface
+
+- `wrangler.toml:43-57` names one shared Worker, `bugdrop-preview`, and one shared preview KV
+  namespace.
+- No workflow currently declares `concurrency`, `cancel-in-progress`, or a queue policy.
+- The merge-queue ruleset allows up to five entries to build concurrently.
+- Both live-preview jobs release from the same deploy job and execute concurrently against the same
+  Worker URL.
+- A second merge-group workflow can deploy a different SHA while the first workflow is still in
+  either live job. Locking only `deploy-preview`, only a new canary job, or separate deploy/test jobs
+  does not protect the interval between deployment and the last preview consumer.
+
+GitHub's current concurrency contract supports a repository-wide workflow or job group,
+`cancel-in-progress`, and `queue: max`. Without `queue: max`, only one pending run is retained, so a
+new merge group can cancel an older pending required-check run even when the active run is not
+canceled. Source:
+https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
+
+Candidate designs for Judge resolution:
+
+1. A workflow-level merge-group concurrency group spanning local gates through every preview
+   consumer and cleanup, with `cancel-in-progress: false` and `queue: max`. This preserves current
+   required check names but serializes complete merge-group CI runs.
+2. Restructure all preview deployment and consumers into one job-level critical section after local
+   gates. This is narrower but conflicts with the existing separately required `Deploy Preview` and
+   `Live Preview Tests` check names unless rule/config aggregation is redesigned.
+3. Per-SHA Worker names would avoid the mutex but changes deployment topology and cleanup scope; it
+   is inconsistent with the stated shared-preview constraint and is not the smallest compatible
+   plan.
+
+## Widget identity proof
+
+The repository already has a strong byte-level widget check:
+
+- `.github/workflows/ci.yml:385-405` and `486-506` rebuild `public/widget.js` from the checked-out
+  merge-group tree, compute SHA-256, and poll the deployed preview asset until it matches.
+- `e2e/widget.live.spec.ts:348-369` reads the actual page's script URL, requires the preview Worker
+  origin, fetches that exact URL, and compares its SHA-256 with `EXPECTED_WIDGET_SHA256`.
+- The Vercel venue's `index.html` uses `src="__BUGDROP_URL__/widget.js"` and
+  `data-repo="mean-weasel/bugdrop-widget-test"`; `vite.config.ts` substitutes
+  `VITE_BUGDROP_URL` (defaulting to production). The fixed preview alias must therefore keep its
+  preview URL configuration, and the DOM-origin/hash assertion is the authoritative runtime proof.
+
+This proves the bytes loaded by the venue equal the widget built from the merge-group checkout. The
+bundle version string is tag-derived rather than SHA-derived, but byte equality is the stronger
+artifact identity signal.
+
+## Missing Worker identity proof
+
+- `src/routes/api.ts:108-115` returns only `status`, `environment`, and a current timestamp from
+  `/api/health`.
+- `src/types.ts:1-29` has no build-SHA binding.
+- Preview deployment is `npx wrangler deploy --env preview`, with no SHA variable or version tag.
+- A healthy response therefore proves only that some preview Worker answered.
+
+Cloudflare's current Wrangler `deploy --var key:value` flag injects a string binding and overrides a
+same-name configured value, so CI can deploy with a nonsecret `BUILD_SHA:$GITHUB_SHA`. Source:
+https://developers.cloudflare.com/workers/wrangler/commands/workers/
+
+Candidate additive proof contract:
+
+- Add optional `BUILD_SHA` to `Env`.
+- Deploy preview with the merge-group `GITHUB_SHA` as `BUILD_SHA`.
+- Return it from health for readiness/diagnostics.
+- Add `X-BugDrop-Build-SHA` to the actual `/feedback` response and assert it on the browser-observed
+  POST response. Health-before-submit alone is insufficient because replacement could occur between
+  health and feedback.
+
+Cloudflare version-metadata exposes a Cloudflare version ID/tag/timestamp, but not the Git SHA unless
+CI also supplies a tag; a direct SHA binding is simpler and directly testable. Source:
+https://developers.cloudflare.com/workers/runtime-apis/bindings/version-metadata/
+
+## Current real-Issue side effect and retry behavior
+
+- `e2e/widget.live.spec.ts:815-864` performs one unmocked `/feedback` POST with title
+  `Live E2E test submission`.
+- It mocks only `/api/check`, waits a fixed eight seconds, and accepts either success or error.
+- It does not capture a response number/URL, independently read GitHub, detect duplicates, or close
+  a created Issue.
+- `playwright.config.ts:5-14` applies two retries to all CI projects; the `chromium-live` project does
+  not override retries. A failed attempt after Issue creation can therefore create another Issue.
+- The same `chromium-live` project is invoked by `.github/workflows/live-tests.yml`, which runs by
+  reusable production call, manual dispatch (preview by default), and a daily production schedule.
+- The production deployment workflow also calls this reusable live workflow after every main
+  deployment. The unmanaged POST is therefore not merge-group-only.
+- T001 proved the consequence: 394 historical exact-title Issues existed, 332 were open before
+  cleanup, and all are now closed.
+
+A dedicated canary file/project must not match the regular live project's pattern. The unmanaged
+submission test must be removed or changed to a fully mocked transport-only assertion so scheduled,
+production, PR, and manual live paths cannot create Issues. The canary invocation must set retries
+to zero both in its project and command line as defense against config drift.
+
+## Real submission and readback contract available today
+
+- `src/routes/api.ts:136-288` gets an installation token from the existing GitHub App, creates the
+  Issue, and returns `issueNumber`, `issueUrl`, and `isPublic`.
+- The verification token is not needed by the Worker or widget and must never be passed to either.
+- The test venue uses the legacy script-tag widget and the target repository.
+- The widget can submit without evidence by explicitly disabling/unchecking screenshot capture; the
+  Issue body should then lack `## Screenshot`.
+- Default bug submission labels are `bug` plus the always-added `bugdrop` label.
+- Existing Issue #576 confirms the creator is `neonwatty-bugdrop[bot]`, labels are `bug` and
+  `bugdrop`, and the body ends with the BugDrop attribution footer.
+
+An Issues read/write fine-grained token scoped only to `mean-weasel/bugdrop-widget-test` can list/get
+Issues and PATCH their state. GitHub documents Issues-read for list/get and Issues-write for update;
+write includes read. Source: https://docs.github.com/en/rest/issues/issues
+
+The verifier can assert these returned Issue fields without Contents access:
+
+- `number`, `html_url`, `state`, `title`, raw `body`, `labels[].name`, `user.login`, `created_at`.
+
+It can close by PATCHing `state=closed` and `state_reason=not_planned`. It must exclude objects with a
+`pull_request` key because GitHub's Issues endpoints also return pull requests.
+
+## Marker, duplicate, and cleanup gaps to close
+
+The current test has no marker. A safe marker should include `GITHUB_RUN_ID`,
+`GITHUB_RUN_ATTEMPT`, and the full merge-group `GITHUB_SHA`, appear in both exact title content and
+description/body, and be unique to one canary attempt. GitHub documents `GITHUB_SHA` for
+`merge_group` as the merge-group SHA:
+https://docs.github.com/en/enterprise-cloud@latest/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group
+
+Readback and cleanup must enumerate repository Issues with `state=all`, paginate, exclude pull
+requests, and filter exact marker content locally. GitHub search indexing is too weak for cleanup
+after a lost response. The immediate cleanup must be a separate workflow step with `if: always()`;
+Playwright hooks or a single returned Issue number are insufficient. The cleanup step must close all
+matches, not merely the first, then paginate again and fail if any remain open.
+
+Hard cancellation or GitHub outage can prevent any same-run cleanup. The plan must explicitly choose
+additional defense, such as a stale-marker sweep after acquiring the same preview lock on the next
+merge-group run, while documenting that no remote system can provide an absolute synchronous
+guarantee during total external failure.
+
+## Candidate implementation/test surfaces
+
+- `.github/workflows/ci.yml`: local-gate dependencies, concurrency critical section, SHA deploy,
+  canary invocation, independent verification, `if: always()` cleanup, artifacts.
+- `.github/workflows/live-tests.yml`: ensure scheduled/manual/production live suites contain no real
+  unmanaged feedback submission.
+- `playwright.config.ts`: dedicated nonmatching canary project with explicit zero retries.
+- `e2e/widget.live.spec.ts`: remove or mock the current unmanaged real-Issue test.
+- New dedicated canary spec, likely `e2e/widget.issue-canary.spec.ts`: real legacy-widget interaction,
+  actual feedback response number/URL/build-SHA assertions, screenshot disabled.
+- `src/types.ts` and `src/routes/api.ts`: optional build SHA and actual-response identity header.
+- `test/api.test.ts`: health/header presence and absence compatibility tests.
+- New scripts/modules under `scripts/` plus focused unit tests: marker construction, paginated
+  discovery, exact verification, duplicate detection, close-all, ambiguous close readback, stale
+  cleanup.
+- `test/ci-workflow-contract.test.sh`: dependency, concurrency, merge-group-only invocation,
+  retry-zero, token-boundary, and `if: always()` cleanup contract checks.
+- `Makefile`, only if a named local canary command materially improves safe invocation.
+- Documentation covering secret scope, setup, cleanup semantics, manual recovery, and local tests
+  that do not create real Issues.
+
+## Verification commands and proof targets
+
+- Focused unit tests for Worker build-SHA behavior and canary helper logic.
+- `bash test/ci-workflow-contract.test.sh` for static workflow invariants.
+- `npm run validate` and relevant local Playwright suites with feedback mocked.
+- A negative fixture for each strongest failure mode: wrong widget bytes, wrong Worker SHA, duplicate
+  matches, response lost after creation, one close failure, leaked open match, and preview-lock
+  omission.
+- The only real-Issue proof runs in `merge_group`; local and PR tests must not have the credential or
+  make a real feedback POST.
+
+## Judge decisions required
+
+1. Workflow-level serialization versus restructuring preview jobs into one critical-section job,
+   including how to preserve required check names.
+2. Whether `queue: max` is required to prevent required merge-group runs from canceling while
+   pending; current GitHub docs say it is.
+3. Exact build-SHA transport: direct Worker variable/header versus version tag plus metadata.
+4. Whether health also exposes SHA in addition to the actual response header.
+5. Helper architecture: testable Node module/CLI versus workflow shell, and how secrets stay out of
+   browser/traces.
+6. Hard-cancellation recovery: next-run stale sweep only, or an additional scheduled janitor.
+7. Whether all local gates includes the local Radix matrix; conservative reading says yes.
+8. Exact title/body marker format and whether attribution means both bot author and footer.
+9. Whether the existing fixed preview Vercel alias needs any additional configuration assertion
+   beyond actual DOM script origin and byte hash.

--- a/docs/goals/merge-queue-issue-canary/notes/T003-architecture-decision.md
+++ b/docs/goals/merge-queue-issue-canary/notes/T003-architecture-decision.md
@@ -1,0 +1,226 @@
+# T003 architecture decision
+
+## Decision
+
+Approved with the concrete architecture below. The implementation plan may proceed; canary code
+must wait for owner approval after the plan-only tranche.
+
+## 1. Preview critical section and local gates
+
+Use one job-level critical section rather than workflow-level serialization.
+
+- The job keeps the required check name `Deploy Preview`.
+- It has `needs: [check, test, e2e, radix-e2e]` and runs only for `merge_group`.
+- It declares the repository-wide concurrency group `bugdrop-shared-preview`,
+  `cancel-in-progress: false`, and `queue: max`.
+- The lock is acquired only after local gates complete, so different merge groups may run local
+  tests concurrently but cannot overlap any shared-preview activity.
+- Inside that same job, run deployment, readiness/SHA proof, current Chromium live tests, live Radix,
+  the Chromium/Firefox/WebKit live smoke set, the real-Issue canary, verification, and cleanup. No
+  shared-preview consumer remains in a separate parallel job.
+- Replace the current `Live Preview Tests` job with an `if: always()` status bridge depending on the
+  critical-section job. It must fail unless `needs.<critical-job>.result == 'success'`. This preserves
+  both externally required check names without claiming success when the critical section failed or
+  was canceled.
+
+Rejected alternatives:
+
+- Workflow-level serialization preserves the current jobs but needlessly serializes all local test
+  time and can collide with the ruleset's 60-minute response timeout when five merge groups build.
+- Separate job locks cannot span the deploy-to-test handoff.
+- Per-SHA Workers change topology and do not satisfy the shared-preview constraint.
+
+Rollback: revert the workflow restructure to the prior three preview jobs. Do not partially retain
+deployment in one job and canary cleanup in another.
+
+## 2. Exact build identity
+
+Widget proof remains byte-based:
+
+1. Build `public/widget.js` from the checked-out merge-group tree.
+2. Compute its SHA-256.
+3. Read the actual venue script URL and require the preview Worker origin.
+4. Fetch those exact script bytes and require the expected SHA-256.
+
+Worker proof is additive:
+
+1. Add optional `BUILD_SHA?: string` to `Env`.
+2. Deploy preview with `--var BUILD_SHA:$GITHUB_SHA` (properly quoted).
+3. Add `buildSha` to preview health output for polling/diagnostics when configured.
+4. Add `X-BugDrop-Build-SHA` to Worker API responses when configured.
+5. The canary captures the actual POST `/api/feedback` response, requires its URL to be the preview
+   Worker endpoint, and requires that response header to equal the full merge-group `GITHUB_SHA`.
+
+Health identity is necessary for readiness but insufficient for the canary. The actual feedback
+response header is the authoritative Worker identity proof.
+
+Rollback: omit `BUILD_SHA`; optional behavior leaves existing self-hosted/production responses
+unchanged except where explicitly configured.
+
+## 3. Dedicated real-Issue canary
+
+Create a dedicated spec/project whose filename does not match the normal live patterns. Its project
+and CLI invocation both specify zero retries, one worker, and Chromium only.
+
+The test:
+
+1. Runs only when the explicit merge-group canary environment is present; otherwise it skips or
+   fails closed according to the dedicated command contract.
+2. Opens the real fixed Vercel preview venue and uses its deployed legacy script-tag widget.
+3. Does not intercept `/api/check` or `/feedback`.
+4. Builds a unique marker from `GITHUB_RUN_ID`, `GITHUB_RUN_ATTEMPT`, and full `GITHUB_SHA`.
+5. Places the marker in both the exact Issue title and description.
+6. Explicitly disables screenshot capture before submission, rather than entering screenshot capture
+   and clicking Skip.
+7. Starts the response waiter before Submit, captures the one POST response, and requires:
+   - preview Worker URL;
+   - expected build-SHA response header;
+   - success JSON;
+   - positive integer Issue number;
+   - canonical URL
+     `https://github.com/mean-weasel/bugdrop-widget-test/issues/<number>`.
+
+The existing unmanaged `Feedback Submission (Live)` test must no longer make a real POST. Convert it
+to a mocked transport/UI assertion or remove it if equivalent mocked coverage already exists. The
+normal `chromium-live` project, reusable production workflow, daily schedule, manual dispatch, and
+PR/local suites must never match or invoke the new canary.
+
+## 4. Independent Issue verifier
+
+Use a testable Node `.mjs` module/CLI rather than embedding the GitHub logic in workflow shell.
+
+- The secret is a fine-grained token scoped only to `mean-weasel/bugdrop-widget-test` with Issues
+  read/write (`write` includes read).
+- Supply it only to verifier/cleanup steps. Never set it at job scope, pass it to Playwright, place it
+  in browser context, send it to the Worker, or include it in traces/artifacts.
+- Issue creation remains exclusively the existing GitHub App path.
+
+Verification enumerates `state=all` repository Issues through REST pagination, excludes entries with
+`pull_request`, and filters the exact current marker locally. It does not depend on GitHub search
+indexing. It requires exactly one match and asserts:
+
+- response number and canonical URL identify that match;
+- exact marker-bearing title and marker in raw body;
+- exact label set `bug`, `bugdrop`;
+- author `neonwatty-bugdrop[bot]`;
+- `## Description`, system-information details, and the BugDrop attribution footer;
+- absence of `## Screenshot`;
+- open state before cleanup.
+
+The Playwright response number/URL assertion and server-side marker discovery are independent proof
+layers. The verifier must not create Issues.
+
+## 5. Duplicate and cleanup contract
+
+Use a reserved format such as:
+
+```text
+bugdrop-ci-canary:<GITHUB_RUN_ID>:<GITHUB_RUN_ATTEMPT>:<GITHUB_SHA>
+```
+
+The full string appears in title and description. A stable title prefix identifies stale canaries;
+the full marker identifies one workflow attempt.
+
+Within the locked critical section:
+
+1. Before deployment, run a preflight stale sweep over all open, non-PR Issues with the reserved
+   prefix/marker contract. Close every match and verify none remain.
+2. Submit once with Playwright retries disabled.
+3. Independently verify exactly one current-marker match. Zero and more-than-one both fail.
+4. Run cleanup as a separate `if: always()` workflow step. Enumerate by the current marker even when
+   the POST response/output is absent, close every open match, read back ambiguous PATCH results
+   before retry, then paginate again and fail if any current-marker match is open.
+5. As a final locked defense, sweep all open reserved-prefix canaries and fail if any remain.
+
+Hard cancellation can prevent same-run `always()` steps. Add a daily stale janitor to the already
+scheduled live workflow. It uses the same repository-wide concurrency group with queueing so it
+cannot close an active merge-group canary, and it performs only server-side stale cleanup—never
+Issue creation. The next merge-group preflight remains a second recovery path.
+
+No system can guarantee synchronous closure during a total GitHub/runner outage. The contract is
+fail-visible immediate cleanup plus two eventual cleanup paths, not an unprovable exactly-once claim.
+
+## 6. Implementation packages for the plan
+
+### Package A: GitHub canary helper and failure-mode tests
+
+Candidate files:
+
+- `scripts/github-issue-canary.mjs`
+- focused test file under `test/`
+
+Cover pagination, PR exclusion, exact marker filtering, duplicate detection, expected field
+assertions, close-all behavior, ambiguous close readback, cleanup verification failure, and stale
+sweep. Tests inject a fake fetch/API and never use real credentials.
+
+Stop if broader than repository-scoped Issues read/write is required or secrets would enter browser
+state.
+
+### Package B: Worker build identity
+
+Candidate files:
+
+- `src/types.ts`
+- `src/routes/api.ts`
+- `test/api.test.ts`
+
+Cover configured header/health SHA, absent-binding compatibility, and actual feedback success/error
+response identity as appropriate.
+
+Stop if the implementation alters existing request bodies, Issue formatting, authentication, label
+behavior, or unconfigured deployments.
+
+### Package C: Isolated Playwright canary and removal of unmanaged mutation
+
+Candidate files:
+
+- new dedicated canary spec under `e2e/`
+- `e2e/widget.live.spec.ts`
+- `playwright.config.ts`
+- focused E2E/helper tests if required
+
+Cover exact response number/URL/SHA, explicit screenshot disablement, one submission, zero retries,
+and nonmatching normal live projects.
+
+Stop if local, PR, production, scheduled, or manual live invocation can create a real Issue.
+
+### Package D: Workflow critical section, recovery, contracts, and docs
+
+Candidate files:
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/live-tests.yml`
+- `test/ci-workflow-contract.test.sh`
+- `Makefile` only if a safe named command is justified
+- relevant CI/testing documentation
+
+Cover local-gate dependencies, exact merge-group condition, single queued mutex, preservation of
+required status names, fail-closed bridge, zero-retry invocation, step-scoped token, `if: always()`
+cleanup, stale preflight, scheduled lock-coordinated janitor, and absence of real POSTs elsewhere.
+
+Stop if required ruleset mutation, new infrastructure, a new GitHub App, or broader token permission
+is necessary.
+
+## 7. Required verification and rollback evidence
+
+- Focused helper and Worker unit tests.
+- Static CI workflow contract tests for every concurrency/gating/isolation/cleanup invariant.
+- `npm run validate` and relevant local E2E suites with all GitHub traffic mocked.
+- Explicit negative tests for wrong widget bytes, wrong actual-response Worker SHA, duplicate matches,
+  lost response, one cleanup PATCH failure, ambiguous PATCH success, leaked open match, PR-shaped API
+  entries, retry drift, and missing mutex coverage.
+- Final implementation evidence must include one successful merge-group canary with its Issue number,
+  URL, exact readback assertions, and confirmed closed state, plus a repository query showing no open
+  reserved-prefix canary Issues.
+
+Rollback must be atomic at package boundaries. In particular, do not ship real submission without
+independent cleanup, and do not remove the unmanaged test until the dedicated canary path and normal
+mocked coverage are both present in the same change.
+
+## Deferred/owner boundaries
+
+- Creating and storing the fine-grained secret is an operator action before the implementation can
+  run live; the plan must name the secret and exact scope.
+- Changing the external GitHub ruleset is not required by this architecture and remains out of
+  scope.
+- Configurable feedback variants remain entirely out of scope.

--- a/docs/goals/merge-queue-issue-canary/state.yaml
+++ b/docs/goals/merge-queue-issue-canary/state.yaml
@@ -1,0 +1,347 @@
+version: 2
+
+goal:
+  title: "Merge-Queue Real-Issue Canary"
+  slug: "merge-queue-issue-canary"
+  kind: existing_plan
+  tranche: "Close the exact legacy automated Issue population, then produce and audit an implementation-ready canary plan without implementing product changes."
+  status: done
+  oracle:
+    signal: "GitHub API readback proves zero open exact-title legacy CI Issues and no collateral closures; a final Judge accepts a plan that proves the merge-group preview path and zero-leak cleanup."
+    cadence: "after cleanup, after architecture mapping, after plan authoring, and at final audit"
+    final_proof: "Cleanup receipt with before/after Issue identities and nonmatch protection, plus a Judge-approved implementation plan mapped to repository evidence and failure-mode verification."
+  intake:
+    original_request: "Clean up the old preview-test Issues, then develop a granular grounded implementation plan using GoalBuddy prep."
+    interpreted_outcome: "Remove the clearly attributable historical CI Issue leak safely and prepare the merge-queue real-Issue canary for an informed implementation decision."
+    input_shape: existing_plan
+    audience: "BugDrop maintainers and merge-queue operators"
+    authority: approved
+    proof_type: artifact
+    completion_proof: "Zero open exact-title legacy automated Issues with unrelated Issues untouched, plus an implementation-ready plan accepted by final audit."
+    likely_misfire: "Closing fuzzy-title or human Issues, or producing a generic plan that does not solve hard cancellation, duplicate creation, shared-preview replacement, and Worker SHA identity."
+    blind_spots_considered:
+      - "Hard workflow cancellation can bypass Playwright cleanup."
+      - "A job mutex does not protect a deploy-to-test gap across separate jobs."
+      - "The existing production-scheduled live spec can create unmanaged Issues."
+      - "Widget byte hashing does not prove Worker code identity."
+      - "The verification credential must not become an alternate Issue-creation path."
+      - "The related variants design is untracked and may be unavailable in another checkout."
+    existing_plan_facts:
+      - "Target repository: mean-weasel/bugdrop-widget-test."
+      - "Legacy cleanup selector: open non-PR Issues with exact title Live E2E test submission."
+      - "Prior evidence snapshot found 394 total exact-title Issues and 332 open, but execution must refresh rather than trust the snapshot."
+      - "Canary is merge-group-only and must wait for local lint, unit, build, E2E, and browser gates."
+      - "The deployed widget and Worker must both correspond to github.sha."
+      - "One real Issue must be created through the legacy widget and existing GitHub App with screenshots disabled."
+      - "Readback must assert number, canonical URL, exact title/body/labels, attribution, unique marker, and exactly one match."
+      - "Retries are disabled and cleanup discovers all marker matches after partial failure."
+      - "The shared preview is serialized across deploy, proof, tests, and cleanup with no cancel-in-progress."
+      - "No new storage/services and no configurable UX variants."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: false
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  exact_human_approval_can_terminal_wait: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/merge-queue-issue-canary/"
+    command: "node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.4.2/skills/goal-prep/surfaces/local-goal-board/scripts/local-goal-board.mjs --goal docs/goals/merge-queue-issue-canary"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Inventory, close, and verify only the exact legacy automated Issues in mean-weasel/bugdrop-widget-test."
+    allowed_files:
+      - "/Users/neonwatty/Desktop/bugdrop/docs/goals/merge-queue-issue-canary/**"
+    verify:
+      - "GitHub API dry-run lists exact target Issue numbers before mutation."
+      - "GitHub API readback reports zero open, non-PR Issues with title exactly Live E2E test submission."
+      - "Before/after evidence proves this task did not close any nonmatching Issue."
+    stop_if:
+      - "The authenticated repository is not mean-weasel/bugdrop-widget-test."
+      - "The selector includes a pull request, fuzzy title, or any title other than the exact legacy title."
+      - "A mutation response is ambiguous and readback cannot establish current Issue state."
+      - "Verification cannot distinguish task mutations from concurrent external changes."
+    receipt:
+      result: done
+      changed_files:
+        - /Users/neonwatty/Desktop/bugdrop/docs/goals/merge-queue-issue-canary/notes/T001-cleanup-evidence.md
+      commands:
+        - cmd: "GitHub API dry-run inventory for open, non-PR Issues with exact title Live E2E test submission"
+          status: pass
+          evidence: "Repository identity matched mean-weasel/bugdrop-widget-test; 332 targets, selector-invalid count 0; explicit target-number SHA-256 e776533febf29b36802889f7761bf1da1e0fba61922c62be8b85090cfece2f81."
+        - cmd: "PATCH each of the 332 reviewed Issue numbers to state=closed and state_reason=not_planned with response/readback guards"
+          status: pass
+          evidence: "332/332 explicit targets returned or read back as the expected number, closed state, and exact title; final target was #576."
+        - cmd: "Independent paginated GitHub API post-cleanup verification"
+          status: pass
+          evidence: "remaining_exact_open=0; all 394 exact-title Issues are closed; nonmatching open Issue count remained 119 and number-set SHA-256 remained beebb8f75fb74bcc3c6a44f41796d4691dfecfd7fc26a925d5370f1cd1212945."
+      summary: "Closed all 332 open, non-PR Issues whose title was exactly Live E2E test submission in mean-weasel/bugdrop-widget-test. Independent paginated readback found zero exact-title Issues open and all 394 historical exact-title Issues closed. The unrelated-open baseline remained exactly 119 Issues with the identical before/after number-set SHA-256, disproving collateral closure by this task."
+      deviations:
+        - "The dedicated GoalBuddy Worker was interrupted after the required first wait timeout showed no external progress; the PM completed the task as deterministic fallback."
+        - "The first local mutation loop failed closed before any PATCH because zsh did not split newline-delimited numbers. The guarded Bash rerun used the same reviewed target and nonmatch fingerprints and completed successfully."
+      remaining_blockers: []
+      verification_attempts: 2
+      stopped_because: null
+      harness: codex
+  - id: T002
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: low
+    objective: "Map the current CI, preview deployment, live-test, Worker identity, GitHub Issue, and test-repository surfaces needed by the canary plan."
+    inputs:
+      - "/Users/neonwatty/Desktop/bugdrop/.github/workflows/ci.yml"
+      - "/Users/neonwatty/Desktop/bugdrop/.github/workflows/live-tests.yml"
+      - "/Users/neonwatty/Desktop/bugdrop/playwright.config.ts"
+      - "/Users/neonwatty/Desktop/bugdrop/e2e/widget.live.spec.ts"
+      - "/Users/neonwatty/Desktop/bugdrop/src/routes/api.ts"
+      - "/Users/neonwatty/Desktop/bugdrop/src/types.ts"
+      - "/Users/neonwatty/Desktop/bugdrop/wrangler.toml"
+      - "/Users/neonwatty/Desktop/bugdrop/test/ci-workflow-contract.test.sh"
+      - "/Users/neonwatty/Desktop/bugdrop/docs/plans/2026-08-01-configurable-feedback-variants-design.md"
+      - "Read-only GitHub metadata for mean-weasel/bugdrop and mean-weasel/bugdrop-widget-test"
+      - "T001 cleanup receipt"
+    constraints:
+      - "Read-only; do not edit repository files or mutate GitHub state."
+      - "Inspect the existing live-test architecture before proposing changes."
+      - "Distinguish widget-byte identity from Worker-code identity."
+      - "Trace every existing path that can make a real feedback POST, including scheduled production workflows."
+      - "Do not design or implement configurable feedback variants."
+    expected_output:
+      - "Current workflow DAG and exact local gates that must precede preview deployment."
+      - "Shared-preview replacement windows and all preview consumers covered by a mutex."
+      - "Existing widget-SHA proof and missing Worker-SHA proof."
+      - "Existing real-Issue side effects, retry inheritance, and cleanup gaps."
+      - "Credential boundary and exact GitHub fields available to an Issues read/write verifier."
+      - "Candidate files, tests, documentation, verification commands, and rollback boundaries."
+      - "Contradictions or decisions requiring Judge resolution."
+    receipt:
+      result: done
+      summary: "Mapped the current preview path. Deployment races unit/E2E gates, one shared Worker has no mutex, widget bytes are strongly hashed but Worker code has no SHA identity, and one regular live test creates unmanaged Issues with two CI retries across merge-group, production, schedule, and manual paths. The plan needs an uninterrupted queued preview critical section, actual-response Worker SHA, an isolated zero-retry canary, server-side Issues-only verification, and marker-based close-all cleanup."
+      note: notes/T002-architecture-map.md
+      evidence:
+        - ".github/workflows/ci.yml:285-519"
+        - ".github/workflows/live-tests.yml:1-116"
+        - "playwright.config.ts:5-81"
+        - "e2e/widget.live.spec.ts:815-864"
+        - "src/routes/api.ts:108-288"
+        - "wrangler.toml:43-57"
+        - "GitHub ruleset 11303548"
+        - "mean-weasel/bugdrop-widget-test issue #576"
+        - notes/T001-cleanup-evidence.md
+      facts:
+        - "deploy-preview needs only check, while unit/build, two Chromium E2E shards, and the Radix browser matrix run independently."
+        - "The fixed bugdrop-preview Worker can be replaced by up to five concurrently built merge groups; no workflow declares concurrency."
+        - "The actual venue script URL and bytes are checked against the locally built widget SHA-256."
+        - "Health exposes no build identity and preview deploy passes no Git SHA."
+        - "The unmanaged live submission accepts success or error, performs no readback/cleanup, and inherits two CI retries."
+        - "The regular live suite runs from merge-group CI, production deploy, daily schedule, and manual dispatch."
+        - "A repository-scoped fine-grained token with Issues write can list/get and close Issues without Contents access; it must remain outside browser and Worker contexts."
+      contradictions:
+        - "The requested canary is merge-group-only, but the current real feedback POST is shared with production, scheduled, and manual live workflows."
+        - "The prompt requires local gates before preview work, but preview deployment currently starts after check alone."
+        - "The prompt requires exact Worker SHA proof, but health only proves that some Worker answered."
+      ambiguity_requiring_judge:
+        - "Workflow-level queued serialization versus restructuring preview jobs while preserving required check names."
+        - "Whether queue:max is required along with cancel-in-progress:false for merge-queue health."
+        - "Direct BUILD_SHA variable/header versus Cloudflare version metadata/tag."
+        - "Next-run stale sweep versus an additional scheduled stale janitor for hard cancellation."
+        - "Whether all local gates includes the Radix browser matrix."
+        - "Exact marker and attribution assertions."
+      commands:
+        - "Inspected numbered CI, live workflow, Playwright, Worker, type, Wrangler, and workflow-contract sources."
+        - "Read active GitHub ruleset 11303548 and test-repository venue configuration/Issue #576."
+        - "Consulted official GitHub Actions concurrency, merge_group, Issues API, and Cloudflare Wrangler/version-metadata documentation."
+      note_needed: true
+      harness: codex
+  - id: T003
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate the proposed canary architecture and choose an implementation breakdown that closes the strongest realistic failure modes."
+    inputs:
+      - "Original canary prompt preserved in the goal intake"
+      - "T001 cleanup receipt"
+      - "T002 architecture receipt"
+      - "AGENTS.md and CLAUDE.md burden-of-proof requirements"
+    constraints:
+      - "Read-only; do not implement or mutate GitHub state."
+      - "Resolve the mutex as one uninterrupted deploy-through-cleanup critical section or provide equally strong proof."
+      - "Require Worker identity on the actual feedback response, not health-only readiness."
+      - "Require cleanup independent of the Playwright happy path and resilient to a lost POST response."
+      - "Keep Issue creation on the existing GitHub App; verification credentials are readback/cleanup only."
+      - "Keep implementation additive, merge-group-only, variant-free, and free of new storage/services."
+    expected_output:
+      - "Approved or rejected architecture with rationale."
+      - "Exact concurrency and cancellation design."
+      - "Exact widget and Worker SHA proof contract."
+      - "Exact unique marker, response, readback, duplicate, and cleanup contract."
+      - "Dedicated canary isolation from production, scheduled, PR, and manually dispatched live suites."
+      - "Granular implementation task sequence with allowed files, verify commands, stop conditions, and rollback notes."
+      - "Deferred decisions and any owner approval required before implementation."
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "Approve a single post-gate, job-level preview critical section that preserves required check names while holding a queued non-cancelling mutex through deploy, all live consumers, canary verification, and cleanup. Use byte-level widget proof plus BUILD_SHA on the actual feedback response, a dedicated zero-retry canary, Issues-only server-side readback, marker-based close-all cleanup, next-run preflight, and a lock-coordinated daily stale janitor. This closes the mapped leak, duplicate, wrong-SHA, and hard-cancellation gaps without new services or variant work."
+      worker_package:
+        objective: "Author the approved implementation-ready merge-queue real-Issue canary plan and proof matrix without changing product or workflow behavior."
+        allowed_files:
+          - /Users/neonwatty/Desktop/bugdrop/docs/plans/2026-08-01-merge-queue-real-issue-canary-plan.md
+          - "/Users/neonwatty/Desktop/bugdrop/docs/goals/merge-queue-issue-canary/**"
+        verify:
+          - "cd /Users/neonwatty/Desktop/bugdrop && npx prettier --check docs/plans/2026-08-01-merge-queue-real-issue-canary-plan.md docs/goals/merge-queue-issue-canary/goal.md"
+          - "Map every original must-have to concrete files, assertions, commands, rollback, and proof."
+          - "Include negative tests for leak, duplicate, lost response, cleanup failure, wrong widget bytes, wrong actual-response Worker SHA, and preview mutex omission."
+          - "Keep implementation deferred pending owner plan review."
+        stop_if:
+          - "The plan requires GitHub ruleset mutation, new infrastructure, a new GitHub App, or broader than repository-scoped Issues read/write."
+          - "Cleanup relies only on Playwright/process-local hooks or search indexing."
+          - "Any normal live, production, scheduled, manual, PR, or local path can create a real canary Issue."
+          - "The task begins implementing canary behavior instead of documenting it."
+      evidence:
+        - notes/T001-cleanup-evidence.md
+        - notes/T002-architecture-map.md
+        - notes/T003-architecture-decision.md
+        - "GitHub ruleset 11303548 required checks and five-entry build concurrency"
+        - "Official GitHub concurrency queue:max and merge_group SHA contracts"
+        - "Official Cloudflare Wrangler --var and version-metadata contracts"
+      subgoal_contract: null
+      parallel_safety: "One plan-writing Worker only; implementation packages are sequentially dependent and are not active in this tranche."
+      blocked_tasks: []
+      missing_evidence: []
+      required_board_updates:
+        - "Activate T004 with its existing plan-only allowed files and use notes/T003-architecture-decision.md as normative architecture input."
+        - "Do not activate implementation packages in this tranche."
+      harness: codex
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Author the Judge-approved, implementation-ready merge-queue canary plan and supporting test/proof matrix without changing product or workflow behavior."
+    allowed_files:
+      - "/Users/neonwatty/Desktop/bugdrop/docs/plans/2026-08-01-merge-queue-real-issue-canary-plan.md"
+      - "/Users/neonwatty/Desktop/bugdrop/docs/goals/merge-queue-issue-canary/**"
+    verify:
+      - "cd /Users/neonwatty/Desktop/bugdrop && npx prettier --check docs/plans/2026-08-01-merge-queue-real-issue-canary-plan.md docs/goals/merge-queue-issue-canary/goal.md"
+      - "Every original must-have requirement maps to at least one concrete task, file, assertion, and verification command."
+      - "Plan explicitly simulates or tests leaked Issue, duplicate Issue, lost response, cleanup partial failure, wrong widget bytes, wrong Worker SHA, and concurrent preview replacement."
+      - "Plan identifies the current unmanaged real-Issue live test and prevents the new canary from production/scheduled/manual paths."
+    stop_if:
+      - "The plan requires files or product decisions outside the Judge-approved architecture."
+      - "A proposed verification needs broader than repository-scoped Issues read/write permission."
+      - "A proposed cleanup guarantee relies only on Playwright hooks or process-local finally blocks."
+      - "The plan begins implementing canary behavior instead of documenting the approved execution tranche."
+      - "Verification fails twice."
+    receipt:
+      result: done
+      changed_files:
+        - /Users/neonwatty/Desktop/bugdrop/docs/plans/2026-08-01-merge-queue-real-issue-canary-plan.md
+      commands:
+        - cmd: "npx prettier --check docs/plans/2026-08-01-merge-queue-real-issue-canary-plan.md docs/goals/merge-queue-issue-canary/goal.md"
+          status: pass
+          evidence: "Both the implementation plan and goal charter use Prettier formatting."
+        - cmd: "Requirement and failure-mode traceability audit"
+          status: pass
+          evidence: "The plan maps every original requirement to packages, files, executable assertions, and verification; it explicitly covers leaks, duplicates, lost responses, partial and ambiguous close failures, wrong widget bytes, wrong health and actual-response Worker SHA, concurrency, retry drift, search lag, accidental invocation, hard cancellation, and token failure."
+        - cmd: "Scope and side-effect audit"
+          status: pass
+          evidence: "The plan identifies e2e/widget.live.spec.ts as the existing unmanaged real-Issue path, requires it to become mocked or nonmutating, isolates the new canary from production/scheduled/manual/PR/local paths, and makes no product, test, or workflow changes in this tranche."
+      summary: "Authored an implementation-ready four-package plan for the merge-queue real-Issue canary. It preserves required check names, puts deployment through cleanup under one queued mutex after every local gate, proves both widget bytes and actual-response Worker SHA, isolates a one-shot zero-retry legacy-widget submission, independently verifies the complete Issue contract, and supplies marker-based immediate and hard-cancellation cleanup paths."
+      deviations:
+        - "The dedicated GoalBuddy Worker was interrupted after the required first wait timeout showed no plan artifact; the PM authored the approved plan as deterministic fallback."
+      remaining_blockers:
+        - "Owner review is required before implementation, including token ownership, Radix gating, marker contract, stale janitor, and first live canary acceptance."
+      verification_attempts: 1
+      stopped_because: null
+      harness: codex
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit the cleanup evidence and implementation plan against the original outcome and strongest failure modes."
+    inputs:
+      - "All completed task receipts"
+      - "/Users/neonwatty/Desktop/bugdrop/docs/plans/2026-08-01-merge-queue-real-issue-canary-plan.md"
+      - "Fresh GitHub API readback of mean-weasel/bugdrop-widget-test"
+      - "Current git diff and status"
+    constraints:
+      - "Read-only; do not implement or mutate GitHub state."
+      - "Reject completion if any exact-title legacy automated Issue remains open."
+      - "Reject completion if cleanup evidence cannot show nonmatching Issues were preserved."
+      - "Reject completion if the plan can leak on partial failure, create duplicates through retries, or test the wrong widget/Worker."
+      - "Reject completion if implementation began before owner review."
+      - "Reject completion if any required task remains queued, active, or blocked."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "Cleanup selection and collateral-mutation proof"
+      - "Strongest failure mode checked"
+      - "Requirement-to-task coverage gaps"
+      - "Recommended implementation approval decision or next corrective task"
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      rationale: "The cleanup and planning tranche is complete. Fresh paginated API readback found zero open exact-title legacy Issues and all 394 closed; the 119 unrelated open Issue numbers retain the pre-cleanup SHA-256 fingerprint. The plan is implementation-ready, keeps creation on the existing App, isolates a zero-retry merge-group canary, proves widget bytes and the actual feedback Worker SHA, serializes the shared preview through cleanup, closes all marker matches after partial failure, and adds lock-coordinated recovery after hard cancellation. No product, workflow, or test implementation changed. Owner review should approve the plan before Packages A-D begin."
+      worker_package:
+        objective: ""
+        allowed_files: []
+        verify: []
+        stop_if: []
+      evidence:
+        - "Fresh GitHub API readback: repo=mean-weasel/bugdrop-widget-test, open_exact=0, all_exact=394, closed_exact=394."
+        - "Fresh unrelated-open proof: count=119 and number-set SHA-256 beebb8f75fb74bcc3c6a44f41796d4691dfecfd7fc26a925d5370f1cd1212945, identical to the pre-mutation baseline."
+        - "Plan contract audit found 21/21 required safety anchors, including marker list pagination, duplicate and response-loss handling, partial cleanup, actual-response Worker SHA, zero retries, shared mutex, hard-cancellation recovery, and non-canary live-path isolation."
+        - "Official GitHub concurrency documentation confirms queue:max retains up to 100 pending runs and cannot be combined with cancel-in-progress:true."
+        - "Prettier check passed for the plan and goal charter; GoalBuddy state checker passed without warnings."
+        - "git status contains only the goal artifacts and planning documents; git diff reports zero tracked product, workflow, or test changes."
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks: []
+      missing_evidence: []
+      required_board_updates:
+        - "Mark T999 done, clear active_task, and mark the planning-and-cleanup goal done."
+      harness: codex-pm-fallback
+checks:
+  dirty_fingerprint: 3c382c0df02bfebc0b8bcee491c1c352c2d97a2e0d9c4bf415439516247db5f5
+  last_verification:
+    result: pass
+    task: T999
+    commands:
+      - "Fresh paginated GitHub API readback: 0 open exact-title, 394/394 closed, unrelated-open fingerprint unchanged."
+      - "Plan contract audit: 21/21 safety and traceability anchors found."
+      - "Prettier and GoalBuddy state validation passed; check-can-stop reported full_outcome_complete."

--- a/docs/merge-queue-issue-canary.md
+++ b/docs/merge-queue-issue-canary.md
@@ -1,0 +1,88 @@
+# Merge-Queue Issue Canary Operations
+
+The CI workflow runs one real-Issue canary only for GitHub `merge_group` events. It uses the fixed
+Vercel preview venue, the shared `bugdrop-preview` Worker, the legacy widget form, and the existing
+BugDrop GitHub App. Pull requests, manual and reusable live workflows, the daily live workflow, and
+local Playwright commands do not select the canary.
+
+## Safety model
+
+`Deploy Preview` is a single queued critical section. It waits for lint/type checks, unit/build,
+both local E2E shards, and all three local Radix browsers. The shared
+`bugdrop-shared-preview` lock then covers stale cleanup, build, deployment, every preview consumer,
+the one-shot canary, independent verification, current-marker cleanup, and a final prefix sweep.
+Active runs are not cancelled and pending merge groups use maximum queueing.
+
+The dependent required check `Live Preview Tests` is a fail-closed bridge: it passes only when the
+entire critical section succeeds. Do not change either required check name without coordinating a
+repository ruleset change.
+
+The marker format is:
+
+```text
+bugdrop-ci-canary:<run-id>:<run-attempt>:<full-merge-group-sha>
+```
+
+The browser sends exactly one screenshot-free request and must observe the expected request origin,
+response origin, full Worker build SHA, positive Issue number, and canonical Issue URL. The
+server-side verifier independently lists repository Issues, rejects duplicates and pull requests,
+and checks the complete Issue contract. Cleanup always rediscovers by marker; it never depends on
+the browser result file.
+
+## Credential and rotation
+
+`BUGDROP_CANARY_GITHUB_TOKEN` must be a fine-grained token restricted to
+`mean-weasel/bugdrop-widget-test` with only Issues read/write. It is resolved only by the preflight,
+verify, cleanup, final sweep, and scheduled janitor step environments. It must never be placed at
+workflow/job scope, passed to Playwright or the Worker, or copied into logs and artifacts.
+
+The repository owner is responsible for rotation. Record the expiry in the repository's private
+credential inventory, rotate before expiry, and validate replacement access with nonmutating Issue
+list/get calls. If policy requires a write exercise, use a separately approved temporary Issue and
+close/reopen it outside the canary. Never print or retrieve the secret value during rotation.
+
+An unavailable, expired, or unapproved token fails preflight before deployment/submission. If it
+expires after Issue creation, cleanup fails visibly and the required status bridge remains red.
+
+## Failure and recovery
+
+Same-run cleanup has two independent passes while holding the lock:
+
+1. close every Issue matching the exact run marker;
+2. close every open Issue with the reserved `[BugDrop CI canary]` prefix and prove zero remain.
+
+Hard cancellation can skip both passes. The next merge group performs a locked prefix preflight
+before deploying, and the daily scheduled live workflow performs the same prefix sweep under the
+same lock. Manual and reusable live runs use unique concurrency groups and remain nonmutating; they
+cannot race the preview mutex or run the canary.
+
+When a run fails, do not rerun merely to obtain green status. First inspect the failed step and
+confirm whether the final sweep ran. If cancellation prevented cleanup, wait for the next locked
+preflight or daily janitor, or initiate a separately authorized recovery workflow change. Do not
+close Issues by title search results; the helper paginates the repository Issues API and compares
+markers locally.
+
+## Evidence checklist
+
+For the first authorized live merge-group run and any incident, retain:
+
+- workflow run URL, run attempt, and full merge-group SHA;
+- completion of every local gate before `Deploy Preview`;
+- expected and served widget SHA-256;
+- preview health environment and full build SHA;
+- actual feedback request/response origins and response build-SHA header;
+- canonical Issue number and URL returned to the widget;
+- independent title, body, labels, author, no-screenshot, and exactly-one readback;
+- current-marker closed-state readback and final zero-open prefix sweep;
+- the final `Deploy Preview` and `Live Preview Tests` conclusions.
+
+Artifacts are uploaded only after both cleanup passes and must not contain the verification token.
+Local workflow checks are nonmutating:
+
+```bash
+bash test/ci-workflow-contract.test.sh
+npm run check:actions-node24
+npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --list
+```
+
+Do not run the canary test itself locally or outside its locked merge-group workflow.

--- a/docs/plans/2026-08-01-configurable-feedback-variants-design.md
+++ b/docs/plans/2026-08-01-configurable-feedback-variants-design.md
@@ -1,0 +1,882 @@
+# Configurable Feedback Variants
+
+**Status:** Proposed
+
+**Date:** 2026-08-01
+
+**Scope:** Additive extension to the BugDrop v1 widget and Worker contracts
+
+## Summary
+
+Extend BugDrop from one fixed feedback wizard into a small, declarative feedback runtime that
+can render multiple independently configured UX variants on the same page. Every successful
+submission still creates a GitHub Issue through BugDrop's existing Worker and GitHub App.
+
+The current widget remains the default and is not redesigned by this work. Existing script tags,
+data attributes, `window.BugDrop` methods, request payloads, GitHub Issue formatting, and screenshot
+flows must continue to behave as they do today when no variant API is used.
+
+The initial variant examples are:
+
+1. A one-to-five-star review with an optional message and explicit Submit button.
+2. A CTA-driven question that opens a simple text-response form.
+3. A single-choice poll with an optional explanation.
+4. A compact suggestion form with a short summary and optional detail.
+
+These are proving fixtures, not the architectural limit. Contributors should be able to compose
+new variants from shared primitives or use the headless submission API for fully custom UI.
+
+## Problem
+
+BugDrop currently owns one hard-coded flow:
+
+1. Optional welcome screen.
+2. Bug, feature, or question category selection.
+3. Required title and optional description.
+4. Optional submitter information and evidence.
+5. Optional screenshot capture and annotation.
+6. GitHub Issue creation.
+
+This flow is valuable and must remain stable, but it is too opinionated for contextual prompts such
+as post-action reviews, embedded polls, or a targeted "Which provider should we add?" CTA. Host
+applications can build those experiences themselves, but they must then duplicate BugDrop's auth,
+metadata, validation, error handling, and GitHub submission behavior.
+
+Loading multiple copies of the current widget is not a safe workaround. The bundle discovers one
+script element, creates one `#bugdrop-host`, stores state in module globals, and assigns one
+`window.BugDrop` object.
+
+## Goals
+
+- Preserve the complete legacy widget contract by default.
+- Load the BugDrop bundle once and support multiple logical variant instances.
+- Provide declarative modal and inline layouts.
+- Provide a small initial field catalog that can grow without rewriting submission logic.
+- Keep one explicit Submit action per response.
+- Create one GitHub Issue for every submission that BugDrop reports as successful.
+- Support configurable user-facing labels, help text, validation, success copy, and safe Issue
+  templates.
+- Keep GitHub label authority on the Worker, not in untrusted browser requests.
+- Provide a headless API for host-rendered experiences.
+- Make new built-in field types and presentations straightforward for contributors to add and test.
+- Require no new database, queue, storage product, or backend service.
+
+## Non-goals
+
+- Replacing or visually redesigning the existing BugDrop wizard.
+- A hosted visual form builder or remote configuration service.
+- Response aggregation, dashboards, surveys, or analytics storage.
+- Conditional branching or multi-page form logic in the first release.
+- A public runtime plugin API that executes third-party renderer code inside BugDrop's Shadow DOM.
+- A strict exactly-once delivery guarantee during GitHub or network outages.
+- Supporting multiple copies of `widget.js` on one page.
+
+## Terminology
+
+- **Legacy widget:** The current BugDrop trigger, wizard, evidence flow, and payload.
+- **Variant:** A named declarative form definition.
+- **Variant handle:** The object returned when a variant is registered.
+- **Instance:** One mounted inline form or one opened modal created from a variant.
+- **Presentation:** The container and interaction model, initially `modal` or `inline`.
+- **Field renderer:** The code that renders, reads, validates, and serializes one field type.
+- **Headless submission:** A host-rendered UI calling BugDrop only for validation, metadata, auth,
+  and submission.
+- **Issue template:** Declarative rules for turning normalized answers into a title and ordered
+  Markdown sections. GitHub labels are configured separately.
+
+## Design Principles
+
+### One runtime, many instances
+
+The page loads one BugDrop script. That runtime owns shared configuration, auth, metadata capture,
+and transport. Each variant registration and mount has isolated form state.
+
+Multiple script tags are explicitly unsupported. Multiple logical instances are supported.
+
+### Composition over named special cases
+
+`rating-review` is not a permanent hard-coded rendering branch. It is a variant composed from a
+`rating` field, a `longText` field, an inline or modal presentation, and an Issue template.
+
+### Rendering is separate from submission
+
+Standard BugDrop renderers and host-rendered forms must produce the same normalized submission.
+The Worker must not care whether BugDrop or React rendered the controls.
+
+### The browser controls UX, the Worker controls GitHub policy
+
+Browser configuration may control copy, field order, validation, and Issue title/body composition.
+It may not apply arbitrary GitHub labels. The Worker resolves labels from server configuration and
+always adds the `bugdrop` label.
+
+### Compatibility is an executable contract
+
+Legacy behavior is protected by tests, not only documentation or convention.
+
+## Backwards-Compatibility Contract
+
+The following behavior is normative:
+
+1. A page using only the existing script tag receives the existing widget.
+2. All existing `data-*` attributes retain their current defaults and meanings.
+3. `window.BugDrop.open()` with no arguments opens the current form and skips the welcome screen,
+   as it does today.
+4. `close()`, `hide()`, `show()`, `isOpen()`, `isButtonVisible()`, and `setTheme()` retain their
+   current behavior and signatures.
+5. The existing `bugdrop:ready` event still fires once after legacy initialization.
+6. The existing `#bugdrop-host` remains the legacy host and is not renamed.
+7. Existing `FeedbackPayload` requests remain valid and retain their current Issue body and label
+   behavior.
+8. Existing localStorage keys and screenshot behavior are unchanged for the legacy flow.
+9. Variant-only CSS, DOM, storage keys, events, and payload fields are namespaced and cannot alter
+   legacy output unless a variant API is called.
+10. Existing `widget.v1.js` consumers receive only additive behavior. Any unavoidable incompatible
+    change requires `widget.v2.js`; it must not be smuggled into the v1 bundle.
+
+The reserved variant ID `legacy` refers to the existing form but cannot be overridden by a caller.
+
+## Public Browser API
+
+The existing object gains additive methods:
+
+```ts
+interface BugDropAPI {
+  // Existing API, unchanged
+  open(): void;
+  close(): void;
+  hide(): void;
+  show(): void;
+  isOpen(): boolean;
+  isButtonVisible(): boolean;
+  setTheme(mode: 'light' | 'dark' | 'auto'): void;
+
+  // Additive variant API
+  registerVariant(config: VariantConfig): VariantHandle;
+  getVariant(id: string): VariantHandle | undefined;
+  unregisterVariant(id: string): void;
+}
+
+interface VariantHandle {
+  readonly id: string;
+  open(options?: VariantOpenOptions): Promise<VariantOutcome>;
+  mount(target: HTMLElement, options?: VariantMountOptions): MountedVariant;
+  submit(
+    answers: Record<string, unknown>,
+    options?: HeadlessSubmitOptions
+  ): Promise<SubmissionResult>;
+}
+
+interface MountedVariant {
+  readonly instanceId: string;
+  reset(): void;
+  unmount(): void;
+}
+
+interface VariantOpenOptions {
+  context?: Record<string, string | number | boolean | null>;
+  initialAnswers?: Record<string, unknown>;
+}
+
+type VariantMountOptions = VariantOpenOptions;
+
+interface HeadlessSubmitOptions {
+  context?: Record<string, string | number | boolean | null>;
+  submissionId?: string;
+}
+
+type VariantOutcome =
+  | { status: 'submitted'; result: SubmissionResult }
+  | { status: 'closed' };
+
+interface SubmissionResult {
+  issueNumber: number;
+  issueUrl: string;
+  isPublic: boolean;
+  warnings?: string[];
+}
+```
+
+`open()` remains overloaded only at runtime: zero arguments always selects the legacy behavior.
+Variant consumers should prefer the returned handle rather than `BugDrop.open(id)`, which keeps the
+legacy method's public TypeScript signature unambiguous.
+
+Registration validates the entire config synchronously. Duplicate IDs, reserved IDs, unknown field
+types, invalid templates, or duplicate field IDs throw a descriptive configuration error. BugDrop
+must not partially register an invalid variant. A successful registration stores a normalized deep
+copy; later mutation of the caller's object cannot alter an active form or its submission payload.
+
+`unregisterVariant()` is allowed only after all of that variant's mounted instances are unmounted
+and no modal instance is active. Otherwise it throws a lifecycle error. This makes cleanup explicit
+and prevents unregistering configuration that an in-flight submission still needs.
+
+## Variant Configuration
+
+```ts
+interface VariantConfig {
+  id: string;
+  configVersion?: 1;
+  presentation: VariantPresentation;
+  content: {
+    title: string;
+    description?: string;
+    submitLabel?: string;
+    cancelLabel?: string;
+    successTitle?: string;
+    successMessage?: string;
+  };
+  fields: VariantField[];
+  issue: VariantIssueTemplate;
+  evidence?: VariantEvidenceConfig;
+}
+
+type VariantPresentation =
+  | {
+      kind: 'modal';
+      size?: 'compact' | 'default' | 'wide';
+      columns?: 1 | 2;
+    }
+  | {
+      kind: 'inline';
+      columns?: 1 | 2;
+    };
+
+interface VariantEvidenceConfig {
+  screenshot?: 'off' | 'optional' | 'required';
+  attachments?: 'off' | 'optional';
+  consoleLogs?: 'off' | 'optional' | 'default-on';
+}
+```
+
+Defaults are conservative: evidence is off for new variants unless explicitly enabled. This avoids
+surprising screenshot capture in lightweight ratings and polls.
+
+Caller-provided content is literal display copy. BugDrop's built-in validation, loading, retry,
+accessibility, and fallback strings continue to come from the active locale dictionary.
+
+### Initial field catalog
+
+```ts
+type VariantField =
+  | ShortTextField
+  | LongTextField
+  | RatingField
+  | SingleChoiceField;
+
+interface BaseField {
+  id: string;
+  label: string;
+  helpText?: string;
+  required?: boolean;
+  layout?: { span?: 1 | 2 };
+}
+
+interface ShortTextField extends BaseField {
+  type: 'shortText';
+  placeholder?: string;
+  minLength?: number;
+  maxLength?: number;
+}
+
+interface LongTextField extends BaseField {
+  type: 'longText';
+  placeholder?: string;
+  rows?: number;
+  minLength?: number;
+  maxLength?: number;
+}
+
+interface RatingField extends BaseField {
+  type: 'rating';
+  min?: 1;
+  max?: 5 | 10;
+  icon?: 'star' | 'number';
+  lowLabel?: string;
+  highLabel?: string;
+}
+
+interface SingleChoiceField extends BaseField {
+  type: 'singleChoice';
+  options: Array<{ value: string; label: string; description?: string }>;
+  display?: 'radio' | 'cards' | 'buttons';
+}
+```
+
+Field IDs must match `[a-z][a-z0-9_-]{0,63}`. Answer values are keyed by field ID. Hidden
+application state is passed as bounded `context`, not represented by a hidden form field.
+
+The initial catalog is intentionally small. Checkboxes, multi-select, date, file, NPS, emoji scale,
+and conditional fields can be added later as new discriminated-union members without changing the
+submission or Worker contracts.
+
+## Issue Templates
+
+Issue templates are declarative rather than arbitrary executable callbacks:
+
+```ts
+interface VariantIssueTemplate {
+  classification?: 'bug' | 'feature' | 'question' | 'feedback';
+  labelSet?: string;
+  title: string;
+  sections?: Array<
+    | {
+        heading: string;
+        field: string;
+        format?: 'text' | 'quote' | 'stars' | 'choice';
+        omitWhenEmpty?: boolean;
+      }
+    | {
+        heading: string;
+        context: string;
+        format?: 'text' | 'code';
+        omitWhenEmpty?: boolean;
+      }
+  >;
+}
+```
+
+Title templates support only escaped field and context placeholders:
+
+```text
+[Export review] {{rating}}/5 — {{context.surface}}
+Cloud provider request — {{provider}}
+```
+
+There are no expressions, loops, conditionals, or function calls. Missing placeholders resolve to
+an empty string, whitespace is collapsed, and the result is length-bounded before the GitHub call.
+
+If `sections` is omitted, the Worker renders all answers in field order using their configured
+labels. The Worker always appends BugDrop's attribution and safe system information; a client
+template cannot remove those sections.
+
+The browser may influence Issue title and body because the legacy payload already permits arbitrary
+user title and description. It may request only a logical `labelSet`. The Worker resolves that key
+through optional server configuration such as:
+
+```json
+{
+  "owner/repo": {
+    "product-review": ["feedback", "rating"],
+    "cloud-provider": ["enhancement", "cloud-import"]
+  }
+}
+```
+
+The suggested Worker variable name is `VARIANT_LABELS`. It follows the existing per-repository
+`CATEGORY_LABELS` precedence model and does not introduce a configuration service.
+
+Unknown or invalid label sets fall back to classification defaults plus `bugdrop`, with an operator
+warning. Client-provided raw GitHub label arrays are rejected.
+
+Classification defaults are:
+
+| Classification | Labels |
+| --- | --- |
+| `bug` | `bug`, `bugdrop` |
+| `feature` | `enhancement`, `bugdrop` |
+| `question` | `question`, `bugdrop` |
+| `feedback` or omitted | `bugdrop` |
+
+## Initial Acceptance Variants
+
+These are documentation examples and automated fixtures. They may be exported as optional helper
+factories, but the runtime must treat them as ordinary configurations.
+
+### 1. One-to-five-star review
+
+```ts
+const review = BugDrop.registerVariant({
+  id: 'export-review',
+  presentation: { kind: 'inline' },
+  content: {
+    title: 'How was this export?',
+    submitLabel: 'Submit review',
+    successTitle: 'Thanks for the review!',
+  },
+  fields: [
+    {
+      id: 'rating',
+      type: 'rating',
+      label: 'Rating',
+      required: true,
+      min: 1,
+      max: 5,
+      icon: 'star',
+    },
+    {
+      id: 'message',
+      type: 'longText',
+      label: 'Anything else?',
+      required: false,
+      maxLength: 1000,
+    },
+  ],
+  issue: {
+    classification: 'feedback',
+    labelSet: 'product-review',
+    title: '[Export review] {{rating}}/5',
+    sections: [
+      { heading: 'Rating', field: 'rating', format: 'stars' },
+      { heading: 'Comment', field: 'message', omitWhenEmpty: true },
+    ],
+  },
+});
+```
+
+Selecting a star updates local state only. Submission occurs only when the explicit Submit button is
+activated. Rating and message create one Issue, not separate rating and follow-up Issues.
+
+### 2. CTA-driven question
+
+The host application owns the CTA placement and copy. The CTA calls the variant handle:
+
+```ts
+const providerQuestion = BugDrop.registerVariant({
+  id: 'cloud-provider-question',
+  presentation: { kind: 'modal', size: 'compact' },
+  content: {
+    title: 'Which cloud provider should we support next?',
+    description: 'Tell us what would fit your workflow.',
+    submitLabel: 'Send idea',
+  },
+  fields: [
+    {
+      id: 'response',
+      type: 'longText',
+      label: 'Your answer',
+      required: true,
+      minLength: 2,
+      maxLength: 1000,
+    },
+  ],
+  issue: {
+    classification: 'feature',
+    labelSet: 'cloud-provider',
+    title: 'Cloud provider request — {{response}}',
+    sections: [{ heading: 'Requested provider or workflow', field: 'response' }],
+  },
+});
+
+button.addEventListener('click', () => {
+  void providerQuestion.open({ context: { surface: 'studio-upload' } });
+});
+```
+
+Long responses are truncated only in the generated title, never in the Issue section.
+
+### 3. Single-choice poll
+
+This variant proves reusable option rendering and optional detail:
+
+```ts
+BugDrop.registerVariant({
+  id: 'next-integration-poll',
+  presentation: { kind: 'inline' },
+  content: {
+    title: 'What should we build next?',
+    submitLabel: 'Vote',
+  },
+  fields: [
+    {
+      id: 'choice',
+      type: 'singleChoice',
+      label: 'Choose one',
+      required: true,
+      display: 'cards',
+      options: [
+        { value: 'onedrive', label: 'OneDrive' },
+        { value: 'box', label: 'Box' },
+        { value: 'other', label: 'Something else' },
+      ],
+    },
+    {
+      id: 'detail',
+      type: 'longText',
+      label: 'Optional detail',
+      maxLength: 500,
+    },
+  ],
+  issue: {
+    classification: 'feature',
+    labelSet: 'integration-poll',
+    title: 'Integration vote — {{choice}}',
+    sections: [
+      { heading: 'Choice', field: 'choice', format: 'choice' },
+      { heading: 'Detail', field: 'detail', omitWhenEmpty: true },
+    ],
+  },
+});
+```
+
+Conditional display of `detail` only when `other` is selected is intentionally deferred. Keeping it
+visible but optional exercises the same data model without introducing a rules engine.
+
+### 4. Compact suggestion
+
+This variant proves multiple text fields and optional evidence:
+
+```ts
+BugDrop.registerVariant({
+  id: 'compact-suggestion',
+  presentation: { kind: 'modal', size: 'default' },
+  content: {
+    title: 'Share an idea',
+    submitLabel: 'Submit idea',
+  },
+  fields: [
+    {
+      id: 'summary',
+      type: 'shortText',
+      label: 'Idea',
+      required: true,
+      maxLength: 120,
+    },
+    {
+      id: 'detail',
+      type: 'longText',
+      label: 'How would this help?',
+      maxLength: 2000,
+    },
+  ],
+  issue: {
+    classification: 'feature',
+    labelSet: 'suggestion',
+    title: '[Idea] {{summary}}',
+    sections: [
+      { heading: 'Idea', field: 'summary' },
+      { heading: 'Why it would help', field: 'detail', omitWhenEmpty: true },
+    ],
+  },
+  evidence: {
+    screenshot: 'optional',
+    attachments: 'off',
+    consoleLogs: 'off',
+  },
+});
+```
+
+## Structured Submission Contract
+
+The Worker accepts a discriminated union of the unchanged legacy payload and a new structured
+payload:
+
+```ts
+interface StructuredFeedbackPayload {
+  schemaVersion: 2;
+  repo: string;
+  variant: {
+    id: string;
+    configVersion: 1;
+    fields: Array<{
+      id: string;
+      label: string;
+      type: 'shortText' | 'longText' | 'rating' | 'singleChoice';
+      required?: boolean;
+      minLength?: number;
+      maxLength?: number;
+      min?: number;
+      max?: number;
+      options?: Array<{ value: string; label: string }>;
+    }>;
+    issue: VariantIssueTemplate;
+  };
+  submissionId: string;
+  answers: Record<string, string | number | null>;
+  context?: Record<string, string | number | boolean | null>;
+  screenshot?: string;
+  attachments?: FeedbackAttachment[];
+  consoleLogs?: ConsoleLogEntry[];
+  metadata: FeedbackMetadata;
+}
+```
+
+The payload includes only Issue-relevant normalized config, not presentation details or success
+copy. This lets a hosted Worker format a contributor-defined variant without storing its browser
+layout. The Worker validates the normalized schema again and never trusts client validation.
+
+Limits for the first release:
+
+- At most 20 fields.
+- At most 50 options across all fields.
+- At most 64 characters per field or variant ID.
+- At most 5,000 characters per answer.
+- At most 20 context keys and 8 KB of serialized context.
+- At most 32 KB for the structured payload before evidence data.
+- Existing screenshot, attachment, and console-log limits remain in force.
+
+Unknown answers, duplicate fields, non-finite numbers, nested answer values, control characters in
+IDs, invalid option values, or an unsupported schema version return `400` without calling GitHub.
+
+## Runtime and DOM Architecture
+
+Introduce a `BugDropRuntime` that owns:
+
+- Legacy adapter.
+- Shared core configuration and auth-token provider.
+- Variant registry.
+- Active modal coordinator.
+- Submission service.
+- Theme and locale services.
+
+Legacy module-global variables remain behind the adapter initially or move into a dedicated
+`LegacyWidgetController` without observable behavior changes.
+
+Suggested source organization:
+
+```text
+src/widget/variants/
+  types.ts
+  validate-config.ts
+  registry.ts
+  runtime.ts
+  submission.ts
+  issue-template.ts
+  presentations/
+    modal.ts
+    inline.ts
+  fields/
+    index.ts
+    short-text.ts
+    long-text.ts
+    rating.ts
+    single-choice.ts
+```
+
+Each field renderer implements an internal contract:
+
+```ts
+interface FieldRenderer<TField extends VariantField> {
+  render(field: TField, state: FieldState, environment: RenderEnvironment): HTMLElement;
+  read(element: HTMLElement, field: TField): unknown;
+  validate(value: unknown, field: TField): ValidationError | null;
+  normalize(value: unknown, field: TField): string | number | null;
+}
+```
+
+Adding a built-in field requires one union member, one renderer registration, focused unit tests,
+and documentation. Submission and Issue formatting must not need a field-specific branch except for
+explicit display formats such as stars.
+
+Inline mounts create unique hosts marked with `data-bugdrop-instance="<id>"`. They must not reuse
+`#bugdrop-host`. Each mount uses a Shadow Root for style isolation and returns an unmount handle.
+Only one BugDrop modal may be open at a time; opening another resolves the first outcome as closed.
+
+## Validation and Accessibility
+
+- Configuration errors are reported at registration time.
+- Answer validation runs on Submit and focuses the first invalid field.
+- Server validation mirrors security-relevant constraints.
+- Required status and errors are exposed with `aria-describedby` and `aria-invalid`.
+- Rating controls use a radiogroup or equivalent keyboard-operable pattern; arrow keys move the
+  selection and Enter/Space selects.
+- Selecting a rating never submits automatically.
+- Single-choice card and button presentations preserve native radio semantics.
+- Modal variants reuse the current focus trap, Escape behavior, background scroll lock, and dialog
+  semantics.
+- Inline variants do not move focus on mount.
+- Loading state disables duplicate Submit activation and remains announced through an ARIA live
+  region.
+- Touch targets remain at least 44 by 44 CSS pixels.
+- Variant styles use the existing theme tokens and custom style configuration.
+
+## Submission Lifecycle and Reliability
+
+1. An instance generates one UUID `submissionId` when its form state is created.
+2. Validation failures retain that ID and do not call the Worker.
+3. Submit disables the form and requests an auth token through the existing provider.
+4. The Worker validates auth, structured config, answers, evidence, and label policy.
+5. The Worker creates the GitHub Issue through the existing GitHub App.
+6. BugDrop reports success only after it receives an Issue number and URL.
+7. A retry reuses the same `submissionId`.
+
+The Issue body includes an invisible marker:
+
+```html
+<!-- bugdrop-submission: <submissionId> -->
+```
+
+The marker enables best-effort duplicate detection and operator forensics. GitHub search and
+Cloudflare KV are not atomic transaction systems, so this design does not promise strict
+exactly-once delivery. Network loss after GitHub accepts an Issue can still race a retry.
+
+For structured variants with evidence, create the Issue before optional asset uploads and patch the
+Issue afterward. This ensures a screenshot or attachment failure does not discard the response.
+Evidence failures are recorded in the Issue and returned as warnings. The legacy evidence ordering
+is unchanged for backwards compatibility unless separately migrated and proven equivalent.
+
+Existing rate limits remain the default. Authenticated self-hosts may later add subject- and
+variant-aware limits using the already verified token subject, but that is not required to ship the
+variant runtime.
+
+## Security and Privacy
+
+- Escape all configured copy before inserting it into widget HTML.
+- Reject control characters and invalid IDs in both browser and Worker validation.
+- Treat answers and context as untrusted user-generated content.
+- Enforce bounded strings, key counts, option counts, and serialized payload sizes.
+- Do not accept executable template expressions or callbacks in Worker payloads.
+- Do not accept raw GitHub labels from variant submissions.
+- Resolve `labelSet` from server-owned per-repository configuration.
+- Continue requiring the existing signed token when the Worker has auth enabled.
+- Continue redacting URL query strings and hashes.
+- Keep screenshots, attachments, and console logs off by default for new variants.
+- Host applications remain responsible for applying `data-bugdrop-mask` to sensitive surfaces.
+- Do not place secrets, full media content, transcripts, or unconstrained application objects in
+  `context`.
+
+## Events and Host Integration
+
+Keep `bugdrop:ready` unchanged. Add namespaced events for optional host analytics:
+
+```text
+bugdrop:variant-registered
+bugdrop:variant-mounted
+bugdrop:variant-opened
+bugdrop:variant-submitted
+bugdrop:variant-failed
+bugdrop:variant-closed
+```
+
+Event details contain variant ID, instance ID, presentation, result status, and Issue number when
+available. They must not contain answers, comments, email addresses, URLs with query strings, or
+arbitrary context.
+
+The runtime does not add an analytics service. Hosts may translate these events into their existing
+analytics tools.
+
+## Contributor Extension Model
+
+The first release supports two safe extension paths:
+
+1. Compose a new variant from public field and presentation primitives.
+2. Render any custom UI in the host application and call `VariantHandle.submit()`.
+
+Contributors extending BugDrop itself add field types through the internal registry contract. A
+public `registerFieldRenderer()` API is deferred because it would require stable DOM lifecycle,
+style, accessibility, sanitization, and serialization contracts for arbitrary third-party code.
+Headless submission provides equivalent product flexibility without freezing that unsafe API early.
+
+Each built-in example should exist as:
+
+- A documented configuration snippet.
+- A local test page.
+- A focused renderer test.
+- A Worker Issue-formatting test.
+- A Playwright flow using the public API.
+
+## Testing and Compatibility Gates
+
+### Legacy regression suite
+
+- Existing script snippets render the same trigger and default form.
+- Existing data attributes produce the same config.
+- `BugDrop.open()` still skips welcome and opens the legacy form.
+- Existing request payload fixtures are byte-for-byte unchanged where timestamps and generated
+  evidence are normalized.
+- Existing GitHub Issue body and labels are unchanged.
+- Screenshot, annotation, retry, locale, theme, and API-only tests continue to pass.
+
+### Variant unit tests
+
+- Complete config validation and descriptive errors.
+- Field rendering, keyboard behavior, validation, normalization, and reset.
+- Template placeholder resolution and output limits.
+- Registry duplicate/reserved ID behavior.
+- Independent state for multiple mounts.
+- Headless and BugDrop-rendered submissions normalize identically.
+
+### Worker tests
+
+- Legacy and schema-v2 payloads both succeed.
+- Unsupported versions and malformed configs fail before GitHub calls.
+- Unknown answers and choice values are rejected.
+- Label sets cannot be injected by the client.
+- Empty optional sections are omitted.
+- Mandatory attribution and system information cannot be suppressed.
+- Submission markers are present and stable across retries.
+- Evidence upload failure still leaves a structured-variant Issue.
+
+### E2E tests
+
+- Each initial acceptance variant in modal and/or inline form.
+- Two inline variants coexist with the legacy widget.
+- Repeated mount/unmount does not leak hosts, listeners, or state.
+- Only one modal opens at a time.
+- Explicit Submit is required for rating and choice controls.
+- Mobile touch targets, focus order, Escape, and error focus.
+- Light, dark, auto, and custom Bleep-like styling.
+
+## Documentation
+
+Add documentation pages or sections for:
+
+- Variant concepts and browser API.
+- Field and presentation reference.
+- Issue templates and server-owned label sets.
+- Modal, inline, and headless examples.
+- React integration and cleanup.
+- Security and context-data guidance.
+- Version pinning and the legacy compatibility promise.
+- A contributor guide for adding a built-in field renderer.
+
+The Quick Start remains the current one-line script installation. Variants are presented as an
+advanced additive capability.
+
+## Rollout Plan
+
+### Phase 1: Runtime foundation
+
+- Extract a shared submission service without changing legacy payloads.
+- Add the variant types, validator, registry, and handle API.
+- Add structured Worker payload validation and generic Issue formatting.
+- Add legacy compatibility fixtures.
+
+### Phase 2: First renderers
+
+- Add modal and inline presentations.
+- Add short text, long text, rating, and single-choice fields.
+- Ship the four initial acceptance examples and local test pages.
+
+### Phase 3: Evidence and hardening
+
+- Add optional screenshot/evidence support for variants.
+- Add submission markers and best-effort retry deduplication.
+- Run accessibility, cross-browser, masking, rate-limit, and failure-path audits.
+
+### Phase 4: Dogfood and documentation
+
+- Dogfood selected examples in a host application such as Bleep without making Bleep-specific copy
+  or fields part of BugDrop core.
+- Publish contributor and integration documentation.
+- Broaden usage only after the legacy and multi-instance E2E contracts remain green.
+
+## Acceptance Criteria
+
+The extension is ready when:
+
+1. Every pre-existing BugDrop unit and E2E test passes without weakening assertions.
+2. A page with no variant registrations is observably unchanged.
+3. The four example variants can be registered from ordinary application JavaScript.
+4. At least two inline instances and the legacy widget coexist on one page.
+5. A host-rendered form can submit through the same normalized path.
+6. Each successful variant submission returns a GitHub Issue number and creates a correctly
+   formatted Issue.
+7. Rating selection alone never submits.
+8. Client attempts to inject raw GitHub labels fail.
+9. New variant code is separated into contributor-oriented modules rather than expanding the
+   already large legacy `index.ts` and `ui.ts` files.
+10. `widget.v1.js`, the legacy Worker payload, and the current JavaScript API remain backwards
+    compatible.
+
+## Strongest Failure Modes to Disprove During Implementation
+
+1. **Legacy regression:** A site that never calls the variant API renders or submits differently.
+   Prove this with normalized DOM, payload, and Issue-body contract fixtures plus existing E2E.
+2. **Cross-instance state leakage:** One mount changes another mount's answers, theme, open state, or
+   cleanup. Prove this with simultaneous mount and repeated unmount tests.
+3. **GitHub policy injection:** A modified browser payload applies unauthorized labels or suppresses
+   mandatory Issue metadata. Prove this with direct Worker requests that bypass the widget.
+4. **False success or duplicate response:** The UI thanks the user without an Issue number, or a
+   routine retry creates a second Issue. Prove success gating with fault injection and audit the
+   best-effort submission marker behavior explicitly.
+5. **Accessibility regression:** Star or card controls work only with a pointer, or a modal loses
+   focus containment. Prove keyboard-only flows and automated accessibility assertions.

--- a/docs/plans/2026-08-01-merge-queue-real-issue-canary-plan.md
+++ b/docs/plans/2026-08-01-merge-queue-real-issue-canary-plan.md
@@ -1,0 +1,497 @@
+# Merge-Queue Real-Issue Canary Implementation Plan
+
+**Status:** Ready for owner review
+
+**Date:** 2026-08-01
+
+**Scope:** Merge-group preview CI, legacy widget submission, Worker build identity, independent GitHub
+Issue verification, and fail-visible cleanup
+
+## Objective
+
+Add one merge-group-only canary that proves the exact widget bytes built from the merge-group SHA,
+runs through the preview Worker built from that same SHA, and creates one real, correctly formatted
+Issue in `mean-weasel/bugdrop-widget-test` through the existing GitHub App. The canary then
+independently reads the Issue with a least-privilege token, rejects duplicates, and closes every
+matching canary Issue even when submission or verification fails partway through.
+
+This document is an implementation plan, not authorization to implement. Configurable feedback
+variants remain out of scope. The legacy behavior protected by
+`docs/plans/2026-08-01-configurable-feedback-variants-design.md` is compatibility context only.
+
+## Why this work is necessary
+
+The current live submission test in `e2e/widget.live.spec.ts` makes an unmanaged real `/feedback`
+request, accepts success or error, inherits two CI retries, records no Issue identity, and performs no
+cleanup. The same live project runs in merge-group, production, scheduled, and manual workflows.
+
+The historical cleanup preceding this plan found 394 Issues titled exactly
+`Live E2E test submission`; 332 were open. All 332 were closed, and a before/after fingerprint proved
+that none of the 119 unrelated open Issues changed. Durable evidence is in
+`docs/goals/merge-queue-issue-canary/notes/T001-cleanup-evidence.md`.
+
+Current architecture also permits a second merge group to overwrite the one shared
+`bugdrop-preview` Worker while the first group is testing it. Preview deployment needs only the
+fast `check` job, not unit, build, local E2E, or the Radix browser matrix. Widget bytes are already
+hashed well, but `/api/health` carries no Worker build identity.
+
+Detailed current-state evidence and the approved architecture are in:
+
+- `docs/goals/merge-queue-issue-canary/notes/T002-architecture-map.md`
+- `docs/goals/merge-queue-issue-canary/notes/T003-architecture-decision.md`
+
+## Non-goals
+
+- No configurable feedback variants, headless submission API, or UX redesign.
+- No new Worker, database, queue, KV namespace, storage service, or external cleanup service.
+- No new GitHub App and no expansion of the existing BugDrop App's role.
+- No production real-Issue canary.
+- No screenshot or attachment upload in the canary.
+- No GitHub ruleset mutation; preserve the required check names `Deploy Preview` and
+  `Live Preview Tests`.
+- No exactly-once delivery claim. GitHub and runner outages make an absolute synchronous cleanup
+  guarantee impossible; the design provides fail-visible immediate cleanup and two eventual
+  recovery paths.
+
+## Invariants
+
+1. Only `merge_group` may create a canary Issue.
+2. Issue creation uses the existing preview Worker and GitHub App. The verification token never
+   creates an Issue.
+3. No shared-preview deployment or consumer overlaps another merge group's preview critical
+   section.
+4. Preview deployment begins only after check, unit/build, local Chromium E2E, and the local Radix
+   browser matrix pass.
+5. The venue's actual widget script bytes equal the bytes built from the checked-out merge-group
+   tree.
+6. The actual `/feedback` response identifies the preview Worker build as the full merge-group SHA.
+7. One canary attempt performs one browser submission with Playwright retries explicitly zero.
+8. A server-side verifier finds exactly one matching non-PR Issue and asserts its complete contract.
+9. Cleanup discovers by marker rather than relying on a response number or GitHub search indexing.
+10. Cleanup closes all matching Issues, then proves none remain open.
+11. Scheduled, production, manual, PR, and local live paths cannot make a real canary submission.
+12. Existing unconfigured Worker and widget behavior remains unchanged.
+
+## Operator prerequisite
+
+Create one fine-grained GitHub token and store it as the repository Actions secret
+`BUGDROP_CANARY_GITHUB_TOKEN`.
+
+- Resource owner: the owner that can grant access to `mean-weasel/bugdrop-widget-test`.
+- Repository access: only `mean-weasel/bugdrop-widget-test`.
+- Repository permission: Issues read/write. Write includes read.
+- No Contents, Actions, Administration, Pull requests, or organization permissions.
+- Give it an expiry and document rotation ownership.
+
+The token is step-scoped only to verification and cleanup commands. It must never be:
+
+- set at workflow or job scope;
+- passed to Playwright or a browser page;
+- sent to the Worker;
+- placed in a trace, report, artifact, Issue, or log;
+- used to create the canary Issue.
+
+Before enabling the live canary, verify the token with non-mutating list/get calls and one
+operator-approved close/reopen exercise on a temporary Issue if organizational policy requires it.
+
+## Marker and expected Issue contract
+
+Construct one marker per workflow attempt:
+
+```text
+bugdrop-ci-canary:<GITHUB_RUN_ID>:<GITHUB_RUN_ATTEMPT>:<GITHUB_SHA>
+```
+
+Use the full merge-group SHA. Put the full marker in both the title and description. Use a stable
+title prefix such as `[BugDrop CI canary]` so preflight and scheduled cleanup can identify stale
+canaries while the full marker identifies one attempt.
+
+The expected Issue contract is:
+
+- positive integer `number`;
+- exact canonical URL
+  `https://github.com/mean-weasel/bugdrop-widget-test/issues/<number>`;
+- exact expected title containing the full marker;
+- raw body contains `## Description`, the full marker, system-information details, and
+  `*Submitted via [BugDrop](https://github.com/mean-weasel/bugdrop)*`;
+- raw body does not contain `## Screenshot`;
+- exact label set `bug`, `bugdrop`;
+- creator `neonwatty-bugdrop[bot]`;
+- state `open` before cleanup;
+- exactly one non-PR Issue matches the current full marker.
+
+The title and body marker make response-loss cleanup possible. Filtering must paginate the REST
+Issues endpoint with `state=all`, reject entries containing `pull_request`, and compare marker/title
+content locally. Do not use GitHub search as cleanup truth because indexing can lag Issue creation.
+
+## Target CI shape
+
+### Required local gates
+
+Keep the existing local jobs parallel, but require all of them before shared-preview work:
+
+```text
+check
+├── test
+├── e2e (two shards)
+└── radix-e2e (three browsers)
+     └── preview-critical-section / check name: Deploy Preview
+          └── live-preview-status / check name: Live Preview Tests
+```
+
+The preview critical-section job uses:
+
+```yaml
+needs: [check, test, e2e, radix-e2e]
+if: github.event_name == 'merge_group'
+concurrency:
+  group: bugdrop-shared-preview
+  cancel-in-progress: false
+  queue: max
+```
+
+`queue: max` matters: `cancel-in-progress: false` protects the active job, but the default
+concurrency queue retains only one pending job and cancels an older pending required-check run.
+
+### One uninterrupted shared-preview job
+
+The job retaining the name `Deploy Preview` owns this entire sequence while holding the mutex:
+
+1. Checkout the merge-group SHA and install dependencies/browsers.
+2. Preflight cleanup of every stale reserved-prefix canary Issue; verify none remain open.
+3. Build all assets from the checkout and compute expected widget SHA-256.
+4. Deploy `bugdrop-preview` with `BUILD_SHA=$GITHUB_SHA`.
+5. Poll health until `environment == preview` and `buildSha == GITHUB_SHA`.
+6. Poll the deployed widget until its bytes match expected SHA-256.
+7. Verify the fixed Vercel venue loads that preview origin and exact asset.
+8. Run the existing nonmutating Chromium live suite and live Radix suite.
+9. Run Chromium, Firefox, and WebKit cross-browser live smoke coverage inside this same job.
+10. Run the dedicated Chromium real-Issue canary once, with zero retries.
+11. Independently verify exactly one real Issue and its complete contract.
+12. In a separate `if: always()` step, close all current-marker matches and re-read them.
+13. In the final locked cleanup step, sweep all open reserved-prefix canaries and fail if any remain.
+14. Upload failure artifacts only after cleanup; no artifact may contain the token.
+
+No preview deployment or live-preview consumer may remain in a separate job. A job-level lock that
+ends after deployment does not protect tests.
+
+### Preserve required status names
+
+The existing ruleset requires `Deploy Preview` and `Live Preview Tests`.
+
+- The critical-section job remains named `Deploy Preview`.
+- Replace the current live job with a lightweight dependent job named `Live Preview Tests`.
+- Give it `if: always()` and make it exit nonzero unless the critical-section job result is exactly
+  `success`.
+
+This is a fail-closed status bridge, not an unconditional no-op. It prevents a skipped downstream
+job from hiding preview or cleanup failure.
+
+## Implementation packages
+
+Follow test-first sequencing within each package. Packages are ordered because later workflow work
+depends on earlier helper and runtime contracts.
+
+### Package A: testable GitHub Issue verifier and cleaner
+
+Candidate files:
+
+- `scripts/github-issue-canary.mjs`
+- `test/githubIssueCanary.test.ts`
+- `knip.json` only if the new CLI must be declared as an entry
+- `package.json` or `Makefile` only if a named command materially reduces unsafe invocation
+
+Implement a module with injected `fetch` for tests and a small CLI for Actions. Suggested commands:
+
+```text
+preflight --repo mean-weasel/bugdrop-widget-test --prefix "[BugDrop CI canary]"
+verify --repo ... --marker ... --result-file test-results/issue-canary-result.json
+cleanup --repo ... --marker ...
+sweep --repo ... --prefix "[BugDrop CI canary]"
+```
+
+Required behavior:
+
+- Parse Link pagination until exhausted.
+- Always request `state=all` for current-marker verification and current cleanup.
+- Exclude `pull_request` entries.
+- Require repository identity and exact marker/prefix inputs.
+- Verify the response result file identifies the same sole Issue found by marker.
+- Assert title, raw body, exact labels, bot author, footer, no screenshot, URL, number, and state.
+- On duplicate verification, fail but return enough structured information for cleanup to close all
+  matches.
+- Cleanup closes every open match, not the first.
+- On an ambiguous PATCH failure, GET that exact Issue before deciding whether retry is safe.
+- A readback showing already closed is idempotent success.
+- A readback showing open may receive one bounded retry; retain all failures and continue closing
+  other matches.
+- Re-enumerate after cleanup and exit nonzero if any match remains open.
+- Never print the Authorization header or token.
+
+Write failure-mode tests before the CLI path. All tests use fake API responses and no credentials.
+
+Focused verification:
+
+```bash
+npx vitest run test/githubIssueCanary.test.ts
+npm run lint
+npm run typecheck
+npx knip
+```
+
+Stop if the helper needs broader than repository-scoped Issues read/write, uses search indexing, or
+cannot keep authorization out of diagnostic output.
+
+Rollback: remove the helper and its tests before any workflow step depends on it.
+
+### Package B: additive Worker build identity
+
+Files:
+
+- `src/types.ts`
+- `src/routes/api.ts`
+- `test/api.test.ts`
+
+Test first:
+
+1. Configured `BUILD_SHA` appears in health JSON.
+2. Configured `BUILD_SHA` appears as `X-BugDrop-Build-SHA` on successful `/feedback` responses.
+3. Decide and test whether the header also appears on feedback errors; consistent middleware is
+   preferable because failure responses remain diagnosable.
+4. With no `BUILD_SHA`, existing health and API contracts remain compatible and no misleading SHA
+   value is emitted.
+5. Existing Issue body, labels, authentication, and response fields remain unchanged.
+
+Implementation:
+
+- Add optional `BUILD_SHA?: string` to `Env`.
+- Add an API middleware/header only when the binding is nonempty.
+- Add `buildSha` to health only when configured.
+- Deploy preview with a properly quoted `--var BUILD_SHA:$GITHUB_SHA` argument.
+- After deployment, assert both `environment == preview` and exact full SHA so a missing/overridden
+  preview variable fails before submission.
+
+Focused verification:
+
+```bash
+npx vitest run test/api.test.ts
+npm run typecheck
+npm run lint
+```
+
+Stop if this changes request bodies, Issue formatting, authentication, label resolution, or behavior
+of an unconfigured deployment.
+
+Rollback: stop passing the variable and revert the optional header/health fields together.
+
+### Package C: isolated legacy-widget Playwright canary
+
+Files:
+
+- new `e2e/widget.issue-canary.spec.ts`
+- `e2e/widget.live.spec.ts`
+- `playwright.config.ts`
+- focused tests/helpers if extraction is needed
+
+First remove the unmanaged side effect:
+
+- Convert `Feedback Submission (Live)` to a fully mocked transport/UI assertion, or remove it only
+  if equivalent mocked coverage already exists.
+- Assert regular live, production, scheduled, and manual paths make no unmocked feedback POST.
+
+Add a dedicated project whose `testMatch` is only the canary spec. Also ensure regular Chromium and
+live projects exclude it. Set:
+
+```text
+fullyParallel: false
+workers: 1
+retries: 0
+```
+
+The workflow command must repeat `--workers=1 --retries=0` as drift defense.
+
+Canary flow:
+
+1. Require explicit `LIVE_TARGET=preview`, expected widget origin/hash, full expected Worker SHA,
+   marker, and result-file path. Fail before interaction when any value is missing.
+2. Open the real fixed Vercel preview venue.
+3. Read its actual script source and prove preview origin and expected bytes.
+4. Do not mock `/api/check` or `/feedback`.
+5. Open the legacy trigger and form.
+6. Fill the exact marker-bearing title and description.
+7. Explicitly uncheck/disable screenshot capture before Submit. Do not enter capture and click Skip.
+8. Start the POST response waiter before clicking Submit.
+9. Require exactly one `/api/feedback` POST to the preview Worker.
+10. Assert `X-BugDrop-Build-SHA` equals the full expected SHA.
+11. Parse success JSON and require a positive integer number and exact canonical URL.
+12. Write only `{ marker, issueNumber, issueUrl, workerSha }` to the ephemeral result file. It
+    contains no credential.
+13. Assert the widget reaches its success UI. Independent GitHub field verification remains
+    server-side.
+
+If the Worker creates an Issue but the response is lost or assertions fail, the result file may be
+absent. Cleanup must still find and close by marker.
+
+Local/PR verification must be nonmutating:
+
+```bash
+npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --list
+npx playwright test --project=chromium
+```
+
+The real canary itself is not a local verification command and must not run without the merge-group
+workflow and token-backed cleanup surrounding it.
+
+Stop if the token enters Playwright, the test can match a non-merge-group project, screenshot upload
+is possible, or more than one submission can occur.
+
+Rollback: restore mocked live coverage and remove the dedicated project/spec before removing cleanup
+or helper code.
+
+### Package D: workflow critical section, recovery, contracts, and docs
+
+Files:
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/live-tests.yml`
+- `test/ci-workflow-contract.test.sh`
+- `Makefile` only if approved by Package A/C
+- relevant CI/testing documentation
+
+Update the static contract test before restructuring the workflow. It must assert:
+
+- critical job is merge-group-only;
+- `needs` includes check, unit/build, local E2E matrix, and Radix matrix;
+- exactly one job owns preview deployment and every preview test/canary step;
+- shared concurrency group, `cancel-in-progress: false`, and `queue: max` are present;
+- both required check names remain;
+- status bridge uses `if: always()` and fails unless the critical job succeeded;
+- canary invocation is explicit, one worker, and zero retries;
+- verification token appears only in verifier/cleanup step environments;
+- cleanup uses `if: always()` and does not require the result file;
+- normal live workflow cannot invoke the canary;
+- current unmanaged real submission is gone or mocked;
+- scheduled janitor uses the same lock and never submits feedback.
+
+Workflow step order follows the target CI shape above. Preserve failure reports, but run cleanup
+before artifacts or status bridging.
+
+For hard-cancellation recovery, add a janitor to the existing daily scheduled live workflow:
+
+- On `schedule`, coordinate through the same `bugdrop-shared-preview` concurrency group with queueing
+  so it cannot close an active merge-group canary.
+- For workflow calls and manual dispatches, use a unique concurrency group so production/manual live
+  checks do not block the preview mutex.
+- Run server-side stale `sweep` in an `if: always()` step with the token scoped only to that step.
+- Never run the canary from this workflow.
+
+Focused verification:
+
+```bash
+bash test/ci-workflow-contract.test.sh
+npm run check:actions-node24
+npm run format:check
+```
+
+Then run the full local oracle before live rollout:
+
+```bash
+npm run validate
+make build-all
+make test-e2e
+make test-radix-e2e BROWSER=chromium
+make test-radix-e2e BROWSER=firefox
+make test-radix-e2e BROWSER=webkit
+```
+
+Stop if required check names would change, a ruleset update becomes necessary, the lock does not span
+all preview consumers, scheduled cleanup can race an active canary, or workflow syntax cannot be
+proven by the contract test.
+
+Rollback: revert the workflow, bridge, and scheduled janitor as one package. Do not leave a real
+submission path enabled without cleanup.
+
+## Failure-mode proof matrix
+
+| Failure mode | Test/injection | Required result |
+| --- | --- | --- |
+| Leaked Issue | Fake cleanup API leaves one marker match open after PATCH | Cleanup exits nonzero and reports the exact number; bridge fails |
+| Duplicate Issues | Verifier receives two non-PR Issues with the full marker | Verification fails; cleanup closes both; final readback is zero open |
+| Response lost after creation | Marker Issue exists but result file is absent | Verification fails; `if: always()` cleanup still finds and closes it |
+| Cleanup partial failure | One close returns error and GET still says open | Continue other closes, bounded retry, final nonzero until none remain |
+| Ambiguous close response | PATCH errors but exact GET says closed | Treat as idempotent success without creating or reopening anything |
+| Wrong widget bytes | Expected hash differs from actual venue script | Fail before Submit; no Issue exists |
+| Wrong Worker SHA before Submit | Health build SHA differs | Fail before Submit; no Issue exists |
+| Wrong Worker on actual POST | Feedback response header differs | Browser test fails; marker cleanup closes any created Issue |
+| Concurrent preview replacement | Static contract removes/changes mutex or leaves a consumer outside job | Workflow contract test fails |
+| Retry drift | Project or command omits zero retries | Config/workflow contract test fails |
+| Pull request returned by Issues API | Fake page contains `pull_request` with marker | Verifier and cleanup ignore it |
+| Search-index lag | Search has no result but paginated list contains marker | List-based verifier/cleanup finds the Issue |
+| Scheduled/production/manual accidental invocation | Normal live project/workflow discovery | Canary is not selected; all feedback POSTs are mocked/absent |
+| Hard cancellation | Same-run cleanup is skipped | Next locked preflight or daily locked janitor closes stale marker |
+| Token missing/expired | Verifier receives 401/403 | Job fails visibly; canary does not silently pass; cleanup recovery remains pending |
+
+## Requirement traceability matrix
+
+| Original requirement | Package/files | Executable assertion | Verification |
+| --- | --- | --- | --- |
+| Merge-queue-only | C/D: canary project and CI workflow | Explicit `merge_group`; normal paths cannot select canary | Playwright list + workflow contract |
+| Exact deployed widget matches SHA | C/D: current hash setup + canary | Actual venue script origin and SHA-256 equal checkout build | Focused Playwright/hash negative test |
+| Exact preview Worker matches SHA | B/C/D: Env, API, deploy, canary | Health and actual POST header equal full `GITHUB_SHA` | API unit tests + wrong-SHA negative test |
+| Real Issue through existing App | C: real legacy widget POST | No `/feedback` mock; response is positive number/canonical URL | One merge-group evidence record |
+| Least-privilege verification/cleanup | A/D: helper and step env | Token only in Issues API steps; helper has no create command | Workflow contract + permission review |
+| Correct title/body/labels/attribution/marker | A/C | Exactly one API Issue matches every expected field | Helper unit tests + live readback receipt |
+| No screenshots | C/A | Screenshot explicitly disabled; body lacks screenshot section | Playwright assertion + API verifier |
+| Disable retries and prevent duplicates | A/C/D | Project and CLI retries zero; exactly one marker match | Config contract + duplicate fixture |
+| Always close matches after partial failure | A/D | Separate `if: always()` close-all and final readback | Lost-response/partial-close fixtures |
+| Recover from hard cancellation | A/D | Locked next-run sweep plus locked daily janitor | Workflow contract + stale fixture |
+| Prevent shared-preview replacement | D | One queued non-cancelling mutex encloses every consumer | Workflow ownership/concurrency contract |
+| Run after local gates | D | Critical job needs check, test, E2E, Radix | Workflow contract |
+| No new storage/services | All | Only ephemeral result file and existing Actions/GitHub/Worker | Diff audit |
+| Preserve existing behavior | B/C | Optional identity; normal live POST mocked; legacy payload unchanged | Existing unit/E2E suites |
+| Update tests/docs | A-D | Focused tests, contract guard, operator docs | `npm run validate` + formatting |
+| No configurable variants | All | No variant API/runtime files changed | Diff audit against allowed scope |
+
+## Live rollout and burden of proof
+
+Do not declare the implementation complete merely because unit tests and workflow syntax pass.
+
+The first live merge-group run must retain evidence of:
+
+1. All local gates completed before preview deployment began.
+2. Concurrency group acquisition and no overlapping preview critical section.
+3. Expected and actual widget SHA-256 match.
+4. Health `buildSha` equals the merge-group SHA.
+5. Actual feedback response header equals the merge-group SHA.
+6. Positive Issue number and canonical URL from the widget response.
+7. Independent API readback of the exact title, body, marker, label set, bot author, footer, and no
+   screenshot section.
+8. Exactly one marker match before cleanup.
+9. The Issue state is closed after cleanup.
+10. A final repository query finds zero open reserved-prefix canary Issues.
+
+Then deliberately try to disprove the implementation with the strongest realistic failures:
+
+- Run the helper fixtures for duplicate, lost response, ambiguous/partial close, and leak.
+- Inspect the workflow DAG to prove no preview consumer sits outside the mutex.
+- Inspect project discovery to prove the canary cannot run from normal live workflows.
+- Force a wrong expected Worker SHA in a noncreating test path and prove it blocks submission.
+- Re-run the complete local oracle, not only focused tests.
+
+The final handoff must include these commands/results and the live Issue URL as an audit record. The
+Issue itself should already be closed. Never publish or log the verification token.
+
+## Owner review checklist
+
+Before approving implementation, confirm:
+
+- [ ] The job-level critical-section restructure and fail-closed required-check bridge are acceptable.
+- [ ] The local Radix matrix should block preview deployment.
+- [ ] The secret name and fine-grained token ownership/rotation plan are acceptable.
+- [ ] The stable marker prefix and exact field expectations are acceptable.
+- [ ] A daily lock-coordinated stale janitor in the existing scheduled workflow is acceptable.
+- [ ] The existing production/scheduled live suite should stop making real feedback submissions.
+- [ ] The first merge-group live run may create one short-lived, automatically closed test Issue.
+
+After approval, execute Packages A-D in order and require a final Judge review against the live
+rollout evidence above.

--- a/e2e/widget.issue-canary.spec.ts
+++ b/e2e/widget.issue-canary.spec.ts
@@ -1,0 +1,201 @@
+import { createHash } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { expect, test, type Page, type Request } from '@playwright/test';
+
+const TEST_REPO = 'mean-weasel/bugdrop-widget-test';
+const PREVIEW_WIDGET_ORIGIN = 'https://bugdrop-preview.neonwatty.workers.dev';
+const TITLE_PREFIX = '[BugDrop CI canary]';
+
+type CanaryEnvironment = {
+  baseUrl: string;
+  expectedWidgetOrigin: string;
+  expectedWidgetSha256: string;
+  expectedWorkerSha: string;
+  marker: string;
+  resultFile: string;
+};
+
+type FeedbackResult = {
+  success?: unknown;
+  issueNumber?: unknown;
+  issueUrl?: unknown;
+};
+
+test.describe.configure({ mode: 'serial', retries: 0 });
+
+test('legacy preview widget creates one real Issue with exact deployment identity', async ({
+  page,
+  request,
+}) => {
+  const environment = requireCanaryEnvironment();
+  await installVercelBypass(page);
+
+  await page.goto('/');
+  const widgetSrc = await page.evaluate(() => {
+    return Array.from(document.scripts)
+      .map(script => script.src)
+      .find(src => new URL(src).pathname === '/widget.js');
+  });
+  expect(widgetSrc, 'The fixed venue must load widget.js').toBeTruthy();
+
+  const widgetUrl = new URL(widgetSrc!);
+  expect(widgetUrl.origin).toBe(environment.expectedWidgetOrigin);
+  expect(widgetUrl.pathname).toBe('/widget.js');
+
+  const widgetResponse = await request.get(widgetUrl.href);
+  expect(widgetResponse.ok()).toBe(true);
+  expect(sha256(await widgetResponse.body())).toBe(environment.expectedWidgetSha256);
+
+  const feedbackPosts: Request[] = [];
+  let rejectedRequest: string | undefined;
+  await page.route('**/feedback', async route => {
+    const outgoing = route.request();
+    if (outgoing.method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+
+    const outgoingUrl = new URL(outgoing.url());
+    expect(outgoingUrl.origin).toBe(environment.expectedWidgetOrigin);
+    expect(outgoingUrl.pathname).toBe('/api/feedback');
+
+    feedbackPosts.push(outgoing);
+    if (feedbackPosts.length > 1) {
+      rejectedRequest = 'The widget attempted more than one feedback POST';
+      await route.abort('blockedbyclient');
+      return;
+    }
+
+    const payload = outgoing.postDataJSON() as Record<string, unknown>;
+    expect(payload.repo).toBe(TEST_REPO);
+    expect(payload.title).toBe(`${TITLE_PREFIX} ${environment.marker}`);
+    expect(payload.description).toContain(environment.marker);
+    expect(payload.category).toBe('bug');
+    expect(payload.screenshot).toBeNull();
+    await route.continue();
+  });
+
+  const host = page.locator('#bugdrop-host');
+  await expect(host.locator('css=.bd-trigger')).toBeVisible({ timeout: 10_000 });
+  await host.locator('css=.bd-trigger').click();
+  await expect(host.locator('css=[data-action="continue"]')).toBeVisible({ timeout: 5_000 });
+  await host.locator('css=[data-action="continue"]').click();
+
+  await expect(host.locator('css=#title')).toBeVisible({ timeout: 5_000 });
+  await host.locator('css=input[name="category"][value="bug"]').check();
+  await host.locator('css=#title').fill(`${TITLE_PREFIX} ${environment.marker}`);
+  await host.locator('css=#description').fill(environment.marker);
+  const screenshotCheckbox = host.locator('css=#include-screenshot');
+  await screenshotCheckbox.uncheck();
+  await expect(screenshotCheckbox).not.toBeChecked();
+
+  const feedbackResponsePromise = page.waitForResponse(response => {
+    const responseUrl = new URL(response.url());
+    return (
+      response.request().method() === 'POST' &&
+      responseUrl.origin === environment.expectedWidgetOrigin &&
+      responseUrl.pathname === '/api/feedback'
+    );
+  });
+  await host.locator('css=#submit-btn').click();
+  const feedbackResponse = await feedbackResponsePromise;
+
+  const feedbackUrl = new URL(feedbackResponse.url());
+  expect(feedbackUrl.origin).toBe(environment.expectedWidgetOrigin);
+  expect(feedbackUrl.pathname).toBe('/api/feedback');
+  expect(feedbackResponse.status()).toBe(200);
+  expect(feedbackResponse.headers()['x-bugdrop-build-sha']).toBe(environment.expectedWorkerSha);
+  const result = (await feedbackResponse.json()) as FeedbackResult;
+  expect(result.success).toBe(true);
+  expect(Number.isInteger(result.issueNumber) && Number(result.issueNumber) > 0).toBe(true);
+  const issueNumber = Number(result.issueNumber);
+  const issueUrl = `https://github.com/${TEST_REPO}/issues/${issueNumber}`;
+  expect(result.issueUrl).toBe(issueUrl);
+
+  await expect(host.locator('css=.bd-success-content')).toBeVisible({ timeout: 10_000 });
+  await page.waitForTimeout(1_000);
+  expect(rejectedRequest).toBeUndefined();
+  expect(feedbackPosts).toHaveLength(1);
+
+  await mkdir(dirname(environment.resultFile), { recursive: true });
+  await writeFile(
+    environment.resultFile,
+    `${JSON.stringify({
+      marker: environment.marker,
+      issueNumber,
+      issueUrl,
+      workerSha: environment.expectedWorkerSha,
+    })}\n`,
+    { encoding: 'utf8', flag: 'wx' }
+  );
+});
+
+function requireCanaryEnvironment(): CanaryEnvironment {
+  if (process.env.BUGDROP_CANARY_GITHUB_TOKEN) {
+    throw new Error('BUGDROP_CANARY_GITHUB_TOKEN must never be available to Playwright');
+  }
+  if (process.env.LIVE_TARGET !== 'preview') {
+    throw new Error('LIVE_TARGET must equal preview for the Issue canary');
+  }
+
+  const baseUrl = requireEnvironment('PLAYWRIGHT_BASE_URL');
+  const expectedWidgetOrigin = requireEnvironment('EXPECTED_WIDGET_ORIGIN');
+  const expectedWidgetSha256 = requireEnvironment('EXPECTED_WIDGET_SHA256');
+  const expectedWorkerSha = requireEnvironment('EXPECTED_WORKER_SHA');
+  const marker = requireEnvironment('BUGDROP_CANARY_MARKER');
+  const resultFile = requireEnvironment('BUGDROP_CANARY_RESULT_FILE');
+
+  const venueUrl = new URL(baseUrl);
+  if (venueUrl.protocol !== 'https:' || !venueUrl.hostname.endsWith('.vercel.app')) {
+    throw new Error('PLAYWRIGHT_BASE_URL must be the HTTPS Vercel preview venue');
+  }
+  const widgetOriginUrl = new URL(expectedWidgetOrigin);
+  if (
+    widgetOriginUrl.origin !== expectedWidgetOrigin ||
+    expectedWidgetOrigin !== PREVIEW_WIDGET_ORIGIN
+  ) {
+    throw new Error(`EXPECTED_WIDGET_ORIGIN must equal ${PREVIEW_WIDGET_ORIGIN}`);
+  }
+  if (!/^[a-f0-9]{64}$/.test(expectedWidgetSha256)) {
+    throw new Error('EXPECTED_WIDGET_SHA256 must be a lowercase SHA-256 digest');
+  }
+  if (!/^[a-f0-9]{40}$/.test(expectedWorkerSha)) {
+    throw new Error('EXPECTED_WORKER_SHA must be a full lowercase Git SHA');
+  }
+  if (!new RegExp(`^bugdrop-ci-canary:[0-9]+:[0-9]+:${expectedWorkerSha}$`).test(marker)) {
+    throw new Error('BUGDROP_CANARY_MARKER must identify this run, attempt, and Worker SHA');
+  }
+
+  return {
+    baseUrl,
+    expectedWidgetOrigin,
+    expectedWidgetSha256,
+    expectedWorkerSha,
+    marker,
+    resultFile,
+  };
+}
+
+function requireEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required for the Issue canary`);
+  return value;
+}
+
+async function installVercelBypass(page: Page): Promise<void> {
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (!bypassSecret) return;
+  await page.route('**/*.vercel.app/**', async route => {
+    await route.continue({
+      headers: {
+        ...route.request().headers(),
+        'x-vercel-protection-bypass': bypassSecret,
+      },
+    });
+  });
+}
+
+function sha256(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}

--- a/e2e/widget.live-radix.spec.ts
+++ b/e2e/widget.live-radix.spec.ts
@@ -44,11 +44,18 @@ async function openFeedbackForm(page: Page) {
   await triggerLabel.click();
 
   const getStartedBtn = host.locator('css=[data-action="continue"]');
-  if (await getStartedBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+  const titleInput = host.locator('css=#title');
+  await expect
+    .poll(async () => (await getStartedBtn.isVisible()) || (await titleInput.isVisible()), {
+      timeout: 5_000,
+    })
+    .toBe(true);
+
+  if (await getStartedBtn.isVisible()) {
     await getStartedBtn.click();
   }
 
-  await expect(host.locator('css=#title')).toBeVisible({ timeout: 5_000 });
+  await expect(titleInput).toBeVisible({ timeout: 5_000 });
   return host;
 }
 

--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -813,7 +813,22 @@ test.describe('Screenshot Capture (Live)', () => {
 });
 
 test.describe('Feedback Submission (Live)', () => {
-  test('feedback form submits and gets expected response', async ({ page }) => {
+  test('feedback form submits through a mocked transport and shows success', async ({ page }) => {
+    const payloads: Array<Record<string, unknown>> = [];
+    await page.route('**/feedback', async route => {
+      payloads.push(route.request().postDataJSON());
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          issueNumber: 1,
+          issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/1',
+          isPublic: false,
+        }),
+      });
+    });
+
     // Mock the installation check to return installed: true
     await page.route('**/api/check/**', async route => {
       await route.fulfill({
@@ -848,18 +863,11 @@ test.describe('Feedback Submission (Live)', () => {
     await expect(skipBtn).toBeVisible({ timeout: 5_000 });
     await skipBtn.click();
 
-    // Wait for submission to complete
-    await page.waitForTimeout(8_000);
-
-    // Check that the widget is showing either a success or error state
-    // (not stuck in the form state, which would indicate a CORS/network failure)
+    // The ordinary live suite verifies UI/transport integration without mutating GitHub.
     const successScreen = page.locator('#bugdrop-host').locator('css=.bd-success-content');
-    const errorMessage = page.locator('#bugdrop-host').locator('css=.bd-error');
-
-    const hasSuccess = await successScreen.isVisible().catch(() => false);
-    const hasError = await errorMessage.isVisible().catch(() => false);
-
-    // Either success or error is fine — both mean the cross-origin request completed
-    expect(hasSuccess || hasError).toBeTruthy();
+    await expect(successScreen).toBeVisible({ timeout: 10_000 });
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].title).toBe('Live E2E test submission');
+    expect(payloads[0].screenshot).toBeNull();
   });
 });

--- a/e2e/widget.radix.spec.ts
+++ b/e2e/widget.radix.spec.ts
@@ -2,6 +2,9 @@ import { test, expect, type Page } from '@playwright/test';
 
 declare global {
   interface Window {
+    BugDrop?: {
+      open: () => void;
+    };
     __hostModalOpen?: boolean;
     __hostDismissEvents?: string[];
     __hostFocusTrapEvents?: string[];
@@ -19,11 +22,23 @@ async function mockInstalledRepo(page: Page): Promise<void> {
   });
 }
 
-async function openFeedbackForm(page: Page) {
+async function openFeedbackForm(page: Page, viaTrigger = false) {
   const host = page.locator('#bugdrop-host');
-  const triggerLabel = host.locator('css=.bd-trigger-label');
-  await expect(triggerLabel).toBeVisible({ timeout: 5000 });
-  await triggerLabel.click();
+  const trigger = host.locator('css=.bd-trigger');
+  await expect(trigger).toBeVisible({ timeout: 5000 });
+  await expect.poll(() => page.evaluate(() => typeof window.BugDrop?.open)).toBe('function');
+
+  if (viaTrigger) {
+    await trigger.evaluate(async element => {
+      await Promise.allSettled(element.getAnimations().map(animation => animation.finished));
+    });
+    const triggerLabel = trigger.locator('css=.bd-trigger-label');
+    await expect(triggerLabel).toBeVisible({ timeout: 5000 });
+    await triggerLabel.click();
+  } else {
+    await page.evaluate(() => window.BugDrop?.open());
+  }
+
   await expect(host.locator('css=#title')).toBeVisible({ timeout: 5000 });
   return host;
 }
@@ -71,7 +86,7 @@ test.describe('Radix dialog compatibility', () => {
 
     const host = page.locator('#bugdrop-host');
     await expect(host).toHaveCSS('pointer-events', 'auto');
-    await openFeedbackForm(page);
+    await openFeedbackForm(page, true);
 
     await expect.poll(() => page.evaluate(() => window.__hostModalOpen)).toBe(true);
     await expect

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -236,8 +236,9 @@ test.describe('Widget Loading', () => {
     await page.setViewportSize({ width: 900, height: 860 });
     await page.setViewportSize({ width: 900, height: 900 });
 
-    const savedAfterResize = await page.evaluate(key => localStorage.getItem(key), storageKey);
-    expect(savedAfterResize).toBe(savedTop);
+    await expect
+      .poll(() => page.evaluate(key => localStorage.getItem(key), storageKey))
+      .toBe(savedTop);
   });
 
   test('missing local test config returns a javascript file', async ({ page }) => {
@@ -637,8 +638,15 @@ test.describe('Widget Interaction', () => {
     expect(afterResize!.x).toBeGreaterThanOrEqual(0);
     expect(afterResize!.width).toBeLessThanOrEqual(390);
   });
-
   test('dragged feedback modal reflows fixed sizing on narrow desktop resize', async ({ page }) => {
+    await page.route('**/api/check**', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ installed: true }),
+      });
+    });
+
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto('/test/');
 
@@ -652,10 +660,16 @@ test.describe('Widget Interaction', () => {
     await dragModalHeader(page, -90, 70);
     await page.setViewportSize({ width: 660, height: 720 });
 
+    await expect
+      .poll(async () => {
+        const box = await modal.boundingBox();
+        return box ? box.x + box.width : Number.POSITIVE_INFINITY;
+      })
+      .toBeLessThanOrEqual(660);
+
     const afterResize = await modal.boundingBox();
     expect(afterResize).not.toBeNull();
     expect(afterResize!.width).toBeLessThanOrEqual(594);
-    expect(afterResize!.x + afterResize!.width).toBeLessThanOrEqual(660);
   });
 
   test('element picker handles SVG elements without errors', async ({ page }) => {

--- a/knip.json
+++ b/knip.json
@@ -1,7 +1,12 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "entry": ["src/index.ts", "src/widget/index.ts", "scripts/build-widget.js"],
-  "project": ["src/**/*.ts", "scripts/**/*.js"],
+  "entry": [
+    "src/index.ts",
+    "src/widget/index.ts",
+    "scripts/build-widget.js",
+    "scripts/github-issue-canary.mjs"
+  ],
+  "project": ["src/**/*.ts", "scripts/**/*.{js,mjs}"],
   "ignore": [],
   "ignoreBinaries": [
     "commitlint",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8787';
+const issueCanaryProject = 'chromium-issue-canary';
+const issueCanaryExplicitlySelected = process.argv.some((argument, index, arguments_) => {
+  return (
+    argument === `--project=${issueCanaryProject}` ||
+    (argument === '--project' && arguments_[index + 1] === issueCanaryProject)
+  );
+});
+const issueCanaryTest = /.*\.issue-canary\.spec\.ts$/;
+const noTests = /$a/;
 
 export default defineConfig({
   testDir: './e2e',
@@ -17,7 +26,7 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
-      testIgnore: /.*\.(?:live|live-radix|cross-browser-live|radix)\.spec\.ts$/,
+      testIgnore: /.*\.(?:live|live-radix|cross-browser-live|issue-canary|radix)\.spec\.ts$/,
     },
     {
       name: 'chromium-radix',
@@ -77,6 +86,21 @@ export default defineConfig({
         ...devices['Desktop Safari'],
       },
       testMatch: /.*\.cross-browser-live\.spec\.ts/,
+      timeout: 60_000,
+    },
+    {
+      name: issueCanaryProject,
+      fullyParallel: false,
+      workers: 1,
+      retries: 0,
+      use: {
+        ...devices['Desktop Chrome'],
+        screenshot: 'off',
+        trace: 'off',
+        video: 'off',
+      },
+      // An unqualified `playwright test` must not discover the real-Issue canary.
+      testMatch: issueCanaryExplicitlySelected ? issueCanaryTest : noTests,
       timeout: 60_000,
     },
   ],

--- a/scripts/github-issue-canary.mjs
+++ b/scripts/github-issue-canary.mjs
@@ -9,6 +9,10 @@ const DEFAULT_API_BASE_URL = 'https://api.github.com';
 const DEFAULT_LABELS = ['bug', 'bugdrop'];
 const DEFAULT_AUTHOR = 'neonwatty-bugdrop[bot]';
 const ATTRIBUTION_FOOTER = '*Submitted via [BugDrop](https://github.com/mean-weasel/bugdrop)*';
+const DEFAULT_CONSISTENCY_ATTEMPTS = 6;
+const DEFAULT_CONSISTENCY_DELAY_MS = 2_000;
+const MAX_CONSISTENCY_ATTEMPTS = 20;
+const MAX_CONSISTENCY_DELAY_MS = 10_000;
 
 export function canaryTitle(marker) {
   requireNonempty(marker, 'marker');
@@ -46,15 +50,43 @@ export async function verifyCanaryIssue({
   result,
   expectedLabels = DEFAULT_LABELS,
   expectedAuthor = DEFAULT_AUTHOR,
+  consistencyAttempts = DEFAULT_CONSISTENCY_ATTEMPTS,
+  consistencyDelayMs = DEFAULT_CONSISTENCY_DELAY_MS,
+  sleepImpl = sleep,
 }) {
   requireNonempty(marker, 'marker');
   requireNonempty(expectedSha, 'expectedSha');
-  const matches = await listMatchingIssues({
+  const consistency = validateConsistencyOptions({
+    consistencyAttempts,
+    consistencyDelayMs,
+    sleepImpl,
+  });
+  const referenceFailures = [];
+  validateBrowserResultReference({
+    failures: referenceFailures,
+    result,
+    marker,
+    expectedSha,
+    repo,
+  });
+  if (referenceFailures.length > 0) {
+    throw new Error(`Browser result failed verification: ${referenceFailures.join('; ')}`);
+  }
+
+  const candidate = await getIssue({
+    fetchImpl,
+    apiBaseUrl,
+    repo,
+    token,
+    number: result.issueNumber,
+  });
+  const matches = await waitForStableSingleton({
     fetchImpl,
     apiBaseUrl,
     repo,
     token,
     marker,
+    consistency,
   });
   const numbers = matches.map(candidate => candidate.number);
   if (matches.length !== 1) {
@@ -63,9 +95,13 @@ export async function verifyCanaryIssue({
     );
   }
 
-  const candidate = matches[0];
   const canonicalUrl = canonicalIssueUrl(repo, candidate.number);
   const failures = [];
+  if (matches[0].number !== candidate.number) {
+    failures.push(
+      `Marker listing found Issue #${matches[0].number}, not browser Issue #${candidate.number}`
+    );
+  }
   if (!Number.isInteger(candidate.number) || candidate.number <= 0) {
     failures.push('Issue number is not a positive integer');
   }
@@ -107,15 +143,27 @@ export async function closeMatchingIssues({
   token,
   marker,
   prefix,
+  consistencyAttempts = DEFAULT_CONSISTENCY_ATTEMPTS,
+  consistencyDelayMs = DEFAULT_CONSISTENCY_DELAY_MS,
+  sleepImpl = sleep,
 }) {
   const selector = validateSelector({ marker, prefix });
-  const matches = await listMatchingIssues({
+  const consistency = validateConsistencyOptions({
+    consistencyAttempts,
+    consistencyDelayMs,
+    sleepImpl,
+  });
+  const matches = await waitForInitialCleanupMatches({
     fetchImpl,
     apiBaseUrl,
     repo,
     token,
     ...selector,
+    consistency,
   });
+  if (marker && matches.length === 0) {
+    throw new Error(`No non-PR Issue for marker ${marker} appeared within the retry bound`);
+  }
   const closedNumbers = [];
   const failures = [];
 
@@ -127,6 +175,7 @@ export async function closeMatchingIssues({
         repo,
         token,
         number: candidate.number,
+        consistency,
       });
       closedNumbers.push(candidate.number);
     } catch (error) {
@@ -134,12 +183,13 @@ export async function closeMatchingIssues({
     }
   }
 
-  const finalMatches = await listMatchingIssues({
+  const finalMatches = await waitForZeroOpenMatches({
     fetchImpl,
     apiBaseUrl,
     repo,
     token,
     ...selector,
+    consistency,
   });
   const openNumbers = finalMatches
     .filter(candidate => candidate.state === 'open')
@@ -169,6 +219,9 @@ export async function runCli(
     readFileImpl = readFile,
     stdout = value => process.stdout.write(`${value}\n`),
     stderr = value => process.stderr.write(`${value}\n`),
+    consistencyAttempts = DEFAULT_CONSISTENCY_ATTEMPTS,
+    consistencyDelayMs = DEFAULT_CONSISTENCY_DELAY_MS,
+    sleepImpl = sleep,
   } = {}
 ) {
   const token = env.BUGDROP_CANARY_GITHUB_TOKEN;
@@ -189,6 +242,9 @@ export async function runCli(
         marker: options.marker,
         expectedSha: options.expectedSha,
         result,
+        consistencyAttempts,
+        consistencyDelayMs,
+        sleepImpl,
       });
       output = { verified: true, issueNumber: candidate.number, issueUrl: candidate.html_url };
     } else if (command === 'cleanup') {
@@ -198,6 +254,9 @@ export async function runCli(
         repo: options.repo,
         token,
         marker: options.marker,
+        consistencyAttempts,
+        consistencyDelayMs,
+        sleepImpl,
       });
     } else if (command === 'preflight' || command === 'sweep') {
       requireNonempty(options.prefix, '--prefix');
@@ -206,6 +265,9 @@ export async function runCli(
         repo: options.repo,
         token,
         prefix: options.prefix,
+        consistencyAttempts,
+        consistencyDelayMs,
+        sleepImpl,
       });
     } else {
       throw new Error(`Unknown command: ${command || '(missing)'}`);
@@ -238,34 +300,107 @@ async function listRepositoryIssues({ fetchImpl, apiBaseUrl, repo, token }) {
   return issues;
 }
 
-async function closeOneIssue({ fetchImpl, apiBaseUrl, repo, token, number }) {
+async function closeOneIssue({ fetchImpl, apiBaseUrl, repo, token, number, consistency }) {
+  let firstError;
   try {
-    const updated = await patchIssueClosed({ fetchImpl, apiBaseUrl, repo, token, number });
-    if (updated.state === 'closed') return;
-    throw new Error(`PATCH returned state ${updated.state ?? 'missing'}`);
-  } catch (firstError) {
-    const afterFirst = await getIssue({ fetchImpl, apiBaseUrl, repo, token, number });
-    if (afterFirst.state === 'closed') return;
-    if (afterFirst.state !== 'open') {
-      throw new Error(
-        `Close was ambiguous and readback returned state ${afterFirst.state ?? 'missing'}: ${safeErrorMessage(firstError, token)}`
-      );
-    }
-    try {
-      const retried = await patchIssueClosed({ fetchImpl, apiBaseUrl, repo, token, number });
-      if (retried.state === 'closed') return;
-    } catch (retryError) {
-      const afterRetry = await getIssue({ fetchImpl, apiBaseUrl, repo, token, number });
-      if (afterRetry.state === 'closed') return;
-      throw new Error(
-        `Close retry failed and Issue remains ${afterRetry.state ?? 'unknown'}: ${safeErrorMessage(retryError, token)}`
-      );
-    }
-    const afterRetry = await getIssue({ fetchImpl, apiBaseUrl, repo, token, number });
-    if (afterRetry.state !== 'closed') {
-      throw new Error(`Close retry returned but Issue remains ${afterRetry.state ?? 'unknown'}`);
-    }
+    await patchIssueClosed({ fetchImpl, apiBaseUrl, repo, token, number });
+  } catch (error) {
+    firstError = error;
   }
+  const afterFirst = await waitForClosedIssue({
+    fetchImpl,
+    apiBaseUrl,
+    repo,
+    token,
+    number,
+    consistency,
+  });
+  if (afterFirst.state === 'closed') return;
+  if (afterFirst.state !== 'open') {
+    throw new Error(
+      `Close readback returned state ${afterFirst.state ?? 'missing'}${firstError ? `: ${safeErrorMessage(firstError, token)}` : ''}`
+    );
+  }
+
+  let retryError;
+  try {
+    await patchIssueClosed({ fetchImpl, apiBaseUrl, repo, token, number });
+  } catch (error) {
+    retryError = error;
+  }
+  const afterRetry = await waitForClosedIssue({
+    fetchImpl,
+    apiBaseUrl,
+    repo,
+    token,
+    number,
+    consistency,
+  });
+  if (afterRetry.state !== 'closed') {
+    throw new Error(
+      `Close retry failed and Issue remains ${afterRetry.state ?? 'unknown'}${retryError ? `: ${safeErrorMessage(retryError, token)}` : ''}`
+    );
+  }
+}
+
+async function waitForStableSingleton({ consistency, ...listOptions }) {
+  let previousNumber;
+  let lastMatches = [];
+  for (let attempt = 1; attempt <= consistency.attempts; attempt += 1) {
+    const matches = await listMatchingIssues(listOptions);
+    lastMatches = matches;
+    if (matches.length > 1) return matches;
+    if (matches.length === 1 && matches[0].number === previousNumber) return matches;
+    previousNumber = matches.length === 1 ? matches[0].number : undefined;
+    await waitBeforeNextAttempt({ attempt, consistency });
+  }
+  if (lastMatches.length === 1) {
+    throw new Error('Exactly-one marker discovery did not stabilize within the retry bound');
+  }
+  return lastMatches;
+}
+
+async function waitForInitialCleanupMatches({ consistency, marker, prefix, ...listOptions }) {
+  let matches = [];
+  for (let attempt = 1; attempt <= consistency.attempts; attempt += 1) {
+    matches = await listMatchingIssues({ ...listOptions, marker, prefix });
+    if (matches.length > 0 || prefix) return matches;
+    await waitBeforeNextAttempt({ attempt, consistency });
+  }
+  return matches;
+}
+
+async function waitForZeroOpenMatches({ consistency, ...listOptions }) {
+  let matches = [];
+  let consecutiveZeroOpenObservations = 0;
+  for (let attempt = 1; attempt <= consistency.attempts; attempt += 1) {
+    matches = await listMatchingIssues(listOptions);
+    if (matches.every(candidate => candidate.state !== 'open')) {
+      consecutiveZeroOpenObservations += 1;
+      if (consecutiveZeroOpenObservations >= 2) return matches;
+    } else {
+      consecutiveZeroOpenObservations = 0;
+    }
+    await waitBeforeNextAttempt({ attempt, consistency });
+  }
+  if (matches.every(candidate => candidate.state !== 'open')) {
+    throw new Error('Zero-open discovery did not stabilize within the retry bound');
+  }
+  return matches;
+}
+
+async function waitForClosedIssue({ consistency, ...issueOptions }) {
+  let candidate;
+  for (let attempt = 1; attempt <= consistency.attempts; attempt += 1) {
+    candidate = await getIssue(issueOptions);
+    if (candidate.state !== 'open') return candidate;
+    await waitBeforeNextAttempt({ attempt, consistency });
+  }
+  return candidate;
+}
+
+async function waitBeforeNextAttempt({ attempt, consistency }) {
+  if (attempt < consistency.attempts) await consistency.sleep(consistency.delayMs);
 }
 
 async function patchIssueClosed({ fetchImpl, apiBaseUrl, repo, token, number }) {
@@ -337,6 +472,20 @@ function validateBrowserResult({ failures, result, marker, expectedSha, candidat
   if (result.workerSha !== expectedSha) failures.push('Browser result Worker SHA differs');
 }
 
+function validateBrowserResultReference({ failures, result, marker, expectedSha, repo }) {
+  if (!result || typeof result !== 'object') {
+    failures.push('Browser result file is missing or invalid');
+    return;
+  }
+  if (result.marker !== marker) failures.push('Browser result marker does not match');
+  if (!Number.isInteger(result.issueNumber) || result.issueNumber <= 0) {
+    failures.push('Browser result Issue number is not a positive integer');
+  } else if (result.issueUrl !== canonicalIssueUrl(repo, result.issueNumber)) {
+    failures.push('Browser result Issue URL is not canonical');
+  }
+  if (result.workerSha !== expectedSha) failures.push('Browser result Worker SHA differs');
+}
+
 function normalizeLabels(labels) {
   if (!Array.isArray(labels)) return [];
   return labels
@@ -396,6 +545,29 @@ function issueApiUrl(apiBaseUrl, repo, number) {
 function requireNonempty(value, name) {
   if (typeof value !== 'string' || !value.trim()) throw new Error(`${name} is required`);
   return value.trim();
+}
+
+function validateConsistencyOptions({ consistencyAttempts, consistencyDelayMs, sleepImpl }) {
+  if (
+    !Number.isInteger(consistencyAttempts) ||
+    consistencyAttempts < 2 ||
+    consistencyAttempts > MAX_CONSISTENCY_ATTEMPTS
+  ) {
+    throw new Error(`consistencyAttempts must be an integer from 2 to ${MAX_CONSISTENCY_ATTEMPTS}`);
+  }
+  if (
+    !Number.isInteger(consistencyDelayMs) ||
+    consistencyDelayMs < 0 ||
+    consistencyDelayMs > MAX_CONSISTENCY_DELAY_MS
+  ) {
+    throw new Error(`consistencyDelayMs must be an integer from 0 to ${MAX_CONSISTENCY_DELAY_MS}`);
+  }
+  if (typeof sleepImpl !== 'function') throw new Error('sleepImpl must be a function');
+  return { attempts: consistencyAttempts, delayMs: consistencyDelayMs, sleep: sleepImpl };
+}
+
+function sleep(delayMs) {
+  return new Promise(resolve => setTimeout(resolve, delayMs));
 }
 
 function safeErrorMessage(error, token) {

--- a/scripts/github-issue-canary.mjs
+++ b/scripts/github-issue-canary.mjs
@@ -1,0 +1,439 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+export const CANARY_TITLE_PREFIX = '[BugDrop CI canary]';
+
+const DEFAULT_API_BASE_URL = 'https://api.github.com';
+const DEFAULT_LABELS = ['bug', 'bugdrop'];
+const DEFAULT_AUTHOR = 'neonwatty-bugdrop[bot]';
+const ATTRIBUTION_FOOTER = '*Submitted via [BugDrop](https://github.com/mean-weasel/bugdrop)*';
+
+export function canaryTitle(marker) {
+  requireNonempty(marker, 'marker');
+  return `${CANARY_TITLE_PREFIX} ${marker}`;
+}
+
+export async function listMatchingIssues({
+  fetchImpl = fetch,
+  apiBaseUrl = DEFAULT_API_BASE_URL,
+  repo,
+  token,
+  marker,
+  prefix,
+}) {
+  const selector = validateSelector({ marker, prefix });
+  const issues = await listRepositoryIssues({ fetchImpl, apiBaseUrl, repo, token });
+  return issues.filter(candidate => {
+    if (candidate.pull_request) return false;
+    if (selector.marker) {
+      return (
+        candidate.title?.includes(selector.marker) || candidate.body?.includes(selector.marker)
+      );
+    }
+    return candidate.title?.startsWith(selector.prefix);
+  });
+}
+
+export async function verifyCanaryIssue({
+  fetchImpl = fetch,
+  apiBaseUrl = DEFAULT_API_BASE_URL,
+  repo,
+  token,
+  marker,
+  expectedSha,
+  result,
+  expectedLabels = DEFAULT_LABELS,
+  expectedAuthor = DEFAULT_AUTHOR,
+}) {
+  requireNonempty(marker, 'marker');
+  requireNonempty(expectedSha, 'expectedSha');
+  const matches = await listMatchingIssues({
+    fetchImpl,
+    apiBaseUrl,
+    repo,
+    token,
+    marker,
+  });
+  const numbers = matches.map(candidate => candidate.number);
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one non-PR Issue for marker ${marker}; found ${matches.length} (${formatNumbers(numbers)})`
+    );
+  }
+
+  const candidate = matches[0];
+  const canonicalUrl = canonicalIssueUrl(repo, candidate.number);
+  const failures = [];
+  if (!Number.isInteger(candidate.number) || candidate.number <= 0) {
+    failures.push('Issue number is not a positive integer');
+  }
+  if (candidate.html_url !== canonicalUrl) failures.push('Issue URL is not canonical');
+  if (candidate.title !== canaryTitle(marker)) failures.push('Issue title does not match exactly');
+  if (!candidate.body?.includes('## Description')) failures.push('Issue body lacks Description');
+  if (!candidate.body?.includes(marker)) failures.push('Issue body lacks the CI marker');
+  if (!candidate.body?.includes('<summary>System Info</summary>')) {
+    failures.push('Issue body lacks System Info');
+  }
+  if (!candidate.body?.includes(ATTRIBUTION_FOOTER)) {
+    failures.push('Issue body lacks BugDrop attribution');
+  }
+  if (candidate.body?.includes('## Screenshot')) failures.push('Issue contains a screenshot');
+  if (candidate.state !== 'open') failures.push(`Issue state is ${candidate.state}, not open`);
+  if (candidate.user?.login !== expectedAuthor) {
+    failures.push(`Issue author is ${candidate.user?.login ?? 'missing'}, not ${expectedAuthor}`);
+  }
+  const actualLabels = normalizeLabels(candidate.labels);
+  if (!sameStringSet(actualLabels, expectedLabels)) {
+    failures.push(
+      `Issue labels are [${actualLabels.join(', ')}], not [${[...expectedLabels].sort().join(', ')}]`
+    );
+  }
+
+  validateBrowserResult({ failures, result, marker, expectedSha, candidate, canonicalUrl });
+  if (failures.length > 0) {
+    throw new Error(
+      `Canary Issue #${candidate.number} failed verification: ${failures.join('; ')}`
+    );
+  }
+  return candidate;
+}
+
+export async function closeMatchingIssues({
+  fetchImpl = fetch,
+  apiBaseUrl = DEFAULT_API_BASE_URL,
+  repo,
+  token,
+  marker,
+  prefix,
+}) {
+  const selector = validateSelector({ marker, prefix });
+  const matches = await listMatchingIssues({
+    fetchImpl,
+    apiBaseUrl,
+    repo,
+    token,
+    ...selector,
+  });
+  const closedNumbers = [];
+  const failures = [];
+
+  for (const candidate of matches.filter(issue => issue.state === 'open')) {
+    try {
+      await closeOneIssue({
+        fetchImpl,
+        apiBaseUrl,
+        repo,
+        token,
+        number: candidate.number,
+      });
+      closedNumbers.push(candidate.number);
+    } catch (error) {
+      failures.push(`#${candidate.number}: ${safeErrorMessage(error, token)}`);
+    }
+  }
+
+  const finalMatches = await listMatchingIssues({
+    fetchImpl,
+    apiBaseUrl,
+    repo,
+    token,
+    ...selector,
+  });
+  const openNumbers = finalMatches
+    .filter(candidate => candidate.state === 'open')
+    .map(candidate => candidate.number);
+  if (failures.length > 0 || openNumbers.length > 0) {
+    const details = [
+      ...failures,
+      ...(openNumbers.length > 0
+        ? [`still open after cleanup: ${formatNumbers(openNumbers)}`]
+        : []),
+    ];
+    throw new Error(`Canary cleanup incomplete: ${details.join('; ')}`);
+  }
+
+  return {
+    matchedNumbers: matches.map(candidate => candidate.number),
+    closedNumbers,
+    openNumbers,
+  };
+}
+
+export async function runCli(
+  argv,
+  {
+    fetchImpl = fetch,
+    env = process.env,
+    readFileImpl = readFile,
+    stdout = value => process.stdout.write(`${value}\n`),
+    stderr = value => process.stderr.write(`${value}\n`),
+  } = {}
+) {
+  const token = env.BUGDROP_CANARY_GITHUB_TOKEN;
+  try {
+    const { command, options } = parseCliArguments(argv);
+    requireNonempty(token, 'BUGDROP_CANARY_GITHUB_TOKEN');
+    requireNonempty(options.repo, '--repo');
+    let output;
+    if (command === 'verify') {
+      requireNonempty(options.marker, '--marker');
+      requireNonempty(options.resultFile, '--result-file');
+      requireNonempty(options.expectedSha, '--expected-sha');
+      const result = JSON.parse(await readFileImpl(options.resultFile, 'utf8'));
+      const candidate = await verifyCanaryIssue({
+        fetchImpl,
+        repo: options.repo,
+        token,
+        marker: options.marker,
+        expectedSha: options.expectedSha,
+        result,
+      });
+      output = { verified: true, issueNumber: candidate.number, issueUrl: candidate.html_url };
+    } else if (command === 'cleanup') {
+      requireNonempty(options.marker, '--marker');
+      output = await closeMatchingIssues({
+        fetchImpl,
+        repo: options.repo,
+        token,
+        marker: options.marker,
+      });
+    } else if (command === 'preflight' || command === 'sweep') {
+      requireNonempty(options.prefix, '--prefix');
+      output = await closeMatchingIssues({
+        fetchImpl,
+        repo: options.repo,
+        token,
+        prefix: options.prefix,
+      });
+    } else {
+      throw new Error(`Unknown command: ${command || '(missing)'}`);
+    }
+    stdout(JSON.stringify(output));
+    return 0;
+  } catch (error) {
+    stderr(`[bugdrop-canary] ${safeErrorMessage(error, token)}`);
+    return 1;
+  }
+}
+
+async function listRepositoryIssues({ fetchImpl, apiBaseUrl, repo, token }) {
+  const { owner, name } = parseRepo(repo);
+  requireNonempty(token, 'token');
+  const url = new URL(
+    `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues`,
+    apiBaseUrl
+  );
+  url.searchParams.set('state', 'all');
+  url.searchParams.set('per_page', '100');
+  let nextUrl = url.toString();
+  const issues = [];
+  while (nextUrl) {
+    const { response, data } = await requestJson({ fetchImpl, url: nextUrl, token });
+    if (!Array.isArray(data)) throw new Error('GitHub Issues response was not an array');
+    issues.push(...data);
+    nextUrl = parseNextLink(response.headers.get('link'));
+  }
+  return issues;
+}
+
+async function closeOneIssue({ fetchImpl, apiBaseUrl, repo, token, number }) {
+  try {
+    const updated = await patchIssueClosed({ fetchImpl, apiBaseUrl, repo, token, number });
+    if (updated.state === 'closed') return;
+    throw new Error(`PATCH returned state ${updated.state ?? 'missing'}`);
+  } catch (firstError) {
+    const afterFirst = await getIssue({ fetchImpl, apiBaseUrl, repo, token, number });
+    if (afterFirst.state === 'closed') return;
+    if (afterFirst.state !== 'open') {
+      throw new Error(
+        `Close was ambiguous and readback returned state ${afterFirst.state ?? 'missing'}: ${safeErrorMessage(firstError, token)}`
+      );
+    }
+    try {
+      const retried = await patchIssueClosed({ fetchImpl, apiBaseUrl, repo, token, number });
+      if (retried.state === 'closed') return;
+    } catch (retryError) {
+      const afterRetry = await getIssue({ fetchImpl, apiBaseUrl, repo, token, number });
+      if (afterRetry.state === 'closed') return;
+      throw new Error(
+        `Close retry failed and Issue remains ${afterRetry.state ?? 'unknown'}: ${safeErrorMessage(retryError, token)}`
+      );
+    }
+    const afterRetry = await getIssue({ fetchImpl, apiBaseUrl, repo, token, number });
+    if (afterRetry.state !== 'closed') {
+      throw new Error(`Close retry returned but Issue remains ${afterRetry.state ?? 'unknown'}`);
+    }
+  }
+}
+
+async function patchIssueClosed({ fetchImpl, apiBaseUrl, repo, token, number }) {
+  return (
+    await requestJson({
+      fetchImpl,
+      url: issueApiUrl(apiBaseUrl, repo, number),
+      token,
+      method: 'PATCH',
+      body: { state: 'closed', state_reason: 'not_planned' },
+    })
+  ).data;
+}
+
+async function getIssue({ fetchImpl, apiBaseUrl, repo, token, number }) {
+  return (
+    await requestJson({
+      fetchImpl,
+      url: issueApiUrl(apiBaseUrl, repo, number),
+      token,
+    })
+  ).data;
+}
+
+async function requestJson({ fetchImpl, url, token, method = 'GET', body }) {
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      method,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+  } catch (error) {
+    throw new Error(`GitHub API ${method} request failed: ${safeErrorMessage(error, token)}`);
+  }
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API ${method} ${redact(String(url), token)} returned ${response.status}: ${redact(text.slice(0, 500), token)}`
+    );
+  }
+  let data = null;
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      throw new Error(`GitHub API ${method} returned invalid JSON`);
+    }
+  }
+  return { response, data };
+}
+
+function validateBrowserResult({ failures, result, marker, expectedSha, candidate, canonicalUrl }) {
+  if (!result || typeof result !== 'object') {
+    failures.push('Browser result file is missing or invalid');
+    return;
+  }
+  if (result.marker !== marker) failures.push('Browser result marker does not match');
+  if (!Number.isInteger(result.issueNumber) || result.issueNumber <= 0) {
+    failures.push('Browser result Issue number is not a positive integer');
+  }
+  if (result.issueNumber !== candidate.number) failures.push('Browser result Issue number differs');
+  if (result.issueUrl !== canonicalUrl) failures.push('Browser result Issue URL differs');
+  if (result.workerSha !== expectedSha) failures.push('Browser result Worker SHA differs');
+}
+
+function normalizeLabels(labels) {
+  if (!Array.isArray(labels)) return [];
+  return labels
+    .map(label => (typeof label === 'string' ? label : label?.name))
+    .filter(label => typeof label === 'string')
+    .sort();
+}
+
+function sameStringSet(left, right) {
+  const normalizedRight = [...right].sort();
+  return (
+    left.length === normalizedRight.length &&
+    left.every((value, index) => value === normalizedRight[index])
+  );
+}
+
+function parseNextLink(value) {
+  if (!value) return '';
+  for (const segment of value.split(',')) {
+    const match = segment.match(/<([^>]+)>;\s*rel="([^"]+)"/);
+    if (match?.[2].split(/\s+/).includes('next')) return match[1];
+  }
+  return '';
+}
+
+function validateSelector({ marker, prefix }) {
+  if (Boolean(marker) === Boolean(prefix)) {
+    throw new Error('Exactly one of marker or prefix is required');
+  }
+  if (marker) return { marker: requireNonempty(marker, 'marker') };
+  return { prefix: requireNonempty(prefix, 'prefix') };
+}
+
+function parseRepo(repo) {
+  requireNonempty(repo, 'repo');
+  const parts = repo.split('/');
+  if (parts.length !== 2 || parts.some(part => !part.trim())) {
+    throw new Error('repo must use owner/name format');
+  }
+  return { owner: parts[0], name: parts[1] };
+}
+
+function canonicalIssueUrl(repo, number) {
+  parseRepo(repo);
+  return `https://github.com/${repo}/issues/${number}`;
+}
+
+function issueApiUrl(apiBaseUrl, repo, number) {
+  const { owner, name } = parseRepo(repo);
+  if (!Number.isInteger(number) || number <= 0) throw new Error('Invalid Issue number');
+  return new URL(
+    `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${number}`,
+    apiBaseUrl
+  ).toString();
+}
+
+function requireNonempty(value, name) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${name} is required`);
+  return value.trim();
+}
+
+function safeErrorMessage(error, token) {
+  return redact(error instanceof Error ? error.message : String(error), token);
+}
+
+function redact(value, token) {
+  if (!token) return value;
+  return value.split(token).join('[REDACTED]');
+}
+
+function formatNumbers(numbers) {
+  return numbers.length > 0 ? numbers.map(number => `#${number}`).join(', ') : 'none';
+}
+
+function parseCliArguments(argv) {
+  const command = argv[0] ?? '';
+  const options = {};
+  const names = {
+    '--repo': 'repo',
+    '--marker': 'marker',
+    '--prefix': 'prefix',
+    '--result-file': 'resultFile',
+    '--expected-sha': 'expectedSha',
+  };
+  for (let index = 1; index < argv.length; index += 1) {
+    const key = argv[index];
+    const name = names[key];
+    if (!name) throw new Error(`Unknown option: ${key}`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`${key} requires a value`);
+    options[name] = value;
+    index += 1;
+  }
+  return { command, options };
+}
+
+const isMain = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (isMain) {
+  process.exitCode = await runCli(process.argv.slice(2));
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -83,6 +83,13 @@ api.use('*', async (c, next) => {
   return corsMiddleware(c, next);
 });
 
+// Additive deployment identity for preview canaries. Keep it off unconfigured deployments.
+api.use('/feedback', async (c, next) => {
+  await next();
+  const buildSha = getBuildSha(c.env);
+  if (buildSha) c.header('X-BugDrop-Build-SHA', buildSha);
+});
+
 // Rate limit: 20 requests per 15 minutes per IP
 api.use(
   '/feedback',
@@ -107,12 +114,18 @@ api.use(
 
 // Health check
 api.get('/health', c => {
+  const buildSha = getBuildSha(c.env);
   return c.json({
     status: 'ok',
     environment: c.env.ENVIRONMENT,
     timestamp: new Date().toISOString(),
+    ...(buildSha ? { buildSha } : {}),
   });
 });
+
+function getBuildSha(env: Env): string | undefined {
+  return env.BUILD_SHA?.trim() || undefined;
+}
 
 // Check if app is installed on repo
 api.get('/check/:owner/:repo', async c => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface Env {
 
   // Variables (from wrangler.toml)
   ENVIRONMENT: string;
+  BUILD_SHA?: string; // Optional deployed source identity for health and feedback responses
   ALLOWED_ORIGINS: string; // Comma-separated list of allowed origins, or "*" for dev
   GITHUB_APP_NAME: string; // Your GitHub App name for install URL
   MAX_SCREENSHOT_SIZE_MB: string; // Max screenshot size in MB (default: 5)

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -93,6 +93,25 @@ describe('API Routes', () => {
 
       expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
     });
+
+    it('should expose the configured Worker build SHA', async () => {
+      const buildSha = 'a'.repeat(40);
+      const req = new Request('http://localhost/health');
+      const res = await app.fetch(req, { ...mockEnv, BUILD_SHA: buildSha });
+      const data = await res.json();
+
+      expect(data.buildSha).toBe(buildSha);
+    });
+
+    it('should omit Worker build identity when BUILD_SHA is unconfigured or blank', async () => {
+      for (const buildSha of [undefined, '', '   ']) {
+        const req = new Request('http://localhost/health');
+        const res = await app.fetch(req, { ...mockEnv, BUILD_SHA: buildSha });
+        const data = await res.json();
+
+        expect(data).not.toHaveProperty('buildSha');
+      }
+    });
   });
 
   describe('GET /check/:owner/:repo', () => {
@@ -257,6 +276,65 @@ describe('API Routes', () => {
         expect.stringContaining('This is a test feedback'),
         ['bug', 'bugdrop']
       );
+    });
+
+    it('should expose the configured Worker build SHA on successful feedback', async () => {
+      const buildSha = 'a'.repeat(40);
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+
+      const res = await app.fetch(req, { ...mockEnv, BUILD_SHA: buildSha });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('X-BugDrop-Build-SHA')).toBe(buildSha);
+    });
+
+    it.each([
+      ['invalid JSON', '{'],
+      ['validation error', JSON.stringify({ ...validPayload, title: '' })],
+    ])('should expose the configured Worker build SHA on %s', async (_name, body) => {
+      const buildSha = 'b'.repeat(40);
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      });
+
+      const res = await app.fetch(req, { ...mockEnv, BUILD_SHA: buildSha });
+
+      expect(res.status).toBe(400);
+      expect(res.headers.get('X-BugDrop-Build-SHA')).toBe(buildSha);
+    });
+
+    it('should expose the configured Worker build SHA on GitHub failures', async () => {
+      const buildSha = 'c'.repeat(40);
+      mockCreateIssue.mockRejectedValueOnce(new Error('GitHub unavailable'));
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+
+      const res = await app.fetch(req, { ...mockEnv, BUILD_SHA: buildSha });
+
+      expect(res.status).toBe(500);
+      expect(res.headers.get('X-BugDrop-Build-SHA')).toBe(buildSha);
+    });
+
+    it('should omit Worker build identity when BUILD_SHA is unconfigured', async () => {
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+
+      const res = await app.fetch(req, mockEnv);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.has('X-BugDrop-Build-SHA')).toBe(false);
     });
 
     it('should reject feedback without a bearer token when token auth is configured', async () => {

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -3,9 +3,41 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-workflow="$repo_root/.github/workflows/ci.yml"
+ci_workflow="$repo_root/.github/workflows/ci.yml"
+live_workflow="$repo_root/.github/workflows/live-tests.yml"
+canary_spec="$repo_root/e2e/widget.issue-canary.spec.ts"
+live_spec="$repo_root/e2e/widget.live.spec.ts"
 
-# GitHub renders the matrix expression; this shell test must match it literally.
+fail() {
+  echo "CI workflow contract failed: $*" >&2
+  exit 1
+}
+
+require_literal() {
+  local file=$1
+  local value=$2
+  grep -Fq -- "$value" "$file" || fail "$(basename "$file") lacks: $value"
+}
+
+require_absent() {
+  local file=$1
+  local value=$2
+  if grep -Fq -- "$value" "$file"; then
+    fail "$(basename "$file") must not contain: $value"
+  fi
+}
+
+job_block() {
+  local file=$1
+  local job=$2
+  awk -v job="$job" '
+    $0 == "  " job ":" { found = 1 }
+    found && $0 ~ /^  [[:alnum:]_-]+:$/ && $0 != "  " job ":" { exit }
+    found { print }
+  ' "$file"
+}
+
+# GitHub renders matrix expressions; match required contexts literally.
 # shellcheck disable=SC2016
 required_contexts=(
   'Lint, Typecheck, Knip, Audit'
@@ -14,28 +46,116 @@ required_contexts=(
   'Deploy Preview'
   'Live Preview Tests'
 )
-
 for context in "${required_contexts[@]}"; do
-  grep -Fq "name: $context" "$workflow" || {
-    echo "Missing required check context: $context" >&2
-    exit 1
-  }
+  require_literal "$ci_workflow" "name: $context"
 done
 
-e2e_block=$(sed -n '/^  e2e:/,/^  radix-e2e:/p' "$workflow")
+e2e_block=$(job_block "$ci_workflow" e2e)
 if grep -Eq '^    if:' <<< "$e2e_block"; then
-  echo 'The required E2E matrix must not use a job-level condition.' >&2
-  exit 1
+  fail 'the required E2E matrix must not use a job-level condition'
+fi
+grep -Fq 'shard: [1, 2]' <<< "$e2e_block" || fail 'the two-shard E2E matrix changed'
+grep -Fq 'Skip expensive E2E for documentation-only changes' <<< "$e2e_block" ||
+  fail 'the documentation-only E2E context bridge is missing'
+require_literal "$ci_workflow" 'Verify previous full CI succeeded'
+require_literal "$ci_workflow" 'steps.previous-ci.outputs.result'
+require_literal "$ci_workflow" "run.app?.slug !== 'github-actions'"
+require_literal "$ci_workflow" 'suites.get(run.check_suite.id)'
+require_literal "$ci_workflow" "const gateName = 'Lint, Typecheck, Knip, Audit'"
+require_literal "$ci_workflow" 'right.runs.get(gateName).id'
+require_literal "$ci_workflow" 'latestSuite?.runs.get(name)?.conclusion'
+
+critical=$(job_block "$ci_workflow" deploy-preview)
+bridge=$(job_block "$ci_workflow" live-preview-tests)
+
+grep -Fq 'name: Deploy Preview' <<< "$critical" || fail 'critical job lost its required name'
+grep -Fq 'needs: [check, test, e2e, radix-e2e]' <<< "$critical" ||
+  fail 'preview deployment is not gated by every local job'
+grep -Fq "if: github.event_name == 'merge_group'" <<< "$critical" ||
+  fail 'critical job is not merge-group-only'
+grep -Fq 'group: bugdrop-shared-preview' <<< "$critical" || fail 'shared preview lock is missing'
+grep -Fq 'cancel-in-progress: false' <<< "$critical" || fail 'active preview runs may be cancelled'
+grep -Fq 'queue: max' <<< "$critical" || fail 'pending merge groups may be dropped'
+
+for command in \
+  'npx wrangler deploy --env preview' \
+  'npx playwright test --project=chromium-live --workers=1 --retries=0' \
+  'make test-live-radix' \
+  'make test-live-cross-browser BROWSER=chromium' \
+  'make test-live-cross-browser BROWSER=firefox' \
+  'make test-live-cross-browser BROWSER=webkit' \
+  'npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --workers=1 --retries=0' \
+  'node scripts/github-issue-canary.mjs verify' \
+  'node scripts/github-issue-canary.mjs cleanup' \
+  'node scripts/github-issue-canary.mjs sweep'; do
+  grep -Fq "$command" <<< "$critical" || fail "critical section lacks: $command"
+done
+grep -Fq -- '--var "BUILD_SHA:$GITHUB_SHA"' <<< "$critical" ||
+  fail 'preview deployment does not receive the full workflow SHA'
+grep -Fq 'ENVIRONMENT" = "preview"' <<< "$critical" ||
+  fail 'health polling does not require the preview environment'
+grep -Fq 'BUILD_SHA" = "$GITHUB_SHA"' <<< "$critical" ||
+  fail 'health polling does not require the exact full SHA'
+grep -Fq 'EXPECTED_WIDGET_SHA256=' <<< "$critical" || fail 'checkout widget hash is not recorded'
+grep -Fq 'ACTUAL_SHA" = "$EXPECTED_WIDGET_SHA256"' <<< "$critical" ||
+  fail 'deployed widget bytes are not polled to an exact hash match'
+
+[[ $(grep -Fc 'npx wrangler deploy --env preview' "$ci_workflow") -eq 1 ]] ||
+  fail 'preview deployment must have exactly one workflow owner'
+[[ $(grep -Fc 'chromium-issue-canary' "$ci_workflow") -eq 1 ]] ||
+  fail 'the real canary must have exactly one workflow invocation'
+[[ $(grep -Fc 'BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}' "$ci_workflow") -eq 4 ]] ||
+  fail 'the token must appear only in preflight, verify, current cleanup, and final sweep step envs'
+for token_step in \
+  'Preflight stale canary cleanup' \
+  'Verify canary Issue independently' \
+  'Cleanup current canary marker' \
+  'Final reserved-prefix sweep'; do
+  token_step_line=$(grep -n "name: $token_step" "$ci_workflow" | cut -d: -f1)
+  [[ -n "$token_step_line" ]] || fail "token-scoped step is missing: $token_step"
+  sed -n "${token_step_line},$((token_step_line + 12))p" "$ci_workflow" |
+    grep -Fq 'BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}' ||
+    fail "the token is not scoped to its intended step: $token_step"
+done
+if grep -Eq '^    env:|^env:' <<< "$critical"; then
+  fail 'the critical job must not have job- or workflow-scoped environment values'
 fi
 
-grep -Fq 'shard: [1, 2]' <<< "$e2e_block"
-grep -Fq 'Skip expensive E2E for documentation-only changes' <<< "$e2e_block"
-grep -Fq 'Verify previous full CI succeeded' "$workflow"
-grep -Fq 'steps.previous-ci.outputs.result' "$workflow"
-grep -Fq "run.app?.slug !== 'github-actions'" "$workflow"
-grep -Fq 'suites.get(run.check_suite.id)' "$workflow"
-grep -Fq "const gateName = 'Lint, Typecheck, Knip, Audit'" "$workflow"
-grep -Fq 'right.runs.get(gateName).id' "$workflow"
-grep -Fq 'latestSuite?.runs.get(name)?.conclusion' "$workflow"
+cleanup_line=$(grep -n 'name: Cleanup current canary marker' "$ci_workflow" | cut -d: -f1)
+sweep_line=$(grep -n 'name: Final reserved-prefix sweep' "$ci_workflow" | cut -d: -f1)
+artifact_line=$(grep -n 'name: Upload preview failure report' "$ci_workflow" | cut -d: -f1)
+[[ -n "$cleanup_line" && -n "$sweep_line" && -n "$artifact_line" ]] || fail 'cleanup/artifact steps missing'
+(( cleanup_line < sweep_line && sweep_line < artifact_line )) || fail 'artifacts must follow both cleanup steps'
+sed -n "${cleanup_line},$((cleanup_line + 8))p" "$ci_workflow" | grep -Fq 'if: always()' ||
+  fail 'current-marker cleanup is not unconditional'
+sed -n "${cleanup_line},$((cleanup_line + 8))p" "$ci_workflow" | grep -Fq -- '--marker "$BUGDROP_CANARY_MARKER"' ||
+  fail 'current cleanup does not discover by marker'
+sed -n "${cleanup_line},$((cleanup_line + 8))p" "$ci_workflow" | grep -Fq -- '--result-file' &&
+  fail 'cleanup must not depend on the browser result file'
+
+grep -Fq 'name: Live Preview Tests' <<< "$bridge" || fail 'status bridge lost its required name'
+grep -Fq 'needs: [deploy-preview]' <<< "$bridge" || fail 'status bridge does not depend on critical job'
+grep -Fq 'always()' <<< "$bridge" || fail 'status bridge does not run after critical failure'
+grep -Fq 'needs.deploy-preview.result' <<< "$bridge" || fail 'status bridge does not inspect job result'
+grep -Fq '!= "success"' <<< "$bridge" || fail 'status bridge is not fail-closed'
+
+require_literal "$live_workflow" "group: \${{ github.event_name == 'schedule' && 'bugdrop-shared-preview'"
+require_literal "$live_workflow" "format('bugdrop-live-{0}-{1}', github.workflow, github.run_id)"
+require_literal "$live_workflow" 'cancel-in-progress: false'
+require_literal "$live_workflow" 'queue: max'
+require_literal "$live_workflow" "if: always() && github.event_name == 'schedule'"
+require_literal "$live_workflow" 'node scripts/github-issue-canary.mjs sweep'
+[[ $(grep -Fc 'BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}' "$live_workflow") -eq 1 ]] ||
+  fail 'the janitor token must exist only on its sweep step'
+require_absent "$live_workflow" 'widget.issue-canary.spec.ts'
+require_absent "$live_workflow" 'chromium-issue-canary'
+require_absent "$live_workflow" 'BUGDROP_CANARY_MARKER'
+
+require_literal "$canary_spec" 'expect(outgoingUrl.origin).toBe(environment.expectedWidgetOrigin)'
+require_literal "$canary_spec" "response.request().method() === 'POST'"
+require_literal "$canary_spec" 'responseUrl.origin === environment.expectedWidgetOrigin'
+require_literal "$canary_spec" "responseUrl.pathname === '/api/feedback'"
+require_literal "$canary_spec" 'expect(feedbackUrl.origin).toBe(environment.expectedWidgetOrigin)'
+require_literal "$live_spec" "page.route('**/feedback'"
 
 echo 'CI workflow contract checks passed'

--- a/test/githubIssueCanary.test.ts
+++ b/test/githubIssueCanary.test.ts
@@ -12,6 +12,7 @@ const REPO = 'mean-weasel/bugdrop-widget-test';
 const MARKER = `bugdrop-ci-canary:123:1:${'a'.repeat(40)}`;
 const SHA = 'a'.repeat(40);
 const TOKEN = 'synthetic-redaction-sentinel-not-a-credential';
+const noWait = vi.fn(async () => {});
 
 type Issue = {
   number: number;
@@ -66,6 +67,15 @@ function result(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function issueFetch(
+  matches: Issue[],
+  direct: Issue = matches[0]
+): ReturnType<typeof vi.fn<typeof fetch>> {
+  return vi.fn<typeof fetch>(async input =>
+    String(input).includes('/issues?') ? jsonResponse(matches) : jsonResponse(direct)
+  );
+}
+
 describe('GitHub Issue canary discovery and verification', () => {
   it('paginates state=all, filters PRs, and discovers a body-only marker', async () => {
     const matching = issue({ number: 42, title: 'unexpected title' });
@@ -98,7 +108,7 @@ describe('GitHub Issue canary discovery and verification', () => {
   });
 
   it('verifies the complete Issue and browser response contract', async () => {
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse([issue()]));
+    const fetchImpl = issueFetch([issue()]);
 
     const verified = await verifyCanaryIssue({
       fetchImpl,
@@ -107,6 +117,7 @@ describe('GitHub Issue canary discovery and verification', () => {
       marker: MARKER,
       expectedSha: SHA,
       result: result(),
+      sleepImpl: noWait,
     });
 
     expect(verified.number).toBe(42);
@@ -121,7 +132,7 @@ describe('GitHub Issue canary discovery and verification', () => {
     ['closed before verification', issue({ state: 'closed' })],
     ['screenshot section', issue({ body: `${issue().body}\n## Screenshot` })],
   ])('rejects %s', async (_name, candidate) => {
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse([candidate]));
+    const fetchImpl = issueFetch([candidate], candidate);
 
     await expect(
       verifyCanaryIssue({
@@ -131,14 +142,14 @@ describe('GitHub Issue canary discovery and verification', () => {
         marker: MARKER,
         expectedSha: SHA,
         result: result(),
+        sleepImpl: noWait,
       })
     ).rejects.toThrow();
   });
 
   it('rejects duplicate marker matches while preserving their numbers for cleanup diagnostics', async () => {
-    const fetchImpl = vi
-      .fn<typeof fetch>()
-      .mockResolvedValue(jsonResponse([issue(), issue({ number: 43 })]));
+    const candidates = [issue(), issue({ number: 43 })];
+    const fetchImpl = issueFetch(candidates);
 
     await expect(
       verifyCanaryIssue({
@@ -148,6 +159,7 @@ describe('GitHub Issue canary discovery and verification', () => {
         marker: MARKER,
         expectedSha: SHA,
         result: result(),
+        sleepImpl: noWait,
       })
     ).rejects.toThrow('exactly one');
   });
@@ -159,7 +171,7 @@ describe('GitHub Issue canary discovery and verification', () => {
     ['wrong URL', result({ issueUrl: `https://github.com/${REPO}/issues/99` })],
     ['wrong Worker SHA', result({ workerSha: 'b'.repeat(40) })],
   ])('rejects a %s independently of cleanup discovery', async (_name, browserResult) => {
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse([issue()]));
+    const fetchImpl = issueFetch([issue()]);
 
     await expect(
       verifyCanaryIssue({
@@ -169,8 +181,93 @@ describe('GitHub Issue canary discovery and verification', () => {
         marker: MARKER,
         expectedSha: SHA,
         result: browserResult,
+        sleepImpl: noWait,
       })
     ).rejects.toThrow();
+  });
+
+  it('uses exact browser Issue readback while bounded list discovery stabilizes', async () => {
+    const candidate = issue();
+    const listResponses = [[], [candidate], [candidate]];
+    const sleepImpl = vi.fn(async () => {});
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      if (!String(input).includes('/issues?')) return jsonResponse(candidate);
+      return jsonResponse(listResponses.shift() ?? [candidate]);
+    });
+
+    const verified = await verifyCanaryIssue({
+      fetchImpl,
+      repo: REPO,
+      token: TOKEN,
+      marker: MARKER,
+      expectedSha: SHA,
+      result: result(),
+      consistencyAttempts: 4,
+      sleepImpl,
+    });
+
+    expect(verified.number).toBe(42);
+    expect(sleepImpl).toHaveBeenCalledTimes(2);
+    expect(String(fetchImpl.mock.calls[0][0])).toMatch(/\/issues\/42$/);
+  });
+
+  it('fails immediately when a duplicate appears during singleton stabilization', async () => {
+    const candidate = issue();
+    const duplicate = issue({ number: 43 });
+    const listResponses = [[candidate], [candidate, duplicate]];
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      if (!String(input).includes('/issues?')) return jsonResponse(candidate);
+      return jsonResponse(listResponses.shift() ?? [candidate, duplicate]);
+    });
+
+    await expect(
+      verifyCanaryIssue({
+        fetchImpl,
+        repo: REPO,
+        token: TOKEN,
+        marker: MARKER,
+        expectedSha: SHA,
+        result: result(),
+        consistencyAttempts: 4,
+        sleepImpl: noWait,
+      })
+    ).rejects.toThrow('found 2');
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('rejects a stable marker singleton that differs from the browser-reported Issue', async () => {
+    const browserIssue = issue();
+    const otherMatch = issue({ number: 43 });
+    const fetchImpl = issueFetch([otherMatch], browserIssue);
+
+    await expect(
+      verifyCanaryIssue({
+        fetchImpl,
+        repo: REPO,
+        token: TOKEN,
+        marker: MARKER,
+        expectedSha: SHA,
+        result: result(),
+        sleepImpl: noWait,
+      })
+    ).rejects.toThrow('not browser Issue #42');
+  });
+
+  it('rejects an unbounded consistency configuration before making a request', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(
+      verifyCanaryIssue({
+        fetchImpl,
+        repo: REPO,
+        token: TOKEN,
+        marker: MARKER,
+        expectedSha: SHA,
+        result: result(),
+        consistencyAttempts: Number.POSITIVE_INFINITY,
+      })
+    ).rejects.toThrow('consistencyAttempts');
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 });
 
@@ -194,6 +291,7 @@ describe('GitHub Issue canary cleanup', () => {
       repo: REPO,
       token: TOKEN,
       marker: MARKER,
+      sleepImpl: noWait,
     });
 
     expect(cleanup.matchedNumbers).toEqual([42, 43]);
@@ -216,9 +314,109 @@ describe('GitHub Issue canary cleanup', () => {
     });
 
     await expect(
-      closeMatchingIssues({ fetchImpl, repo: REPO, token: TOKEN, marker: MARKER })
+      closeMatchingIssues({
+        fetchImpl,
+        repo: REPO,
+        token: TOKEN,
+        marker: MARKER,
+        consistencyAttempts: 2,
+        sleepImpl: noWait,
+      })
     ).rejects.toThrow('42');
     expect(issues[1].state).toBe('closed');
+  });
+
+  it('waits for a newly-created marker Issue to appear before cleanup', async () => {
+    const candidate = issue();
+    const listResponses = [[], [], [candidate], [candidate]];
+    const sleepImpl = vi.fn(async () => {});
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      if (String(input).includes('/issues?')) {
+        return jsonResponse(listResponses.shift() ?? [candidate]);
+      }
+      if (init?.method === 'PATCH') candidate.state = 'closed';
+      return jsonResponse(candidate);
+    });
+
+    const cleanup = await closeMatchingIssues({
+      fetchImpl,
+      repo: REPO,
+      token: TOKEN,
+      marker: MARKER,
+      consistencyAttempts: 4,
+      sleepImpl,
+    });
+
+    expect(cleanup.closedNumbers).toEqual([42]);
+    expect(cleanup.openNumbers).toEqual([]);
+    expect(sleepImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails closed when marker cleanup never observes the newly-created Issue', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse([]));
+
+    await expect(
+      closeMatchingIssues({
+        fetchImpl,
+        repo: REPO,
+        token: TOKEN,
+        marker: MARKER,
+        consistencyAttempts: 3,
+        sleepImpl: noWait,
+      })
+    ).rejects.toThrow('appeared within the retry bound');
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('requires stable zero-open evidence after cleanup', async () => {
+    const candidate = issue();
+    const listResponses = [[candidate], [], []];
+    const sleepImpl = vi.fn(async () => {});
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      if (String(input).includes('/issues?')) {
+        return jsonResponse(listResponses.shift() ?? []);
+      }
+      if (init?.method === 'PATCH') candidate.state = 'closed';
+      return jsonResponse(candidate);
+    });
+
+    const cleanup = await closeMatchingIssues({
+      fetchImpl,
+      repo: REPO,
+      token: TOKEN,
+      marker: MARKER,
+      consistencyAttempts: 3,
+      sleepImpl,
+    });
+
+    expect(cleanup.openNumbers).toEqual([]);
+    expect(listResponses).toEqual([]);
+    expect(sleepImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a late open match after a transient empty final list', async () => {
+    const candidate = issue();
+    const lateDuplicate = issue({ number: 43 });
+    const listResponses = [[candidate], [], [lateDuplicate], [lateDuplicate]];
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      if (String(input).includes('/issues?')) {
+        return jsonResponse(listResponses.shift() ?? [lateDuplicate]);
+      }
+      if (init?.method === 'PATCH') candidate.state = 'closed';
+      return jsonResponse(candidate);
+    });
+
+    await expect(
+      closeMatchingIssues({
+        fetchImpl,
+        repo: REPO,
+        token: TOKEN,
+        marker: MARKER,
+        consistencyAttempts: 3,
+        sleepImpl: noWait,
+      })
+    ).rejects.toThrow('still open after cleanup: #43');
+    expect(listResponses).toEqual([]);
   });
 
   it('treats an ambiguous close as success when exact readback is closed', async () => {
@@ -242,10 +440,11 @@ describe('GitHub Issue canary cleanup', () => {
       repo: REPO,
       token: TOKEN,
       marker: MARKER,
+      sleepImpl: noWait,
     });
 
     expect(cleanup.closedNumbers).toEqual([42]);
-    expect(listCount).toBe(2);
+    expect(listCount).toBe(3);
   });
 
   it('retries an ambiguous close once only after readback proves the Issue is still open', async () => {
@@ -262,10 +461,48 @@ describe('GitHub Issue canary cleanup', () => {
       return jsonResponse(candidate);
     });
 
-    await closeMatchingIssues({ fetchImpl, repo: REPO, token: TOKEN, marker: MARKER });
+    await closeMatchingIssues({
+      fetchImpl,
+      repo: REPO,
+      token: TOKEN,
+      marker: MARKER,
+      sleepImpl: noWait,
+    });
 
     expect(patchCount).toBe(2);
     expect(candidate.state).toBe('closed');
+  });
+
+  it('waits for stale exact and paginated close readbacks without another PATCH', async () => {
+    const openCandidate = issue();
+    const closedCandidate = issue({ state: 'closed' });
+    const exactStates = [openCandidate, openCandidate, closedCandidate];
+    const listStates = [[openCandidate], [openCandidate], [openCandidate], [closedCandidate]];
+    const sleepImpl = vi.fn(async () => {});
+    let patchCount = 0;
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      if (init?.method === 'PATCH') {
+        patchCount += 1;
+        return jsonResponse(closedCandidate);
+      }
+      if (String(input).includes('/issues?')) {
+        return jsonResponse(listStates.shift() ?? [closedCandidate]);
+      }
+      return jsonResponse(exactStates.shift() ?? closedCandidate);
+    });
+
+    const cleanup = await closeMatchingIssues({
+      fetchImpl,
+      repo: REPO,
+      token: TOKEN,
+      marker: MARKER,
+      consistencyAttempts: 4,
+      sleepImpl,
+    });
+
+    expect(cleanup.openNumbers).toEqual([]);
+    expect(patchCount).toBe(1);
+    expect(sleepImpl).toHaveBeenCalledTimes(5);
   });
 
   it('sweeps only open non-PR Issues with the reserved title prefix', async () => {
@@ -289,6 +526,7 @@ describe('GitHub Issue canary cleanup', () => {
       repo: REPO,
       token: TOKEN,
       prefix: CANARY_TITLE_PREFIX,
+      sleepImpl: noWait,
     });
 
     expect(cleanup.matchedNumbers).toEqual([42]);
@@ -319,7 +557,7 @@ describe('GitHub Issue canary cleanup', () => {
 
 describe('GitHub Issue canary CLI', () => {
   it('verifies through the CLI without exposing its token', async () => {
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse([issue()]));
+    const fetchImpl = issueFetch([issue()]);
     const output: string[] = [];
     const errors: string[] = [];
 
@@ -341,6 +579,7 @@ describe('GitHub Issue canary CLI', () => {
         readFileImpl: vi.fn().mockResolvedValue(JSON.stringify(result())),
         stdout: value => output.push(value),
         stderr: value => errors.push(value),
+        sleepImpl: noWait,
       }
     );
 

--- a/test/githubIssueCanary.test.ts
+++ b/test/githubIssueCanary.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CANARY_TITLE_PREFIX,
+  canaryTitle,
+  closeMatchingIssues,
+  listMatchingIssues,
+  runCli,
+  verifyCanaryIssue,
+} from '../scripts/github-issue-canary.mjs';
+
+const REPO = 'mean-weasel/bugdrop-widget-test';
+const MARKER = `bugdrop-ci-canary:123:1:${'a'.repeat(40)}`;
+const SHA = 'a'.repeat(40);
+const TOKEN = 'synthetic-redaction-sentinel-not-a-credential';
+
+type Issue = {
+  number: number;
+  html_url: string;
+  title: string;
+  body: string;
+  state: 'open' | 'closed';
+  labels: Array<{ name: string }>;
+  user: { login: string };
+  pull_request?: { url: string };
+};
+
+function issue(overrides: Partial<Issue> = {}): Issue {
+  const number = overrides.number ?? 42;
+  return {
+    number,
+    html_url: `https://github.com/${REPO}/issues/${number}`,
+    title: canaryTitle(MARKER),
+    body: [
+      '## Description',
+      MARKER,
+      '',
+      '<details>',
+      '<summary>System Info</summary>',
+      '</details>',
+      '',
+      '---',
+      '*Submitted via [BugDrop](https://github.com/mean-weasel/bugdrop)*',
+    ].join('\n'),
+    state: 'open',
+    labels: [{ name: 'bug' }, { name: 'bugdrop' }],
+    user: { login: 'neonwatty-bugdrop[bot]' },
+    ...overrides,
+  };
+}
+
+function jsonResponse(value: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json', ...init.headers },
+    ...init,
+  });
+}
+
+function result(overrides: Record<string, unknown> = {}) {
+  return {
+    marker: MARKER,
+    issueNumber: 42,
+    issueUrl: `https://github.com/${REPO}/issues/42`,
+    workerSha: SHA,
+    ...overrides,
+  };
+}
+
+describe('GitHub Issue canary discovery and verification', () => {
+  it('paginates state=all, filters PRs, and discovers a body-only marker', async () => {
+    const matching = issue({ number: 42, title: 'unexpected title' });
+    const pullRequest = issue({
+      number: 43,
+      pull_request: { url: 'https://api.github.com/repos/example/pulls/43' },
+    });
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse([pullRequest], {
+          headers: {
+            Link: `<https://api.github.com/repos/mean-weasel/bugdrop-widget-test/issues?state=all&per_page=100&page=2>; rel="next"`,
+          },
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse([matching]));
+
+    const matches = await listMatchingIssues({
+      fetchImpl,
+      repo: REPO,
+      token: TOKEN,
+      marker: MARKER,
+    });
+
+    expect(matches.map(candidate => candidate.number)).toEqual([42]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(String(fetchImpl.mock.calls[0][0])).toContain('state=all');
+    expect(String(fetchImpl.mock.calls[0][0])).toContain('per_page=100');
+  });
+
+  it('verifies the complete Issue and browser response contract', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse([issue()]));
+
+    const verified = await verifyCanaryIssue({
+      fetchImpl,
+      repo: REPO,
+      token: TOKEN,
+      marker: MARKER,
+      expectedSha: SHA,
+      result: result(),
+    });
+
+    expect(verified.number).toBe(42);
+    expect(verified.html_url).toBe(`https://github.com/${REPO}/issues/42`);
+  });
+
+  it.each([
+    ['wrong title', issue({ title: `${CANARY_TITLE_PREFIX} wrong` })],
+    ['missing body marker', issue({ body: '## Description\nmissing marker' })],
+    ['unexpected labels', issue({ labels: [{ name: 'bug' }] })],
+    ['wrong author', issue({ user: { login: 'someone-else' } })],
+    ['closed before verification', issue({ state: 'closed' })],
+    ['screenshot section', issue({ body: `${issue().body}\n## Screenshot` })],
+  ])('rejects %s', async (_name, candidate) => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse([candidate]));
+
+    await expect(
+      verifyCanaryIssue({
+        fetchImpl,
+        repo: REPO,
+        token: TOKEN,
+        marker: MARKER,
+        expectedSha: SHA,
+        result: result(),
+      })
+    ).rejects.toThrow();
+  });
+
+  it('rejects duplicate marker matches while preserving their numbers for cleanup diagnostics', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse([issue(), issue({ number: 43 })]));
+
+    await expect(
+      verifyCanaryIssue({
+        fetchImpl,
+        repo: REPO,
+        token: TOKEN,
+        marker: MARKER,
+        expectedSha: SHA,
+        result: result(),
+      })
+    ).rejects.toThrow('exactly one');
+  });
+
+  it.each([
+    ['missing result', undefined],
+    ['wrong marker', result({ marker: 'wrong-marker' })],
+    ['wrong number', result({ issueNumber: 99 })],
+    ['wrong URL', result({ issueUrl: `https://github.com/${REPO}/issues/99` })],
+    ['wrong Worker SHA', result({ workerSha: 'b'.repeat(40) })],
+  ])('rejects a %s independently of cleanup discovery', async (_name, browserResult) => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse([issue()]));
+
+    await expect(
+      verifyCanaryIssue({
+        fetchImpl,
+        repo: REPO,
+        token: TOKEN,
+        marker: MARKER,
+        expectedSha: SHA,
+        result: browserResult,
+      })
+    ).rejects.toThrow();
+  });
+});
+
+describe('GitHub Issue canary cleanup', () => {
+  it('closes every duplicate marker match and proves none remain open', async () => {
+    const issues = [issue(), issue({ number: 43 })];
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input);
+      if (url.includes('/issues?')) return jsonResponse(issues);
+      const number = Number(url.split('/').pop());
+      const candidate = issues.find(item => item.number === number)!;
+      if (init?.method === 'PATCH') {
+        candidate.state = 'closed';
+        return jsonResponse(candidate);
+      }
+      return jsonResponse(candidate);
+    });
+
+    const cleanup = await closeMatchingIssues({
+      fetchImpl,
+      repo: REPO,
+      token: TOKEN,
+      marker: MARKER,
+    });
+
+    expect(cleanup.matchedNumbers).toEqual([42, 43]);
+    expect(cleanup.closedNumbers).toEqual([42, 43]);
+    expect(issues.every(candidate => candidate.state === 'closed')).toBe(true);
+  });
+
+  it('continues closing later matches after one close fails, then reports the remaining leak', async () => {
+    const issues = [issue(), issue({ number: 43 })];
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input);
+      if (url.includes('/issues?')) return jsonResponse(issues);
+      const number = Number(url.split('/').pop());
+      const candidate = issues.find(item => item.number === number)!;
+      if (init?.method === 'PATCH' && number === 42) {
+        return new Response('close failed', { status: 500 });
+      }
+      if (init?.method === 'PATCH') candidate.state = 'closed';
+      return jsonResponse(candidate);
+    });
+
+    await expect(
+      closeMatchingIssues({ fetchImpl, repo: REPO, token: TOKEN, marker: MARKER })
+    ).rejects.toThrow('42');
+    expect(issues[1].state).toBe('closed');
+  });
+
+  it('treats an ambiguous close as success when exact readback is closed', async () => {
+    const candidate = issue();
+    let listCount = 0;
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input);
+      if (url.includes('/issues?')) {
+        listCount += 1;
+        return jsonResponse([candidate]);
+      }
+      if (init?.method === 'PATCH') {
+        candidate.state = 'closed';
+        return new Response('gateway lost the response', { status: 502 });
+      }
+      return jsonResponse(candidate);
+    });
+
+    const cleanup = await closeMatchingIssues({
+      fetchImpl,
+      repo: REPO,
+      token: TOKEN,
+      marker: MARKER,
+    });
+
+    expect(cleanup.closedNumbers).toEqual([42]);
+    expect(listCount).toBe(2);
+  });
+
+  it('retries an ambiguous close once only after readback proves the Issue is still open', async () => {
+    const candidate = issue();
+    let patchCount = 0;
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input);
+      if (url.includes('/issues?')) return jsonResponse([candidate]);
+      if (init?.method === 'PATCH') {
+        patchCount += 1;
+        if (patchCount === 1) return new Response('timeout', { status: 504 });
+        candidate.state = 'closed';
+      }
+      return jsonResponse(candidate);
+    });
+
+    await closeMatchingIssues({ fetchImpl, repo: REPO, token: TOKEN, marker: MARKER });
+
+    expect(patchCount).toBe(2);
+    expect(candidate.state).toBe('closed');
+  });
+
+  it('sweeps only open non-PR Issues with the reserved title prefix', async () => {
+    const stale = issue({ title: `${CANARY_TITLE_PREFIX} stale-run`, body: 'stale' });
+    const human = issue({ number: 43, title: 'Human issue', body: CANARY_TITLE_PREFIX });
+    const pullRequest = issue({
+      number: 44,
+      title: `${CANARY_TITLE_PREFIX} pull-request`,
+      pull_request: { url: 'https://api.github.com/pulls/44' },
+    });
+    const issues = [stale, human, pullRequest];
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input);
+      if (url.includes('/issues?')) return jsonResponse(issues);
+      stale.state = init?.method === 'PATCH' ? 'closed' : stale.state;
+      return jsonResponse(stale);
+    });
+
+    const cleanup = await closeMatchingIssues({
+      fetchImpl,
+      repo: REPO,
+      token: TOKEN,
+      prefix: CANARY_TITLE_PREFIX,
+    });
+
+    expect(cleanup.matchedNumbers).toEqual([42]);
+    expect(human.state).toBe('open');
+    expect(pullRequest.state).toBe('open');
+  });
+
+  it('redacts the token from API errors and never calls the Issues create endpoint', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(`failure echoed ${TOKEN}`, {
+        status: 401,
+        headers: { 'Content-Type': 'text/plain' },
+      })
+    );
+
+    let message = '';
+    try {
+      await listMatchingIssues({ fetchImpl, repo: REPO, token: TOKEN, marker: MARKER });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).not.toContain(TOKEN);
+    expect(message).toContain('[REDACTED]');
+    expect(fetchImpl.mock.calls.every(call => initMethod(call[1]) !== 'POST')).toBe(true);
+  });
+});
+
+describe('GitHub Issue canary CLI', () => {
+  it('verifies through the CLI without exposing its token', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse([issue()]));
+    const output: string[] = [];
+    const errors: string[] = [];
+
+    const exitCode = await runCli(
+      [
+        'verify',
+        '--repo',
+        REPO,
+        '--marker',
+        MARKER,
+        '--expected-sha',
+        SHA,
+        '--result-file',
+        'result.json',
+      ],
+      {
+        fetchImpl,
+        env: { BUGDROP_CANARY_GITHUB_TOKEN: TOKEN },
+        readFileImpl: vi.fn().mockResolvedValue(JSON.stringify(result())),
+        stdout: value => output.push(value),
+        stderr: value => errors.push(value),
+      }
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(output[0])).toEqual({
+      verified: true,
+      issueNumber: 42,
+      issueUrl: `https://github.com/${REPO}/issues/42`,
+    });
+    expect(errors).toEqual([]);
+    expect(output.join('\n')).not.toContain(TOKEN);
+  });
+
+  it('fails closed before an API request when the token is missing', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const errors: string[] = [];
+
+    const exitCode = await runCli(['sweep', '--repo', REPO, '--prefix', CANARY_TITLE_PREFIX], {
+      fetchImpl,
+      env: {},
+      stdout: vi.fn(),
+      stderr: value => errors.push(value),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(errors.join('\n')).toContain('BUGDROP_CANARY_GITHUB_TOKEN is required');
+  });
+
+  it('reports malformed arguments without an uncaught exception', async () => {
+    const errors: string[] = [];
+
+    const exitCode = await runCli(['cleanup', '--marker'], {
+      fetchImpl: vi.fn<typeof fetch>(),
+      env: { BUGDROP_CANARY_GITHUB_TOKEN: TOKEN },
+      stdout: vi.fn(),
+      stderr: value => errors.push(value),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(errors).toEqual(['[bugdrop-canary] --marker requires a value']);
+  });
+});
+
+function initMethod(init: RequestInit | undefined): string {
+  return init?.method ?? 'GET';
+}


### PR DESCRIPTION
## Summary

- add one merge-group-only, zero-retry legacy-widget canary that creates a real Issue in mean-weasel/bugdrop-widget-test
- prove the deployed widget bytes and actual preview Worker response match the merge-group SHA
- independently verify Issue formatting, then close every matching canary and prove zero remain open
- serialize the full shared-preview critical section and preserve the required Deploy Preview and Live Preview Tests statuses
- remove the unmanaged real submission from ordinary live paths

## Safety

- BUGDROP_CANARY_GITHUB_TOKEN is scoped only to server-side verification and cleanup steps and is never passed to Playwright
- no repository auto-merge or repository settings are changed
- no new storage, service, Worker, or GitHub App is added

## Verification

- make check
- make build-all
- npm test -- --reporter=dot (372 passed)
- make test-e2e (230 passed)
- make test-radix-e2e BROWSER=chromium (5 passed)
- make test-radix-e2e BROWSER=firefox (5 passed)
- make test-radix-e2e BROWSER=webkit (5 passed)
- focused helper redaction suite (23 passed)
- staged and committed credential-literal scans passed

The PR will not be added to the existing merge queue until its ordinary required checks pass.