### PR TITLE
feat: add configurable feedback variants foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,9 @@ jobs:
       - name: Install dependencies
         run: make install
 
+      - name: Verify legacy compatibility provenance
+        run: npm run verify:legacy-compat
+
       - name: Run unit tests
         run: make test
 
@@ -430,7 +433,7 @@ jobs:
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
-      - name: Run one real-Issue canary
+      - name: Run one structured real-Issue canary
         run: npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --workers=1 --retries=0
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,8 @@ jobs:
     if: needs.check.outputs.full_ci != 'false'
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,7 @@ jobs:
           echo "BUGDROP_CANARY_MARKER=bugdrop-ci-canary:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${GITHUB_SHA}" >> "$GITHUB_ENV"
           echo "BUGDROP_CANARY_RESULT_FILE=test-results/issue-canary-result.json" >> "$GITHUB_ENV"
           echo "BUGDROP_CANARY_ATTEMPT_FILE=test-results/issue-canary-attempted" >> "$GITHUB_ENV"
-          echo "EXACT_WIDGET_FIXTURE_PATH=$GITHUB_WORKSPACE/test-results/exact-preview-widget.js" >> "$GITHUB_ENV"
+          echo "EXACT_WIDGET_FIXTURE_PATH=$RUNNER_TEMP/bugdrop-exact-preview-widget-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.js" >> "$GITHUB_ENV"
           echo "EXPECTED_WORKER_SHA=${GITHUB_SHA}" >> "$GITHUB_ENV"
           echo "EXPECTED_WIDGET_ORIGIN=https://bugdrop-preview.neonwatty.workers.dev" >> "$GITHUB_ENV"
           echo "LIVE_TARGET=preview" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,8 @@ jobs:
         run: |
           echo "BUGDROP_CANARY_MARKER=bugdrop-ci-canary:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${GITHUB_SHA}" >> "$GITHUB_ENV"
           echo "BUGDROP_CANARY_RESULT_FILE=test-results/issue-canary-result.json" >> "$GITHUB_ENV"
+          echo "BUGDROP_CANARY_ATTEMPT_FILE=test-results/issue-canary-attempted" >> "$GITHUB_ENV"
+          echo "EXACT_WIDGET_FIXTURE_PATH=$GITHUB_WORKSPACE/test-results/exact-preview-widget.js" >> "$GITHUB_ENV"
           echo "EXPECTED_WORKER_SHA=${GITHUB_SHA}" >> "$GITHUB_ENV"
           echo "EXPECTED_WIDGET_ORIGIN=https://bugdrop-preview.neonwatty.workers.dev" >> "$GITHUB_ENV"
           echo "LIVE_TARGET=preview" >> "$GITHUB_ENV"
@@ -383,10 +385,18 @@ jobs:
       - name: Wait for exact preview widget asset
         run: |
           WIDGET_URL="$EXPECTED_WIDGET_ORIGIN/widget.js"
+          CANDIDATE_PATH="$EXACT_WIDGET_FIXTURE_PATH.candidate"
+          mkdir -p "$(dirname "$EXACT_WIDGET_FIXTURE_PATH")"
           echo "Waiting for $WIDGET_URL to serve $EXPECTED_WIDGET_SHA256..."
           for i in $(seq 1 30); do
-            ACTUAL_SHA="$(curl -sSf "$WIDGET_URL" | shasum -a 256 | awk '{print $1}')"
+            if ! curl -sSf "$WIDGET_URL" -o "$CANDIDATE_PATH"; then
+              echo "Attempt $i/30 could not download the preview widget; waiting 5s..."
+              sleep 5
+              continue
+            fi
+            ACTUAL_SHA="$(shasum -a 256 "$CANDIDATE_PATH" | awk '{print $1}')"
             if [ "$ACTUAL_SHA" = "$EXPECTED_WIDGET_SHA256" ]; then
+              mv "$CANDIDATE_PATH" "$EXACT_WIDGET_FIXTURE_PATH"
               echo "Preview widget asset matched after $((i * 5))s"
               exit 0
             fi
@@ -436,7 +446,10 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run one structured real-Issue canary
-        run: npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --workers=1 --retries=0
+        run: |
+          mkdir -p "$(dirname "$BUGDROP_CANARY_ATTEMPT_FILE")"
+          : > "$BUGDROP_CANARY_ATTEMPT_FILE"
+          npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --workers=1 --retries=0
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
@@ -452,10 +465,14 @@ jobs:
 
       - name: Cleanup current canary marker
         if: always()
-        run: >-
-          node scripts/github-issue-canary.mjs cleanup
-          --repo mean-weasel/bugdrop-widget-test
-          --marker "$BUGDROP_CANARY_MARKER"
+        run: |
+          if [ ! -f "$BUGDROP_CANARY_ATTEMPT_FILE" ]; then
+            echo 'The Issue canary never started; no current marker can exist.'
+            exit 0
+          fi
+          node scripts/github-issue-canary.mjs cleanup \
+            --repo mean-weasel/bugdrop-widget-test \
+            --marker "$BUGDROP_CANARY_MARKER"
         env:
           BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,9 @@ test-results/
 coverage/
 .playwright-cli/
 
+# Immutable compatibility goldens (formatting would invalidate their hashes/contracts)
+test/fixtures/legacy-compat/
+
 # Lock files
 package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@
 
 In-app feedback → GitHub Issues. Screenshots, annotations, the works.
 
+The Worker also accepts a versioned, field-agnostic structured submission envelope for custom UXs.
+It validates bounded Issue drafts, keeps raw GitHub labels server-controlled through
+`VARIANT_LABELS`, and reuses the legacy endpoint, authentication, rate limits, GitHub App, and
+success response. `window.BugDrop.registerVariant(config).submit(answers)` provides the headless
+browser path; rendered modal and inline variants follow in a later phase. Existing script tags and
+legacy payloads remain unchanged.
+
 Featured on Product Hunt and ranked #6 Product of the Day on May 9, 2026.
 
 ![bugdrop-demo-small](https://github.com/user-attachments/assets/22d234fa-aa0f-4d01-bc4f-4c3e8f107165)

--- a/docs/goals/configurable-feedback-variants-phase-1/goal.md
+++ b/docs/goals/configurable-feedback-variants-phase-1/goal.md
@@ -1,0 +1,125 @@
+# Configurable Feedback Variants — Phase 1
+
+## Objective
+
+Implement and prove the compatibility and structured-headless foundation for configurable BugDrop
+feedback variants, ending with one real structured GitHub Issue created from the exact merge-tip
+preview, independently verified, closed, and swept without changing legacy-only behavior.
+
+## Original Request
+
+Proceed with Phase 1 of the approved configurable feedback variants design using GoalBuddy and
+bounded sub-agents, preserving backwards compatibility and the completed Phase 0 real-Issue canary.
+
+## Intake Summary
+
+- Input shape: `existing_plan`
+- Audience: BugDrop maintainers, contributors, and host applications such as Bleep
+- Authority: `approved`
+- Proof type: `test`
+- Completion proof: Historical and current v1 contracts remain green; the published browser types,
+  lazy sidecar, structured Worker handler, and headless submission work together; and the locked
+  merge-queue canary creates, independently verifies, closes, and sweeps exactly one correctly
+  formatted structured Issue from the exact preview Worker.
+- Goal oracle: Immutable compatibility fixtures plus local contract suites and a successful
+  merge-group structured real-Issue canary with exact widget/Worker identity and zero leaked Issues.
+- Likely misfire: Stopping after planning or types, beginning Phase 2 renderers, refactoring the
+  legacy wizard, weakening legacy assertions, or multiplying real-Issue canaries per UX/browser.
+- Blind spots considered: Historical exact-version assets currently return 404 except the current
+  release; `package.json` versioning does not track release tags; old bundles remain coupled to the
+  newest Worker; browser-selected variant IDs classify labels but are not authorization; variant and
+  legacy traffic share rate limits; live canary publication/merge-queue execution may require
+  explicit external authority.
+- Existing plan facts: Preserve
+  `docs/plans/2026-08-01-configurable-feedback-variants-design.md`; Phase 0 is complete through PR
+  #258/run `30724180366`/Issue #578; deliver Worker support before the widget calls it; use a lazy
+  sidecar rather than a legacy runtime rewrite; send a field-agnostic Issue draft; defer rendered UX,
+  evidence, dynamic registry lifecycle, and public variant events; reuse the existing canary lock,
+  verifier, token boundary, and cleanup framework.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`Historical v1 and current legacy contracts pass against the candidate Worker; a typed host can
+register and submit a headless structured variant while a legacy-only page performs no variant work;
+and one locked zero-retry merge-tip preview canary creates, verifies, closes, and sweeps exactly one
+structured GitHub Issue with the expected sections, labels, attribution, marker, widget hash, and
+Worker SHA.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, a passing helper, or a
+mocked GitHub call is not enough. The goal finishes only when a final Judge audit maps current
+receipts and verification to every clause and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`existing_plan`
+
+## Current Tranche
+
+Complete Phase 1 continuously through four coherent packages:
+
+1. Freeze and test the legacy compatibility baseline, including an explicit decision and proof for
+   historical exact bundles and the existing version-retention defect.
+2. Add the isolated field-agnostic structured Worker contract and server-owned variant label policy.
+3. Publish public declarations and add the lazy registration/headless sidecar without rendered UX.
+4. Extend the existing locked canary to prove one real structured Issue and zero cleanup leaks.
+
+Phase 2 modal, inline, rating, choice, and other rendered UX work is out of this tranche.
+
+## Non-Negotiable Constraints
+
+- Preserve all existing script tags, data attributes, legacy API methods, event timing, payloads,
+  responses, Issue formatting, labels, storage, screenshot flows, and `widget.v1.js` behavior.
+- Do not reinterpret arguments passed to legacy `BugDrop.open()`.
+- Do not move the legacy wizard behind a new runtime/controller in Phase 1.
+- Keep the legacy and structured Worker handlers and formatters isolated.
+- Use `kind: 'bugdrop.variant-submission'` plus `schemaVersion: 1`; a legacy payload containing an
+  unrelated `schemaVersion` remains legacy.
+- The structured payload is field-agnostic and contains no field schema, raw labels, `labelSet`,
+  screenshots, attachments, annotations, or console logs.
+- Raw labels remain Worker-owned; `{repo, variantId}` mapping is classification, not authorization.
+- Variant-only initialization is lazy and inert until `registerVariant()` is called.
+- Publish a real `.d.ts` integration contract rather than documentation-only types.
+- Add no database, queue, storage product, or backend service.
+- Create only one routine real-Issue canary per merge group and reuse Phase 0 safety machinery.
+- Do not run the real canary locally, manually, on pull requests, production, or ordinary live paths.
+- Preserve unrelated user changes and the existing untracked GoalBuddy artifacts.
+- Do not create a PR, enqueue a merge, or mutate repository settings without authority recorded on
+  the board or obtained from the operator.
+
+## Stop Rule
+
+Stop only when a final audit proves the full Phase 1 oracle is complete.
+
+Do not stop after planning, compatibility fixtures, Worker support, or a mocked structured request
+if the next safe package can proceed. If live merge-queue proof awaits external authority, block only
+that task and continue every local non-destructive verification and audit available.
+
+## Slice Sizing
+
+Each Worker owns one coherent reversible package: compatibility foundation, Worker structured
+contract, public types/headless sidecar, or canary extension. Avoid helper-only slices and avoid
+parallel writers because these contracts share the widget API, Worker route, tests, and CI boundary.
+
+## Board Health
+
+Machine truth lives at
+`docs/goals/configurable-feedback-variants-phase-1/state.yaml`. The PM uses the bundled checker and
+receipt applier and keeps exactly one active task.
+
+## Canonical Board
+
+`docs/goals/configurable-feedback-variants-phase-1/state.yaml`
+
+## Run Command
+
+```text
+/goal Follow docs/goals/configurable-feedback-variants-phase-1/goal.md.
+```
+
+## PM Loop
+
+On every continuation, read this charter, the GoalBuddy execution contract, and `state.yaml`; work
+only the active task; record its receipt; advance immediately to the next safe task; and run the
+final oracle plus `check-can-stop.mjs` before claiming completion.

--- a/docs/goals/configurable-feedback-variants-phase-1/notes/T001-plan-validation.md
+++ b/docs/goals/configurable-feedback-variants-phase-1/notes/T001-plan-validation.md
@@ -1,0 +1,47 @@
+# T001 — Phase 1 plan validation
+
+## Decision
+
+Approve the four-package sequence with one correction: the first compatibility package must call
+the old artifact a **tag-reconstructed immutable bundle**, not an exact copy of previously deployed
+bytes. Production currently serves `widget.v1.53.1.js` and `widget.v1.js`, while
+`widget.v1.1.0.js` returns 404. Generated widget files are ignored by git, and clean release builds
+produce only the current version aliases.
+
+## Evidence
+
+- `v1.1.0` resolves to commit `5ec3aead9d49a9a9573c25ccdff86aada15cadc9`.
+- `v1.53.1` resolves to commit `5cf06f4ec3eab7cc7a507fc4c4d082a84e279539`.
+- Both tags contain `package-lock.json`, `scripts/build-widget.js`, and `src/widget/index.ts`, so a
+  provenance-recorded reconstruction is possible from repository history without new storage.
+- `.gitignore` excludes `public/widget.js`, `public/widget.v*.js`, and `public/versions.json`; none is
+  a historical fixture.
+- Live readback on 2026-08-02 returned `404` for `widget.v1.1.0.js` and `200` with 148,406 bytes for
+  both `widget.v1.53.1.js` and `widget.v1.js`.
+- The current compatibility seams are `window.BugDrop` and `bugdrop:ready` in
+  `src/widget/index.ts`, `submitFeedback()` in that file, and the legacy `/feedback` handler plus
+  `formatIssueBody()` in `src/routes/api.ts`.
+
+## First Worker package
+
+Freeze compatibility before production behavior changes:
+
+1. Reconstruct immutable v1.1.0 and v1.53.1 bundles from their tag commits and lockfiles in an
+   isolated temporary checkout; store provenance and SHA-256 values.
+2. Add legacy API/bootstrap tests for ignored arguments, detached calls, exact ready-event
+   semantics, and no variant-only work.
+3. Add normalized legacy request/response/createIssue title-body-label goldens, including a
+   screenshot-free flow and an evidence-bearing API fixture.
+4. Exercise the tag-reconstructed v1.1.0 bundle against the candidate local Worker.
+5. Record the v1.53.1 minified/gzip size baseline used by the 25% budget.
+
+The package must not fix production asset retention, alter legacy behavior, or regenerate baselines
+from changed Phase 1 code.
+
+## Deferred compatibility defect
+
+The exact-version retention mismatch is real but predates this feature. Repairing release artifact
+retention is a separate product/release task because it changes deployment artifact policy and must
+recover or explicitly redefine historical availability. Phase 1 still proves candidate-Worker
+compatibility with provenance-recorded tag reconstructions. Do not claim that reconstructed bytes
+are the exact bytes historically deployed.

--- a/docs/goals/configurable-feedback-variants-phase-1/notes/T005-pre-canary-audit.md
+++ b/docs/goals/configurable-feedback-variants-phase-1/notes/T005-pre-canary-audit.md
@@ -1,0 +1,34 @@
+# T005 pre-canary audit
+
+Decision: approved for one bounded structured-canary replacement package.
+
+## Evidence
+
+- The legacy discriminator remains the default; only the exact
+  `kind: bugdrop.variant-submission` enters the isolated handler, and unrelated legacy
+  `schemaVersion` payloads remain accepted.
+- Structured tests reject unsupported versions, raw labels, `labelSet`, evidence, unknown policy
+  fields, duplicate headings, nested values, invalid metadata, and oversized payloads before any
+  GitHub call. Existing auth and both rate-limit middleware layers remain shared.
+- `VARIANT_LABELS` is read only from Worker environment state. Missing/invalid mappings fall back to
+  classification labels plus `bugdrop`; custom-label rejection retries defaults.
+- The sidecar manager is created inside `registerVariant()`. Code inspection and browser tests show
+  no variant DOM or storage before registration, no rendered UI after headless registration, and no
+  mutation leak from the caller's config.
+- Package dry-run includes `src/widget/public-api.ts` and all referenced declarations; widget and
+  package typechecks pass. The public-types test proves the declared registration/submit shape.
+- The tag-reconstructed old widget still passes against the candidate Worker. The full 201-test
+  Chromium widget suite, 415 Vitest tests, lint, knip, formatting, and typechecking pass.
+- The built widget is 45,093 gzip bytes, below the recorded 52,597-byte ceiling.
+
+## Canary decision
+
+Do not create a second routine Issue. Replace the current legacy browser action inside the existing
+locked canary with one deployed headless structured submission. Preserve the fixed preview venue,
+widget hash, Worker SHA, zero retries, single POST guard, server-only verification token, marker
+rediscovery, unconditional cleanup, prefix sweep, and required-check bridge. Extend the independent
+verifier to require the structured section and exact submission marker while retaining title,
+labels, author, attribution, system information, no-screenshot, canonical URL, and singleton checks.
+
+The Phase 0 receipt remains the live proof for the legacy path. This canary transition proves the
+new shared path without increasing destructive operations per merge group.

--- a/docs/goals/configurable-feedback-variants-phase-1/state.yaml
+++ b/docs/goals/configurable-feedback-variants-phase-1/state.yaml
@@ -628,6 +628,37 @@ tasks:
         - cmd: "git diff --check"
           status: pass
       summary: "Independent pre-PR review gaps are closed: actual conditional .d.ts package exports resolve from a packed artifact; complete runtime config validation rejects malformed JavaScript values; empty-section semantics are explicit; required whitespace-only text is rejected; post-format Issue bodies are bounded; multiple registrations remain isolated; malformed responses fail closed; exact canary section values are independently verified; provenance runs in required CI; and both reconstructed legacy bundles have browser coverage. The final widget is 46,440 gzip bytes within the 52,597-byte budget."
+  - id: T009
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: low
+    objective: "Keep immutable compatibility goldens outside automatic formatting so required CI validates rather than rewrites their exact bytes."
+    allowed_files:
+      - ".prettierignore"
+    verify:
+      - "npm run format:check"
+      - "node scripts/verify-legacy-compat.mjs"
+      - "npm test"
+      - "git diff --check"
+    stop_if:
+      - "The fix would weaken hash verification or change any frozen fixture byte."
+    receipt:
+      result: done
+      harness: codex
+      changed_files:
+        - .prettierignore
+      commands:
+        - cmd: "npm run format:check"
+          status: pass
+        - cmd: "node scripts/verify-legacy-compat.mjs"
+          status: pass
+        - cmd: "npm test"
+          status: pass
+          evidence: "30 files and 442 tests passed after the ignore rule."
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Required CI had tried to enforce Prettier on immutable tag bundles and the exact Issue golden. The compatibility fixture directory is now explicitly ignored by formatting while its dedicated hash, size, gzip, provenance, and behavior checks remain required. No frozen fixture byte changed."
 checks:
   dirty_fingerprint: unknown
   last_verification:

--- a/docs/goals/configurable-feedback-variants-phase-1/state.yaml
+++ b/docs/goals/configurable-feedback-variants-phase-1/state.yaml
@@ -659,6 +659,38 @@ tasks:
         - cmd: "git diff --check"
           status: pass
       summary: "Required CI had tried to enforce Prettier on immutable tag bundles and the exact Issue golden. The compatibility fixture directory is now explicitly ignored by formatting while its dedicated hash, size, gzip, provenance, and behavior checks remain required. No frozen fixture byte changed."
+  - id: T010
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: low
+    objective: "Give the required provenance job access to the release tags it verifies and lock that checkout requirement into the CI contract."
+    allowed_files:
+      - ".github/workflows/ci.yml"
+      - "test/ci-workflow-contract.test.sh"
+    verify:
+      - "bash test/ci-workflow-contract.test.sh"
+      - "node scripts/verify-legacy-compat.mjs"
+      - "npm run format:check"
+      - "git diff --check"
+    stop_if:
+      - "The change would skip tag-to-commit verification or weaken the required Unit job."
+    receipt:
+      result: done
+      harness: codex
+      changed_files:
+        - .github/workflows/ci.yml
+        - test/ci-workflow-contract.test.sh
+      commands:
+        - cmd: "bash test/ci-workflow-contract.test.sh"
+          status: pass
+        - cmd: "node scripts/verify-legacy-compat.mjs"
+          status: pass
+        - cmd: "npm run format:check"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "The required Unit job now uses checkout fetch-depth 0, making v1.1.0 and v1.53.1 tag commits available to the provenance verifier. The CI contract fails if that tag-history checkout is removed."
 checks:
   dirty_fingerprint: unknown
   last_verification:

--- a/docs/goals/configurable-feedback-variants-phase-1/state.yaml
+++ b/docs/goals/configurable-feedback-variants-phase-1/state.yaml
@@ -1,0 +1,636 @@
+version: 2
+
+goal:
+  title: "Configurable Feedback Variants — Phase 1"
+  slug: "configurable-feedback-variants-phase-1"
+  kind: existing_plan
+  tranche: "Implement and prove the complete compatibility and structured-headless foundation, including one real structured merge-tip canary, before any rendered UX work."
+  status: active
+  oracle:
+    signal: "Historical v1 and current legacy contracts pass; a typed lazy headless variant submits through the isolated structured Worker contract; and one locked zero-retry exact-preview canary creates, verifies, closes, and sweeps exactly one structured GitHub Issue."
+    cadence: "after each Worker package, before canary exposure, and at final audit"
+    final_proof: "Receipt-backed compatibility goldens, full local gates, exact structured createIssue assertions, no-variant bootstrap proof, and a successful merge-group canary with Issue readback and zero-open sweep."
+  intake:
+    original_request: "Follow docs/goals/configurable-feedback-variants-phase-1/goal.md."
+    interpreted_outcome: "Ship Phase 1 of configurable feedback variants without breaking BugDrop v1, ending in a real structured Issue proof on the exact merge-tip preview."
+    input_shape: existing_plan
+    audience: "BugDrop maintainers, contributors, and host applications"
+    authority: approved
+    proof_type: test
+    completion_proof: "Historical/current v1 compatibility, typed lazy headless submission, isolated structured Worker behavior, and one independently verified and cleaned real structured canary are all proven against current state."
+    likely_misfire: "Stop after planning or types, begin Phase 2 rendering, refactor legacy code unnecessarily, accept mocked GitHub evidence as live proof, or create multiple destructive canaries."
+    blind_spots_considered:
+      - "Only the current exact production widget asset is live; older documented exact URLs currently return 404."
+      - "package.json version does not track the release tag used to build production widget assets."
+      - "Historical bundles call the newest Worker and need candidate-Worker compatibility proof."
+      - "variantId label mapping is classification rather than an authorization boundary."
+      - "Variant and legacy submissions share existing rate-limit buckets."
+      - "PR/merge-queue publication and live execution may require explicit external authority."
+    existing_plan_facts:
+      - "Normative design: docs/plans/2026-08-01-configurable-feedback-variants-design.md."
+      - "Phase 0 proof: PR #258, merge-group run 30724180366, and closed Issue #578."
+      - "Worker support lands before a widget begins sending structured payloads."
+      - "Use a lazy sidecar; do not introduce BugDropRuntime or LegacyWidgetController in Phase 1."
+      - "The structured payload carries a generic Issue draft, not field definitions."
+      - "Rendered modal/inline UX and evidence are deferred beyond Phase 1."
+      - "Reuse the existing canary lock, identity checks, verifier, token boundary, and cleanup."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  exact_human_approval_can_terminal_wait: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/configurable-feedback-variants-phase-1/"
+    command: "node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.4.2/skills/goal-prep/surfaces/local-goal-board/scripts/local-goal-board.mjs --goal docs/goals/configurable-feedback-variants-phase-1"
+
+active_task: T007
+
+tasks:
+  - id: T001
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate the existing Phase 1 plan against current repository evidence and select the largest safe first Worker package."
+    inputs:
+      - "docs/plans/2026-08-01-configurable-feedback-variants-design.md"
+      - "docs/merge-queue-issue-canary.md"
+      - "docs/website/version-pinning.mdx"
+      - "Current branch, dirty diff, public API, Worker route, build, packaging, tests, and CI"
+    constraints:
+      - "Read-only; do not edit implementation or control files."
+      - "Preserve the four-package Phase 1 outcome but reject unsafe sequencing or unsupported assumptions."
+      - "Resolve how historical fixtures and the existing exact-version retention defect affect the first package."
+      - "Do not select Phase 2 renderers or evidence work."
+    expected_output:
+      - "approved | revise | blocked"
+      - "Evidence-backed Phase 1 sequencing decision"
+      - "Exact first Worker objective"
+      - "allowed_files"
+      - "verify"
+      - "stop_if"
+      - "Deferred or separately tracked compatibility work"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "PM fallback approved the four-package sequence after the Goal Judge timed out. The first package must freeze compatibility before product changes, using provenance-recorded tag reconstructions rather than claiming unavailable historical deployed bytes. The live exact-version retention defect predates Phase 1 and is deferred as separate release-policy work; candidate-Worker compatibility remains in scope."
+      worker_package:
+        objective: "Freeze the legacy compatibility contract using tag-reconstructed v1.1.0 and v1.53.1 bundles, immutable legacy goldens, API/event/bootstrap checks, and a recorded bundle budget without changing production behavior."
+        allowed_files:
+          - docs/plans/2026-08-01-configurable-feedback-variants-design.md
+          - scripts/verify-legacy-compat.mjs
+          - "test/fixtures/legacy-compat/*"
+          - test/legacyCompatibility.test.ts
+          - test/api.test.ts
+          - e2e/legacy-compat.spec.ts
+          - e2e/widget.spec.ts
+          - playwright.config.ts
+          - package.json
+          - knip.json
+        verify:
+          - "node scripts/verify-legacy-compat.mjs"
+          - "npx vitest run test/legacyCompatibility.test.ts test/api.test.ts"
+          - "npx playwright test e2e/legacy-compat.spec.ts --project=chromium --workers=1"
+          - "npm run typecheck"
+          - "npx prettier --check <all non-generated allowed files>"
+          - "git diff --check"
+        stop_if:
+          - "Need files outside allowed_files."
+          - "A baseline would be generated from changed Phase 1 code."
+          - "Artifact provenance cannot be tied to tag commit, lockfile, build command, and SHA-256."
+          - "Production exact-version retention or legacy behavior must change."
+      evidence:
+        - notes/T001-plan-validation.md
+        - "v1.1.0 commit 5ec3aead9d49a9a9573c25ccdff86aada15cadc9"
+        - "v1.53.1 commit 5cf06f4ec3eab7cc7a507fc4c4d082a84e279539"
+        - "Production widget.v1.1.0.js returned 404; widget.v1.53.1.js and widget.v1.js returned 200 with 148406 bytes on 2026-08-02"
+        - "Goal Judge dispatch timed out once and was interrupted per the execution contract; PM fallback completed the read-only decision"
+      blocked_tasks: []
+      missing_evidence:
+        - "No surviving authoritative copy of historically deployed v1.1.0 bytes is available; use a tag reconstruction and do not claim byte identity."
+      required_board_updates:
+        - "Populate and activate T002 with the compatibility package in this receipt."
+        - "Keep exact-version retention repair outside T002 and record it as deferred release-policy work."
+  - id: T002
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Freeze the legacy compatibility contract using provenance-recorded tag reconstructions and immutable request, response, Issue, API, DOM, storage, and bundle-budget fixtures without changing production behavior."
+    allowed_files:
+      - "docs/plans/2026-08-01-configurable-feedback-variants-design.md"
+      - "scripts/verify-legacy-compat.mjs"
+      - "test/fixtures/legacy-compat/manifest.json"
+      - "test/fixtures/legacy-compat/v1.1.0/widget.js"
+      - "test/fixtures/legacy-compat/v1.53.1/widget.js"
+      - "test/fixtures/legacy-compat/legacy-payload.json"
+      - "test/fixtures/legacy-compat/legacy-response.json"
+      - "test/fixtures/legacy-compat/legacy-issue.md"
+      - "test/legacyCompatibility.test.ts"
+      - "test/api.test.ts"
+      - "e2e/legacy-compat.spec.ts"
+      - "e2e/widget.spec.ts"
+      - "e2e/widget.spec.ts"
+      - "playwright.config.ts"
+      - "package.json"
+      - "knip.json"
+      - "knip.json"
+    verify:
+      - "node scripts/verify-legacy-compat.mjs"
+      - "npx vitest run test/legacyCompatibility.test.ts test/api.test.ts"
+      - "npx playwright test e2e/legacy-compat.spec.ts --project=chromium --workers=1"
+      - "npm run typecheck"
+      - "npx prettier --check scripts/verify-legacy-compat.mjs test/fixtures/legacy-compat/manifest.json test/fixtures/legacy-compat/legacy-payload.json test/fixtures/legacy-compat/legacy-response.json test/legacyCompatibility.test.ts test/api.test.ts e2e/legacy-compat.spec.ts e2e/widget.spec.ts playwright.config.ts package.json knip.json docs/plans/2026-08-01-configurable-feedback-variants-design.md"
+      - "git diff --check"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "Historical artifact provenance or support policy is ambiguous."
+      - "A proposed golden would be generated from the changed implementation rather than an immutable baseline."
+      - "A tag-reconstructed artifact cannot be tied to the tag commit, lockfile, build command, and SHA-256."
+      - "The package would repair or redefine production exact-version asset retention."
+      - "Legacy runtime, Worker, CI, or release behavior must change."
+      - "Verification fails twice for an unexplained reason."
+    receipt:
+      result: done
+      harness: codex
+      changed_files:
+        - docs/plans/2026-08-01-configurable-feedback-variants-design.md
+        - scripts/verify-legacy-compat.mjs
+        - test/fixtures/legacy-compat/manifest.json
+        - test/fixtures/legacy-compat/v1.1.0/widget.js
+        - test/fixtures/legacy-compat/v1.53.1/widget.js
+        - test/fixtures/legacy-compat/legacy-payload.json
+        - test/fixtures/legacy-compat/legacy-response.json
+        - test/fixtures/legacy-compat/legacy-issue.md
+        - test/legacyCompatibility.test.ts
+        - test/api.test.ts
+        - e2e/legacy-compat.spec.ts
+        - e2e/widget.spec.ts
+        - package.json
+        - knip.json
+      commands:
+        - cmd: "node scripts/verify-legacy-compat.mjs"
+          status: pass
+        - cmd: "npx vitest run test/legacyCompatibility.test.ts test/api.test.ts"
+          status: pass
+        - cmd: "npx playwright test e2e/legacy-compat.spec.ts --project=chromium --workers=1"
+          status: pass
+        - cmd: "npx playwright test e2e/widget.spec.ts --project=chromium --workers=1 --grep \"exact event semantics|detachable|variant-only work\""
+          status: pass
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "npx prettier --check <non-generated allowed files>"
+          status: pass
+        - cmd: "npx eslint scripts/verify-legacy-compat.mjs test/legacyCompatibility.test.ts test/api.test.ts e2e/legacy-compat.spec.ts e2e/widget.spec.ts"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Frozen tag-reconstructed v1.1.0 and v1.53.1 bundles with commit, lockfile, output-hash, size, and gzip-budget provenance; exact legacy request/response/Issue fixtures; candidate-Worker parsing proof; open-shadow/storage checks; and current ready-event/detached-API/no-variant-work checks. No production runtime or Worker behavior changed. Exact old CDN retention remains separate release-policy work. The dedicated Goal Worker timed out once; PM fallback completed and verified the bounded package."
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Add the isolated field-agnostic structured Worker contract and server-owned variant label mapping after compatibility foundations are green."
+    allowed_files:
+      - "src/types.ts"
+      - "src/routes/api.ts"
+      - "src/routes/structured-feedback.ts"
+      - "test/api.test.ts"
+      - "test/structuredFeedback.test.ts"
+      - "wrangler.toml"
+      - "README.md"
+      - "docs/website/configuration.mdx"
+      - "docs/plans/2026-08-01-configurable-feedback-variants-design.md"
+    verify:
+      - "npx prettier --check src/types.ts src/routes/api.ts src/routes/structured-feedback.ts test/api.test.ts test/structuredFeedback.test.ts README.md docs/website/configuration.mdx docs/plans/2026-08-01-configurable-feedback-variants-design.md"
+      - "npm run typecheck"
+      - "npx vitest run test/api.test.ts test/structuredFeedback.test.ts"
+      - "git diff --check"
+    stop_if:
+      - "The legacy route or formatter must be behaviorally rewritten."
+      - "The Worker needs field definitions or trusts browser validation."
+      - "Raw labels or labelSet must be accepted from the browser."
+      - "Need files outside allowed_files."
+    receipt:
+      result: done
+      harness: codex
+      changed_files:
+        - src/types.ts
+        - src/routes/api.ts
+        - src/routes/structured-feedback.ts
+        - test/structuredFeedback.test.ts
+        - wrangler.toml
+        - README.md
+        - docs/website/configuration.mdx
+      commands:
+        - cmd: "npx prettier --check src/types.ts src/routes/api.ts src/routes/structured-feedback.ts test/api.test.ts test/structuredFeedback.test.ts README.md docs/website/configuration.mdx docs/plans/2026-08-01-configurable-feedback-variants-design.md"
+          status: pass
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "npx vitest run test/api.test.ts test/structuredFeedback.test.ts"
+          status: pass
+        - cmd: "npm test"
+          status: pass
+        - cmd: "npx playwright test e2e/legacy-compat.spec.ts --project=chromium --workers=1"
+          status: pass
+        - cmd: "node scripts/verify-legacy-compat.mjs"
+          status: pass
+        - cmd: "npx eslint src/types.ts src/routes/api.ts src/routes/structured-feedback.ts test/api.test.ts test/structuredFeedback.test.ts"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Added an isolated, field-agnostic structured submission handler behind the collision-resistant kind/version discriminator. It strictly validates bounded drafts and metadata, rejects raw labels, label sets, evidence, unknown policy fields, and noncanonical Issue results before reporting success, redacts URL secrets, appends attribution and a submission marker, reuses existing auth/rate-limit/GitHub infrastructure, and resolves labels only from VARIANT_LABELS with safe fallbacks. Full Vitest (404 tests) and reconstructed-v1 browser compatibility remain green. The dedicated Goal Worker timed out once; PM fallback completed and verified the bounded package."
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Publish the public declarations and implement lazy registration plus headless structured submission without rendered variant UI."
+    allowed_files:
+      - "package.json"
+      - "knip.json"
+      - "tsconfig.widget.json"
+      - "src/widget/index.ts"
+      - "src/widget/public-api.ts"
+      - "src/widget/variants/public-types.ts"
+      - "src/widget/variants/validate-config.ts"
+      - "src/widget/variants/manager.ts"
+      - "src/widget/variants/submission.ts"
+      - "src/widget/variants/issue-draft.ts"
+      - "src/routes/structured-feedback.ts"
+      - "test/variantConfig.test.ts"
+      - "test/variantIssueDraft.test.ts"
+      - "test/variantPublicTypes.test.ts"
+      - "e2e/widget.spec.ts"
+      - "README.md"
+      - "docs/website/javascript-api.mdx"
+      - "docs/plans/2026-08-01-configurable-feedback-variants-design.md"
+    verify:
+      - "npm run typecheck"
+      - "npx vitest run test/variantConfig.test.ts test/variantIssueDraft.test.ts test/variantPublicTypes.test.ts"
+      - "npm run build:widget"
+      - "npx playwright test e2e/widget.spec.ts --project=chromium --workers=1"
+      - "npm run knip"
+      - "git diff --check"
+    stop_if:
+      - "Legacy open, close, ready, payload, storage, or screenshot behavior must change."
+      - "Variant-only DOM, UUID, listener, observer, or storage work occurs before registration."
+      - "Rendered modal, inline, rating, or choice UI is required."
+      - "Need files outside allowed_files."
+    receipt:
+      result: done
+      harness: codex
+      changed_files:
+        - package.json
+        - knip.json
+        - src/widget/index.ts
+        - src/widget/public-api.ts
+        - src/widget/variants/public-types.ts
+        - src/widget/variants/validate-config.ts
+        - src/widget/variants/manager.ts
+        - src/widget/variants/submission.ts
+        - src/widget/variants/issue-draft.ts
+        - test/variantConfig.test.ts
+        - test/variantIssueDraft.test.ts
+        - test/variantPublicTypes.test.ts
+        - e2e/widget.spec.ts
+        - README.md
+        - docs/website/javascript-api.mdx
+      commands:
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "npx vitest run test/variantConfig.test.ts test/variantIssueDraft.test.ts test/variantPublicTypes.test.ts"
+          status: pass
+        - cmd: "npm run build:widget"
+          status: pass
+        - cmd: "npx playwright test e2e/widget.spec.ts --project=chromium --workers=1"
+          status: pass
+        - cmd: "npm run knip"
+          status: pass
+        - cmd: "npm test"
+          status: pass
+        - cmd: "node widget-gzip-budget-check (45093 <= 52597)"
+          status: pass
+        - cmd: "npx eslint <T004 TypeScript and E2E files>"
+          status: pass
+        - cmd: "npx prettier --check <T004 non-generated allowed files>"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Published package-level browser declarations and added immutable synchronous registration, pure answer/template compilation, lazy manager creation, and headless structured submission. Legacy methods remain closure-based and ignore extra arguments; no variant DOM, listeners, observers, storage, or IDs occur before registration/submission. Exact browser payload proof, config mutation isolation, 415 unit tests, and all 201 legacy Chromium widget tests pass. The 45093-byte gzip build remains below the 52597-byte ceiling. Rendered open/mount intentionally remain unavailable until Phase 2. The dedicated Goal Worker timed out once; PM fallback completed and verified the package."
+  - id: T005
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit the compatibility, Worker, and headless packages before exposing the structured path to the real-Issue canary."
+    inputs:
+      - "T002-T004 receipts"
+      - "Current diff and full local verification"
+      - "Phase 1 oracle and existing canary safety contract"
+    constraints:
+      - "Read-only."
+      - "Reject canary exposure if legacy compatibility, discriminator collision safety, label policy, lazy initialization, or public types are weakly proven."
+      - "Select an exact bounded canary Worker package if approved."
+    expected_output:
+      - "approved | revise | blocked"
+      - "Risk audit"
+      - "Exact canary Worker package or corrective package"
+      - "allowed_files"
+      - "verify"
+      - "stop_if"
+    receipt:
+      result: done
+      harness: codex
+      decision: approved
+      full_outcome_complete: false
+      rationale: "PM fallback approved canary exposure after direct audit of receipts, diff, packaging, 415 unit tests, the full 201-test legacy Chromium suite, the reconstructed-v1 candidate-Worker test, label/auth rejection tests, lazy-sidecar source, and bundle budget. The structured canary must replace—not add to—the existing one-Issue action and reuse every Phase 0 safety boundary."
+      worker_package:
+        objective: "Replace the existing locked legacy canary browser action with exactly one deployed headless structured submission and independently verify its structured Issue marker without creating a second canary system or Issue."
+        allowed_files:
+          - e2e/widget.issue-canary.spec.ts
+          - scripts/github-issue-canary.mjs
+          - test/githubIssueCanary.test.ts
+          - test/ci-workflow-contract.test.sh
+          - .github/workflows/ci.yml
+          - docs/merge-queue-issue-canary.md
+          - docs/plans/2026-08-01-configurable-feedback-variants-design.md
+        verify:
+          - "npx vitest run test/githubIssueCanary.test.ts test/structuredFeedback.test.ts test/variantConfig.test.ts test/variantIssueDraft.test.ts"
+          - "bash test/ci-workflow-contract.test.sh"
+          - "npm run typecheck"
+          - "npm run build:widget"
+          - "npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --list"
+          - "npx prettier --check e2e/widget.issue-canary.spec.ts scripts/github-issue-canary.mjs test/githubIssueCanary.test.ts .github/workflows/ci.yml docs/merge-queue-issue-canary.md docs/plans/2026-08-01-configurable-feedback-variants-design.md"
+          - "git diff --check"
+        stop_if:
+          - "More than one routine Issue could be created per merge group."
+          - "The verification token reaches Playwright, the Worker, job scope, logs, or artifacts."
+          - "Any non-merge-group, unlocked, retried, or non-preview path can submit."
+          - "Widget-byte or Worker-SHA identity proof is weakened."
+          - "Cleanup stops rediscovering by marker or the final sweep stops proving zero open reserved-prefix Issues."
+          - "The canary requires rendered Phase 2 UX or files outside allowed_files."
+      evidence:
+        - notes/T005-pre-canary-audit.md
+        - "T002-T004 done receipts"
+        - "415 Vitest tests passed"
+        - "201 Chromium widget tests passed"
+        - "tag-reconstructed v1.1.0 candidate-Worker browser test passed"
+        - "widget gzip 45093 <= 52597"
+      blocked_tasks: []
+      missing_evidence:
+        - "A live merge-group run of the structured canary is still required before Phase 1 completion."
+      required_board_updates:
+        - "Populate T006 from this Worker package and activate it."
+        - "Keep T999 queued until local canary checks pass and live merge-group evidence exists."
+  - id: T006
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Replace the existing locked legacy canary browser action with exactly one deployed headless structured submission and independently verify its structured Issue marker without creating a second canary system or Issue."
+    allowed_files:
+      - "e2e/widget.issue-canary.spec.ts"
+      - "scripts/github-issue-canary.mjs"
+      - "test/githubIssueCanary.test.ts"
+      - "test/structuredFeedback.test.ts"
+      - "test/ci-workflow-contract.test.sh"
+      - ".github/workflows/ci.yml"
+      - "docs/merge-queue-issue-canary.md"
+      - "docs/plans/2026-08-01-configurable-feedback-variants-design.md"
+    verify:
+      - "npx vitest run test/githubIssueCanary.test.ts test/structuredFeedback.test.ts test/variantConfig.test.ts test/variantIssueDraft.test.ts"
+      - "bash test/ci-workflow-contract.test.sh"
+      - "npm run typecheck"
+      - "npm run build:widget"
+      - "npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --list"
+      - "npx prettier --check e2e/widget.issue-canary.spec.ts scripts/github-issue-canary.mjs test/githubIssueCanary.test.ts .github/workflows/ci.yml docs/merge-queue-issue-canary.md docs/plans/2026-08-01-configurable-feedback-variants-design.md"
+      - "git diff --check"
+    stop_if:
+      - "More than one routine Issue could be created per merge group."
+      - "The verification token reaches Playwright, the Worker, job scope, logs, or artifacts."
+      - "Any non-merge-group, unlocked, retried, or non-preview path can submit."
+      - "Widget-byte or Worker-SHA identity proof is weakened."
+      - "Cleanup stops rediscovering by marker or the final sweep stops proving zero open reserved-prefix Issues."
+      - "The canary requires rendered Phase 2 UX or files outside allowed_files."
+    receipt:
+      result: done
+      harness: codex
+      changed_files:
+        - e2e/widget.issue-canary.spec.ts
+        - scripts/github-issue-canary.mjs
+        - test/githubIssueCanary.test.ts
+        - .github/workflows/ci.yml
+        - docs/merge-queue-issue-canary.md
+      commands:
+        - cmd: "npx vitest run test/githubIssueCanary.test.ts test/structuredFeedback.test.ts test/variantConfig.test.ts test/variantIssueDraft.test.ts"
+          status: pass
+        - cmd: "bash test/ci-workflow-contract.test.sh"
+          status: pass
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "npm run build:widget"
+          status: pass
+        - cmd: "npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --list"
+          status: pass
+        - cmd: "npx prettier --check e2e/widget.issue-canary.spec.ts scripts/github-issue-canary.mjs test/githubIssueCanary.test.ts .github/workflows/ci.yml docs/merge-queue-issue-canary.md docs/plans/2026-08-01-configurable-feedback-variants-design.md"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Replaced the single locked legacy canary browser action with one deployed headless structured submission while preserving the fixed venue, exact widget hash, Worker SHA, zero retries, one-POST guard, server-only token, independent readback, marker cleanup, prefix sweep, and required bridge. The verifier now requires the structured section and exact submission marker and rejects legacy body shape. Local discovery lists exactly one canary test; it was not executed locally. A live merge-group run remains required for final Phase 1 proof. The dedicated Goal Worker timed out once; PM fallback completed and verified the package."
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit the complete Phase 1 outcome against every oracle clause and reject completion without current local and live proof."
+    inputs:
+      - "All task receipts"
+      - "Full oracle verification"
+      - "Current branch, dirty diff, and external canary evidence"
+    constraints:
+      - "Read-only."
+      - "Reject completion if any required Worker remains queued, active, blocked without replacement, or weakly verified."
+      - "Reject completion if only mocked GitHub evidence exists for the structured path."
+      - "Reject completion if legacy compatibility was inferred rather than proven."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "Requirement-by-requirement evidence map"
+      - "Missing evidence and next task if incomplete"
+    receipt:
+      result: done
+      harness: codex
+      decision: not_complete
+      full_outcome_complete: false
+      rationale: "PM fallback rejects final completion. Compatibility, structured Worker, typed lazy headless API, one-Issue canary replacement, and all local gates are receipt-backed, but the oracle explicitly requires a successful locked merge-group run with real structured Issue readback, cleanup, and zero-open sweep. No such run exists for this uncommitted branch."
+      worker_package:
+        objective: "Publish the verified branch as a pull request, obtain one successful locked merge-group structured canary, and record the run, Issue verification, cleanup, and zero-open sweep evidence."
+        allowed_files:
+          - docs/goals/configurable-feedback-variants-phase-1/notes/T007-live-proof.md
+        verify:
+          - "All required PR and merge-group checks are green."
+          - "Exact widget bytes and Worker SHA match the merge-group checkout."
+          - "Exactly one structured Issue is independently verified, closed, and followed by a zero-open reserved-prefix sweep."
+        stop_if:
+          - "Commit, push, or pull-request authority is absent."
+          - "Unrelated user-owned changes cannot be separated safely."
+          - "Any destructive canary boundary changes."
+      evidence:
+        - "T002 compatibility receipt"
+        - "T003 structured Worker receipt"
+        - "T004 headless API receipt"
+        - "T005 pre-canary audit"
+        - "T006 canary implementation receipt"
+        - "415 unit tests passed"
+        - "201 Chromium widget tests passed"
+        - "One structured canary test is discoverable only in the merge-group project"
+      blocked_tasks:
+        - T007
+      missing_evidence:
+        - "Published pull request and successful merge_group run for the structured canary."
+        - "Live structured Issue number/URL, independent verifier result, closure readback, and zero-open sweep."
+      required_board_updates:
+        - "Activate T007 and obtain explicit user authorization before commit, push, or pull-request creation."
+        - "After live proof, run a fresh final Judge audit rather than reusing this not-complete receipt."
+  - id: T007
+    type: worker
+    assignee: Worker
+    status: active
+    reasoning_hint: medium
+    objective: "Publish the verified Phase 1 branch as a pull request, obtain one successful locked merge-group structured canary, and record the run, Issue verification, cleanup, and zero-open sweep evidence."
+    allowed_files:
+      - "docs/goals/configurable-feedback-variants-phase-1/notes/T007-live-proof.md"
+    verify:
+      - "The pull request reports all required local and CI checks green."
+      - "One merge_group Deploy Preview run uses the exact merge-group widget bytes and Worker SHA."
+      - "The structured canary creates exactly one Issue, independently verifies it, closes it, and proves zero reserved-prefix Issues remain open."
+    stop_if:
+      - "The user has not authorized commit, push, and pull-request creation."
+      - "The branch contains unrelated user-owned changes that cannot be separated safely."
+      - "Any canary safety boundary would be weakened or more than one Issue could be created."
+    receipt: null
+  - id: T008
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Close the independent pre-PR review gaps in package type publication, complete runtime config validation, multi-registration isolation, canary exact-value verification, and required compatibility CI coverage."
+    allowed_files:
+      - "package.json"
+      - "knip.json"
+      - "src/widget/public-api.ts"
+      - "src/widget/public-api.d.ts"
+      - "src/widget/variants/public-types.ts"
+      - "src/widget/variants/public-types.d.ts"
+      - "src/widget/variants/validate-config.ts"
+      - "src/widget/variants/issue-draft.ts"
+      - "src/routes/structured-feedback.ts"
+      - "test/variantPublicTypes.test.ts"
+      - "test/variantConfig.test.ts"
+      - "test/variantIssueDraft.test.ts"
+      - "test/variantManager.test.ts"
+      - "test/githubIssueCanary.test.ts"
+      - "test/structuredFeedback.test.ts"
+      - "scripts/github-issue-canary.mjs"
+      - "e2e/legacy-compat.spec.ts"
+      - "e2e/widget.spec.ts"
+      - ".github/workflows/ci.yml"
+      - "test/ci-workflow-contract.test.sh"
+    verify:
+      - "An actual packed-package TypeScript consumer resolves BugDrop's public declarations."
+      - "Malformed values for every public variant config surface reject synchronously before registration."
+      - "Two distinct registrations submit isolated drafts and a duplicate cannot corrupt the original handle."
+      - "The canary verifier rejects an Issue whose structured section contains the wrong value even when the marker remains in the submission comment."
+      - "The Worker rejects a request whose escaped final Issue body would exceed GitHub's body limit before calling GitHub."
+      - "Required text answers reject whitespace-only values after normalization."
+      - "Required CI runs the provenance verifier, and both reconstructed legacy bundles pass the browser compatibility contract."
+      - "npm test"
+      - "npm run typecheck"
+      - "npm run lint"
+      - "git diff --check"
+    stop_if:
+      - "Fixing a review gap requires rendered Phase 2 UI or a breaking legacy API change."
+      - "Packed declarations require a new publishing service or release infrastructure."
+      - "The real-Issue canary would create more than one Issue or weaken cleanup."
+    receipt:
+      result: done
+      harness: codex
+      changed_files:
+        - package.json
+        - knip.json
+        - src/widget/public-api.d.ts
+        - src/widget/variants/public-types.d.ts
+        - src/widget/variants/validate-config.ts
+        - src/widget/variants/issue-draft.ts
+        - src/routes/structured-feedback.ts
+        - test/variantPublicTypes.test.ts
+        - test/variantConfig.test.ts
+        - test/variantIssueDraft.test.ts
+        - test/structuredFeedback.test.ts
+        - test/githubIssueCanary.test.ts
+        - scripts/github-issue-canary.mjs
+        - e2e/legacy-compat.spec.ts
+        - e2e/widget.spec.ts
+        - .github/workflows/ci.yml
+        - test/ci-workflow-contract.test.sh
+      commands:
+        - cmd: "npm test"
+          status: pass
+          evidence: "30 files and 442 tests passed, including an actual packed-package TypeScript consumer."
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "npm run lint"
+          status: pass
+        - cmd: "npm run knip"
+          status: pass
+          evidence: "Exit 0; only existing configuration hints remain."
+        - cmd: "bash test/ci-workflow-contract.test.sh"
+          status: pass
+        - cmd: "node scripts/verify-legacy-compat.mjs"
+          status: pass
+        - cmd: "npx playwright test e2e/legacy-compat.spec.ts --project=chromium --workers=1"
+          status: pass
+          evidence: "Both tag-reconstructed v1.1.0 and v1.53.1 browser contracts passed."
+        - cmd: "npx playwright test e2e/widget.spec.ts --project=chromium --workers=1 --grep \"registers multiple isolated variants|rejects failed and noncanonical\""
+          status: pass
+          evidence: "Two focused cases passed: isolated multiple registration and failed/noncanonical response rejection."
+        - cmd: "npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --list"
+          status: pass
+          evidence: "Exactly one real-Issue canary remains selected."
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Independent pre-PR review gaps are closed: actual conditional .d.ts package exports resolve from a packed artifact; complete runtime config validation rejects malformed JavaScript values; empty-section semantics are explicit; required whitespace-only text is rejected; post-format Issue bodies are bounded; multiple registrations remain isolated; malformed responses fail closed; exact canary section values are independently verified; provenance runs in required CI; and both reconstructed legacy bundles have browser coverage. The final widget is 46,440 gzip bytes within the 52,597-byte budget."
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: unknown
+    task: null
+    commands: []

--- a/docs/merge-queue-issue-canary.md
+++ b/docs/merge-queue-issue-canary.md
@@ -1,9 +1,10 @@
 # Merge-Queue Issue Canary Operations
 
 The CI workflow runs one real-Issue canary only for GitHub `merge_group` events. It uses the fixed
-Vercel preview venue, the shared `bugdrop-preview` Worker, the legacy widget form, and the existing
-BugDrop GitHub App. Pull requests, manual and reusable live workflows, the daily live workflow, and
-local Playwright commands do not select the canary.
+Vercel preview venue, the shared `bugdrop-preview` Worker, the deployed widget's headless structured
+API, and the existing BugDrop GitHub App. Pull requests, manual and reusable live workflows, the
+daily live workflow, and local Playwright commands do not select the canary. The Phase 0 run remains
+the retained live proof for the legacy form; the routine action was replaced rather than duplicated.
 
 ## Safety model
 
@@ -23,11 +24,13 @@ The marker format is:
 bugdrop-ci-canary:<run-id>:<run-attempt>:<full-merge-group-sha>
 ```
 
-The browser sends exactly one screenshot-free request and must observe the expected request origin,
-response origin, full Worker build SHA, positive Issue number, and canonical Issue URL. The
-server-side verifier independently lists repository Issues, rejects duplicates and pull requests,
-and checks the complete Issue contract. Cleanup always rediscovers by marker; it never depends on
-the browser result file.
+The browser registers one headless canary variant and sends exactly one screenshot-free structured
+request. It asserts the discriminator, schema version, generic Issue draft, server-owned label
+boundary, submission ID, request origin, response origin, full Worker build SHA, positive Issue
+number, and canonical Issue URL. The server-side verifier independently lists repository Issues,
+rejects duplicates and pull requests, and checks the structured section, exact submission marker,
+title, labels, author, attribution, system information, and absence of screenshots. Cleanup always
+rediscovers by marker; it never depends on the browser result file.
 
 ## Credential and rotation
 
@@ -72,7 +75,8 @@ For the first authorized live merge-group run and any incident, retain:
 - preview health environment and full build SHA;
 - actual feedback request/response origins and response build-SHA header;
 - canonical Issue number and URL returned to the widget;
-- independent title, body, labels, author, no-screenshot, and exactly-one readback;
+- independent structured section/submission marker, title, body, labels, author, no-screenshot, and
+  exactly-one readback;
 - current-marker closed-state readback and final zero-open prefix sweep;
 - the final `Deploy Preview` and `Live Preview Tests` conclusions.
 

--- a/docs/plans/2026-08-01-configurable-feedback-variants-design.md
+++ b/docs/plans/2026-08-01-configurable-feedback-variants-design.md
@@ -1,6 +1,6 @@
 # Configurable Feedback Variants
 
-**Status:** Proposed
+**Status:** Proposed; Phase 0 prerequisite complete
 
 **Date:** 2026-08-01
 
@@ -8,23 +8,45 @@
 
 ## Summary
 
-Extend BugDrop from one fixed feedback wizard into a small, declarative feedback runtime that
-can render multiple independently configured UX variants on the same page. Every successful
-submission still creates a GitHub Issue through BugDrop's existing Worker and GitHub App.
+Extend BugDrop from one fixed feedback wizard into a small declarative feedback system that can
+render multiple independently configured UX variants on the same page. Every submission that
+BugDrop reports as successful creates a GitHub Issue through the existing Worker and GitHub App.
 
 The current widget remains the default and is not redesigned by this work. Existing script tags,
-data attributes, `window.BugDrop` methods, request payloads, GitHub Issue formatting, and screenshot
-flows must continue to behave as they do today when no variant API is used.
+data attributes, `window.BugDrop` methods, request payloads, GitHub Issue formatting, storage, and
+screenshot flows remain unchanged when no variant API is used.
 
-The initial variant examples are:
+The initial proving variants are:
 
 1. A one-to-five-star review with an optional message and explicit Submit button.
 2. A CTA-driven question that opens a simple text-response form.
 3. A single-choice poll with an optional explanation.
 4. A compact suggestion form with a short summary and optional detail.
 
-These are proving fixtures, not the architectural limit. Contributors should be able to compose
-new variants from shared primitives or use the headless submission API for fully custom UI.
+These are acceptance fixtures, not the architectural limit. Contributors can compose additional
+variants from shared primitives or use the headless submission API with host-rendered UI.
+
+## Phase 0 Baseline
+
+The merge-queue real-Issue canary was implemented and proven before variant work began. PR #258 and
+merge-group run `30724180366` demonstrated the following existing contract:
+
+- The tested `widget.js` bytes match the merge-group checkout.
+- Preview health and the actual `/api/feedback` response identify the merge-group Worker SHA.
+- Preview deployment and all preview consumers run under the `bugdrop-shared-preview` lock.
+- The deployed legacy widget makes one screenshot-free submission with Playwright retries disabled.
+- The existing GitHub App creates one real Issue.
+- A server-side verifier independently checks the Issue number, URL, title, body, labels, author,
+  attribution, system information, marker, and absence of a screenshot.
+- Cleanup closes every Issue matching the run marker and proves no reserved-prefix canary Issue
+  remains open.
+- Pull-request, local, production, scheduled, manual, and ordinary live paths cannot select the
+  mutating browser canary.
+
+The operational contract is documented in
+[`docs/merge-queue-issue-canary.md`](../merge-queue-issue-canary.md). Variant work reuses this
+critical section, identity proof, verifier, token boundary, and cleanup model. It must not create a
+second independent canary system.
 
 ## Problem
 
@@ -38,36 +60,39 @@ BugDrop currently owns one hard-coded flow:
 6. GitHub Issue creation.
 
 This flow is valuable and must remain stable, but it is too opinionated for contextual prompts such
-as post-action reviews, embedded polls, or a targeted "Which provider should we add?" CTA. Host
+as post-action reviews, embedded polls, or a targeted “Which provider should we add?” CTA. Host
 applications can build those experiences themselves, but they must then duplicate BugDrop's auth,
-metadata, validation, error handling, and GitHub submission behavior.
+metadata, transport, error handling, and GitHub submission behavior.
 
 Loading multiple copies of the current widget is not a safe workaround. The bundle discovers one
-script element, creates one `#bugdrop-host`, stores state in module globals, and assigns one
+script element, creates one `#bugdrop-host`, stores legacy state in module globals, and assigns one
 `window.BugDrop` object.
 
 ## Goals
 
 - Preserve the complete legacy widget contract by default.
 - Load the BugDrop bundle once and support multiple logical variant instances.
-- Provide declarative modal and inline layouts.
-- Provide a small initial field catalog that can grow without rewriting submission logic.
+- Provide declarative modal and inline presentations.
+- Provide a small field catalog that can grow without changing the Worker protocol.
 - Keep one explicit Submit action per response.
 - Create one GitHub Issue for every submission that BugDrop reports as successful.
-- Support configurable user-facing labels, help text, validation, success copy, and safe Issue
-  templates.
-- Keep GitHub label authority on the Worker, not in untrusted browser requests.
+- Support configurable copy, validation, success states, and safe Issue templates.
+- Keep raw GitHub label authority on the Worker.
 - Provide a headless API for host-rendered experiences.
-- Make new built-in field types and presentations straightforward for contributors to add and test.
+- Publish usable JavaScript and TypeScript integration contracts.
+- Make built-in fields and presentations straightforward for contributors to add and test.
 - Require no new database, queue, storage product, or backend service.
 
 ## Non-goals
 
 - Replacing or visually redesigning the existing BugDrop wizard.
+- Refactoring the legacy wizard behind a new runtime or controller in the first release.
 - A hosted visual form builder or remote configuration service.
 - Response aggregation, dashboards, surveys, or analytics storage.
 - Conditional branching or multi-page form logic in the first release.
+- Screenshot, attachment, or console-log evidence for variants in the first release.
 - A public runtime plugin API that executes third-party renderer code inside BugDrop's Shadow DOM.
+- Dynamic variant lookup, unregistration, or public analytics events in the first release.
 - A strict exactly-once delivery guarantee during GitHub or network outages.
 - Supporting multiple copies of `widget.js` on one page.
 
@@ -75,43 +100,54 @@ script element, creates one `#bugdrop-host`, stores state in module globals, and
 
 - **Legacy widget:** The current BugDrop trigger, wizard, evidence flow, and payload.
 - **Variant:** A named declarative form definition.
-- **Variant handle:** The object returned when a variant is registered.
+- **Variant handle:** The durable object returned when a variant is registered.
 - **Instance:** One mounted inline form or one opened modal created from a variant.
 - **Presentation:** The container and interaction model, initially `modal` or `inline`.
-- **Field renderer:** The code that renders, reads, validates, and serializes one field type.
-- **Headless submission:** A host-rendered UI calling BugDrop only for validation, metadata, auth,
-  and submission.
-- **Issue template:** Declarative rules for turning normalized answers into a title and ordered
-  Markdown sections. GitHub labels are configured separately.
+- **Field controller:** The internal renderer-owned DOM and lifecycle controller for one field.
+- **Headless submission:** A host-rendered UI calling BugDrop for metadata, auth, and submission.
+- **Issue template:** Browser-side declarative rules that produce a bounded Issue draft.
+- **Issue draft:** A field-agnostic title and ordered list of generic sections sent to the Worker.
 
-## Design Principles
+## Design Decisions
 
-### One runtime, many instances
+### One script, one legacy widget, many variant instances
 
-The page loads one BugDrop script. That runtime owns shared configuration, auth, metadata capture,
-and transport. Each variant registration and mount has isolated form state.
+The page loads one BugDrop script. The existing widget remains the only legacy instance. A lazy
+sidecar manager owns variant definitions and isolated instance state.
 
-Multiple script tags are explicitly unsupported. Multiple logical instances are supported.
+Multiple script tags remain unsupported. Multiple logical variant instances are supported.
+
+### Sidecar before refactor
+
+The first release does not introduce a `BugDropRuntime`, legacy adapter, or
+`LegacyWidgetController`. It leaves `openFeedbackFlow()` and legacy module globals structurally
+intact. Only two shared seams may be extracted when tests prove them equivalent:
+
+1. Authenticated JSON transport and metadata collection.
+2. Pure generic Issue-draft validation and formatting for structured submissions.
+
+This keeps the largest compatibility risk out of the initial implementation.
 
 ### Composition over named special cases
 
-`rating-review` is not a permanent hard-coded rendering branch. It is a variant composed from a
-`rating` field, a `longText` field, an inline or modal presentation, and an Issue template.
+`rating-review` is not a permanent hard-coded branch. It combines a rating field, an optional long
+text field, a presentation, and an Issue template. New combinations do not require Worker changes.
 
 ### Rendering is separate from submission
 
-Standard BugDrop renderers and host-rendered forms must produce the same normalized submission.
-The Worker must not care whether BugDrop or React rendered the controls.
+BugDrop-rendered and host-rendered forms produce the same normalized Issue draft. The Worker does
+not need to know whether BugDrop, React, or another host renderer produced it.
 
-### The browser controls UX, the Worker controls GitHub policy
+### The browser controls UX; the Worker controls GitHub policy
 
-Browser configuration may control copy, field order, validation, and Issue title/body composition.
-It may not apply arbitrary GitHub labels. The Worker resolves labels from server configuration and
-always adds the `bugdrop` label.
+Browser configuration controls copy, field order, client validation, and Issue-draft composition.
+The Worker treats all of it as untrusted, enforces generic limits, renders bounded Markdown,
+appends mandatory attribution and system information, resolves raw labels, and creates the Issue.
 
-### Compatibility is an executable contract
+### Compatibility is executable
 
-Legacy behavior is protected by tests, not only documentation or convention.
+Legacy behavior is protected by historical fixtures and candidate-Worker tests, not only by
+documentation or by rerunning tests generated from the new implementation.
 
 ## Backwards-Compatibility Contract
 
@@ -119,25 +155,63 @@ The following behavior is normative:
 
 1. A page using only the existing script tag receives the existing widget.
 2. All existing `data-*` attributes retain their current defaults and meanings.
-3. `window.BugDrop.open()` with no arguments opens the current form and skips the welcome screen,
-   as it does today.
-4. `close()`, `hide()`, `show()`, `isOpen()`, `isButtonVisible()`, and `setTheme()` retain their
-   current behavior and signatures.
-5. The existing `bugdrop:ready` event still fires once after legacy initialization.
-6. The existing `#bugdrop-host` remains the legacy host and is not renamed.
-7. Existing `FeedbackPayload` requests remain valid and retain their current Issue body and label
-   behavior.
-8. Existing localStorage keys and screenshot behavior are unchanged for the legacy flow.
-9. Variant-only CSS, DOM, storage keys, events, and payload fields are namespaced and cannot alter
-   legacy output unless a variant API is called.
-10. Existing `widget.v1.js` consumers receive only additive behavior. Any unavoidable incompatible
-    change requires `widget.v2.js`; it must not be smuggled into the v1 bundle.
+3. `window.BugDrop.open(...ignoredArguments)` always opens the legacy form and skips the welcome
+   screen. Extra arguments—including DOM events, strings matching variant IDs, `null`, and arbitrary
+   objects—remain ignored. Variants open only through a returned `VariantHandle`.
+4. Existing API methods remain synchronous, context-independent closure functions with the same
+   return values. Destructuring a method or passing it directly as an event callback remains valid.
+5. `close()`, `hide()`, `show()`, `isOpen()`, `isButtonVisible()`, and `setTheme()` remain scoped to
+   the legacy widget and retain their current behavior and signatures.
+6. `bugdrop:ready` fires exactly once as a non-bubbling, non-cancelable `CustomEvent` on `window`,
+   after the final additive API object is installed. Its `detail` remains `null`.
+7. The existing `#bugdrop-host` remains the legacy host and is not renamed.
+8. Existing `FeedbackPayload` requests remain valid and retain their current validation, response,
+   Issue body, label, and error behavior.
+9. Existing localStorage keys, values, scoping, and screenshot behavior are unchanged for the
+   legacy flow.
+10. Variant-only CSS, DOM, storage, and payload fields are namespaced and inert until a variant API
+    is called.
+11. Existing `widget.v1.js` consumers receive additive behavior only. Any unavoidable incompatible
+    change requires `widget.v2.js`.
+12. Variant-only capabilities are feature-detected lazily. A browser that can run the current
+    widget must not fail legacy startup because a variant-only global is unavailable.
 
-The reserved variant ID `legacy` refers to the existing form but cannot be overridden by a caller.
+Record the v1.53.1 minified and gzip bundle sizes before implementation. The first release may not
+increase compressed `widget.js` by more than 25% without a separately reviewed exception. A
+legacy-only bootstrap test removes variant-only globals, asserts no variant DOM/listeners/UUID work,
+and records initialization timing so a material startup regression cannot hide behind functional
+tests.
+
+Before implementation changes the legacy submission path, check in reviewed goldens captured from
+at least one tag-reconstructed v1 bundle and the current v1 tag. Each fixture records its source
+commit, lockfile hash, deterministic build command, output hash, and an explicit disclaimer that it
+is not claimed to be byte-identical to historically deployed CDN bytes. The baseline covers
+bootstrap, API methods, detached calls, event timing, normalized request payloads, Issue formatting
+and labels, semantic DOM, storage, and screenshot-free and evidence-bearing flows. Candidate Workers
+must accept these legacy requests. Exact old-version CDN retention is a separate, pre-existing
+release-policy concern and is not silently broadened by this phase.
+
+The reserved variant ID `legacy` cannot be registered by a caller.
+
+## Modal Arbitration
+
+Legacy semantics win over the additive sidecar:
+
+| Existing state | Requested action | Required result |
+| --- | --- | --- |
+| No modal | Open variant | Open the variant modal |
+| Legacy modal active | Open variant | Return a documented `busy` outcome; do not alter legacy DOM or state |
+| Variant modal active | Open another variant | Close the first through its cancellation controller, then open the second |
+| Variant modal active | Call legacy `BugDrop.open()` | Close the variant through its controller, then open the legacy flow |
+| Variant modal active | Call legacy `BugDrop.close()` | Preserve legacy-scoped no-op behavior; do not close the variant |
+
+Removing DOM is not a cancellation primitive. Every variant modal owns an explicit controller that
+settles its result exactly once and restores focus. Variant code must never remove a legacy wizard
+or interfere with an awaited legacy screenshot or annotation step.
 
 ## Public Browser API
 
-The existing object gains additive methods:
+The first release adds one method to the existing object:
 
 ```ts
 interface BugDropAPI {
@@ -152,18 +226,22 @@ interface BugDropAPI {
 
   // Additive variant API
   registerVariant(config: VariantConfig): VariantHandle;
-  getVariant(id: string): VariantHandle | undefined;
-  unregisterVariant(id: string): void;
 }
 
 interface VariantHandle {
   readonly id: string;
-  open(options?: VariantOpenOptions): Promise<VariantOutcome>;
+  open(options?: VariantOpenOptions): OpenedVariant;
   mount(target: HTMLElement, options?: VariantMountOptions): MountedVariant;
   submit(
     answers: Record<string, unknown>,
     options?: HeadlessSubmitOptions
   ): Promise<SubmissionResult>;
+}
+
+interface OpenedVariant {
+  readonly instanceId: string;
+  readonly result: Promise<VariantOutcome>;
+  close(): void;
 }
 
 interface MountedVariant {
@@ -186,28 +264,29 @@ interface HeadlessSubmitOptions {
 
 type VariantOutcome =
   | { status: 'submitted'; result: SubmissionResult }
-  | { status: 'closed' };
+  | { status: 'closed' }
+  | { status: 'busy' };
 
 interface SubmissionResult {
   issueNumber: number;
   issueUrl: string;
   isPublic: boolean;
-  warnings?: string[];
+  labelMappingWarnings?: string[];
 }
 ```
 
-`open()` remains overloaded only at runtime: zero arguments always selects the legacy behavior.
-Variant consumers should prefer the returned handle rather than `BugDrop.open(id)`, which keeps the
-legacy method's public TypeScript signature unambiguous.
+Registration validates the complete configuration synchronously and stores an immutable normalized
+copy. Duplicate or reserved IDs, unknown field types, invalid templates, or duplicate field IDs
+throw before any partial registration occurs. Later mutation of the caller's object cannot alter
+an active instance or its submission.
 
-Registration validates the entire config synchronously. Duplicate IDs, reserved IDs, unknown field
-types, invalid templates, or duplicate field IDs throw a descriptive configuration error. BugDrop
-must not partially register an invalid variant. A successful registration stores a normalized deep
-copy; later mutation of the caller's object cannot alter an active form or its submission payload.
+`getVariant()`, `unregisterVariant()`, public renderer registration, and public variant lifecycle
+events are deferred until real integrations demonstrate a need. A successful registration returns
+a durable handle, which is sufficient for the initial CTA, mount, and headless use cases.
 
-`unregisterVariant()` is allowed only after all of that variant's mounted instances are unmounted
-and no modal instance is active. Otherwise it throws a lifecycle error. This makes cleanup explicit
-and prevents unregistering configuration that an in-flight submission still needs.
+The repository must publish the public types as a supported `.d.ts` entry. Script-tag JavaScript
+after `bugdrop:ready` and TypeScript consumers using that declaration are both supported integration
+modes; the interfaces must not remain documentation-only pseudocode.
 
 ## Variant Configuration
 
@@ -216,6 +295,11 @@ interface VariantConfig {
   id: string;
   configVersion?: 1;
   presentation: VariantPresentation;
+  appearance?: {
+    theme?: 'light' | 'dark' | 'auto';
+    accentColor?: string;
+    density?: 'compact' | 'comfortable';
+  };
   content: {
     title: string;
     description?: string;
@@ -226,7 +310,6 @@ interface VariantConfig {
   };
   fields: VariantField[];
   issue: VariantIssueTemplate;
-  evidence?: VariantEvidenceConfig;
 }
 
 type VariantPresentation =
@@ -239,19 +322,21 @@ type VariantPresentation =
       kind: 'inline';
       columns?: 1 | 2;
     };
-
-interface VariantEvidenceConfig {
-  screenshot?: 'off' | 'optional' | 'required';
-  attachments?: 'off' | 'optional';
-  consoleLogs?: 'off' | 'optional' | 'default-on';
-}
 ```
 
-Defaults are conservative: evidence is off for new variants unless explicitly enabled. This avoids
-surprising screenshot capture in lightweight ratings and polls.
+Variant IDs and field IDs match `[a-z][a-z0-9_-]{0,63}`. Caller-provided content is literal display
+copy. Built-in validation, loading, retry, accessibility, and fallback strings continue to come
+from the active locale dictionary.
 
-Caller-provided content is literal display copy. BugDrop's built-in validation, loading, retry,
-accessibility, and fallback strings continue to come from the active locale dictionary.
+`open()` is valid for modal configurations and `mount()` for inline configurations; using the
+opposite method throws a synchronous, descriptive presentation error. Headless `submit()` is valid
+for either. Appearance defaults to the script configuration captured at registration. The legacy
+`setTheme()` method remains legacy-scoped; a variant that needs a distinct theme supplies explicit
+appearance when it is first registered. Runtime variant-theme mutation is deferred.
+
+Evidence is unavailable for structured variants in the first release. Headless submission never
+silently opens BugDrop UI. Screenshot, attachment, and console-log support requires a later API that
+distinguishes caller-supplied evidence from a BugDrop-owned capture flow.
 
 ### Initial field catalog
 
@@ -287,8 +372,7 @@ interface LongTextField extends BaseField {
 
 interface RatingField extends BaseField {
   type: 'rating';
-  min?: 1;
-  max?: 5 | 10;
+  scale?: 5 | 10;
   icon?: 'star' | 'number';
   lowLabel?: string;
   highLabel?: string;
@@ -301,21 +385,17 @@ interface SingleChoiceField extends BaseField {
 }
 ```
 
-Field IDs must match `[a-z][a-z0-9_-]{0,63}`. Answer values are keyed by field ID. Hidden
-application state is passed as bounded `context`, not represented by a hidden form field.
+Answer values are keyed by field ID. Hidden application state is passed as bounded `context`, not
+represented as a hidden field. New field types can be added without changing the Worker protocol
+because the browser converts answers into generic Issue sections before transport.
 
-The initial catalog is intentionally small. Checkboxes, multi-select, date, file, NPS, emoji scale,
-and conditional fields can be added later as new discriminated-union members without changing the
-submission or Worker contracts.
+## Issue Templates and Label Policy
 
-## Issue Templates
-
-Issue templates are declarative rather than arbitrary executable callbacks:
+Issue templates are declarative rather than executable callbacks:
 
 ```ts
 interface VariantIssueTemplate {
   classification?: 'bug' | 'feature' | 'question' | 'feedback';
-  labelSet?: string;
   title: string;
   sections?: Array<
     | {
@@ -334,42 +414,38 @@ interface VariantIssueTemplate {
 }
 ```
 
-Title templates support only escaped field and context placeholders:
+Title templates allow only `{{field-id}}` and `{{context.key}}`. IDs and keys follow their normal
+syntax; there are no expressions, loops, conditionals, function calls, or nested object access.
+Missing placeholders resolve to an empty string, whitespace is collapsed, and the final title is
+bounded to 256 characters.
 
-```text
-[Export review] {{rating}}/5 — {{context.surface}}
-Cloud provider request — {{provider}}
-```
+The browser validates answers and compiles the template into an Issue draft. `stars` becomes a
+bounded textual rating and `choice` resolves the stored value to its configured display label.
+The Worker never receives field definitions, option catalogs, or the complete context object. Only
+context values explicitly referenced by an Issue section become section values in the draft.
 
-There are no expressions, loops, conditionals, or function calls. Missing placeholders resolve to
-an empty string, whitespace is collapsed, and the result is length-bounded before the GitHub call.
-
-If `sections` is omitted, the Worker renders all answers in field order using their configured
-labels. The Worker always appends BugDrop's attribution and safe system information; a client
-template cannot remove those sections.
-
-The browser may influence Issue title and body because the legacy payload already permits arbitrary
-user title and description. It may request only a logical `labelSet`. The Worker resolves that key
-through optional server configuration such as:
+The browser sends `variantId` and an optional classification but no `labelSet` or raw label array.
+The Worker resolves optional custom labels by `{repo, variantId}` through `VARIANT_LABELS`:
 
 ```json
 {
   "owner/repo": {
-    "product-review": ["feedback", "rating"],
-    "cloud-provider": ["enhancement", "cloud-import"]
+    "export-review": ["feedback", "rating"],
+    "cloud-provider-question": ["enhancement", "cloud-import"]
   }
 }
 ```
 
-The suggested Worker variable name is `VARIANT_LABELS`. It follows the existing per-repository
-`CATEGORY_LABELS` precedence model and does not introduce a configuration service.
+This follows the existing per-repository `CATEGORY_LABELS` configuration model and introduces no
+configuration service. Unknown variants fall back to classification defaults plus `bugdrop` and
+produce an operator warning. A payload containing raw `labels` or `labelSet` is rejected before a
+GitHub call.
 
-Unknown or invalid label sets fall back to classification defaults plus `bugdrop`, with an operator
-warning. Client-provided raw GitHub label arrays are rejected.
+The mapping is classification, not authorization: a modified public client can claim another known
+variant ID. Operators must not attach security-sensitive automation to a variant label alone. A
+future privileged mapping would also need to bind allowed variant IDs to verified auth-token claims.
 
-Classification defaults are:
-
-| Classification | Labels |
+| Classification | Default labels |
 | --- | --- |
 | `bug` | `bug`, `bugdrop` |
 | `feature` | `enhancement`, `bugdrop` |
@@ -378,8 +454,8 @@ Classification defaults are:
 
 ## Initial Acceptance Variants
 
-These are documentation examples and automated fixtures. They may be exported as optional helper
-factories, but the runtime must treat them as ordinary configurations.
+These examples are documentation snippets and automated fixtures. The runtime treats them as
+ordinary configurations rather than named core branches.
 
 ### 1. One-to-five-star review
 
@@ -398,21 +474,18 @@ const review = BugDrop.registerVariant({
       type: 'rating',
       label: 'Rating',
       required: true,
-      min: 1,
-      max: 5,
+      scale: 5,
       icon: 'star',
     },
     {
       id: 'message',
       type: 'longText',
       label: 'Anything else?',
-      required: false,
       maxLength: 1000,
     },
   ],
   issue: {
     classification: 'feedback',
-    labelSet: 'product-review',
     title: '[Export review] {{rating}}/5',
     sections: [
       { heading: 'Rating', field: 'rating', format: 'stars' },
@@ -420,14 +493,16 @@ const review = BugDrop.registerVariant({
     ],
   },
 });
+
+review.mount(document.querySelector('#export-review-slot')!);
 ```
 
-Selecting a star updates local state only. Submission occurs only when the explicit Submit button is
-activated. Rating and message create one Issue, not separate rating and follow-up Issues.
+Selecting a star changes local state only. One Issue is created only after the explicit Submit
+button is activated.
 
 ### 2. CTA-driven question
 
-The host application owns the CTA placement and copy. The CTA calls the variant handle:
+The host owns CTA placement and calls the returned handle:
 
 ```ts
 const providerQuestion = BugDrop.registerVariant({
@@ -450,22 +525,19 @@ const providerQuestion = BugDrop.registerVariant({
   ],
   issue: {
     classification: 'feature',
-    labelSet: 'cloud-provider',
     title: 'Cloud provider request — {{response}}',
     sections: [{ heading: 'Requested provider or workflow', field: 'response' }],
   },
 });
 
 button.addEventListener('click', () => {
-  void providerQuestion.open({ context: { surface: 'studio-upload' } });
+  providerQuestion.open({ context: { surface: 'studio-upload' } });
 });
 ```
 
-Long responses are truncated only in the generated title, never in the Issue section.
+Long responses are truncated only in the generated title, not the Issue section.
 
 ### 3. Single-choice poll
-
-This variant proves reusable option rendering and optional detail:
 
 ```ts
 BugDrop.registerVariant({
@@ -497,7 +569,6 @@ BugDrop.registerVariant({
   ],
   issue: {
     classification: 'feature',
-    labelSet: 'integration-poll',
     title: 'Integration vote — {{choice}}',
     sections: [
       { heading: 'Choice', field: 'choice', format: 'choice' },
@@ -507,12 +578,10 @@ BugDrop.registerVariant({
 });
 ```
 
-Conditional display of `detail` only when `other` is selected is intentionally deferred. Keeping it
-visible but optional exercises the same data model without introducing a rules engine.
+Conditional display when `other` is selected is deferred; the detail field remains visible and
+optional so the first release does not introduce a rules engine.
 
 ### 4. Compact suggestion
-
-This variant proves multiple text fields and optional evidence:
 
 ```ts
 BugDrop.registerVariant({
@@ -539,97 +608,72 @@ BugDrop.registerVariant({
   ],
   issue: {
     classification: 'feature',
-    labelSet: 'suggestion',
     title: '[Idea] {{summary}}',
     sections: [
       { heading: 'Idea', field: 'summary' },
       { heading: 'Why it would help', field: 'detail', omitWhenEmpty: true },
     ],
   },
-  evidence: {
-    screenshot: 'optional',
-    attachments: 'off',
-    consoleLogs: 'off',
-  },
 });
 ```
 
 ## Structured Submission Contract
 
-The Worker accepts a discriminated union of the unchanged legacy payload and a new structured
-payload:
+The Worker accepts the unchanged legacy payload and a collision-resistant structured payload:
 
 ```ts
 interface StructuredFeedbackPayload {
-  schemaVersion: 2;
+  kind: 'bugdrop.variant-submission';
+  schemaVersion: 1;
   repo: string;
-  variant: {
-    id: string;
-    configVersion: 1;
-    fields: Array<{
-      id: string;
-      label: string;
-      type: 'shortText' | 'longText' | 'rating' | 'singleChoice';
-      required?: boolean;
-      minLength?: number;
-      maxLength?: number;
-      min?: number;
-      max?: number;
-      options?: Array<{ value: string; label: string }>;
-    }>;
-    issue: VariantIssueTemplate;
-  };
+  variantId: string;
   submissionId: string;
-  answers: Record<string, string | number | null>;
-  context?: Record<string, string | number | boolean | null>;
-  screenshot?: string;
-  attachments?: FeedbackAttachment[];
-  consoleLogs?: ConsoleLogEntry[];
+  issue: {
+    title: string;
+    classification?: 'bug' | 'feature' | 'question' | 'feedback';
+    sections: Array<{
+      heading: string;
+      value: string;
+      format?: 'text' | 'quote' | 'code';
+    }>;
+  };
   metadata: FeedbackMetadata;
 }
 ```
 
-The payload includes only Issue-relevant normalized config, not presentation details or success
-copy. This lets a hosted Worker format a contributor-defined variant without storing its browser
-layout. The Worker validates the normalized schema again and never trusts client validation.
+The Worker selects the structured handler only when both `kind` and `schemaVersion` match. An
+arbitrary legacy caller that already sends a `schemaVersion` property remains on the legacy path.
+A matching `kind` with an unsupported version returns `400` without calling GitHub.
 
-Limits for the first release:
+The structured payload is deliberately field-agnostic. The untrusted browser cannot make its own
+validation rules authoritative by resending a field schema. The Worker validates only transport,
+security, Markdown rendering, metadata, label policy, and size constraints.
 
-- At most 20 fields.
-- At most 50 options across all fields.
-- At most 64 characters per field or variant ID.
-- At most 5,000 characters per answer.
-- At most 20 context keys and 8 KB of serialized context.
-- At most 32 KB for the structured payload before evidence data.
-- Existing screenshot, attachment, and console-log limits remain in force.
+Initial limits:
 
-Unknown answers, duplicate fields, non-finite numbers, nested answer values, control characters in
-IDs, invalid option values, or an unsupported schema version return `400` without calling GitHub.
+- At most 20 Issue sections.
+- At most 64 characters for `variantId` and 120 characters per heading.
+- At most 256 characters for the normalized title.
+- At most 5,000 characters per section value.
+- At most 32 KB for the complete structured payload.
+- No screenshot, attachment, annotation, or console-log properties.
 
-## Runtime and DOM Architecture
+Duplicate or empty headings, nested values, non-finite numbers, control characters in identifiers,
+unknown top-level policy fields, raw labels, invalid metadata, or an unsupported version return
+`400` before GitHub is called. The Worker renders generic formats safely and always appends system
+information, attribution, and the submission marker.
 
-Introduce a `BugDropRuntime` that owns:
-
-- Legacy adapter.
-- Shared core configuration and auth-token provider.
-- Variant registry.
-- Active modal coordinator.
-- Submission service.
-- Theme and locale services.
-
-Legacy module-global variables remain behind the adapter initially or move into a dedicated
-`LegacyWidgetController` without observable behavior changes.
+## Sidecar and DOM Architecture
 
 Suggested source organization:
 
 ```text
 src/widget/variants/
-  types.ts
+  public-types.ts
   validate-config.ts
-  registry.ts
-  runtime.ts
+  manager.ts
   submission.ts
-  issue-template.ts
+  issue-draft.ts
   presentations/
     modal.ts
     inline.ts
@@ -639,244 +683,324 @@ src/widget/variants/
     long-text.ts
     rating.ts
     single-choice.ts
+
+src/routes/
+  structured-feedback.ts
 ```
 
-Each field renderer implements an internal contract:
+The sidecar manager initializes lazily when `registerVariant()` is first called. It does not create
+variant hosts, UUIDs, observers, listeners, or storage during a legacy-only bootstrap.
+
+`mount(target)` appends one BugDrop-owned child host to `target`; it does not convert or replace the
+target. Inline and modal hosts carry both:
+
+```html
+data-bugdrop-owned
+data-bugdrop-instance="<instance-id>"
+```
+
+A shared `isBugDropOwnedNode()` predicate is used by screenshot capture, element picking, masking,
+and host-compatibility code. All BugDrop-owned hosts are excluded from legacy capture and cannot be
+selected as legacy evidence. Capture modes that cannot exclude DOM nodes directly temporarily hide
+all owned hosts and restore them in `finally`.
+
+Radix compatibility remains one runtime-level listener backed by a live set of owned roots. Mounting
+two variants must not install duplicate global listeners or call `stopImmediatePropagation()` for
+unrelated host content.
+
+Each field renderer returns a controller rather than requiring later DOM rediscovery:
 
 ```ts
-interface FieldRenderer<TField extends VariantField> {
-  render(field: TField, state: FieldState, environment: RenderEnvironment): HTMLElement;
-  read(element: HTMLElement, field: TField): unknown;
-  validate(value: unknown, field: TField): ValidationError | null;
-  normalize(value: unknown, field: TField): string | number | null;
+interface FieldController {
+  element: HTMLElement;
+  getValue(): unknown;
+  setValue(value: unknown): void;
+  focus(): void;
+  dispose(): void;
 }
 ```
 
-Adding a built-in field requires one union member, one renderer registration, focused unit tests,
-and documentation. Submission and Issue formatting must not need a field-specific branch except for
-explicit display formats such as stars.
-
-Inline mounts create unique hosts marked with `data-bugdrop-instance="<id>"`. They must not reuse
-`#bugdrop-host`. Each mount uses a Shadow Root for style isolation and returns an unmount handle.
-Only one BugDrop modal may be open at a time; opening another resolves the first outcome as closed.
+Normalization and validation remain pure field-descriptor functions. A contributor adding a field
+adds one union member, renderer/controller, conformance fixture, focused tests, and documentation;
+the Worker formatter does not change.
 
 ## Validation and Accessibility
 
-- Configuration errors are reported at registration time.
-- Answer validation runs on Submit and focuses the first invalid field.
-- Server validation mirrors security-relevant constraints.
-- Required status and errors are exposed with `aria-describedby` and `aria-invalid`.
-- Rating controls use a radiogroup or equivalent keyboard-operable pattern; arrow keys move the
-  selection and Enter/Space selects.
-- Selecting a rating never submits automatically.
-- Single-choice card and button presentations preserve native radio semantics.
-- Modal variants reuse the current focus trap, Escape behavior, background scroll lock, and dialog
-  semantics.
-- Inline variants do not move focus on mount.
-- Loading state disables duplicate Submit activation and remains announced through an ARIA live
-  region.
-- Touch targets remain at least 44 by 44 CSS pixels.
-- Variant styles use the existing theme tokens and custom style configuration.
+- Configuration errors are reported synchronously at registration.
+- Answer validation runs only on Submit and focuses the first invalid field.
+- Required state and errors use `aria-describedby` and `aria-invalid`.
+- Rating controls expose native or equivalent radiogroup semantics. Arrow keys move selection and
+  Enter/Space select without submitting.
+- Single-choice cards and buttons preserve radio semantics.
+- Variant modal presentation implements a new accessible shell with `role="dialog"`, an accessible
+  name, `aria-modal`, Escape handling, focus containment, focus restoration, and background scroll
+  locking.
+- The new shell initially serves variants only. Migrating the legacy modal is a separate
+  compatibility-proven change; the current legacy modal does not supply these primitives.
+- Inline mounts do not move focus.
+- Loading disables duplicate Submit activation and is announced through an ARIA live region.
+- Pointer targets are at least 44 by 44 CSS pixels.
+- Repeated mount/unmount and modal open/close dispose listeners and controllers.
+- Stable semantic selectors use roles, accessible names, and namespaced `data-bugdrop-field`
+  attributes rather than private CSS classes.
 
 ## Submission Lifecycle and Reliability
 
-1. An instance generates one UUID `submissionId` when its form state is created.
+1. A form state creates one `submissionId`.
 2. Validation failures retain that ID and do not call the Worker.
-3. Submit disables the form and requests an auth token through the existing provider.
-4. The Worker validates auth, structured config, answers, evidence, and label policy.
+3. Submit disables the form, builds the normalized Issue draft, and requests auth through the
+   existing provider.
+4. The Worker validates auth, the structured envelope, generic sections, metadata, and label policy.
 5. The Worker creates the GitHub Issue through the existing GitHub App.
-6. BugDrop reports success only after it receives an Issue number and URL.
-7. A retry reuses the same `submissionId`.
+6. BugDrop reports success only after receiving a positive Issue number and canonical Issue URL.
+7. Transport retries for the same response reuse the same `submissionId`.
+8. After success, a mounted form cannot submit again until `reset()`; reset creates a new ID.
 
-The Issue body includes an invisible marker:
+The Issue contains:
 
 ```html
 <!-- bugdrop-submission: <submissionId> -->
 ```
 
-The marker enables best-effort duplicate detection and operator forensics. GitHub search and
-Cloudflare KV are not atomic transaction systems, so this design does not promise strict
-exactly-once delivery. Network loss after GitHub accepts an Issue can still race a retry.
+The marker supports forensics and best-effort duplicate detection. Without new durable storage,
+network loss after GitHub accepts an Issue can still race a retry; exactly-once delivery is not
+promised.
 
-For structured variants with evidence, create the Issue before optional asset uploads and patch the
-Issue afterward. This ensures a screenshot or attachment failure does not discard the response.
-Evidence failures are recorded in the Issue and returned as warnings. The legacy evidence ordering
-is unchanged for backwards compatibility unless separately migrated and proven equivalent.
-
-Existing rate limits remain the default. Authenticated self-hosts may later add subject- and
-variant-aware limits using the already verified token subject, but that is not required to ship the
-variant runtime.
+Variant and legacy submissions share the existing IP and repository rate-limit buckets. This is an
+accepted v1 interaction and is covered by a mixed-quota test.
 
 ## Security and Privacy
 
-- Escape all configured copy before inserting it into widget HTML.
-- Reject control characters and invalid IDs in both browser and Worker validation.
-- Treat answers and context as untrusted user-generated content.
-- Enforce bounded strings, key counts, option counts, and serialized payload sizes.
-- Do not accept executable template expressions or callbacks in Worker payloads.
-- Do not accept raw GitHub labels from variant submissions.
-- Resolve `labelSet` from server-owned per-repository configuration.
-- Continue requiring the existing signed token when the Worker has auth enabled.
+- Escape configured display copy before inserting it into widget HTML.
+- Treat Issue-draft content and context as untrusted user-generated content.
+- Enforce bounded strings, key counts, sections, and serialized payload size.
+- Do not accept executable templates or callbacks in Worker payloads.
+- Do not accept raw labels or browser-selected logical label sets.
+- Resolve optional custom labels by server-owned `{repo, variantId}` configuration.
+- Continue requiring the existing signed token when Worker auth is enabled.
 - Continue redacting URL query strings and hashes.
-- Keep screenshots, attachments, and console logs off by default for new variants.
-- Host applications remain responsible for applying `data-bugdrop-mask` to sensitive surfaces.
-- Do not place secrets, full media content, transcripts, or unconstrained application objects in
-  `context`.
-
-## Events and Host Integration
-
-Keep `bugdrop:ready` unchanged. Add namespaced events for optional host analytics:
-
-```text
-bugdrop:variant-registered
-bugdrop:variant-mounted
-bugdrop:variant-opened
-bugdrop:variant-submitted
-bugdrop:variant-failed
-bugdrop:variant-closed
-```
-
-Event details contain variant ID, instance ID, presentation, result status, and Issue number when
-available. They must not contain answers, comments, email addresses, URLs with query strings, or
-arbitrary context.
-
-The runtime does not add an analytics service. Hosts may translate these events into their existing
-analytics tools.
+- Keep screenshots, attachments, annotations, and console logs unavailable for initial variants.
+- Host applications remain responsible for masking sensitive host surfaces.
+- Do not place secrets, media, transcripts, email addresses, or unconstrained objects in context.
+- Public lifecycle events are deferred so answer or context data cannot accidentally become a
+  permanent analytics contract.
 
 ## Contributor Extension Model
 
-The first release supports two safe extension paths:
+The initial release supports two extension paths:
 
-1. Compose a new variant from public field and presentation primitives.
-2. Render any custom UI in the host application and call `VariantHandle.submit()`.
+1. Compose a variant from public fields and presentations.
+2. Render custom UI in the host and call `VariantHandle.submit()`.
 
-Contributors extending BugDrop itself add field types through the internal registry contract. A
-public `registerFieldRenderer()` API is deferred because it would require stable DOM lifecycle,
-style, accessibility, sanitization, and serialization contracts for arbitrary third-party code.
-Headless submission provides equivalent product flexibility without freezing that unsafe API early.
+A public `registerFieldRenderer()` API is deferred because it would freeze DOM lifecycle, styling,
+accessibility, sanitization, and serialization contracts for arbitrary code. Headless submission
+provides product flexibility without that unsafe commitment.
 
-Each built-in example should exist as:
+Every built-in example includes:
 
-- A documented configuration snippet.
-- A local test page.
-- A focused renderer test.
-- A Worker Issue-formatting test.
+- A typed documented configuration.
+- A local fixture page.
+- Field-controller conformance tests.
+- An Issue-draft golden.
+- Worker formatting and policy tests.
 - A Playwright flow using the public API.
 
 ## Testing and Compatibility Gates
 
-### Legacy regression suite
+Testing is layered. A mocked browser response cannot satisfy a real-GitHub claim, and a real-GitHub
+canary is not multiplied across every browser or visual layout.
+
+| Claim | Required proof layer |
+| --- | --- |
+| Config validation, field normalization, template resolution | Vitest pure-unit tests |
+| Generic Issue formatting, bounds, label rejection and mapping | Worker tests with GitHub mocked |
+| Each acceptance UX, explicit Submit, errors, reset, cleanup | Local Chromium Playwright with `/feedback` intercepted and exact draft asserted |
+| Rating/choice keyboard behavior and modal focus | Focused Chromium, Firefox, and WebKit Playwright |
+| Multiple mounts and legacy coexistence | Local Chromium Playwright |
+| Legacy v1 request and Issue behavior | Immutable goldens plus tag-reconstructed bundle against candidate Worker |
+| Exact deployed bundle, cross-origin behavior, `/widget.js` and `/widget.v1.js` | Locked merge-queue preview Playwright |
+| Actual structured Worker rejection | Direct preview requests with no GitHub side effect |
+| Preview Worker → GitHub App → real Issue | One locked, zero-retry, independently verified and cleaned canary |
+
+### Legacy regression gate
 
 - Existing script snippets render the same trigger and default form.
 - Existing data attributes produce the same config.
-- `BugDrop.open()` still skips welcome and opens the legacy form.
-- Existing request payload fixtures are byte-for-byte unchanged where timestamps and generated
-  evidence are normalized.
-- Existing GitHub Issue body and labels are unchanged.
-- Screenshot, annotation, retry, locale, theme, and API-only tests continue to pass.
+- Legacy methods ignore extra arguments, work detached, and remain synchronous.
+- `bugdrop:ready` target, timing, count, bubbling, cancelability, and detail remain exact.
+- Historical normalized payloads, Issue bodies, labels, response shapes, and storage remain exact.
+- A tag-reconstructed v1 bundle submits against the candidate Worker.
+- Compressed bundle size stays within the recorded 25% budget and legacy-only bootstrap performs no
+  variant instance work.
+- Legacy full-page, area, and element capture exclude two simultaneously mounted inline variants.
+- Existing screenshot, annotation, retry, locale, theme, Radix, and API-only suites remain green.
 
-### Variant unit tests
+### Variant unit and conformance gate
 
 - Complete config validation and descriptive errors.
-- Field rendering, keyboard behavior, validation, normalization, and reset.
-- Template placeholder resolution and output limits.
-- Registry duplicate/reserved ID behavior.
-- Independent state for multiple mounts.
-- Headless and BugDrop-rendered submissions normalize identically.
+- Every field passes shared rendering, keyboard, validation, normalization, reset, and disposal tests.
+- Template grammar, choice-label resolution, star formatting, escaping, and output bounds.
+- Duplicate and reserved ID behavior.
+- Independent state for simultaneous mounts.
+- Headless and BugDrop-rendered submissions normalize to identical Issue drafts.
+- One submission ID survives validation and retry; reset after success creates a new ID.
 
-### Worker tests
+### Worker gate
 
-- Legacy and schema-v2 payloads both succeed.
-- Unsupported versions and malformed configs fail before GitHub calls.
-- Unknown answers and choice values are rejected.
-- Label sets cannot be injected by the client.
+- Legacy and structured payloads both succeed through isolated handlers.
+- A legacy payload containing an unrelated `schemaVersion` remains legacy.
+- Unsupported structured versions and malformed drafts fail before GitHub calls.
+- Raw labels, `labelSet`, policy-field injection, oversized values, and nested values are rejected.
 - Empty optional sections are omitted.
-- Mandatory attribution and system information cannot be suppressed.
-- Submission markers are present and stable across retries.
-- Evidence upload failure still leaves a structured-variant Issue.
+- Choice display labels and generic formats produce exact Markdown.
+- Mandatory attribution, system information, and submission marker cannot be suppressed.
+- Mixed legacy and variant traffic consumes the documented shared quota.
 
-### E2E tests
+### Local and preview E2E gate
 
-- Each initial acceptance variant in modal and/or inline form.
+- All four acceptance variants run in their intended modal or inline presentation.
 - Two inline variants coexist with the legacy widget.
-- Repeated mount/unmount does not leak hosts, listeners, or state.
-- Only one modal opens at a time.
-- Explicit Submit is required for rating and choice controls.
-- Mobile touch targets, focus order, Escape, and error focus.
-- Light, dark, auto, and custom Bleep-like styling.
+- Repeated mount/unmount leaves no hosts, global listeners, controllers, or shared state.
+- Modal arbitration follows the normative matrix in both directions.
+- Rating and choice controls never submit without explicit Submit.
+- Mobile targets, focus order, Escape, restoration, first-error focus, and live regions are asserted.
+- Light, dark, auto, and Bleep-inspired custom styling remain readable.
+- A compact variant smoke runs in the existing three-browser local and live matrices.
+- The deployed preview loads both `/widget.js` and `/widget.v1.js` from the expected origin and
+  verifies their checkout hashes.
+
+### Real-Issue canary strategy
+
+The Phase 0 legacy canary remains the safety baseline while the structured transport is developed.
+When the structured handler and headless API are ready, extend the existing canary—not its token or
+cleanup framework—to submit one representative field-agnostic variant Issue. That canary verifies
+the structured discriminator, generic sections, `{repo, variantId}` labels, marker, attribution,
+actual response Worker SHA, canonical Issue URL, and zero-leak cleanup.
+
+Routine merge-group CI creates only one real canary Issue. It does not create one Issue per UX or
+browser. Each rendered UX proves its exact normalized draft in deployed/local browser tests; Worker
+tests prove that draft's `createIssue` arguments; the single real canary proves the shared deployed
+GitHub path. Together these layers cover every variant without multiplying destructive side
+effects, retries, notifications, or rate-limit pressure.
 
 ## Documentation
 
-Add documentation pages or sections for:
+Add documentation for:
 
 - Variant concepts and browser API.
-- Field and presentation reference.
-- Issue templates and server-owned label sets.
+- Published TypeScript declarations.
+- Field and presentation references.
+- Issue templates and server-owned variant label mappings.
 - Modal, inline, and headless examples.
 - React integration and cleanup.
 - Security and context-data guidance.
 - Version pinning and the legacy compatibility promise.
-- A contributor guide for adding a built-in field renderer.
+- Contributor field-controller conformance tests.
+- The distinction between per-UX mocked/deployed coverage and the single real-Issue canary.
 
-The Quick Start remains the current one-line script installation. Variants are presented as an
-advanced additive capability.
+The Quick Start remains the current one-line script installation. Variants are an advanced,
+explicitly opt-in capability.
 
 ## Rollout Plan
 
-### Phase 1: Runtime foundation
+### Phase 0: real-Issue preview proof — complete
 
-- Extract a shared submission service without changing legacy payloads.
-- Add the variant types, validator, registry, and handle API.
-- Add structured Worker payload validation and generic Issue formatting.
-- Add legacy compatibility fixtures.
+- Exact preview Worker and widget identity.
+- Serialized preview critical section.
+- One zero-retry legacy browser submission.
+- Independent Issue verification and unconditional cleanup.
+- Nonmutating ordinary live paths and documented token rotation.
 
-### Phase 2: First renderers
+Evidence: PR #258, run `30724180366`, and closed test Issue #578.
 
-- Add modal and inline presentations.
-- Add short text, long text, rating, and single-choice fields.
-- Ship the four initial acceptance examples and local test pages.
+### Phase 1: compatibility and structured headless foundation
 
-### Phase 3: Evidence and hardening
+- Capture immutable tag-reconstructed v1 bootstrap, payload, response, Issue, storage, and DOM
+  goldens with reproducible provenance.
+- Publish the additive `.d.ts` browser API contract.
+- Add the lazy sidecar registration and durable handle API without moving the legacy call graph.
+- Extract only proven transport/metadata seams.
+- Add the field-agnostic structured Worker handler and headless submission.
+- Add server-owned `{repo, variantId}` label resolution.
+- Extend the existing merge-queue canary with one structured representative after local gates pass.
 
-- Add optional screenshot/evidence support for variants.
-- Add submission markers and best-effort retry deduplication.
-- Run accessibility, cross-browser, masking, rate-limit, and failure-path audits.
+### Phase 2: first rendered UXs
 
-### Phase 4: Dogfood and documentation
+- Add the accessible variant modal and isolated inline presentation.
+- Add short text, long text, and rating controllers.
+- Ship the one-to-five-star review and CTA-driven question.
+- Prove modal arbitration, legacy capture exclusion, Radix coexistence, and TypeScript examples.
 
-- Dogfood selected examples in a host application such as Bleep without making Bleep-specific copy
-  or fields part of BugDrop core.
-- Publish contributor and integration documentation.
-- Broaden usage only after the legacy and multi-instance E2E contracts remain green.
+### Phase 3: composition and contributor proof
+
+- Add the single-choice controller and compact suggestion.
+- Ship the poll and suggestion fixtures.
+- Prove two simultaneous inline variants, reset identity, cleanup, and shared conformance tests.
+- Add focused Firefox/WebKit and deployed preview coverage.
+
+### Phase 4: dogfood and documentation
+
+- Dogfood selected examples in Bleep without making Bleep-specific copy or fields core branches.
+- Publish integration, security, testing, and contributor documentation.
+- Broaden usage only after legacy, multi-instance, and structured canary contracts remain green.
+
+### Later: evidence and optional lifecycle surface
+
+- Design caller-supplied versus BugDrop-owned evidence explicitly.
+- Add screenshot/evidence support only after legacy capture coexistence is proven.
+- Consider lookup, unregistration, lifecycle events, and public renderers only from demonstrated use
+  cases.
+- Consider a broader legacy runtime refactor only after the sidecar has shipped and goldens are
+  stable.
 
 ## Acceptance Criteria
 
-The extension is ready when:
+The initial extension is ready when:
 
-1. Every pre-existing BugDrop unit and E2E test passes without weakening assertions.
-2. A page with no variant registrations is observably unchanged.
-3. The four example variants can be registered from ordinary application JavaScript.
-4. At least two inline instances and the legacy widget coexist on one page.
-5. A host-rendered form can submit through the same normalized path.
-6. Each successful variant submission returns a GitHub Issue number and creates a correctly
-   formatted Issue.
-7. Rating selection alone never submits.
-8. Client attempts to inject raw GitHub labels fail.
-9. New variant code is separated into contributor-oriented modules rather than expanding the
-   already large legacy `index.ts` and `ui.ts` files.
-10. `widget.v1.js`, the legacy Worker payload, and the current JavaScript API remain backwards
+1. Every pre-existing BugDrop unit and E2E test passes without weakened assertions.
+2. Historical exact v1 bundles and payload goldens pass against the candidate Worker.
+3. A page with no variant registration is observably unchanged and performs no variant-only work.
+4. Legacy methods, extra-argument behavior, detached calls, and `bugdrop:ready` remain exact.
+5. The four example variants register from ordinary JavaScript and type-check through published
+   declarations.
+6. At least two inline instances and the legacy widget coexist without capture, picker, Radix,
+   storage, theme, or cleanup interference.
+7. A host-rendered form and BugDrop-rendered form produce the same Issue draft.
+8. Every successful structured submission returns a positive Issue number and canonical URL.
+9. The locked merge-queue canary proves one real structured Issue through the exact preview Worker,
+   verifies its complete contract independently, closes it, and proves zero matching Issues remain.
+10. Every rendered acceptance UX has local and deployed browser coverage of its exact Issue draft.
+11. Rating or choice selection alone never submits.
+12. Raw labels and browser-selected label sets are rejected before GitHub calls.
+13. New code lives in contributor-oriented sidecar and structured-route modules instead of growing
+    the legacy wizard or forcing a legacy controller migration.
+14. `/widget.v1.js`, the legacy Worker handler, and the existing JavaScript API remain backwards
     compatible.
 
-## Strongest Failure Modes to Disprove During Implementation
+## Strongest Failure Modes to Disprove
 
-1. **Legacy regression:** A site that never calls the variant API renders or submits differently.
-   Prove this with normalized DOM, payload, and Issue-body contract fixtures plus existing E2E.
-2. **Cross-instance state leakage:** One mount changes another mount's answers, theme, open state, or
-   cleanup. Prove this with simultaneous mount and repeated unmount tests.
-3. **GitHub policy injection:** A modified browser payload applies unauthorized labels or suppresses
-   mandatory Issue metadata. Prove this with direct Worker requests that bypass the widget.
-4. **False success or duplicate response:** The UI thanks the user without an Issue number, or a
-   routine retry creates a second Issue. Prove success gating with fault injection and audit the
-   best-effort submission marker behavior explicitly.
-5. **Accessibility regression:** Star or card controls work only with a pointer, or a modal loses
-   focus containment. Prove keyboard-only flows and automated accessibility assertions.
+1. **Legacy regression:** A page that never registers a variant renders, initializes, stores, opens,
+   captures, or submits differently. Disprove this with immutable historical goldens, detached and
+   extra-argument API tests, and existing E2E.
+2. **Wrong preview or false integration proof:** CI tests one widget SHA but submits to another
+   Worker, or a mocked response is mistaken for a GitHub Issue. Disprove this using the implemented
+   preview lock, checkout widget hash, health SHA, actual response SHA, independent Issue readback,
+   and final sweep.
+3. **Cross-instance or host interference:** A mounted variant enters a legacy screenshot, becomes
+   selectable as evidence, steals Radix focus, or leaks listeners/state. Disprove this with two
+   simultaneous mounts, every capture mode, host-dialog focus, and repeated disposal tests.
+4. **GitHub policy injection:** A modified browser selects privileged labels, suppresses mandatory
+   metadata, or injects unsafe Markdown. Disprove this with direct structured requests that bypass
+   widget validation.
+5. **False success or duplicate response:** The UI thanks the user without a valid Issue number, a
+   retry creates multiple Issues, or reset reuses a completed submission ID. Disprove success gating
+   with fault injection and keep the existing real-canary duplicate and cleanup audits.
+6. **Modal cancellation deadlock:** Variant coordination removes DOM without settling its promise or
+   interferes with an awaited legacy wizard step. Disprove every arbitration transition and assert
+   each variant result settles once with focus restored.
+7. **Accessibility regression:** Rating or choice works only by pointer, modal focus escapes, or
+   inline mounting moves focus. Disprove explicit keyboard flows, semantic assertions, target-size
+   checks, and automated accessibility scans.
+8. **Contributor extension changes the Worker:** Adding a new field requires a protocol or Worker
+   formatter branch. Disprove this with a test-only field descriptor that compiles to the unchanged
+   generic Issue-draft contract.

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -245,6 +245,35 @@ Self-hosted deployments can also let pages set labels via the `data-category-lab
 
 Only enable this when your worker's `ALLOWED_ORIGINS` is locked down to trusted domains.
 
+### Structured variant labels
+
+Structured submissions can request only a classification (`bug`, `feature`, `question`, or
+`feedback`). They cannot send raw labels or select a named label set. Self-hosted Workers may map a
+repository and variant ID to labels with `VARIANT_LABELS`:
+
+```json
+{
+  "acme-corp/my-app": {
+    "export-review": ["feedback", "rating"],
+    "cloud-provider-question": ["enhancement", "cloud-import"]
+  },
+  "*": {
+    "product-suggestion": "product-feedback"
+  }
+}
+```
+
+BugDrop always adds `bugdrop`. Missing, malformed, or invalid mappings fall back to the submitted
+classification (`bug`, `enhancement`, `question`, or only `bugdrop` for `feedback`) and surface a
+warning in Worker logs, the Issue body, and the success response. A configured variant ID is a
+classification hint, not an authorization boundary: do not attach security-sensitive automation to
+one of these labels without separately verifying the submitter.
+
+The structured envelope uses the existing `/api/feedback` endpoint and shares its CORS, auth-token,
+IP-rate-limit, repository-rate-limit, GitHub App, and response behavior. It is intentionally
+field-agnostic and does not accept field schemas, screenshots, attachments, annotations, console
+logs, raw `labels`, or `labelSet` values.
+
 ## Auth Token Provider
 
 Self-hosted deployments can require short-lived host-app auth tokens before BugDrop accepts feedback. This is useful when the widget is only meant for authenticated users in your product.

--- a/docs/website/javascript-api.mdx
+++ b/docs/website/javascript-api.mdx
@@ -12,8 +12,9 @@ The `window.BugDrop` object is available after the widget initializes. It provid
 | `BugDrop.close()` | Method | Closes the feedback form |
 | `BugDrop.hide()` | Method | Hides the floating button |
 | `BugDrop.show()` | Method | Shows the floating button |
-| `BugDrop.isOpen` | Property (boolean) | `true` if the feedback form is currently open |
-| `BugDrop.isButtonVisible` | Property (boolean) | `true` if the floating button is currently visible |
+| `BugDrop.isOpen()` | Method | Returns `true` if the feedback form is currently open |
+| `BugDrop.isButtonVisible()` | Method | Returns `true` if the floating button is currently visible |
+| `BugDrop.registerVariant(config)` | Method | Registers an immutable custom feedback definition and returns a durable handle |
 
 ### Basic Usage
 
@@ -32,12 +33,12 @@ The `window.BugDrop` object is available after the widget initializes. It provid
   window.BugDrop.show();
 
   // Check if the form is open
-  if (window.BugDrop.isOpen) {
+  if (window.BugDrop.isOpen()) {
     console.log('Form is currently open');
   }
 
   // Check if the button is visible
-  if (window.BugDrop.isButtonVisible) {
+  if (window.BugDrop.isButtonVisible()) {
     console.log('Button is visible');
   }
 </script>
@@ -81,7 +82,7 @@ A common pattern is integrating BugDrop into your application's navigation or he
 
 ### Using the `bugdrop:ready` Event
 
-BugDrop dispatches a `bugdrop:ready` event on the `document` when it finishes initializing. This is the recommended way to set up integrations:
+BugDrop dispatches a non-bubbling `bugdrop:ready` event on `window` when it finishes initialization. This is the recommended way to set up integrations:
 
 ```html
 <nav>
@@ -103,7 +104,7 @@ BugDrop dispatches a `bugdrop:ready` event on the `document` when it finishes in
 ></script>
 
 <script>
-  document.addEventListener('bugdrop:ready', function () {
+  window.addEventListener('bugdrop:ready', function () {
     const link = document.getElementById('report-bug-link');
     link.style.display = '';
     link.addEventListener('click', function (e) {
@@ -132,7 +133,7 @@ If your code runs after the page is fully loaded and you want to check whether B
     window.BugDrop.open();
   } else {
     // Wait for it
-    document.addEventListener('bugdrop:ready', function () {
+    window.addEventListener('bugdrop:ready', function () {
       window.BugDrop.open();
     });
   }
@@ -140,6 +141,43 @@ If your code runs after the page is fully loaded and you want to check whether B
 ```
 
 This "check first, listen second" pattern is useful in single-page applications where your code might run at various points in the page lifecycle.
+
+## Headless Variants
+
+Use a registered variant when your application owns the UI but should reuse BugDrop's validation,
+metadata, auth, Worker policy, and GitHub Issue creation. Registration validates synchronously and
+stores an immutable copy. The variant sidecar does no DOM, listener, observer, storage, or ID work
+until registration or submission requires it.
+
+```js
+const review = window.BugDrop.registerVariant({
+  id: 'export-review',
+  presentation: { kind: 'inline' },
+  content: { title: 'How was this export?' },
+  fields: [
+    { id: 'rating', type: 'rating', label: 'Rating', required: true, scale: 5 },
+    { id: 'message', type: 'longText', label: 'Anything else?', maxLength: 1000 },
+  ],
+  issue: {
+    classification: 'feedback',
+    title: '[Export review] {{rating}}/5',
+    sections: [
+      { heading: 'Rating', field: 'rating', format: 'stars' },
+      { heading: 'Comment', field: 'message', omitWhenEmpty: true },
+    ],
+  },
+});
+
+const result = await review.submit(
+  { rating: 5, message: 'Fast and clear.' },
+  { context: { surface: 'export-complete' } }
+);
+console.log(result.issueNumber, result.issueUrl);
+```
+
+Selecting or changing a value in host UI never submits. Only `submit()` sends a request. Rendered
+`open()` and `mount()` variants are not part of the Phase 1 headless foundation. TypeScript consumers
+can import `VariantConfig`, `VariantHandle`, and related declarations from the `bugdrop` package.
 
 ## Keyboard Shortcut Example
 
@@ -151,7 +189,7 @@ You can bind BugDrop to a keyboard shortcut for power users:
     // Ctrl+Shift+B (or Cmd+Shift+B on Mac) to toggle bug report
     if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'B') {
       e.preventDefault();
-      if (window.BugDrop && window.BugDrop.isOpen) {
+      if (window.BugDrop && window.BugDrop.isOpen()) {
         window.BugDrop.close();
       } else if (window.BugDrop) {
         window.BugDrop.open();

--- a/e2e/legacy-compat.spec.ts
+++ b/e2e/legacy-compat.spec.ts
@@ -1,0 +1,162 @@
+import { readFile } from 'node:fs/promises';
+import { test, expect, type Page } from '@playwright/test';
+
+interface HistoricalPayload {
+  repo: string;
+  title: string;
+  description: string;
+  screenshot: null;
+  metadata: {
+    url: string;
+    userAgent: string;
+    viewport: { width: number; height: number };
+    timestamp: string;
+    elementSelector: null;
+  };
+}
+
+const fixtureRoot = new URL('../test/fixtures/legacy-compat/', import.meta.url);
+const historicalBundle = await readFile(new URL('v1.1.0/widget.js', fixtureRoot), 'utf8');
+const currentLegacyBundle = await readFile(new URL('v1.53.1/widget.js', fixtureRoot), 'utf8');
+const legacyPayloads = JSON.parse(
+  await readFile(new URL('legacy-payload.json', fixtureRoot), 'utf8')
+) as { historicalV1_1_0Submission: HistoricalPayload };
+const legacyResponse = JSON.parse(
+  await readFile(new URL('legacy-response.json', fixtureRoot), 'utf8')
+) as Record<string, unknown>;
+
+async function mountHistoricalWidget(
+  page: Page,
+  options: { repo?: string; buttonDismissible?: boolean; bundle?: string } = {}
+) {
+  const repo = options.repo ?? legacyPayloads.historicalV1_1_0Submission.repo;
+  const dismissible = options.buttonDismissible ? ' data-button-dismissible="true"' : '';
+
+  await page.route('**/legacy-compat-fixture', route =>
+    route.fulfill({
+      contentType: 'text/html',
+      body: `<!doctype html><html><body><main>Legacy host</main><script src="/widget.js" data-repo="${repo}"${dismissible}></script></body></html>`,
+    })
+  );
+  await page.route('**/widget.js', route =>
+    route.fulfill({ contentType: 'text/javascript', body: options.bundle ?? historicalBundle })
+  );
+  await page.route('**/api/check/**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{"installed":true}' })
+  );
+  await page.goto('/legacy-compat-fixture');
+  await expect(page.locator('#bugdrop-host').locator('css=.bd-trigger')).toBeVisible();
+}
+
+async function fillCurrentLegacyScreenshotFreeForm(page: Page) {
+  const root = page.locator('#bugdrop-host');
+  await root.locator('css=.bd-trigger').click();
+  await root.locator('css=[data-action="continue"]').click();
+  await root.locator('css=#title').fill('Current legacy compatibility');
+  await root.locator('css=#description').fill('Tag-reconstructed v1.53.1 browser submission');
+  const screenshotCheckbox = root.locator('css=#include-screenshot');
+  if (await screenshotCheckbox.count()) await screenshotCheckbox.uncheck();
+  await root.locator('css=#submit-btn').click();
+}
+
+async function fillHistoricalScreenshotFreeForm(page: Page) {
+  const root = page.locator('#bugdrop-host');
+  await root.locator('css=.bd-trigger').click();
+  await root.locator('css=[data-action="skip"]').click();
+  await root.locator('css=#title').fill(legacyPayloads.historicalV1_1_0Submission.title);
+  await root
+    .locator('css=#description')
+    .fill(legacyPayloads.historicalV1_1_0Submission.description);
+  await root.locator('css=#submit-btn').click();
+}
+
+test.describe('tag-reconstructed v1.1.0 compatibility', () => {
+  test('emits the frozen screenshot-free request and accepts the frozen response', async ({
+    page,
+  }) => {
+    let submittedPayload: HistoricalPayload | undefined;
+    await page.route('**/api/feedback', async route => {
+      submittedPayload = route.request().postDataJSON() as HistoricalPayload;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(legacyResponse),
+      });
+    });
+    await mountHistoricalWidget(page);
+
+    await fillHistoricalScreenshotFreeForm(page);
+
+    await expect(page.locator('#bugdrop-host').locator('css=.bd-success-content')).toBeVisible();
+    expect(submittedPayload).toBeDefined();
+    const normalizedPayload = {
+      ...submittedPayload!,
+      metadata: {
+        ...submittedPayload!.metadata,
+        url: new URL(submittedPayload!.metadata.url).pathname,
+        userAgent: '<user-agent>',
+        timestamp: '<timestamp>',
+      },
+    };
+    expect(normalizedPayload).toEqual(legacyPayloads.historicalV1_1_0Submission);
+  });
+
+  test('is parsed by the candidate Worker before a deliberately impossible repository is rejected', async ({
+    page,
+  }) => {
+    const impossibleOwner = 'x'.repeat(40);
+    await mountHistoricalWidget(page, { repo: `${impossibleOwner}/legacy-compat` });
+    const feedbackResponse = page.waitForResponse(response =>
+      response.url().endsWith('/api/feedback')
+    );
+
+    await fillHistoricalScreenshotFreeForm(page);
+
+    const response = await feedbackResponse;
+    expect(response.status()).not.toBe(400);
+    expect(response.status()).not.toBe(200);
+    await expect(page.locator('#bugdrop-host').locator('css=.bd-error-message')).toBeVisible();
+  });
+
+  test('keeps the legacy open shadow root and dismissal storage contract', async ({ page }) => {
+    await mountHistoricalWidget(page, { buttonDismissible: true });
+    const host = page.locator('#bugdrop-host');
+
+    expect(await host.evaluate(element => element.shadowRoot?.mode)).toBe('open');
+    await host.locator('css=.bd-trigger-close').click();
+
+    await expect(host.locator('css=.bd-trigger')).toHaveCount(0);
+    expect(await page.evaluate(() => localStorage.getItem('bugdrop_dismissed'))).toBe('true');
+  });
+});
+
+test.describe('tag-reconstructed v1.53.1 compatibility', () => {
+  test('keeps the current legacy bootstrap and is parsed by the candidate Worker', async ({
+    page,
+  }) => {
+    const impossibleOwner = 'x'.repeat(40);
+    await mountHistoricalWidget(page, {
+      repo: `${impossibleOwner}/legacy-compat`,
+      bundle: currentLegacyBundle,
+    });
+    const host = page.locator('#bugdrop-host');
+    expect(await host.evaluate(element => element.shadowRoot?.mode)).toBe('open');
+    expect(
+      await page.evaluate(() => ({
+        hasLegacyOpen: typeof window.BugDrop?.open === 'function',
+        hasLegacyClose: typeof window.BugDrop?.close === 'function',
+        hasVariantRegistration: typeof window.BugDrop?.registerVariant === 'function',
+      }))
+    ).toEqual({ hasLegacyOpen: true, hasLegacyClose: true, hasVariantRegistration: false });
+
+    const feedbackResponse = page.waitForResponse(response =>
+      response.url().endsWith('/api/feedback')
+    );
+    await fillCurrentLegacyScreenshotFreeForm(page);
+
+    const response = await feedbackResponse;
+    expect(response.status()).not.toBe(400);
+    expect(response.status()).not.toBe(200);
+    await expect(host.locator('css=.bd-error-message')).toBeVisible();
+  });
+});

--- a/e2e/live-preview-widget.spec.ts
+++ b/e2e/live-preview-widget.spec.ts
@@ -1,0 +1,37 @@
+import { readFile } from 'node:fs/promises';
+import { expect, test } from '@playwright/test';
+import {
+  assertExactPreviewWidgetResponse,
+  installExactPreviewWidget,
+  sha256,
+  waitForPreviewWidgetResponse,
+} from './live-preview-widget';
+
+const fixturePath = 'test/fixtures/legacy-compat/v1.1.0/widget.js';
+
+test('pins a browser script request to the verified widget fixture', async ({ context, page }) => {
+  const widgetOrigin = 'https://unresolvable-preview-widget.invalid';
+  const expectedSha256 = sha256(await readFile(fixturePath));
+  await installExactPreviewWidget(context, { fixturePath, expectedSha256, widgetOrigin });
+
+  const responsePromise = waitForPreviewWidgetResponse(page, widgetOrigin);
+  await page.setContent(
+    `<script src="${widgetOrigin}/widget.js" data-repo="mean-weasel/bugdrop-widget-test"></script>`
+  );
+  const response = await responsePromise;
+
+  await assertExactPreviewWidgetResponse(response, expectedSha256);
+  expect(response.headers()['x-bugdrop-widget-sha256']).toBe(expectedSha256);
+});
+
+test('rejects a fixture whose bytes do not match the expected deployment hash', async ({
+  context,
+}) => {
+  await expect(
+    installExactPreviewWidget(context, {
+      fixturePath,
+      expectedSha256: '0'.repeat(64),
+      widgetOrigin: 'https://unresolvable-preview-widget.invalid',
+    })
+  ).rejects.toThrow('Exact preview widget fixture hash');
+});

--- a/e2e/live-preview-widget.ts
+++ b/e2e/live-preview-widget.ts
@@ -1,0 +1,113 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { test as base, type BrowserContext, type Page, type Response } from '@playwright/test';
+
+type ExactPreviewWidgetOptions = {
+  fixturePath: string;
+  expectedSha256: string;
+  widgetOrigin: string;
+};
+
+type ExactPreviewWidgetFixtures = {
+  exactPreviewWidget: void;
+};
+
+export const test = base.extend<ExactPreviewWidgetFixtures>({
+  exactPreviewWidget: [
+    async ({ context }, use) => {
+      await installExactPreviewWidgetFromEnvironment(context);
+      await use();
+    },
+    { auto: true },
+  ],
+});
+
+export async function installExactPreviewWidgetFromEnvironment(
+  context: BrowserContext
+): Promise<void> {
+  const fixturePath = process.env.EXACT_WIDGET_FIXTURE_PATH?.trim();
+  const expectedSha256 = process.env.EXPECTED_WIDGET_SHA256?.trim();
+  const widgetOrigin = process.env.EXPECTED_WIDGET_ORIGIN?.trim();
+
+  if (!fixturePath && !expectedSha256 && !widgetOrigin) return;
+  if (!fixturePath || !expectedSha256 || !widgetOrigin) {
+    throw new Error(
+      'EXACT_WIDGET_FIXTURE_PATH, EXPECTED_WIDGET_SHA256, and EXPECTED_WIDGET_ORIGIN must be set together'
+    );
+  }
+  await installExactPreviewWidget(context, { fixturePath, expectedSha256, widgetOrigin });
+}
+
+export async function installExactPreviewWidget(
+  context: BrowserContext,
+  options: ExactPreviewWidgetOptions
+): Promise<void> {
+  const expectedSha256 = requireSha256(options.expectedSha256);
+  const widgetOrigin = requireOrigin(options.widgetOrigin);
+  const body = await readFile(options.fixturePath);
+  const actualSha256 = sha256(body);
+
+  if (actualSha256 !== expectedSha256) {
+    throw new Error(
+      `Exact preview widget fixture hash is ${actualSha256}, expected ${expectedSha256}`
+    );
+  }
+
+  await context.route(`${widgetOrigin}/widget.js`, async route => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/javascript; charset=utf-8',
+      headers: {
+        'access-control-allow-origin': '*',
+        'cache-control': 'no-store',
+        'x-bugdrop-widget-sha256': expectedSha256,
+      },
+      body,
+    });
+  });
+}
+
+export function waitForPreviewWidgetResponse(page: Page, widgetOrigin: string): Promise<Response> {
+  const origin = requireOrigin(widgetOrigin);
+  return page.waitForResponse(response => {
+    const url = new URL(response.url());
+    return url.origin === origin && url.pathname === '/widget.js';
+  });
+}
+
+export async function assertExactPreviewWidgetResponse(
+  response: Response,
+  expectedSha256: string
+): Promise<void> {
+  if (!response.ok()) {
+    throw new Error(`Preview widget response failed with ${response.status()}`);
+  }
+  const expected = requireSha256(expectedSha256);
+  const actual = sha256(await response.body());
+  if (actual !== expected) {
+    throw new Error(`Browser loaded preview widget hash ${actual}, expected ${expected}`);
+  }
+}
+
+export function sha256(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+function requireOrigin(value: string): string {
+  const url = new URL(value);
+  if (url.origin !== value) {
+    throw new Error(`Expected an origin without a path: ${value}`);
+  }
+  return url.origin;
+}
+
+function requireSha256(value: string): string {
+  if (!/^[a-f0-9]{64}$/.test(value)) {
+    throw new Error('Expected a lowercase SHA-256 digest');
+  }
+  return value;
+}

--- a/e2e/widget.cross-browser-live.spec.ts
+++ b/e2e/widget.cross-browser-live.spec.ts
@@ -1,5 +1,9 @@
-import { createHash } from 'node:crypto';
-import { test, expect, type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
+import {
+  assertExactPreviewWidgetResponse,
+  test,
+  waitForPreviewWidgetResponse,
+} from './live-preview-widget';
 
 const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
 const expectedWidgetOrigin =
@@ -23,10 +27,6 @@ if (bypassSecret) {
       });
     });
   });
-}
-
-function sha256(buffer: Buffer): string {
-  return createHash('sha256').update(buffer).digest('hex');
 }
 
 async function mockInstalledRepo(page: Page) {
@@ -74,7 +74,10 @@ async function padDomToNodeCount(page: Page, targetNodeCount: number) {
 }
 
 test.describe('Cross-Browser Live Preview Smoke', () => {
-  test('loads the expected preview widget asset', async ({ page, request }) => {
+  test('loads the expected preview widget asset', async ({ page }) => {
+    const responsePromise = expectedWidgetOrigin
+      ? waitForPreviewWidgetResponse(page, expectedWidgetOrigin)
+      : undefined;
     await page.goto(venuePath);
 
     const host = page.locator('#bugdrop-host');
@@ -95,11 +98,8 @@ test.describe('Cross-Browser Live Preview Smoke', () => {
       expect(widgetSrc).toContain(`${expectedWidgetOrigin}/widget.js`);
     }
 
-    const response = await request.get(widgetSrc);
-    expect(response.ok()).toBeTruthy();
-
-    if (expectedWidgetSha256) {
-      expect(sha256(await response.body())).toBe(expectedWidgetSha256);
+    if (responsePromise && expectedWidgetSha256) {
+      await assertExactPreviewWidgetResponse(await responsePromise, expectedWidgetSha256);
     }
   });
 

--- a/e2e/widget.issue-canary.spec.ts
+++ b/e2e/widget.issue-canary.spec.ts
@@ -1,7 +1,11 @@
-import { createHash } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { expect, test, type Page, type Request } from '@playwright/test';
+import { expect, type Page, type Request } from '@playwright/test';
+import {
+  assertExactPreviewWidgetResponse,
+  test,
+  waitForPreviewWidgetResponse,
+} from './live-preview-widget';
 
 const TEST_REPO = 'mean-weasel/bugdrop-widget-test';
 const PREVIEW_WIDGET_ORIGIN = 'https://bugdrop-preview.neonwatty.workers.dev';
@@ -26,12 +30,15 @@ test.describe.configure({ mode: 'serial', retries: 0 });
 
 test('headless structured preview widget creates one real Issue with exact deployment identity', async ({
   page,
-  request,
 }) => {
   const environment = requireCanaryEnvironment();
   const submissionId = `ci:${environment.marker}`;
   await installVercelBypass(page);
 
+  const widgetResponsePromise = waitForPreviewWidgetResponse(
+    page,
+    environment.expectedWidgetOrigin
+  );
   await page.goto('/');
   const widgetSrc = await page.evaluate(() => {
     return Array.from(document.scripts)
@@ -44,9 +51,10 @@ test('headless structured preview widget creates one real Issue with exact deplo
   expect(widgetUrl.origin).toBe(environment.expectedWidgetOrigin);
   expect(widgetUrl.pathname).toBe('/widget.js');
 
-  const widgetResponse = await request.get(widgetUrl.href);
-  expect(widgetResponse.ok()).toBe(true);
-  expect(sha256(await widgetResponse.body())).toBe(environment.expectedWidgetSha256);
+  await assertExactPreviewWidgetResponse(
+    await widgetResponsePromise,
+    environment.expectedWidgetSha256
+  );
 
   const feedbackPosts: Request[] = [];
   let rejectedRequest: string | undefined;
@@ -215,8 +223,4 @@ async function installVercelBypass(page: Page): Promise<void> {
       },
     });
   });
-}
-
-function sha256(buffer: Buffer): string {
-  return createHash('sha256').update(buffer).digest('hex');
 }

--- a/e2e/widget.issue-canary.spec.ts
+++ b/e2e/widget.issue-canary.spec.ts
@@ -24,11 +24,12 @@ type FeedbackResult = {
 
 test.describe.configure({ mode: 'serial', retries: 0 });
 
-test('legacy preview widget creates one real Issue with exact deployment identity', async ({
+test('headless structured preview widget creates one real Issue with exact deployment identity', async ({
   page,
   request,
 }) => {
   const environment = requireCanaryEnvironment();
+  const submissionId = `ci:${environment.marker}`;
   await installVercelBypass(page);
 
   await page.goto('/');
@@ -69,26 +70,24 @@ test('legacy preview widget creates one real Issue with exact deployment identit
 
     const payload = outgoing.postDataJSON() as Record<string, unknown>;
     expect(payload.repo).toBe(TEST_REPO);
-    expect(payload.title).toBe(`${TITLE_PREFIX} ${environment.marker}`);
-    expect(payload.description).toContain(environment.marker);
-    expect(payload.category).toBe('bug');
-    expect(payload.screenshot).toBeNull();
+    expect(payload).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      repo: TEST_REPO,
+      variantId: 'merge-queue-canary',
+      submissionId,
+      issue: {
+        title: `${TITLE_PREFIX} ${environment.marker}`,
+        classification: 'bug',
+        sections: [{ heading: 'Canary marker', value: environment.marker, format: 'text' }],
+      },
+    });
+    expect(payload).not.toHaveProperty('labels');
+    expect(payload).not.toHaveProperty('labelSet');
+    expect(payload).not.toHaveProperty('screenshot');
+    expect(payload).not.toHaveProperty('fields');
     await route.continue();
   });
-
-  const host = page.locator('#bugdrop-host');
-  await expect(host.locator('css=.bd-trigger')).toBeVisible({ timeout: 10_000 });
-  await host.locator('css=.bd-trigger').click();
-  await expect(host.locator('css=[data-action="continue"]')).toBeVisible({ timeout: 5_000 });
-  await host.locator('css=[data-action="continue"]').click();
-
-  await expect(host.locator('css=#title')).toBeVisible({ timeout: 5_000 });
-  await host.locator('css=input[name="category"][value="bug"]').check();
-  await host.locator('css=#title').fill(`${TITLE_PREFIX} ${environment.marker}`);
-  await host.locator('css=#description').fill(environment.marker);
-  const screenshotCheckbox = host.locator('css=#include-screenshot');
-  await screenshotCheckbox.uncheck();
-  await expect(screenshotCheckbox).not.toBeChecked();
 
   const feedbackResponsePromise = page.waitForResponse(response => {
     const responseUrl = new URL(response.url());
@@ -98,7 +97,24 @@ test('legacy preview widget creates one real Issue with exact deployment identit
       responseUrl.pathname === '/api/feedback'
     );
   });
-  await host.locator('css=#submit-btn').click();
+  const result = await page.evaluate(
+    async ({ marker, submissionId, titlePrefix }) => {
+      if (!window.BugDrop) throw new Error('BugDrop API is unavailable');
+      const handle = window.BugDrop.registerVariant({
+        id: 'merge-queue-canary',
+        presentation: { kind: 'inline' },
+        content: { title: 'Merge-queue canary' },
+        fields: [{ id: 'marker', type: 'longText', label: 'Marker', required: true }],
+        issue: {
+          classification: 'bug',
+          title: `${titlePrefix} {{marker}}`,
+          sections: [{ heading: 'Canary marker', field: 'marker' }],
+        },
+      });
+      return handle.submit({ marker }, { submissionId });
+    },
+    { marker: environment.marker, submissionId, titlePrefix: TITLE_PREFIX }
+  );
   const feedbackResponse = await feedbackResponsePromise;
 
   const feedbackUrl = new URL(feedbackResponse.url());
@@ -106,14 +122,17 @@ test('legacy preview widget creates one real Issue with exact deployment identit
   expect(feedbackUrl.pathname).toBe('/api/feedback');
   expect(feedbackResponse.status()).toBe(200);
   expect(feedbackResponse.headers()['x-bugdrop-build-sha']).toBe(environment.expectedWorkerSha);
-  const result = (await feedbackResponse.json()) as FeedbackResult;
-  expect(result.success).toBe(true);
-  expect(Number.isInteger(result.issueNumber) && Number(result.issueNumber) > 0).toBe(true);
-  const issueNumber = Number(result.issueNumber);
+  const responseResult = (await feedbackResponse.json()) as FeedbackResult;
+  expect(responseResult.success).toBe(true);
+  expect(result.issueNumber).toBe(responseResult.issueNumber);
+  expect(result.issueUrl).toBe(responseResult.issueUrl);
+  expect(
+    Number.isInteger(responseResult.issueNumber) && Number(responseResult.issueNumber) > 0
+  ).toBe(true);
+  const issueNumber = Number(responseResult.issueNumber);
   const issueUrl = `https://github.com/${TEST_REPO}/issues/${issueNumber}`;
-  expect(result.issueUrl).toBe(issueUrl);
+  expect(responseResult.issueUrl).toBe(issueUrl);
 
-  await expect(host.locator('css=.bd-success-content')).toBeVisible({ timeout: 10_000 });
   await page.waitForTimeout(1_000);
   expect(rejectedRequest).toBeUndefined();
   expect(feedbackPosts).toHaveLength(1);
@@ -123,6 +142,8 @@ test('legacy preview widget creates one real Issue with exact deployment identit
     environment.resultFile,
     `${JSON.stringify({
       marker: environment.marker,
+      kind: 'structured',
+      submissionId,
       issueNumber,
       issueUrl,
       workerSha: environment.expectedWorkerSha,

--- a/e2e/widget.live-radix.spec.ts
+++ b/e2e/widget.live-radix.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
+import { test } from './live-preview-widget';
 
 const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
 const venuePath = process.env.LIVE_VENUE_PATH || '/';

--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -1,5 +1,10 @@
-import { createHash } from 'node:crypto';
-import { test, expect, type Locator, type Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
+import {
+  assertExactPreviewWidgetResponse,
+  installExactPreviewWidgetFromEnvironment,
+  test,
+  waitForPreviewWidgetResponse,
+} from './live-preview-widget';
 
 /**
  * Live E2E tests for BugDrop widget on a real cross-origin deployment.
@@ -34,10 +39,6 @@ if (bypassSecret) {
       await route.continue({ headers });
     });
   });
-}
-
-function sha256(buffer: Buffer): string {
-  return createHash('sha256').update(buffer).digest('hex');
 }
 
 async function mockInstalledRepo(page: Page) {
@@ -345,7 +346,10 @@ test.describe('Widget Loading (Live)', () => {
     expect(unexpectedErrors).toHaveLength(0);
   });
 
-  test('venue loads the expected deployed widget asset', async ({ page, request }) => {
+  test('venue loads the expected deployed widget asset', async ({ page }) => {
+    const responsePromise = expectedWidgetOrigin
+      ? waitForPreviewWidgetResponse(page, expectedWidgetOrigin)
+      : undefined;
     await page.goto(venuePath);
 
     const widgetSrc = await page.evaluate(() => {
@@ -360,12 +364,8 @@ test.describe('Widget Loading (Live)', () => {
       expect(widgetSrc).toContain(`${expectedWidgetOrigin}/widget.js`);
     }
 
-    const response = await request.get(widgetSrc);
-    expect(response.ok()).toBeTruthy();
-
-    if (expectedWidgetSha256) {
-      const body = await response.body();
-      expect(sha256(body)).toBe(expectedWidgetSha256);
+    if (responsePromise && expectedWidgetSha256) {
+      await assertExactPreviewWidgetResponse(await responsePromise, expectedWidgetSha256);
     }
   });
 });
@@ -641,6 +641,7 @@ test.describe('Screenshot Capture (Live)', () => {
       isMobile: true,
       viewport: { width: 390, height: 844 },
     });
+    await installExactPreviewWidgetFromEnvironment(context);
     if (bypassSecret) {
       await context.route('**/*.vercel.app/**', async route => {
         const headers = {

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2527,6 +2527,7 @@ test.describe('JavaScript API', () => {
     expect(apiMethods).toContain('show');
     expect(apiMethods).toContain('isOpen');
     expect(apiMethods).toContain('isButtonVisible');
+    expect(apiMethods).toContain('registerVariant');
   });
 
   test('bugdrop:ready event fires after initialization', async ({ page }) => {
@@ -2545,6 +2546,272 @@ test.describe('JavaScript API', () => {
     // Verify the event was received
     const statusText = await page.locator('#status').textContent();
     expect(statusText).toContain('BugDrop ready');
+  });
+
+  test('bugdrop:ready keeps its exact event semantics and exposes the API first', async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      const state = {
+        documentCount: 0,
+        events: [] as Array<Record<string, unknown>>,
+      };
+      (window as Window & { __bugdropReadyState?: typeof state }).__bugdropReadyState = state;
+      document.addEventListener('bugdrop:ready', () => {
+        state.documentCount += 1;
+      });
+      window.addEventListener('bugdrop:ready', event => {
+        state.events.push({
+          targetIsWindow: event.target === window,
+          bubbles: event.bubbles,
+          cancelable: event.cancelable,
+          detail: (event as CustomEvent).detail,
+          apiMethods: Object.keys(window.BugDrop ?? {}).sort(),
+        });
+      });
+    });
+
+    await page.goto('/test/');
+    await page.locator('#bugdrop-host').locator('css=.bd-trigger').waitFor();
+
+    const state = await page.evaluate(
+      () =>
+        (
+          window as Window & {
+            __bugdropReadyState?: {
+              documentCount: number;
+              events: Array<Record<string, unknown>>;
+            };
+          }
+        ).__bugdropReadyState
+    );
+    expect(state).toEqual({
+      documentCount: 0,
+      events: [
+        {
+          targetIsWindow: true,
+          bubbles: false,
+          cancelable: false,
+          detail: null,
+          apiMethods: [
+            'close',
+            'hide',
+            'isButtonVisible',
+            'isOpen',
+            'open',
+            'registerVariant',
+            'setTheme',
+            'show',
+          ],
+        },
+      ],
+    });
+  });
+
+  test('legacy API methods remain detachable and ignore extra arguments', async ({ page }) => {
+    await page.route('**/api/check**', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"installed":true}' })
+    );
+    await page.goto('/test/');
+    await page.locator('#bugdrop-host').locator('css=.bd-trigger').waitFor();
+
+    const openResult = await page.evaluate(() => {
+      const { open } = window.BugDrop!;
+      return (open as (...arguments_: unknown[]) => unknown)('future-instance-id', {
+        ignored: true,
+      });
+    });
+    expect(openResult).toBeUndefined();
+    await expect(page.locator('#bugdrop-host').locator('css=.bd-modal')).toBeVisible();
+
+    const closeResult = await page.evaluate(() => {
+      const { close } = window.BugDrop!;
+      return (close as (...arguments_: unknown[]) => unknown)('future-instance-id');
+    });
+    expect(closeResult).toBeUndefined();
+    await expect(page.locator('#bugdrop-host').locator('css=.bd-modal')).not.toBeVisible();
+  });
+
+  test('does no variant-only work before any future variant registration', async ({ page }) => {
+    await page.goto('/test/');
+    await page.locator('#bugdrop-host').locator('css=.bd-trigger').waitFor();
+
+    const variantWork = await page.evaluate(() => ({
+      ownedRoots: document.querySelectorAll('[data-bugdrop-owned]').length,
+      storageKeys: Object.keys(localStorage).filter(key => key.startsWith('bugdrop_variant_')),
+    }));
+    expect(variantWork).toEqual({ ownedRoots: 0, storageKeys: [] });
+  });
+
+  test('registers multiple isolated variants and submits exact headless drafts', async ({
+    page,
+  }) => {
+    const submitted: Record<string, unknown>[] = [];
+    await page.route('**/api/feedback', route => {
+      submitted.push(route.request().postDataJSON() as Record<string, unknown>);
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          issueNumber: 91,
+          issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/91',
+          isPublic: true,
+        }),
+      });
+    });
+    await page.goto('/test/?private=redacted#secret');
+    await page.locator('#bugdrop-host').locator('css=.bd-trigger').waitFor();
+
+    const result = await page.evaluate(async () => {
+      const source: Parameters<NonNullable<typeof window.BugDrop>['registerVariant']>[0] = {
+        id: 'export-review',
+        presentation: { kind: 'inline' },
+        content: { title: 'Export review' },
+        fields: [
+          { id: 'rating', type: 'rating', label: 'Rating', required: true, scale: 5 },
+          { id: 'message', type: 'longText', label: 'Comment' },
+        ],
+        issue: {
+          classification: 'feedback',
+          title: 'Review {{rating}}/5',
+          sections: [
+            { heading: 'Rating', field: 'rating', format: 'stars' },
+            { heading: 'Comment', field: 'message', omitWhenEmpty: true },
+          ],
+        },
+      };
+      const handle = window.BugDrop!.registerVariant(source);
+      const ctaHandle = window.BugDrop!.registerVariant({
+        id: 'cloud-provider-idea',
+        presentation: { kind: 'modal' },
+        content: { title: 'Which cloud provider should we add?' },
+        fields: [{ id: 'idea', type: 'shortText', label: 'Provider', required: true }],
+        issue: {
+          classification: 'feature',
+          title: 'Cloud provider idea: {{idea}}',
+          sections: [{ heading: 'Idea', field: 'idea' }],
+        },
+      });
+      source.issue.title = 'mutated {{message}}';
+      let duplicateError = '';
+      try {
+        window.BugDrop!.registerVariant(source);
+      } catch (error) {
+        duplicateError = error instanceof Error ? error.message : String(error);
+      }
+      const submission = await handle.submit(
+        { rating: 5, message: '' },
+        { submissionId: 'e2e-submission-1' }
+      );
+      const ctaSubmission = await ctaHandle.submit(
+        { idea: 'Google Cloud' },
+        { submissionId: 'e2e-submission-2' }
+      );
+      return {
+        id: handle.id,
+        submission,
+        ctaId: ctaHandle.id,
+        ctaSubmission,
+        duplicateError,
+        ownedRoots: document.querySelectorAll('[data-bugdrop-owned]').length,
+        variantStorage: Object.keys(localStorage).filter(key => key.startsWith('bugdrop_variant_')),
+      };
+    });
+
+    expect(result).toEqual({
+      id: 'export-review',
+      submission: {
+        issueNumber: 91,
+        issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/91',
+        isPublic: true,
+      },
+      ctaId: 'cloud-provider-idea',
+      ctaSubmission: {
+        issueNumber: 91,
+        issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/91',
+        isPublic: true,
+      },
+      duplicateError: 'BugDrop variant is already registered: export-review',
+      ownedRoots: 0,
+      variantStorage: [],
+    });
+    expect(submitted).toHaveLength(2);
+    expect(submitted[0]).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      repo: 'mean-weasel/bugdrop-widget-test',
+      variantId: 'export-review',
+      submissionId: 'e2e-submission-1',
+      issue: {
+        title: 'Review 5/5',
+        classification: 'feedback',
+        sections: [{ heading: 'Rating', value: '★★★★★ (5/5)', format: 'text' }],
+      },
+      metadata: { url: 'http://localhost:8787/test/' },
+    });
+    expect(submitted[1]).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      repo: 'mean-weasel/bugdrop-widget-test',
+      variantId: 'cloud-provider-idea',
+      submissionId: 'e2e-submission-2',
+      issue: {
+        title: 'Cloud provider idea: Google Cloud',
+        classification: 'feature',
+        sections: [{ heading: 'Idea', value: 'Google Cloud', format: 'text' }],
+      },
+    });
+    for (const payload of submitted) {
+      expect(payload).not.toHaveProperty('labels');
+      expect(payload).not.toHaveProperty('fields');
+    }
+  });
+
+  test('rejects failed and noncanonical structured submission responses', async ({ page }) => {
+    await page.route('**/api/feedback', route => {
+      const payload = route.request().postDataJSON() as { submissionId?: string };
+      if (payload.submissionId === 'bad-http') {
+        return route.fulfill({
+          status: 422,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Submission rejected' }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          issueNumber: 91,
+          issueUrl: 'https://attacker.test/not-an-issue',
+          isPublic: true,
+        }),
+      });
+    });
+    await page.goto('/test/');
+    await page.locator('#bugdrop-host').locator('css=.bd-trigger').waitFor();
+
+    const errors = await page.evaluate(async () => {
+      const handle = window.BugDrop!.registerVariant({
+        id: 'failure-contract',
+        presentation: { kind: 'inline' },
+        content: { title: 'Failure contract' },
+        fields: [{ id: 'message', type: 'shortText', label: 'Message', required: true }],
+        issue: { title: 'Failure: {{message}}' },
+      });
+      const messages: string[] = [];
+      for (const submissionId of ['bad-http', 'bad-result']) {
+        try {
+          await handle.submit({ message: 'test' }, { submissionId });
+        } catch (error) {
+          messages.push(error instanceof Error ? error.message : String(error));
+        }
+      }
+      return messages;
+    });
+
+    expect(errors).toEqual(['Submission rejected', 'BugDrop received an invalid Issue result']);
   });
 
   test('BugDrop.open() opens the modal', async ({ page }) => {

--- a/knip.json
+++ b/knip.json
@@ -3,8 +3,10 @@
   "entry": [
     "src/index.ts",
     "src/widget/index.ts",
+    "src/widget/public-api.d.ts",
     "scripts/build-widget.js",
-    "scripts/github-issue-canary.mjs"
+    "scripts/github-issue-canary.mjs",
+    "scripts/verify-legacy-compat.mjs"
   ],
   "project": ["src/**/*.ts", "scripts/**/*.{js,mjs}"],
   "ignore": [],

--- a/package.json
+++ b/package.json
@@ -4,10 +4,20 @@
   "description": "In-app feedback → GitHub Issues. Screenshots, annotations, the works.",
   "type": "module",
   "main": "./public/widget.js",
+  "types": "./src/widget/public-api.d.ts",
   "exports": {
-    ".": "./public/widget.js",
-    "./widget": "./public/widget.js",
-    "./widget.js": "./public/widget.js"
+    ".": {
+      "types": "./src/widget/public-api.d.ts",
+      "default": "./public/widget.js"
+    },
+    "./widget": {
+      "types": "./src/widget/public-api.d.ts",
+      "default": "./public/widget.js"
+    },
+    "./widget.js": {
+      "types": "./src/widget/public-api.d.ts",
+      "default": "./public/widget.js"
+    }
   },
   "files": [
     "public/widget.js",
@@ -22,6 +32,7 @@
     "build:widget": "node scripts/build-widget.js",
     "deploy": "wrangler deploy",
     "render:board-gallery": "node scripts/render-board-gallery.mjs",
+    "verify:legacy-compat": "node scripts/verify-legacy-compat.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
@@ -30,6 +41,7 @@
     "typecheck": "tsc --noEmit && tsc --project tsconfig.widget.json --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
+    "knip": "knip",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "check:actions-node24": "node -e \"const {execSync}=require('node:child_process'); const out=execSync('rg -n \\\\\\\"actions/(checkout|setup-node|cache|upload-artifact)@v4|cloudflare/wrangler-action\\\\\\\" .github/workflows || true',{encoding:'utf8'}); if(out.trim()){ console.error(out); process.exit(1); } console.log('GitHub Actions are Node 24-ready');\"",

--- a/scripts/github-issue-canary.mjs
+++ b/scripts/github-issue-canary.mjs
@@ -107,8 +107,12 @@ export async function verifyCanaryIssue({
   }
   if (candidate.html_url !== canonicalUrl) failures.push('Issue URL is not canonical');
   if (candidate.title !== canaryTitle(marker)) failures.push('Issue title does not match exactly');
-  if (!candidate.body?.includes('## Description')) failures.push('Issue body lacks Description');
-  if (!candidate.body?.includes(marker)) failures.push('Issue body lacks the CI marker');
+  if (!candidate.body?.includes(`## Canary marker\n\n${marker}\n`)) {
+    failures.push('Issue body lacks the exact structured Canary marker section and value');
+  }
+  if (!candidate.body?.includes(`<!-- bugdrop-submission: ${result.submissionId} -->`)) {
+    failures.push('Issue body lacks the exact structured submission marker');
+  }
   if (!candidate.body?.includes('<summary>System Info</summary>')) {
     failures.push('Issue body lacks System Info');
   }
@@ -464,6 +468,10 @@ function validateBrowserResult({ failures, result, marker, expectedSha, candidat
     return;
   }
   if (result.marker !== marker) failures.push('Browser result marker does not match');
+  if (result.kind !== 'structured') failures.push('Browser result kind is not structured');
+  if (result.submissionId !== `ci:${marker}`) {
+    failures.push('Browser result submission ID does not match the canary marker');
+  }
   if (!Number.isInteger(result.issueNumber) || result.issueNumber <= 0) {
     failures.push('Browser result Issue number is not a positive integer');
   }
@@ -478,6 +486,10 @@ function validateBrowserResultReference({ failures, result, marker, expectedSha,
     return;
   }
   if (result.marker !== marker) failures.push('Browser result marker does not match');
+  if (result.kind !== 'structured') failures.push('Browser result kind is not structured');
+  if (result.submissionId !== `ci:${marker}`) {
+    failures.push('Browser result submission ID does not match the canary marker');
+  }
   if (!Number.isInteger(result.issueNumber) || result.issueNumber <= 0) {
     failures.push('Browser result Issue number is not a positive integer');
   } else if (result.issueUrl !== canonicalIssueUrl(repo, result.issueNumber)) {

--- a/scripts/verify-legacy-compat.mjs
+++ b/scripts/verify-legacy-compat.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { gzipSync } from 'node:zlib';
+
+const root = new URL('../', import.meta.url);
+const manifestUrl = new URL('test/fixtures/legacy-compat/manifest.json', root);
+const manifest = JSON.parse(readFileSync(manifestUrl, 'utf8'));
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function git(...args) {
+  return execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+}
+
+const failures = [];
+
+for (const [name, fixture] of Object.entries(manifest.bundles)) {
+  const bundle = readFileSync(new URL(fixture.bundle, root));
+  const tagCommit = git('rev-list', '-n', '1', fixture.tag);
+  const lockfile = execFileSync('git', ['show', `${fixture.tag}:package-lock.json`], {
+    cwd: root,
+  });
+  const observed = {
+    commit: tagCommit,
+    packageLockSha256: sha256(lockfile),
+    sha256: sha256(bundle),
+    rawBytes: bundle.byteLength,
+    gzipBytes: gzipSync(bundle, { level: 9 }).byteLength,
+  };
+
+  for (const [field, value] of Object.entries(observed)) {
+    if (value !== fixture[field]) {
+      failures.push(`${name}.${field}: expected ${fixture[field]}, observed ${value}`);
+    }
+  }
+
+  if (!fixture.buildCommand.includes(`VERSION=${fixture.tag}`)) {
+    failures.push(`${name}.buildCommand does not bind the tag version`);
+  }
+}
+
+const baseline = manifest.bundles[manifest.bundleBudget.baselineTag];
+if (!baseline) {
+  failures.push(`Missing bundle-budget baseline ${manifest.bundleBudget.baselineTag}`);
+} else {
+  const expectedMaximum = Math.ceil(
+    baseline.gzipBytes * (1 + manifest.bundleBudget.maxGzipGrowthPercent / 100)
+  );
+  if (manifest.bundleBudget.baselineRawBytes !== baseline.rawBytes) {
+    failures.push('Bundle-budget raw baseline does not match the immutable current fixture');
+  }
+  if (manifest.bundleBudget.baselineGzipBytes !== baseline.gzipBytes) {
+    failures.push('Bundle-budget gzip baseline does not match the immutable current fixture');
+  }
+  if (manifest.bundleBudget.maxGzipBytes !== expectedMaximum) {
+    failures.push(
+      `Bundle-budget maximum: expected ${expectedMaximum}, observed ${manifest.bundleBudget.maxGzipBytes}`
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`Legacy compatibility verification failed:\n- ${failures.join('\n- ')}`);
+  process.exit(1);
+}
+
+console.log(
+  `Legacy compatibility fixtures verified (${Object.keys(manifest.bundles).join(', ')}; gzip budget ${manifest.bundleBudget.maxGzipBytes} bytes).`
+);

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -19,9 +19,10 @@ import {
 import { rateLimit, rateLimitByRepo } from '../middleware/rateLimit';
 import { resolveAccentColor } from '../defaults';
 import { verifyBugDropAuthToken } from '../lib/authToken';
+import { handleStructuredFeedback, isStructuredFeedbackRequest } from './structured-feedback';
 
 type ApiVariables = {
-  feedbackPayload?: FeedbackPayload;
+  feedbackPayload?: unknown;
 };
 type ApiEnv = { Bindings: Env; Variables: ApiVariables };
 
@@ -149,12 +150,18 @@ api.get('/check/:owner/:repo', async c => {
 // Submit feedback
 api.post('/feedback', async c => {
   // Parse payload
-  let payload: FeedbackPayload;
+  let requestPayload: unknown;
   try {
-    payload = c.get('feedbackPayload') ?? (await c.req.json());
+    requestPayload = c.get('feedbackPayload') ?? (await c.req.json());
   } catch {
     return c.json({ error: 'Invalid JSON' }, 400);
   }
+
+  if (isStructuredFeedbackRequest(requestPayload)) {
+    return handleStructuredFeedback(c, requestPayload);
+  }
+
+  const payload = requestPayload as FeedbackPayload;
 
   // Validate required fields (description is optional — many reports are title + screenshot)
   if (!payload.repo || !payload.title) {
@@ -307,9 +314,9 @@ async function requireBugDropFeedbackAuthToken(
   if (!hasBugDropAuthTokenSecret(c.env) || c.req.method !== 'POST') return next();
 
   try {
-    const payload = (await c.req.raw.clone().json()) as FeedbackPayload;
+    const payload = (await c.req.raw.clone().json()) as unknown;
     c.set('feedbackPayload', payload);
-    if (typeof payload.repo !== 'string') return next();
+    if (!isPlainObject(payload) || typeof payload.repo !== 'string') return next();
 
     const authError = await requireBugDropAuthToken(c, payload.repo);
     if (authError) return authError;

--- a/src/routes/structured-feedback.ts
+++ b/src/routes/structured-feedback.ts
@@ -1,0 +1,641 @@
+/* eslint-disable max-lines -- Keep the isolated structured contract out of the legacy route. */
+import type { Context } from 'hono';
+import { GitHubLabelError, createIssue, getInstallationToken, isRepoPublic } from '../lib/github';
+import type {
+  Env,
+  FeedbackMetadata,
+  StructuredFeedbackClassification,
+  StructuredFeedbackPayload,
+  StructuredFeedbackSectionFormat,
+} from '../types';
+
+const STRUCTURED_KIND = 'bugdrop.variant-submission';
+const STRUCTURED_SCHEMA_VERSION = 1;
+const MAX_PAYLOAD_BYTES = 32 * 1024;
+const MAX_SECTIONS = 20;
+const MAX_VARIANT_ID_CHARS = 64;
+const MAX_SUBMISSION_ID_CHARS = 128;
+const MAX_TITLE_CHARS = 256;
+const MAX_HEADING_CHARS = 120;
+const MAX_SECTION_VALUE_CHARS = 5_000;
+const MAX_ISSUE_BODY_CHARS = 65_536;
+const MAX_LABELS = 5;
+const MAX_LABEL_CHARS = 50;
+const VARIANT_ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
+const SUBMISSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const CLASSIFICATIONS = new Set<StructuredFeedbackClassification>([
+  'bug',
+  'feature',
+  'question',
+  'feedback',
+]);
+const SECTION_FORMATS = new Set<StructuredFeedbackSectionFormat>(['text', 'quote', 'code']);
+const TOP_LEVEL_KEYS = new Set([
+  'kind',
+  'schemaVersion',
+  'repo',
+  'variantId',
+  'submissionId',
+  'issue',
+  'metadata',
+]);
+const ISSUE_KEYS = new Set(['title', 'classification', 'sections']);
+const SECTION_KEYS = new Set(['heading', 'value', 'format']);
+const METADATA_KEYS = new Set([
+  'url',
+  'userAgent',
+  'viewport',
+  'timestamp',
+  'elementSelector',
+  'fullElementSelector',
+  'selectedElementHighlightColor',
+  'browser',
+  'os',
+  'devicePixelRatio',
+  'language',
+]);
+
+type StructuredContext = Context<{
+  Bindings: Env;
+  Variables: { feedbackPayload?: unknown };
+}>;
+
+type ValidationResult =
+  | { valid: true; payload: StructuredFeedbackPayload }
+  | { valid: false; error: string };
+
+type LabelResolution = {
+  labels: string[];
+  warnings: string[];
+  usedCustomLabels: boolean;
+};
+
+export function isStructuredFeedbackRequest(value: unknown): boolean {
+  return isPlainObject(value) && value.kind === STRUCTURED_KIND;
+}
+
+export async function handleStructuredFeedback(c: StructuredContext, input: unknown) {
+  const validation = validateStructuredFeedback(input);
+  if (!validation.valid) {
+    return c.json({ error: validation.error }, 400);
+  }
+
+  const payload = validation.payload;
+  const [owner, repo] = payload.repo.split('/');
+
+  try {
+    const token = await getInstallationToken(c.env, owner, repo);
+    if (!token) {
+      const appName = c.env.GITHUB_APP_NAME || 'your-app-name';
+      return c.json(
+        {
+          error: 'GitHub App not installed on this repository',
+          installUrl: `https://github.com/apps/${appName}/installations/new`,
+        },
+        403
+      );
+    }
+
+    const labelResolution = resolveVariantLabels(
+      c.env.VARIANT_LABELS,
+      payload.repo,
+      payload.variantId,
+      payload.issue.classification
+    );
+    if (labelResolution.warnings.length > 0) {
+      console.warn('[BugDrop] Variant label config warnings:', {
+        repo: payload.repo,
+        variantId: payload.variantId,
+        warnings: labelResolution.warnings,
+      });
+    }
+
+    let warnings = labelResolution.warnings;
+    let body = formatStructuredIssueBody(payload, warnings);
+    assertIssueBodyWithinLimit(body);
+    const isPublic = await isRepoPublic(token, owner, repo);
+    let issue;
+    try {
+      issue = await createIssue(
+        token,
+        owner,
+        repo,
+        payload.issue.title,
+        body,
+        labelResolution.labels
+      );
+    } catch (error) {
+      if (!labelResolution.usedCustomLabels || !(error instanceof GitHubLabelError)) throw error;
+
+      const fallbackLabels = defaultLabels(payload.issue.classification);
+      warnings = [
+        ...warnings,
+        `GitHub rejected configured labels (${formatLabelList(labelResolution.labels)}); BugDrop retried with defaults (${formatLabelList(fallbackLabels)}).`,
+      ];
+      body = formatStructuredIssueBody(payload, warnings);
+      assertIssueBodyWithinLimit(body);
+      issue = await createIssue(token, owner, repo, payload.issue.title, body, fallbackLabels);
+    }
+
+    if (
+      !Number.isInteger(issue.number) ||
+      issue.number <= 0 ||
+      !isCanonicalIssueUrl(issue.html_url, owner, repo, issue.number)
+    ) {
+      throw new Error('GitHub returned an invalid Issue result');
+    }
+
+    return c.json({
+      success: true,
+      issueNumber: issue.number,
+      issueUrl: issue.html_url,
+      isPublic,
+      ...(warnings.length > 0 ? { labelMappingWarnings: warnings } : {}),
+    });
+  } catch (error) {
+    console.error('Error creating structured feedback:', error);
+    if (error instanceof StructuredFeedbackBodyError) {
+      return c.json({ error: error.message }, 400);
+    }
+    return c.json(
+      { error: error instanceof Error ? error.message : 'Failed to create issue' },
+      500
+    );
+  }
+}
+
+class StructuredFeedbackBodyError extends Error {}
+
+function assertIssueBodyWithinLimit(body: string): void {
+  if (body.length > MAX_ISSUE_BODY_CHARS) {
+    throw new StructuredFeedbackBodyError(
+      `Structured Issue body exceeds ${MAX_ISSUE_BODY_CHARS} characters after formatting`
+    );
+  }
+}
+
+function validateStructuredFeedback(input: unknown): ValidationResult {
+  if (!isPlainObject(input)) return invalid('Invalid structured feedback payload');
+
+  let payloadSize: number;
+  try {
+    payloadSize = new TextEncoder().encode(JSON.stringify(input)).byteLength;
+  } catch {
+    return invalid('Invalid structured feedback payload');
+  }
+  if (payloadSize > MAX_PAYLOAD_BYTES) {
+    return invalid(`Structured feedback payload exceeds ${MAX_PAYLOAD_BYTES} bytes`);
+  }
+  const unknownTopLevelKey = firstUnknownKey(input, TOP_LEVEL_KEYS);
+  if (unknownTopLevelKey) {
+    return invalid(`Unknown structured feedback property: ${unknownTopLevelKey}`);
+  }
+  if (input.kind !== STRUCTURED_KIND) return invalid('Invalid structured feedback kind');
+  if (input.schemaVersion !== STRUCTURED_SCHEMA_VERSION) {
+    return invalid(`Unsupported structured feedback schemaVersion: ${String(input.schemaVersion)}`);
+  }
+  if (typeof input.repo !== 'string' || !REPO_PATTERN.test(input.repo)) {
+    return invalid('Invalid repo format. Expected: owner/repo');
+  }
+  if (
+    typeof input.variantId !== 'string' ||
+    input.variantId.length > MAX_VARIANT_ID_CHARS ||
+    !VARIANT_ID_PATTERN.test(input.variantId)
+  ) {
+    return invalid('Invalid variantId');
+  }
+  if (
+    typeof input.submissionId !== 'string' ||
+    input.submissionId.length > MAX_SUBMISSION_ID_CHARS ||
+    !SUBMISSION_ID_PATTERN.test(input.submissionId)
+  ) {
+    return invalid('Invalid submissionId');
+  }
+
+  const issueResult = validateIssue(input.issue);
+  if (!issueResult.valid) return issueResult;
+  const metadataResult = validateMetadata(input.metadata);
+  if (!metadataResult.valid) return metadataResult;
+
+  return {
+    valid: true,
+    payload: {
+      kind: STRUCTURED_KIND,
+      schemaVersion: STRUCTURED_SCHEMA_VERSION,
+      repo: input.repo,
+      variantId: input.variantId,
+      submissionId: input.submissionId,
+      issue: issueResult.issue,
+      metadata: metadataResult.metadata,
+    },
+  };
+}
+
+function validateIssue(
+  value: unknown
+): { valid: true; issue: StructuredFeedbackPayload['issue'] } | { valid: false; error: string } {
+  if (!isPlainObject(value)) return invalid('Invalid structured Issue draft');
+  const unknownKey = firstUnknownKey(value, ISSUE_KEYS);
+  if (unknownKey) return invalid(`Unknown structured Issue property: ${unknownKey}`);
+  if (typeof value.title !== 'string') return invalid('Invalid structured Issue title');
+
+  const title = collapseWhitespace(value.title);
+  if (!title || title.length > MAX_TITLE_CHARS) {
+    return invalid(`Structured Issue title must be 1-${MAX_TITLE_CHARS} characters`);
+  }
+  const classification = value.classification;
+  if (
+    classification !== undefined &&
+    (typeof classification !== 'string' ||
+      !CLASSIFICATIONS.has(classification as StructuredFeedbackClassification))
+  ) {
+    return invalid('Invalid structured Issue classification');
+  }
+  if (!Array.isArray(value.sections) || value.sections.length > MAX_SECTIONS) {
+    return invalid(`Structured Issue sections must contain at most ${MAX_SECTIONS} entries`);
+  }
+
+  const headings = new Set<string>();
+  const sections: StructuredFeedbackPayload['issue']['sections'] = [];
+  for (const section of value.sections) {
+    if (!isPlainObject(section)) return invalid('Invalid structured Issue section');
+    const unknownKey = firstUnknownKey(section, SECTION_KEYS);
+    if (unknownKey) return invalid(`Unknown structured Issue section property: ${unknownKey}`);
+    if (typeof section.heading !== 'string' || typeof section.value !== 'string') {
+      return invalid('Structured Issue section heading and value must be strings');
+    }
+    const heading = section.heading.trim();
+    if (!heading || heading.length > MAX_HEADING_CHARS || hasControlChars(heading)) {
+      return invalid(`Structured Issue headings must be 1-${MAX_HEADING_CHARS} characters`);
+    }
+    const headingKey = heading.toLocaleLowerCase('en-US');
+    if (headings.has(headingKey)) return invalid(`Duplicate structured Issue heading: ${heading}`);
+    headings.add(headingKey);
+    if (section.value.length > MAX_SECTION_VALUE_CHARS) {
+      return invalid(
+        `Structured Issue section values must be at most ${MAX_SECTION_VALUE_CHARS} characters`
+      );
+    }
+    const format = section.format ?? 'text';
+    if (
+      typeof format !== 'string' ||
+      !SECTION_FORMATS.has(format as StructuredFeedbackSectionFormat)
+    ) {
+      return invalid('Invalid structured Issue section format');
+    }
+
+    if (section.value.trim()) {
+      sections.push({
+        heading,
+        value: section.value,
+        format: format as StructuredFeedbackSectionFormat,
+      });
+    }
+  }
+
+  return {
+    valid: true,
+    issue: {
+      title,
+      ...(classification
+        ? { classification: classification as StructuredFeedbackClassification }
+        : {}),
+      sections,
+    },
+  };
+}
+
+function validateMetadata(
+  value: unknown
+): { valid: true; metadata: FeedbackMetadata } | { valid: false; error: string } {
+  if (!isPlainObject(value)) return invalid('Invalid structured feedback metadata');
+  const unknownKey = firstUnknownKey(value, METADATA_KEYS);
+  if (unknownKey) return invalid(`Unknown structured metadata property: ${unknownKey}`);
+  if (typeof value.url !== 'string' || value.url.length > 2_048) {
+    return invalid('Invalid structured metadata URL');
+  }
+
+  let redactedUrl: string;
+  try {
+    const parsed = new URL(value.url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') throw new Error('protocol');
+    parsed.search = '';
+    parsed.hash = '';
+    redactedUrl = parsed.toString();
+  } catch {
+    return invalid('Invalid structured metadata URL');
+  }
+  if (typeof value.userAgent !== 'string' || value.userAgent.length > 1_000) {
+    return invalid('Invalid structured metadata userAgent');
+  }
+  if (
+    !isPlainObject(value.viewport) ||
+    !hasOnlyKeys(value.viewport, new Set(['width', 'height']))
+  ) {
+    return invalid('Invalid structured metadata viewport');
+  }
+  const width = value.viewport.width;
+  const height = value.viewport.height;
+  if (!isPositiveBoundedInteger(width, 100_000) || !isPositiveBoundedInteger(height, 100_000)) {
+    return invalid('Invalid structured metadata viewport');
+  }
+  if (
+    typeof value.timestamp !== 'string' ||
+    value.timestamp.length > 64 ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value.timestamp) ||
+    Number.isNaN(Date.parse(value.timestamp))
+  ) {
+    return invalid('Invalid structured metadata timestamp');
+  }
+
+  const metadata: FeedbackMetadata = {
+    url: redactedUrl,
+    userAgent: value.userAgent,
+    viewport: { width, height },
+    timestamp: value.timestamp,
+  };
+  for (const key of [
+    'elementSelector',
+    'fullElementSelector',
+    'selectedElementHighlightColor',
+    'language',
+  ] as const) {
+    const optionalValue = value[key];
+    if (optionalValue === undefined) continue;
+    if (typeof optionalValue !== 'string' || optionalValue.length > 2_048) {
+      return invalid(`Invalid structured metadata ${key}`);
+    }
+    metadata[key] = optionalValue;
+  }
+  for (const key of ['browser', 'os'] as const) {
+    const optionalValue = value[key];
+    if (optionalValue === undefined) continue;
+    if (
+      !isPlainObject(optionalValue) ||
+      !hasOnlyKeys(optionalValue, new Set(['name', 'version'])) ||
+      typeof optionalValue.name !== 'string' ||
+      typeof optionalValue.version !== 'string' ||
+      !optionalValue.name ||
+      optionalValue.name.length > 120 ||
+      optionalValue.version.length > 120
+    ) {
+      return invalid(`Invalid structured metadata ${key}`);
+    }
+    metadata[key] = { name: optionalValue.name, version: optionalValue.version };
+  }
+  if (value.devicePixelRatio !== undefined) {
+    if (
+      typeof value.devicePixelRatio !== 'number' ||
+      !Number.isFinite(value.devicePixelRatio) ||
+      value.devicePixelRatio <= 0 ||
+      value.devicePixelRatio > 10
+    ) {
+      return invalid('Invalid structured metadata devicePixelRatio');
+    }
+    metadata.devicePixelRatio = value.devicePixelRatio;
+  }
+
+  return { valid: true, metadata };
+}
+
+function resolveVariantLabels(
+  rawConfig: string | undefined,
+  repo: string,
+  variantId: string,
+  classification: StructuredFeedbackClassification | undefined
+): LabelResolution {
+  const fallback = defaultLabels(classification);
+  if (!rawConfig) return { labels: fallback, warnings: [], usedCustomLabels: false };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawConfig);
+  } catch {
+    return labelFallback(fallback, 'Invalid server variant label config: malformed JSON.');
+  }
+  if (!isPlainObject(parsed)) {
+    return labelFallback(fallback, 'Invalid server variant label config: expected an object.');
+  }
+  const repoConfig = parsed[repo] ?? parsed['*'];
+  if (!isPlainObject(repoConfig)) {
+    return labelFallback(
+      fallback,
+      `Server variant label config has no mapping for ${formatInlineCode(repo)} and no wildcard fallback.`
+    );
+  }
+  if (!(variantId in repoConfig)) {
+    return labelFallback(
+      fallback,
+      `Server variant label config has no mapping for ${formatInlineCode(`${repo}:${variantId}`)}.`
+    );
+  }
+
+  const normalized = normalizeLabels(repoConfig[variantId]);
+  if (!normalized.valid) return labelFallback(fallback, normalized.warning);
+  return {
+    labels: addBugDropLabel(normalized.labels),
+    warnings: [],
+    usedCustomLabels: true,
+  };
+}
+
+function normalizeLabels(
+  value: unknown
+): { valid: true; labels: string[] } | { valid: false; warning: string } {
+  const rawLabels = typeof value === 'string' ? [value] : Array.isArray(value) ? value : null;
+  if (!rawLabels || rawLabels.length === 0 || rawLabels.length > MAX_LABELS) {
+    return {
+      valid: false,
+      warning: `Invalid server variant labels: expected 1-${MAX_LABELS} labels.`,
+    };
+  }
+
+  const labels: string[] = [];
+  for (const value of rawLabels) {
+    if (
+      typeof value !== 'string' ||
+      hasControlChars(value) ||
+      !value.trim() ||
+      value.trim().length > MAX_LABEL_CHARS
+    ) {
+      return {
+        valid: false,
+        warning: `Invalid server variant labels: labels must be 1-${MAX_LABEL_CHARS} characters without control characters.`,
+      };
+    }
+    labels.push(value.trim());
+  }
+  return { valid: true, labels: [...new Set(labels)] };
+}
+
+function defaultLabels(classification: StructuredFeedbackClassification | undefined): string[] {
+  const labels =
+    classification === 'bug'
+      ? ['bug']
+      : classification === 'feature'
+        ? ['enhancement']
+        : classification === 'question'
+          ? ['question']
+          : [];
+  return addBugDropLabel(labels);
+}
+
+function addBugDropLabel(labels: string[]): string[] {
+  return [...new Set([...labels, 'bugdrop'])];
+}
+
+function labelFallback(labels: string[], warning: string): LabelResolution {
+  return { labels, warnings: [warning], usedCustomLabels: false };
+}
+
+function formatStructuredIssueBody(payload: StructuredFeedbackPayload, warnings: string[]): string {
+  const sections: string[] = [];
+  for (const section of payload.issue.sections) {
+    sections.push(`## ${escapeMarkdown(section.heading)}`);
+    sections.push('');
+    sections.push(formatSectionValue(section.value, section.format ?? 'text'));
+    sections.push('');
+  }
+  if (warnings.length > 0) {
+    sections.push('## Label mapping warning', '');
+    for (const warning of warnings) sections.push(`- ${escapeMarkdown(warning)}`);
+    sections.push('');
+  }
+
+  sections.push('<details>', '<summary>System Info</summary>', '');
+  sections.push('| Property | Value |', '|----------|-------|');
+  if (payload.metadata.browser) {
+    sections.push(
+      `| **Browser** | ${escapeTableValue(`${payload.metadata.browser.name} ${payload.metadata.browser.version}`.trim())} |`
+    );
+  }
+  if (payload.metadata.os) {
+    sections.push(
+      `| **OS** | ${escapeTableValue(`${payload.metadata.os.name} ${payload.metadata.os.version}`.trim())} |`
+    );
+  }
+  const ratio = payload.metadata.devicePixelRatio ? ` @${payload.metadata.devicePixelRatio}x` : '';
+  sections.push(
+    `| **Viewport** | ${payload.metadata.viewport.width}×${payload.metadata.viewport.height}${ratio} |`
+  );
+  if (payload.metadata.language) {
+    sections.push(`| **Language** | ${escapeTableValue(payload.metadata.language)} |`);
+  }
+  sections.push(`| **Page** | ${escapeTableValue(payload.metadata.url)} |`);
+  sections.push(`| **Timestamp** | ${escapeTableValue(payload.metadata.timestamp)} |`);
+  sections.push('', '</details>', '');
+  sections.push(`<!-- bugdrop-submission: ${payload.submissionId} -->`, '');
+  sections.push('---');
+  sections.push('*Submitted via [BugDrop](https://github.com/mean-weasel/bugdrop)*');
+  return sections.join('\n');
+}
+
+function formatSectionValue(value: string, format: StructuredFeedbackSectionFormat): string {
+  const normalized = normalizeMultilineText(value);
+  if (format === 'code') return formatFencedBlock(normalized);
+  const escaped = escapeMarkdown(normalized);
+  if (format === 'quote')
+    return escaped
+      .split('\n')
+      .map(line => `> ${line}`)
+      .join('\n');
+  return escaped;
+}
+
+function normalizeMultilineText(value: string): string {
+  let normalized = '';
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code === 0x0d) {
+      normalized += '\n';
+      if (value.charCodeAt(index + 1) === 0x0a) index += 1;
+    } else if ((code < 0x20 && code !== 0x09 && code !== 0x0a) || code === 0x7f) {
+      normalized += ' ';
+    } else {
+      normalized += value[index];
+    }
+  }
+  return normalized;
+}
+
+function escapeMarkdown(value: string): string {
+  const markdownCharacters = new Set(['\\', '`', '*', '_', '{', '}', '[', ']', '<', '>', '#', '|']);
+  return Array.from(value, character =>
+    markdownCharacters.has(character) ? `\\${character}` : character
+  ).join('');
+}
+
+function escapeTableValue(value: string): string {
+  return escapeMarkdown(normalizeMultilineText(value).replace(/\n/g, ' '));
+}
+
+function formatFencedBlock(value: string): string {
+  const runs = value.match(/`+/g);
+  const length = Math.max(3, runs ? Math.max(...runs.map(run => run.length)) + 1 : 3);
+  const fence = '`'.repeat(length);
+  return `${fence}\n${value}\n${fence}`;
+}
+
+function formatInlineCode(value: string): string {
+  return `\`${value.replace(/`/g, '\\`')}\``;
+}
+
+function formatLabelList(labels: string[]): string {
+  return labels.map(formatInlineCode).join(', ');
+}
+
+function isCanonicalIssueUrl(
+  url: string,
+  owner: string,
+  repo: string,
+  issueNumber: number
+): boolean {
+  try {
+    const parsed = new URL(url);
+    const expectedPath = `/${owner}/${repo}/issues/${issueNumber}`.toLocaleLowerCase('en-US');
+    return (
+      parsed.protocol === 'https:' &&
+      parsed.hostname === 'github.com' &&
+      parsed.username === '' &&
+      parsed.password === '' &&
+      parsed.search === '' &&
+      parsed.hash === '' &&
+      parsed.pathname.toLocaleLowerCase('en-US') === expectedPath
+    );
+  } catch {
+    return false;
+  }
+}
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function invalid(error: string): { valid: false; error: string } {
+  return { valid: false, error };
+}
+
+function firstUnknownKey(value: Record<string, unknown>, allowed: Set<string>): string | undefined {
+  return Object.keys(value).find(key => !allowed.has(key));
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: Set<string>): boolean {
+  return firstUnknownKey(value, allowed) === undefined;
+}
+
+function isPositiveBoundedInteger(value: unknown, maximum: number): value is number {
+  return Number.isInteger(value) && (value as number) > 0 && (value as number) <= maximum;
+}
+
+function hasControlChars(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code < 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface Env {
   GITHUB_APP_NAME: string; // Your GitHub App name for install URL
   MAX_SCREENSHOT_SIZE_MB: string; // Max screenshot size in MB (default: 5)
   CATEGORY_LABELS?: string; // Optional JSON category-label mapping keyed by repo or "*"
+  VARIANT_LABELS?: string; // Optional JSON variant-label mapping keyed by repo then variant ID
   ALLOW_CLIENT_CATEGORY_LABELS?: string; // Self-host escape hatch for script-tag mappings
   ROOT_REDIRECT_URL?: string; // Optional landing page for self-hosted deployments
   AUTH_TOKEN_SECRET?: string; // Optional HMAC secret for host-app submission tokens
@@ -32,6 +33,41 @@ export interface Env {
 export type FeedbackCategory = 'bug' | 'feature' | 'question';
 type CategoryLabelConfig = Partial<Record<FeedbackCategory, string | string[]>>;
 
+export interface FeedbackMetadata {
+  url: string;
+  userAgent: string;
+  viewport: { width: number; height: number };
+  timestamp: string;
+  elementSelector?: string;
+  fullElementSelector?: string;
+  selectedElementHighlightColor?: string;
+  browser?: { name: string; version: string };
+  os?: { name: string; version: string };
+  devicePixelRatio?: number;
+  language?: string;
+}
+
+export type StructuredFeedbackClassification = FeedbackCategory | 'feedback';
+export type StructuredFeedbackSectionFormat = 'text' | 'quote' | 'code';
+
+export interface StructuredFeedbackPayload {
+  kind: 'bugdrop.variant-submission';
+  schemaVersion: 1;
+  repo: string;
+  variantId: string;
+  submissionId: string;
+  issue: {
+    title: string;
+    classification?: StructuredFeedbackClassification;
+    sections: Array<{
+      heading: string;
+      value: string;
+      format?: StructuredFeedbackSectionFormat;
+    }>;
+  };
+  metadata: FeedbackMetadata;
+}
+
 export interface FeedbackPayload {
   repo: string; // "owner/repo" format
   title: string;
@@ -47,20 +83,7 @@ export interface FeedbackPayload {
     name?: string;
     email?: string;
   };
-  metadata: {
-    url: string;
-    userAgent: string;
-    viewport: { width: number; height: number };
-    timestamp: string;
-    elementSelector?: string;
-    fullElementSelector?: string;
-    selectedElementHighlightColor?: string;
-    // Parsed system info
-    browser?: { name: string; version: string };
-    os?: { name: string; version: string };
-    devicePixelRatio?: number;
-    language?: string;
-  };
+  metadata: FeedbackMetadata;
 }
 
 export interface FeedbackAttachment {

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -32,6 +32,8 @@ import {
 import { escapeWidgetText, resolveLocale, setLocale, t, type SupportedLocale } from './i18n';
 import { installRadixDialogCompatibility } from './radix-compat';
 import { resolveAccentColor } from '../defaults';
+import type { BugDropPublicAPI } from './variants/public-types';
+import { createVariantManager, type VariantManager } from './variants/manager';
 
 type FeedbackCategory = 'bug' | 'feature' | 'question';
 type CategoryLabelConfig = Partial<Record<FeedbackCategory, string | string[]>>;
@@ -88,21 +90,10 @@ interface WidgetConfig {
   locale: SupportedLocale;
 }
 
-// BugDrop JavaScript API interface
-interface BugDropAPI {
-  open: () => void;
-  close: () => void;
-  hide: () => void;
-  show: () => void;
-  isOpen: () => boolean;
-  isButtonVisible: () => boolean;
-  setTheme: (mode: ThemeMode) => void;
-}
-
 // Declare global BugDrop API
 declare global {
   interface Window {
-    BugDrop?: BugDropAPI;
+    BugDrop?: BugDropPublicAPI;
   }
 }
 
@@ -892,6 +883,7 @@ function exposeBugDropAPI(root: HTMLElement, config: WidgetConfig) {
   // the matchMedia listener below and mutated by setTheme. No module-level
   // state needed — keeps per-init isolation if multi-instance is ever added.
   let currentMode: ThemeMode = config.theme;
+  let variantManager: VariantManager | undefined;
 
   window.BugDrop = {
     // Open the feedback modal programmatically
@@ -971,6 +963,17 @@ function exposeBugDropAPI(root: HTMLElement, config: WidgetConfig) {
       const resolved = resolveTheme(mode);
       applyThemeClass(root, resolved);
       applyCustomStyles(root, config, resolved);
+    },
+
+    // The sidecar is created only on the first registration. Legacy-only pages
+    // do not allocate variant maps, IDs, DOM, listeners, observers, or storage.
+    registerVariant: variantConfig => {
+      variantManager ??= createVariantManager({
+        repo: config.repo,
+        apiUrl: config.apiUrl,
+        authTokenProvider: config.authTokenProvider,
+      });
+      return variantManager.register(variantConfig);
     },
   };
 

--- a/src/widget/public-api.d.ts
+++ b/src/widget/public-api.d.ts
@@ -1,0 +1,31 @@
+export type {
+  BugDropPublicAPI,
+  HeadlessSubmitOptions,
+  LongTextField,
+  MountedVariant,
+  OpenedVariant,
+  RatingField,
+  ShortTextField,
+  SingleChoiceField,
+  SubmissionResult,
+  VariantClassification,
+  VariantConfig,
+  VariantContext,
+  VariantContextValue,
+  VariantContent,
+  VariantField,
+  VariantHandle,
+  VariantIssueSection,
+  VariantMountOptions,
+  VariantOpenOptions,
+  VariantOutcome,
+  VariantTheme,
+} from './variants/public-types';
+
+import type { BugDropPublicAPI } from './variants/public-types';
+
+declare global {
+  interface Window {
+    BugDrop?: BugDropPublicAPI;
+  }
+}

--- a/src/widget/variants/issue-draft.ts
+++ b/src/widget/variants/issue-draft.ts
@@ -1,0 +1,154 @@
+import type {
+  VariantConfig,
+  VariantContext,
+  VariantField,
+  VariantIssueSection,
+} from './public-types';
+
+interface CompiledIssueDraft {
+  title: string;
+  classification?: 'bug' | 'feature' | 'question' | 'feedback';
+  sections: Array<{ heading: string; value: string; format: 'text' | 'quote' | 'code' }>;
+}
+
+export function compileIssueDraft(
+  config: Readonly<VariantConfig>,
+  answers: Record<string, unknown>,
+  context: VariantContext = {}
+): CompiledIssueDraft {
+  validateContext(context);
+  const normalizedAnswers = normalizeAnswers(config.fields, answers);
+  const title = config.issue.title
+    .replace(/{{\s*([^{}]+?)\s*}}/g, (_match, reference: string) => {
+      const value = reference.startsWith('context.')
+        ? context[reference.slice('context.'.length)]
+        : normalizedAnswers[reference];
+      return displayValue(config.fields, reference, value, 'text');
+    })
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 256)
+    .trim();
+  if (!title) throw new TypeError('BugDrop variant produced an empty Issue title');
+
+  const sections = (config.issue.sections ?? []).flatMap(section => {
+    const value = resolveSectionValue(section, config.fields, normalizedAnswers, context);
+    if (!value.trim() && section.omitWhenEmpty) return [];
+    return [
+      {
+        heading: section.heading.trim(),
+        value: value.trim() ? value : 'Not provided.',
+        format: workerFormat(section),
+      },
+    ];
+  });
+  return {
+    title,
+    ...(config.issue.classification ? { classification: config.issue.classification } : {}),
+    sections,
+  };
+}
+
+function normalizeAnswers(
+  fields: ReadonlyArray<VariantField>,
+  answers: Record<string, unknown>
+): Record<string, string | number> {
+  if (!isObject(answers)) throw new TypeError('BugDrop variant answers must be an object');
+  const knownFields = new Set(fields.map(field => field.id));
+  const unknown = Object.keys(answers).find(key => !knownFields.has(key));
+  if (unknown) throw new TypeError(`Unknown BugDrop variant answer: ${unknown}`);
+
+  const normalized: Record<string, string | number> = {};
+  for (const field of fields) {
+    const raw = answers[field.id];
+    if (field.type === 'shortText' || field.type === 'longText') {
+      if (raw === undefined || raw === null || raw === '') {
+        if (field.required) throw new TypeError(`Answer ${field.id} is required`);
+        normalized[field.id] = '';
+        continue;
+      }
+      if (typeof raw !== 'string') throw new TypeError(`Answer ${field.id} must be text`);
+      const value = raw.trim();
+      if (field.required && !value) throw new TypeError(`Answer ${field.id} is required`);
+      const minimum = field.minLength ?? 0;
+      const maximum = field.maxLength ?? (field.type === 'shortText' ? 500 : 5_000);
+      if (value.length < minimum || value.length > maximum) {
+        throw new TypeError(`Answer ${field.id} must be ${minimum}-${maximum} characters`);
+      }
+      normalized[field.id] = value;
+    } else if (field.type === 'rating') {
+      const scale = field.scale ?? 5;
+      if (raw === undefined || raw === null || raw === '') {
+        if (field.required) throw new TypeError(`Answer ${field.id} is required`);
+        normalized[field.id] = '';
+      } else if (!Number.isInteger(raw) || (raw as number) < 1 || (raw as number) > scale) {
+        throw new TypeError(`Answer ${field.id} must be a rating from 1-${scale}`);
+      } else {
+        normalized[field.id] = raw as number;
+      }
+    } else {
+      if (raw === undefined || raw === null || raw === '') {
+        if (field.required) throw new TypeError(`Answer ${field.id} is required`);
+        normalized[field.id] = '';
+      } else if (typeof raw !== 'string' || !field.options.some(option => option.value === raw)) {
+        throw new TypeError(`Answer ${field.id} must be a configured choice`);
+      } else {
+        normalized[field.id] = raw;
+      }
+    }
+  }
+  return normalized;
+}
+
+function resolveSectionValue(
+  section: VariantIssueSection,
+  fields: ReadonlyArray<VariantField>,
+  answers: Record<string, string | number>,
+  context: VariantContext
+): string {
+  if ('context' in section) return String(context[section.context] ?? '');
+  return displayValue(fields, section.field, answers[section.field], section.format ?? 'text');
+}
+
+function displayValue(
+  fields: ReadonlyArray<VariantField>,
+  fieldId: string,
+  value: unknown,
+  format: string
+): string {
+  if (value === undefined || value === null || value === '') return '';
+  const field = fields.find(candidate => candidate.id === fieldId);
+  if (format === 'stars' && field?.type === 'rating' && typeof value === 'number') {
+    const scale = field.scale ?? 5;
+    return `${'★'.repeat(value)}${'☆'.repeat(scale - value)} (${value}/${scale})`;
+  }
+  if (format === 'choice' && field?.type === 'singleChoice') {
+    return field.options.find(option => option.value === value)?.label ?? String(value);
+  }
+  return String(value);
+}
+
+function workerFormat(section: VariantIssueSection): 'text' | 'quote' | 'code' {
+  return section.format === 'quote' || section.format === 'code' ? section.format : 'text';
+}
+
+function validateContext(context: VariantContext): void {
+  if (!isObject(context) || Object.keys(context).length > 50) {
+    throw new TypeError('BugDrop variant context must contain at most 50 values');
+  }
+  for (const [key, value] of Object.entries(context)) {
+    if (!/^[a-z][a-z0-9_-]{0,63}$/.test(key)) throw new TypeError(`Invalid context key: ${key}`);
+    if (!['string', 'number', 'boolean'].includes(typeof value) && value !== null) {
+      throw new TypeError(`Invalid context value: ${key}`);
+    }
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+      throw new TypeError(`Invalid context value: ${key}`);
+    }
+    if (String(value ?? '').length > 5_000)
+      throw new TypeError(`Context value is too long: ${key}`);
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/widget/variants/manager.ts
+++ b/src/widget/variants/manager.ts
@@ -1,0 +1,34 @@
+import type { VariantConfig, VariantHandle } from './public-types';
+import { validateAndFreezeVariantConfig } from './validate-config';
+import { submitVariant, type VariantTransportConfig } from './submission';
+
+export interface VariantManager {
+  register(config: VariantConfig): VariantHandle;
+}
+
+export function createVariantManager(transport: VariantTransportConfig): VariantManager {
+  const variants = new Map<string, Readonly<VariantConfig>>();
+
+  return {
+    register(config) {
+      const normalized = validateAndFreezeVariantConfig(config);
+      if (variants.has(normalized.id)) {
+        throw new TypeError(`BugDrop variant is already registered: ${normalized.id}`);
+      }
+      variants.set(normalized.id, normalized);
+
+      return Object.freeze({
+        id: normalized.id,
+        open() {
+          throw new Error('BugDrop rendered variants are not available in the headless foundation');
+        },
+        mount() {
+          throw new Error('BugDrop rendered variants are not available in the headless foundation');
+        },
+        submit(answers: Record<string, unknown>, options = {}) {
+          return submitVariant(transport, normalized, answers, options);
+        },
+      });
+    },
+  };
+}

--- a/src/widget/variants/public-types.d.ts
+++ b/src/widget/variants/public-types.d.ts
@@ -1,0 +1,143 @@
+export type VariantClassification = 'bug' | 'feature' | 'question' | 'feedback';
+export type VariantTheme = 'light' | 'dark' | 'auto';
+export type VariantContextValue = string | number | boolean | null;
+export type VariantContext = Record<string, VariantContextValue>;
+
+export interface VariantContent {
+  title: string;
+  description?: string;
+  submitLabel?: string;
+  cancelLabel?: string;
+  successTitle?: string;
+  successMessage?: string;
+}
+
+interface BaseField {
+  id: string;
+  label: string;
+  helpText?: string;
+  required?: boolean;
+  layout?: { span?: 1 | 2 };
+}
+
+export interface ShortTextField extends BaseField {
+  type: 'shortText';
+  placeholder?: string;
+  minLength?: number;
+  maxLength?: number;
+}
+
+export interface LongTextField extends BaseField {
+  type: 'longText';
+  placeholder?: string;
+  rows?: number;
+  minLength?: number;
+  maxLength?: number;
+}
+
+export interface RatingField extends BaseField {
+  type: 'rating';
+  scale?: 5 | 10;
+  icon?: 'star' | 'number';
+  lowLabel?: string;
+  highLabel?: string;
+}
+
+export interface SingleChoiceField extends BaseField {
+  type: 'singleChoice';
+  options: Array<{ value: string; label: string; description?: string }>;
+  display?: 'radio' | 'cards' | 'buttons';
+}
+
+export type VariantField = ShortTextField | LongTextField | RatingField | SingleChoiceField;
+
+export type VariantIssueSection =
+  | {
+      heading: string;
+      field: string;
+      format?: 'text' | 'quote' | 'stars' | 'choice';
+      omitWhenEmpty?: boolean;
+    }
+  | {
+      heading: string;
+      context: string;
+      format?: 'text' | 'code';
+      omitWhenEmpty?: boolean;
+    };
+
+export interface VariantConfig {
+  id: string;
+  configVersion?: 1;
+  presentation:
+    | { kind: 'modal'; size?: 'compact' | 'default' | 'wide'; columns?: 1 | 2 }
+    | { kind: 'inline'; columns?: 1 | 2 };
+  appearance?: {
+    theme?: VariantTheme;
+    accentColor?: string;
+    density?: 'compact' | 'comfortable';
+  };
+  content: VariantContent;
+  fields: VariantField[];
+  issue: {
+    classification?: VariantClassification;
+    title: string;
+    sections?: VariantIssueSection[];
+  };
+}
+
+export interface VariantOpenOptions {
+  context?: VariantContext;
+  initialAnswers?: Record<string, unknown>;
+}
+
+export type VariantMountOptions = VariantOpenOptions;
+
+export interface HeadlessSubmitOptions {
+  context?: VariantContext;
+  submissionId?: string;
+}
+
+export interface SubmissionResult {
+  issueNumber: number;
+  issueUrl: string;
+  isPublic: boolean;
+  labelMappingWarnings?: string[];
+}
+
+export type VariantOutcome =
+  | { status: 'submitted'; result: SubmissionResult }
+  | { status: 'closed' }
+  | { status: 'busy' };
+
+export interface OpenedVariant {
+  readonly instanceId: string;
+  readonly result: Promise<VariantOutcome>;
+  close(): void;
+}
+
+export interface MountedVariant {
+  readonly instanceId: string;
+  reset(): void;
+  unmount(): void;
+}
+
+export interface VariantHandle {
+  readonly id: string;
+  open(options?: VariantOpenOptions): OpenedVariant;
+  mount(target: HTMLElement, options?: VariantMountOptions): MountedVariant;
+  submit(
+    answers: Record<string, unknown>,
+    options?: HeadlessSubmitOptions
+  ): Promise<SubmissionResult>;
+}
+
+export interface BugDropPublicAPI {
+  open(): void;
+  close(): void;
+  hide(): void;
+  show(): void;
+  isOpen(): boolean;
+  isButtonVisible(): boolean;
+  setTheme(mode: VariantTheme): void;
+  registerVariant(config: VariantConfig): VariantHandle;
+}

--- a/src/widget/variants/submission.ts
+++ b/src/widget/variants/submission.ts
@@ -1,0 +1,123 @@
+import { getAuthHeaders, type BugDropAuthTokenProvider } from '../auth-token';
+import type { HeadlessSubmitOptions, SubmissionResult, VariantConfig } from './public-types';
+import { compileIssueDraft } from './issue-draft';
+
+export interface VariantTransportConfig {
+  repo: string;
+  apiUrl: string;
+  authTokenProvider?: BugDropAuthTokenProvider;
+}
+
+export async function submitVariant(
+  transport: VariantTransportConfig,
+  config: Readonly<VariantConfig>,
+  answers: Record<string, unknown>,
+  options: HeadlessSubmitOptions = {}
+): Promise<SubmissionResult> {
+  const submissionId = options.submissionId ?? createSubmissionId();
+  const issue = compileIssueDraft(config, answers, options.context);
+  const response = await fetch(`${transport.apiUrl}/feedback`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await getAuthHeaders(transport.authTokenProvider)),
+    },
+    body: JSON.stringify({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      repo: transport.repo,
+      variantId: config.id,
+      submissionId,
+      issue,
+      metadata: collectMetadata(),
+    }),
+  });
+  const result = (await response.json()) as Record<string, unknown>;
+  if (!response.ok || result.success !== true) {
+    throw new Error(typeof result.error === 'string' ? result.error : 'Failed to submit feedback');
+  }
+  if (
+    !Number.isInteger(result.issueNumber) ||
+    (result.issueNumber as number) <= 0 ||
+    typeof result.issueUrl !== 'string' ||
+    !isCanonicalIssueUrl(result.issueUrl, transport.repo, result.issueNumber as number) ||
+    typeof result.isPublic !== 'boolean'
+  ) {
+    throw new Error('BugDrop received an invalid Issue result');
+  }
+  return {
+    issueNumber: result.issueNumber as number,
+    issueUrl: result.issueUrl,
+    isPublic: result.isPublic,
+    ...(Array.isArray(result.labelMappingWarnings) &&
+    result.labelMappingWarnings.every(value => typeof value === 'string')
+      ? { labelMappingWarnings: result.labelMappingWarnings as string[] }
+      : {}),
+  };
+}
+
+function createSubmissionId(): string {
+  if (typeof crypto?.randomUUID === 'function') return crypto.randomUUID();
+  if (typeof crypto?.getRandomValues !== 'function') {
+    throw new Error('BugDrop variants require a cryptographically secure random generator');
+  }
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function collectMetadata() {
+  const url = new URL(window.location.href);
+  url.search = '';
+  url.hash = '';
+  return {
+    url: url.toString(),
+    userAgent: navigator.userAgent,
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    timestamp: new Date().toISOString(),
+    browser: parseBrowser(navigator.userAgent),
+    os: parseOS(navigator.userAgent),
+    devicePixelRatio: window.devicePixelRatio,
+    language: navigator.language,
+  };
+}
+
+function parseBrowser(userAgent: string): { name: string; version: string } {
+  for (const [name, pattern] of [
+    ['Edge', /Edg\/(\d+[\d.]*)/],
+    ['Chrome', /Chrome\/(\d+[\d.]*)/],
+    ['Safari', /Version\/(\d+[\d.]*).*Safari/],
+    ['Firefox', /Firefox\/(\d+[\d.]*)/],
+  ] as const) {
+    const match = userAgent.match(pattern);
+    if (match) return { name, version: match[1] ?? 'unknown' };
+  }
+  return { name: 'Unknown', version: 'unknown' };
+}
+
+function parseOS(userAgent: string): { name: string; version: string } {
+  const match = userAgent.match(/(?:Mac OS X|Windows NT|Android) ([\d_.]+)/);
+  if (match) {
+    const name = userAgent.includes('Mac OS X')
+      ? 'macOS'
+      : userAgent.includes('Windows NT')
+        ? 'Windows'
+        : 'Android';
+    return { name, version: (match[1] ?? 'unknown').replaceAll('_', '.') };
+  }
+  return { name: userAgent.includes('Linux') ? 'Linux' : 'Unknown', version: 'unknown' };
+}
+
+function isCanonicalIssueUrl(url: string, repo: string, issueNumber: number): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.protocol === 'https:' &&
+      parsed.hostname === 'github.com' &&
+      parsed.pathname.toLowerCase() === `/${repo}/issues/${issueNumber}`.toLowerCase() &&
+      !parsed.search &&
+      !parsed.hash
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/widget/variants/validate-config.ts
+++ b/src/widget/variants/validate-config.ts
@@ -1,0 +1,355 @@
+/* eslint-disable max-lines -- Keep complete synchronous public-config validation at one boundary. */
+import type { VariantConfig, VariantField, VariantIssueSection } from './public-types';
+
+const ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
+const PLACEHOLDER_PATTERN = /{{\s*([^{}]+?)\s*}}/g;
+const CLASSIFICATIONS = new Set(['bug', 'feature', 'question', 'feedback']);
+const FIELD_TYPES = new Set(['shortText', 'longText', 'rating', 'singleChoice']);
+const TOP_LEVEL_KEYS = new Set([
+  'id',
+  'configVersion',
+  'presentation',
+  'appearance',
+  'content',
+  'fields',
+  'issue',
+]);
+const CONTENT_KEYS = new Set([
+  'title',
+  'description',
+  'submitLabel',
+  'cancelLabel',
+  'successTitle',
+  'successMessage',
+]);
+const APPEARANCE_KEYS = new Set(['theme', 'accentColor', 'density']);
+const ISSUE_KEYS = new Set(['classification', 'title', 'sections']);
+const BASE_FIELD_KEYS = ['id', 'type', 'label', 'helpText', 'required', 'layout'];
+const FIELD_KEYS: Record<VariantField['type'], Set<string>> = {
+  shortText: new Set([...BASE_FIELD_KEYS, 'placeholder', 'minLength', 'maxLength']),
+  longText: new Set([...BASE_FIELD_KEYS, 'placeholder', 'rows', 'minLength', 'maxLength']),
+  rating: new Set([...BASE_FIELD_KEYS, 'scale', 'icon', 'lowLabel', 'highLabel']),
+  singleChoice: new Set([...BASE_FIELD_KEYS, 'options', 'display']),
+};
+
+export function validateAndFreezeVariantConfig(input: VariantConfig): Readonly<VariantConfig> {
+  if (!isObject(input)) throw new TypeError('BugDrop variant config must be an object');
+  assertOnlyKeys(input, TOP_LEVEL_KEYS, 'variant config');
+  if (typeof input.id !== 'string' || !ID_PATTERN.test(input.id) || input.id === 'legacy') {
+    throw new TypeError('BugDrop variant id must match [a-z][a-z0-9_-]{0,63} and cannot be legacy');
+  }
+  if (input.configVersion !== undefined && input.configVersion !== 1) {
+    throw new TypeError('BugDrop variant configVersion must be 1');
+  }
+  validatePresentation(input.presentation);
+  validateAppearance(input.appearance);
+  validateContent(input.content);
+  if (!Array.isArray(input.fields) || input.fields.length === 0 || input.fields.length > 20) {
+    throw new TypeError('BugDrop variant fields must contain 1-20 entries');
+  }
+
+  const fields = new Map<string, VariantField>();
+  for (const field of input.fields) validateField(field, fields);
+  validateIssue(input, fields);
+
+  return deepFreeze(clone(input));
+}
+
+function validatePresentation(value: VariantConfig['presentation']): void {
+  if (!isObject(value) || (value.kind !== 'modal' && value.kind !== 'inline')) {
+    throw new TypeError('BugDrop variant presentation must be modal or inline');
+  }
+  assertOnlyKeys(
+    value,
+    value.kind === 'modal' ? new Set(['kind', 'size', 'columns']) : new Set(['kind', 'columns']),
+    'variant presentation'
+  );
+  if (value.columns !== undefined && value.columns !== 1 && value.columns !== 2) {
+    throw new TypeError('BugDrop variant presentation columns must be 1 or 2');
+  }
+  if (
+    value.kind === 'modal' &&
+    value.size !== undefined &&
+    !['compact', 'default', 'wide'].includes(value.size)
+  ) {
+    throw new TypeError('BugDrop modal size must be compact, default, or wide');
+  }
+}
+
+function validateAppearance(value: VariantConfig['appearance']): void {
+  if (value === undefined) return;
+  if (!isObject(value)) throw new TypeError('BugDrop variant appearance must be an object');
+  assertOnlyKeys(value, APPEARANCE_KEYS, 'variant appearance');
+  if (value.theme !== undefined && !['light', 'dark', 'auto'].includes(value.theme)) {
+    throw new TypeError('BugDrop variant appearance theme is invalid');
+  }
+  if (
+    value.accentColor !== undefined &&
+    (!nonEmptyString(value.accentColor, 120) || hasControlChars(value.accentColor))
+  ) {
+    throw new TypeError('BugDrop variant appearance accentColor is invalid');
+  }
+  if (
+    value.density !== undefined &&
+    value.density !== 'compact' &&
+    value.density !== 'comfortable'
+  ) {
+    throw new TypeError('BugDrop variant appearance density is invalid');
+  }
+}
+
+function validateContent(value: VariantConfig['content']): void {
+  if (!isObject(value)) throw new TypeError('BugDrop variant content must be an object');
+  assertOnlyKeys(value, CONTENT_KEYS, 'variant content');
+  if (!nonEmptyString(value.title, 500)) {
+    throw new TypeError('BugDrop variant content.title is required');
+  }
+  validateOptionalCopy(value.description, 'description', 2_000);
+  validateOptionalCopy(value.submitLabel, 'submitLabel', 120);
+  validateOptionalCopy(value.cancelLabel, 'cancelLabel', 120);
+  validateOptionalCopy(value.successTitle, 'successTitle', 500);
+  validateOptionalCopy(value.successMessage, 'successMessage', 2_000);
+}
+
+function validateOptionalCopy(value: unknown, key: string, maximum: number): void {
+  if (value !== undefined && !nonEmptyString(value, maximum)) {
+    throw new TypeError(`BugDrop variant content.${key} is invalid`);
+  }
+}
+
+function validateField(field: VariantField, fields: Map<string, VariantField>): void {
+  if (
+    !isObject(field) ||
+    !FIELD_TYPES.has(field.type) ||
+    typeof field.id !== 'string' ||
+    !ID_PATTERN.test(field.id)
+  ) {
+    throw new TypeError('BugDrop variant field has an invalid type or id');
+  }
+  assertOnlyKeys(field, FIELD_KEYS[field.type], `field ${field.id}`);
+  if (fields.has(field.id)) throw new TypeError(`Duplicate BugDrop variant field id: ${field.id}`);
+  fields.set(field.id, field);
+  if (!nonEmptyString(field.label, 500)) throw new TypeError(`Field ${field.id} requires a label`);
+  if (field.helpText !== undefined && !nonEmptyString(field.helpText, 1_000)) {
+    throw new TypeError(`Field ${field.id} has invalid helpText`);
+  }
+  if (field.required !== undefined && typeof field.required !== 'boolean') {
+    throw new TypeError(`Field ${field.id} required must be boolean`);
+  }
+  validateLayout(field);
+
+  if (field.type === 'shortText' || field.type === 'longText') {
+    validateTextField(field);
+  } else if (field.type === 'rating') {
+    validateRatingField(field);
+  } else {
+    validateChoiceField(field);
+  }
+}
+
+function validateLayout(field: VariantField): void {
+  if (field.layout === undefined) return;
+  if (!isObject(field.layout)) throw new TypeError(`Field ${field.id} layout must be an object`);
+  assertOnlyKeys(field.layout, new Set(['span']), `field ${field.id} layout`);
+  if (field.layout.span !== undefined && field.layout.span !== 1 && field.layout.span !== 2) {
+    throw new TypeError(`Field ${field.id} layout span must be 1 or 2`);
+  }
+}
+
+function validateTextField(field: Extract<VariantField, { type: 'shortText' | 'longText' }>): void {
+  if (field.placeholder !== undefined && !nonEmptyString(field.placeholder, 500)) {
+    throw new TypeError(`Field ${field.id} has invalid placeholder`);
+  }
+  const defaultMaximum = field.type === 'shortText' ? 500 : 5_000;
+  if (
+    (field.minLength !== undefined && !isBoundedInteger(field.minLength, 0, 5_000)) ||
+    (field.maxLength !== undefined && !isBoundedInteger(field.maxLength, 1, 5_000))
+  ) {
+    throw new TypeError(`Field ${field.id} has invalid text bounds`);
+  }
+  const minimum = field.minLength === undefined ? 0 : field.minLength;
+  const maximum = field.maxLength === undefined ? defaultMaximum : field.maxLength;
+  if (
+    !isBoundedInteger(minimum, 0, 5_000) ||
+    !isBoundedInteger(maximum, 1, 5_000) ||
+    minimum > maximum
+  ) {
+    throw new TypeError(`Field ${field.id} has invalid text bounds`);
+  }
+  if (
+    field.type === 'longText' &&
+    field.rows !== undefined &&
+    !isBoundedInteger(field.rows, 1, 50)
+  ) {
+    throw new TypeError(`Field ${field.id} rows must be an integer from 1-50`);
+  }
+}
+
+function validateRatingField(field: Extract<VariantField, { type: 'rating' }>): void {
+  if (field.scale !== undefined && field.scale !== 5 && field.scale !== 10) {
+    throw new TypeError(`Field ${field.id} rating scale must be 5 or 10`);
+  }
+  if (field.icon !== undefined && field.icon !== 'star' && field.icon !== 'number') {
+    throw new TypeError(`Field ${field.id} rating icon must be star or number`);
+  }
+  if (field.lowLabel !== undefined && !nonEmptyString(field.lowLabel, 500)) {
+    throw new TypeError(`Field ${field.id} has invalid lowLabel`);
+  }
+  if (field.highLabel !== undefined && !nonEmptyString(field.highLabel, 500)) {
+    throw new TypeError(`Field ${field.id} has invalid highLabel`);
+  }
+}
+
+function validateChoiceField(field: Extract<VariantField, { type: 'singleChoice' }>): void {
+  if (!Array.isArray(field.options) || field.options.length < 2 || field.options.length > 50) {
+    throw new TypeError(`Field ${field.id} requires 2-50 choices`);
+  }
+  if (
+    field.display !== undefined &&
+    field.display !== 'radio' &&
+    field.display !== 'cards' &&
+    field.display !== 'buttons'
+  ) {
+    throw new TypeError(`Field ${field.id} choice display is invalid`);
+  }
+  const values = new Set<string>();
+  for (const option of field.options) {
+    if (!isObject(option)) throw new TypeError(`Field ${field.id} has an invalid choice`);
+    assertOnlyKeys(option, new Set(['value', 'label', 'description']), `field ${field.id} choice`);
+    if (!nonEmptyString(option.value, 120) || !nonEmptyString(option.label, 500)) {
+      throw new TypeError(`Field ${field.id} has an invalid choice`);
+    }
+    if (option.description !== undefined && !nonEmptyString(option.description, 1_000)) {
+      throw new TypeError(`Field ${field.id} has an invalid choice description`);
+    }
+    if (values.has(option.value)) throw new TypeError(`Field ${field.id} has duplicate choices`);
+    values.add(option.value);
+  }
+}
+
+function validateIssue(config: VariantConfig, fields: Map<string, VariantField>): void {
+  if (!isObject(config.issue)) throw new TypeError('BugDrop variant issue must be an object');
+  assertOnlyKeys(config.issue, ISSUE_KEYS, 'variant issue');
+  if (!nonEmptyString(config.issue.title, 2_000)) {
+    throw new TypeError('BugDrop variant issue.title is required');
+  }
+  if (
+    config.issue.classification !== undefined &&
+    !CLASSIFICATIONS.has(config.issue.classification)
+  ) {
+    throw new TypeError('BugDrop variant issue.classification is invalid');
+  }
+  for (const token of config.issue.title.matchAll(PLACEHOLDER_PATTERN)) {
+    const reference = token[1];
+    if (reference.startsWith('context.')) {
+      if (!ID_PATTERN.test(reference.slice('context.'.length))) throw invalidTemplate();
+    } else if (!fields.has(reference)) {
+      throw new TypeError(`Unknown BugDrop variant title field: ${reference}`);
+    }
+  }
+  if (config.issue.title.replace(PLACEHOLDER_PATTERN, '').includes('{{')) throw invalidTemplate();
+
+  if (config.issue.sections !== undefined && !Array.isArray(config.issue.sections)) {
+    throw new TypeError('BugDrop variant Issue accepts at most 20 sections');
+  }
+  const sections = config.issue.sections ?? [];
+  if (sections.length > 20)
+    throw new TypeError('BugDrop variant Issue accepts at most 20 sections');
+  const headings = new Set<string>();
+  for (const section of sections) validateSection(section, fields, headings);
+}
+
+function validateSection(
+  section: VariantIssueSection,
+  fields: Map<string, VariantField>,
+  headings: Set<string>
+): void {
+  if (!isObject(section) || !nonEmptyString(section.heading, 120)) {
+    throw new TypeError('BugDrop variant Issue section requires a heading');
+  }
+  const isFieldSection = 'field' in section;
+  const isContextSection = 'context' in section;
+  if (isFieldSection === isContextSection) {
+    throw new TypeError('BugDrop variant Issue section must reference one field or context key');
+  }
+  assertOnlyKeys(
+    section,
+    isFieldSection
+      ? new Set(['heading', 'field', 'format', 'omitWhenEmpty'])
+      : new Set(['heading', 'context', 'format', 'omitWhenEmpty']),
+    'variant Issue section'
+  );
+  if (section.omitWhenEmpty !== undefined && typeof section.omitWhenEmpty !== 'boolean') {
+    throw new TypeError('BugDrop variant Issue section omitWhenEmpty must be boolean');
+  }
+  const heading = section.heading.trim().toLowerCase();
+  if (headings.has(heading))
+    throw new TypeError(`Duplicate BugDrop Issue heading: ${section.heading}`);
+  headings.add(heading);
+
+  if (isFieldSection) {
+    const field = fields.get(section.field);
+    if (!field) throw new TypeError(`Unknown Issue field: ${section.field}`);
+    const format = section.format === undefined ? 'text' : section.format;
+    if (!['text', 'quote', 'stars', 'choice'].includes(format)) {
+      throw new TypeError(`Invalid Issue field format: ${String(format)}`);
+    }
+    if (format === 'stars' && field.type !== 'rating') {
+      throw new TypeError('BugDrop stars format requires a rating field');
+    }
+    if (format === 'choice' && field.type !== 'singleChoice') {
+      throw new TypeError('BugDrop choice format requires a singleChoice field');
+    }
+  } else {
+    if (typeof section.context !== 'string' || !ID_PATTERN.test(section.context)) {
+      throw new TypeError(`Invalid Issue context key: ${section.context}`);
+    }
+    if (section.format !== undefined && section.format !== 'text' && section.format !== 'code') {
+      throw new TypeError(`Invalid Issue context format: ${String(section.format)}`);
+    }
+  }
+}
+
+function invalidTemplate(): TypeError {
+  return new TypeError('BugDrop variant title contains an invalid placeholder');
+}
+
+function assertOnlyKeys(value: Record<string, unknown>, allowed: Set<string>, label: string): void {
+  const unknown = Object.keys(value).find(key => !allowed.has(key));
+  if (unknown) throw new TypeError(`Unknown BugDrop ${label} property: ${unknown}`);
+}
+
+function nonEmptyString(value: unknown, maximum: number): value is string {
+  return typeof value === 'string' && value.trim().length > 0 && value.length <= maximum;
+}
+
+function isBoundedInteger(value: unknown, minimum: number, maximum: number): value is number {
+  return Number.isInteger(value) && (value as number) >= minimum && (value as number) <= maximum;
+}
+
+function hasControlChars(value: string): boolean {
+  return Array.from(value).some(character => {
+    const code = character.charCodeAt(0);
+    return code < 0x20 || code === 0x7f;
+  });
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function clone<T>(value: T): T {
+  if (Array.isArray(value)) return value.map(item => clone(item)) as T;
+  if (isObject(value)) {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, clone(item)])) as T;
+  }
+  return value;
+}
+
+function deepFreeze<T>(value: T): Readonly<T> {
+  if (value && typeof value === 'object') {
+    Object.freeze(value);
+    for (const child of Object.values(value)) deepFreeze(child);
+  }
+  return value;
+}

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import type { Env, FeedbackPayload } from '../src/types';
@@ -33,6 +34,21 @@ const createApiRoutes = async () => {
   const { default: api } = await import('../src/routes/api');
   return api;
 };
+
+const legacyFixtureRoot = new URL('./fixtures/legacy-compat/', import.meta.url);
+const legacyPayloads = JSON.parse(
+  readFileSync(new URL('legacy-payload.json', legacyFixtureRoot), 'utf8')
+) as {
+  screenshotFree: FeedbackPayload;
+  evidenceBearing: FeedbackPayload;
+};
+const legacyResponse = JSON.parse(
+  readFileSync(new URL('legacy-response.json', legacyFixtureRoot), 'utf8')
+) as Record<string, unknown>;
+const legacyIssueBody = readFileSync(
+  new URL('legacy-issue.md', legacyFixtureRoot),
+  'utf8'
+).trimEnd();
 
 describe('API Routes', () => {
   const validPngDataUrl =
@@ -245,6 +261,78 @@ describe('API Routes', () => {
         timestamp: '2025-01-15T12:00:00Z',
       },
     };
+
+    it('preserves the frozen screenshot-free legacy request and response contract', async () => {
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(legacyPayloads.screenshotFree),
+      });
+
+      const res = await app.fetch(req, mockEnv);
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(legacyResponse);
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        'test-token',
+        'testowner',
+        'testrepo',
+        legacyPayloads.screenshotFree.title,
+        expect.stringContaining(legacyPayloads.screenshotFree.description),
+        ['enhancement', 'bugdrop']
+      );
+      expect(mockUploadScreenshotAsAsset).not.toHaveBeenCalled();
+      expect(mockUploadAttachmentAsAsset).not.toHaveBeenCalled();
+    });
+
+    it('preserves the frozen evidence-bearing Issue body and GitHub arguments', async () => {
+      mockUploadScreenshotAsAsset.mockResolvedValue('https://assets.test/screenshot.png');
+      mockUploadAttachmentAsAsset.mockResolvedValue('https://assets.test/evidence.pdf');
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(legacyPayloads.evidenceBearing),
+      });
+
+      const res = await app.fetch(req, mockEnv);
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(legacyResponse);
+      expect(mockUploadScreenshotAsAsset).toHaveBeenCalledWith(
+        'test-token',
+        'testowner',
+        'testrepo',
+        legacyPayloads.evidenceBearing.screenshot
+      );
+      expect(mockUploadAttachmentAsAsset).toHaveBeenCalledWith(
+        'test-token',
+        'testowner',
+        'testrepo',
+        legacyPayloads.evidenceBearing.attachments?.[0]
+      );
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        'test-token',
+        'testowner',
+        'testrepo',
+        legacyPayloads.evidenceBearing.title,
+        legacyIssueBody,
+        ['bug', 'bugdrop']
+      );
+    });
+
+    it('does not treat an unrelated top-level schemaVersion as a variant discriminator', async () => {
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...legacyPayloads.screenshotFree, schemaVersion: 2 }),
+      });
+
+      const res = await app.fetch(req, mockEnv);
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(legacyResponse);
+      expect(mockCreateIssue).toHaveBeenCalledOnce();
+    });
 
     it('should create issue with valid payload', async () => {
       mockGetInstallationToken.mockResolvedValue('test-token');

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -7,6 +7,9 @@ ci_workflow="$repo_root/.github/workflows/ci.yml"
 live_workflow="$repo_root/.github/workflows/live-tests.yml"
 canary_spec="$repo_root/e2e/widget.issue-canary.spec.ts"
 live_spec="$repo_root/e2e/widget.live.spec.ts"
+live_radix_spec="$repo_root/e2e/widget.live-radix.spec.ts"
+cross_browser_live_spec="$repo_root/e2e/widget.cross-browser-live.spec.ts"
+exact_widget_fixture="$repo_root/e2e/live-preview-widget.ts"
 
 fail() {
   echo "CI workflow contract failed: $*" >&2
@@ -106,6 +109,10 @@ grep -Fq 'BUILD_SHA" = "$GITHUB_SHA"' <<< "$critical" ||
 grep -Fq 'EXPECTED_WIDGET_SHA256=' <<< "$critical" || fail 'checkout widget hash is not recorded'
 grep -Fq 'ACTUAL_SHA" = "$EXPECTED_WIDGET_SHA256"' <<< "$critical" ||
   fail 'deployed widget bytes are not polled to an exact hash match'
+grep -Fq 'EXACT_WIDGET_FIXTURE_PATH=' <<< "$critical" ||
+  fail 'the exact deployed widget snapshot path is not recorded'
+grep -Fq 'mv "$CANDIDATE_PATH" "$EXACT_WIDGET_FIXTURE_PATH"' <<< "$critical" ||
+  fail 'the exact deployed widget response is not retained for browser execution'
 
 [[ $(grep -Fc 'npx wrangler deploy --env preview' "$ci_workflow") -eq 1 ]] ||
   fail 'preview deployment must have exactly one workflow owner'
@@ -133,12 +140,17 @@ sweep_line=$(grep -n 'name: Final reserved-prefix sweep' "$ci_workflow" | cut -d
 artifact_line=$(grep -n 'name: Upload preview failure report' "$ci_workflow" | cut -d: -f1)
 [[ -n "$cleanup_line" && -n "$sweep_line" && -n "$artifact_line" ]] || fail 'cleanup/artifact steps missing'
 (( cleanup_line < sweep_line && sweep_line < artifact_line )) || fail 'artifacts must follow both cleanup steps'
-sed -n "${cleanup_line},$((cleanup_line + 8))p" "$ci_workflow" | grep -Fq 'if: always()' ||
+sed -n "${cleanup_line},$((cleanup_line + 12))p" "$ci_workflow" | grep -Fq 'if: always()' ||
   fail 'current-marker cleanup is not unconditional'
-sed -n "${cleanup_line},$((cleanup_line + 8))p" "$ci_workflow" | grep -Fq -- '--marker "$BUGDROP_CANARY_MARKER"' ||
+sed -n "${cleanup_line},$((cleanup_line + 12))p" "$ci_workflow" | grep -Fq -- '--marker "$BUGDROP_CANARY_MARKER"' ||
   fail 'current cleanup does not discover by marker'
-sed -n "${cleanup_line},$((cleanup_line + 8))p" "$ci_workflow" | grep -Fq -- '--result-file' &&
+sed -n "${cleanup_line},$((cleanup_line + 12))p" "$ci_workflow" | grep -Fq -- '--result-file' &&
   fail 'cleanup must not depend on the browser result file'
+grep -Fq ': > "$BUGDROP_CANARY_ATTEMPT_FILE"' <<< "$critical" ||
+  fail 'the canary does not record that its browser action started'
+sed -n "${cleanup_line},$((cleanup_line + 12))p" "$ci_workflow" |
+  grep -Fq 'if [ ! -f "$BUGDROP_CANARY_ATTEMPT_FILE" ]' ||
+  fail 'current-marker cleanup does not distinguish a skipped canary from an attempted canary'
 
 grep -Fq 'name: Live Preview Tests' <<< "$bridge" || fail 'status bridge lost its required name'
 grep -Fq 'needs: [deploy-preview]' <<< "$bridge" || fail 'status bridge does not depend on critical job'
@@ -159,10 +171,17 @@ require_absent "$live_workflow" 'chromium-issue-canary'
 require_absent "$live_workflow" 'BUGDROP_CANARY_MARKER'
 
 require_literal "$canary_spec" 'expect(outgoingUrl.origin).toBe(environment.expectedWidgetOrigin)'
+require_literal "$canary_spec" "from './live-preview-widget'"
 require_literal "$canary_spec" "response.request().method() === 'POST'"
 require_literal "$canary_spec" 'responseUrl.origin === environment.expectedWidgetOrigin'
 require_literal "$canary_spec" "responseUrl.pathname === '/api/feedback'"
 require_literal "$canary_spec" 'expect(feedbackUrl.origin).toBe(environment.expectedWidgetOrigin)'
 require_literal "$live_spec" "page.route('**/feedback'"
+require_literal "$live_spec" 'installExactPreviewWidgetFromEnvironment(context)'
+for live_browser_spec in "$live_spec" "$live_radix_spec" "$cross_browser_live_spec"; do
+  require_literal "$live_browser_spec" "from './live-preview-widget'"
+done
+require_literal "$exact_widget_fixture" 'EXACT_WIDGET_FIXTURE_PATH'
+require_literal "$exact_widget_fixture" 'x-bugdrop-widget-sha256'
 
 echo 'CI workflow contract checks passed'

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -49,6 +49,10 @@ required_contexts=(
 for context in "${required_contexts[@]}"; do
   require_literal "$ci_workflow" "name: $context"
 done
+require_literal "$ci_workflow" 'name: Verify legacy compatibility provenance'
+require_literal "$ci_workflow" 'run: npm run verify:legacy-compat'
+[[ $(grep -Fc 'npm run verify:legacy-compat' "$ci_workflow") -eq 1 ]] ||
+  fail 'legacy compatibility provenance must have exactly one required CI invocation'
 
 e2e_block=$(job_block "$ci_workflow" e2e)
 if grep -Eq '^    if:' <<< "$e2e_block"; then

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -53,6 +53,9 @@ require_literal "$ci_workflow" 'name: Verify legacy compatibility provenance'
 require_literal "$ci_workflow" 'run: npm run verify:legacy-compat'
 [[ $(grep -Fc 'npm run verify:legacy-compat' "$ci_workflow") -eq 1 ]] ||
   fail 'legacy compatibility provenance must have exactly one required CI invocation'
+unit_block=$(job_block "$ci_workflow" test)
+grep -Fq 'fetch-depth: 0' <<< "$unit_block" ||
+  fail 'the provenance job must fetch tag history before verification'
 
 e2e_block=$(job_block "$ci_workflow" e2e)
 if grep -Eq '^    if:' <<< "$e2e_block"; then

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -111,6 +111,11 @@ grep -Fq 'ACTUAL_SHA" = "$EXPECTED_WIDGET_SHA256"' <<< "$critical" ||
   fail 'deployed widget bytes are not polled to an exact hash match'
 grep -Fq 'EXACT_WIDGET_FIXTURE_PATH=' <<< "$critical" ||
   fail 'the exact deployed widget snapshot path is not recorded'
+grep -Fq 'EXACT_WIDGET_FIXTURE_PATH=$RUNNER_TEMP/' <<< "$critical" ||
+  fail "Playwright may delete the exact widget snapshot unless it lives in RUNNER_TEMP"
+if grep -Fq 'EXACT_WIDGET_FIXTURE_PATH=$GITHUB_WORKSPACE/test-results/' <<< "$critical"; then
+  fail 'the exact widget snapshot must not live in Playwright outputDir'
+fi
 grep -Fq 'mv "$CANDIDATE_PATH" "$EXACT_WIDGET_FIXTURE_PATH"' <<< "$critical" ||
   fail 'the exact deployed widget response is not retained for browser execution'
 

--- a/test/fixtures/legacy-compat/legacy-issue.md
+++ b/test/fixtures/legacy-compat/legacy-issue.md
@@ -1,0 +1,32 @@
+## Submitted by
+**Compatibility Bot** (compat@example.test)
+
+## Description
+Frozen legacy evidence description.
+
+## Screenshot
+![Screenshot](https://assets.test/screenshot.png)
+
+_Selected element is indicated by the rounded highlight border (`#ff00aa`)._
+
+## Attachments
+- [evidence.pdf](https://assets.test/evidence.pdf)
+
+<details>
+<summary>System Info</summary>
+
+| Property | Value |
+|----------|-------|
+| **Browser** | Firefox 128.0 |
+| **OS** | Linux 6.8 |
+| **Viewport** | 1440×900 @1.5x |
+| **Language** | en-GB |
+| **Page** | https://example.test/checkout |
+| **Timestamp** | 2026-08-01T01:02:03.000Z |
+| **Element** | `#checkout > button.submit` |
+| **Full CSS path** | `html > body > main#checkout > button.submit` |
+
+</details>
+
+---
+*Submitted via [BugDrop](https://github.com/mean-weasel/bugdrop)*

--- a/test/fixtures/legacy-compat/legacy-payload.json
+++ b/test/fixtures/legacy-compat/legacy-payload.json
@@ -1,0 +1,84 @@
+{
+  "historicalV1_1_0Submission": {
+    "repo": "mean-weasel/bugdrop-widget-test",
+    "title": "Historical v1.1.0 compatibility",
+    "description": "Tag-reconstructed browser submission",
+    "screenshot": null,
+    "metadata": {
+      "url": "/legacy-compat-fixture",
+      "userAgent": "<user-agent>",
+      "viewport": {
+        "width": 1280,
+        "height": 720
+      },
+      "timestamp": "<timestamp>",
+      "elementSelector": null
+    }
+  },
+  "screenshotFree": {
+    "repo": "testowner/testrepo",
+    "title": "Legacy compatibility: screenshot-free",
+    "description": "Frozen legacy description.",
+    "category": "feature",
+    "metadata": {
+      "url": "https://example.test/feedback",
+      "userAgent": "FrozenAgent/1.0",
+      "viewport": {
+        "width": 1280,
+        "height": 720
+      },
+      "timestamp": "2026-08-01T00:00:00.000Z",
+      "browser": {
+        "name": "Chrome",
+        "version": "126.0"
+      },
+      "os": {
+        "name": "macOS",
+        "version": "14.5"
+      },
+      "devicePixelRatio": 2,
+      "language": "en-US"
+    }
+  },
+  "evidenceBearing": {
+    "repo": "testowner/testrepo",
+    "title": "Legacy compatibility: evidence",
+    "description": "Frozen legacy evidence description.",
+    "category": "bug",
+    "screenshot": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+    "attachments": [
+      {
+        "name": "evidence.pdf",
+        "type": "application/pdf",
+        "size": 9,
+        "dataUrl": "data:application/pdf;base64,JVBERi0xLjQK"
+      }
+    ],
+    "submitter": {
+      "name": "Compatibility Bot",
+      "email": "compat@example.test"
+    },
+    "metadata": {
+      "url": "https://example.test/checkout",
+      "userAgent": "FrozenAgent/1.0",
+      "viewport": {
+        "width": 1440,
+        "height": 900
+      },
+      "timestamp": "2026-08-01T01:02:03.000Z",
+      "elementSelector": "#checkout > button.submit",
+      "fullElementSelector": "html > body > main#checkout > button.submit",
+      "selectedElementHighlightColor": "#ff00aa",
+      "browser": {
+        "name": "Firefox",
+        "version": "128.0"
+      },
+      "os": {
+        "name": "Linux",
+        "version": "6.8"
+      },
+      "devicePixelRatio": 1.5,
+      "language": "en-GB"
+    }
+  }
+}

--- a/test/fixtures/legacy-compat/legacy-response.json
+++ b/test/fixtures/legacy-compat/legacy-response.json
@@ -1,0 +1,6 @@
+{
+  "success": true,
+  "issueNumber": 42,
+  "issueUrl": "https://github.com/testowner/testrepo/issues/42",
+  "isPublic": true
+}

--- a/test/fixtures/legacy-compat/manifest.json
+++ b/test/fixtures/legacy-compat/manifest.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": 1,
+  "provenancePolicy": "Tag-reconstructed bundles are immutable compatibility fixtures built from the named git commit and lockfile. They are not claimed to be byte-identical to historically deployed assets.",
+  "bundleBudget": {
+    "baselineTag": "v1.53.1",
+    "maxGzipGrowthPercent": 25,
+    "baselineRawBytes": 148406,
+    "baselineGzipBytes": 42077,
+    "maxGzipBytes": 52597,
+    "gzipMeasurement": "node:zlib gzipSync level 9"
+  },
+  "bundles": {
+    "v1.1.0": {
+      "tag": "v1.1.0",
+      "commit": "5ec3aead9d49a9a9573c25ccdff86aada15cadc9",
+      "packageLockSha256": "d57cb54e35141ba9e363b7661b84e1c2917f67cb526d625c27bed8385e5dd5eb",
+      "buildCommand": "npm ci --ignore-scripts --no-audit --no-fund && VERSION=v1.1.0 npm run build:widget",
+      "bundle": "test/fixtures/legacy-compat/v1.1.0/widget.js",
+      "sha256": "5de4ee13f96e588a67b57b588c6e20be0b6ab1e3a38d6199e3a345aadcaba462",
+      "rawBytes": 34629,
+      "gzipBytes": 9014
+    },
+    "v1.53.1": {
+      "tag": "v1.53.1",
+      "commit": "5cf06f4ec3eab7cc7a507fc4c4d082a84e279539",
+      "packageLockSha256": "06ca1e524ecc457deff83f07d323f000a3c46230c98dea0548d11372d9686b1d",
+      "buildCommand": "npm ci --ignore-scripts --no-audit --no-fund && VERSION=v1.53.1 npm run build:widget",
+      "bundle": "test/fixtures/legacy-compat/v1.53.1/widget.js",
+      "sha256": "3398aa9052e561e63c84c7dde1e6bff344c7367061b23a6e449af536f36d973c",
+      "rawBytes": 148406,
+      "gzipBytes": 42077
+    }
+  },
+  "legacyBootstrap": {
+    "hostId": "bugdrop-host",
+    "shadowRootMode": "open",
+    "readyEvent": {
+      "target": "window",
+      "count": 1,
+      "bubbles": false,
+      "cancelable": false,
+      "detail": null
+    },
+    "storageKeys": [
+      "bugdrop_dismissed",
+      "bugdrop_trigger_position_<repo>",
+      "bugdrop_welcomed_<repo>",
+      "bugdrop_complex_screenshot_skipped_<repo>"
+    ]
+  },
+  "liveObservation": {
+    "observedAt": "2026-08-02",
+    "widget.v1.1.0.js": 404,
+    "widget.v1.53.1.js": 200,
+    "widget.v1.js": 200
+  }
+}

--- a/test/fixtures/legacy-compat/v1.1.0/widget.js
+++ b/test/fixtures/legacy-compat/v1.1.0/widget.js
@@ -1,0 +1,872 @@
+"use strict";(()=>{var A="https://cdn.jsdelivr.net/npm/html-to-image@1.11.13/dist/html-to-image.js",E=null;async function N(){return E||new Promise((o,r)=>{let e=document.createElement("script");e.src=A,e.onload=()=>{E=window.htmlToImage,o(E)},e.onerror=()=>r(new Error("Failed to load html-to-image")),document.head.appendChild(e)})}async function M(o){let r=await N(),e=o||document.body;return await r.toPng(e,{cacheBust:!0,pixelRatio:window.devicePixelRatio||1,filter:n=>n.id!=="bugdrop-host"})}function S(){return new Promise(o=>{setTimeout(()=>{_(o)},50)})}function _(o){let r=document.createElement("div");r.id="bugdrop-element-picker-highlight",r.style.cssText=`
+    position: fixed;
+    pointer-events: none;
+    border: 3px solid #14b8a6;
+    background: rgba(20, 184, 166, 0.15);
+    z-index: 2147483646;
+    transition: all 0.05s ease-out;
+    box-shadow: 0 0 0 4px rgba(20, 184, 166, 0.3);
+    border-radius: 6px;
+  `,document.body.appendChild(r);let e=document.createElement("div");e.id="bugdrop-element-picker-tooltip",e.style.cssText=`
+    position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #0f172a;
+    color: #f1f5f9;
+    padding: 14px 28px;
+    border-radius: 10px;
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    z-index: 2147483647;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3), 0 0 40px rgba(34, 211, 238, 0.1);
+    border: 1px solid #334155;
+  `,e.textContent="Click on any element to capture it (ESC to cancel)",document.body.appendChild(e);let t=null;function n(c){let m=document.elementsFromPoint(c.clientX,c.clientY).find(u=>!(u===r||u===e||u.id==="bugdrop-element-picker-highlight"||u.id==="bugdrop-element-picker-tooltip"||u.closest("#bugdrop-host")));if(!m)return;t=m;let p=m.getBoundingClientRect();r.style.top=`${p.top-2}px`,r.style.left=`${p.left-2}px`,r.style.width=`${p.width+4}px`,r.style.height=`${p.height+4}px`,r.style.display="block"}function a(c){c.preventDefault(),c.stopPropagation(),d(),o(t)}function i(c){c.key==="Escape"&&(d(),o(null))}function d(){document.removeEventListener("mousemove",n,!0),document.removeEventListener("click",a,!0),document.removeEventListener("keydown",i),r.remove(),e.remove(),document.body.style.cursor=""}document.body.style.cursor="crosshair",document.addEventListener("mousemove",n,!0),document.addEventListener("click",a,!0),document.addEventListener("keydown",i)}function H(o,r){let e=document.createElement("canvas"),t=e.getContext("2d"),n="draw",a=!1,i=[],d=[],c=new Image;c.onload=()=>{let l=o.clientWidth||600,s=Math.min(1,l/c.width);e.width=c.width*s,e.height=c.height*s,e.style.maxWidth="100%",e.style.cursor="crosshair",t.scale(s,s),t.drawImage(c,0,0),p()},c.src=r,o.appendChild(e);let b="#ff0000",m=3;function p(){d.push(t.getImageData(0,0,e.width,e.height))}function u(l){let s=e.getBoundingClientRect(),g=c.width/s.width,v=c.height/s.height;return{x:(l.clientX-s.left)*g,y:(l.clientY-s.top)*v}}function x(l,s){t.beginPath(),t.moveTo(l.x,l.y),t.lineTo(s.x,s.y),t.strokeStyle=b,t.lineWidth=m,t.lineCap="round",t.stroke()}function y(l,s){x(l,s);let g=Math.atan2(s.y-l.y,s.x-l.x),v=15;t.beginPath(),t.moveTo(s.x,s.y),t.lineTo(s.x-v*Math.cos(g-Math.PI/6),s.y-v*Math.sin(g-Math.PI/6)),t.lineTo(s.x-v*Math.cos(g+Math.PI/6),s.y-v*Math.sin(g+Math.PI/6)),t.closePath(),t.fillStyle=b,t.fill()}function w(l,s){t.strokeStyle=b,t.lineWidth=m,t.strokeRect(l.x,l.y,s.x-l.x,s.y-l.y)}return e.addEventListener("mousedown",l=>{a=!0,i=[u(l)],p()}),e.addEventListener("mousemove",l=>{if(!a)return;let s=u(l);n==="draw"?(x(i[i.length-1],s),i.push(s)):(t.putImageData(d[d.length-1],0,0),n==="arrow"?y(i[0],s):n==="rect"&&w(i[0],s))}),e.addEventListener("mouseup",l=>{if(!a)return;a=!1;let s=u(l);n==="arrow"?y(i[0],s):n==="rect"&&w(i[0],s),i=[]}),{setTool(l){n=l},undo(){d.length>1&&(d.pop(),t.putImageData(d[d.length-1],0,0))},getImageData(){return e.toDataURL("image/png")},destroy(){e.remove()}}}function $(){return typeof window<"u"&&window.matchMedia&&window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light"}function C(o,r){let e=r.position==="bottom-left"?"left: 20px":"right: 20px",n=(r.theme==="auto"?$():r.theme)==="dark",a=document.createElement("style");a.textContent=`
+    @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap');
+
+    :host {
+      /* Typography */
+      --bd-font: 'Space Grotesk', system-ui, sans-serif;
+
+      /* Radius */
+      --bd-radius-sm: 6px;
+      --bd-radius-md: 10px;
+      --bd-radius-lg: 14px;
+
+      /* Transitions */
+      --bd-transition: 0.15s ease;
+      --bd-transition-slow: 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    /* Light Theme (Default) */
+    .bd-root {
+      --bd-bg-primary: #fafaf9;
+      --bd-bg-secondary: #f5f5f4;
+      --bd-bg-tertiary: #e7e5e4;
+      --bd-text-primary: #1c1917;
+      --bd-text-secondary: #57534e;
+      --bd-text-muted: #a8a29e;
+      --bd-border: #e7e5e4;
+      --bd-border-focus: #14b8a6;
+      --bd-primary: #14b8a6;
+      --bd-primary-hover: #0d9488;
+      --bd-primary-text: #ffffff;
+      --bd-overlay-bg: rgba(0, 0, 0, 0.4);
+      --bd-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+      --bd-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+      --bd-shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.12);
+      --bd-shadow-glow: none;
+      --bd-success: #22c55e;
+      --bd-error: #ef4444;
+    }
+
+    /* Dark Theme */
+    .bd-root.bd-dark {
+      --bd-bg-primary: #0f172a;
+      --bd-bg-secondary: #1e293b;
+      --bd-bg-tertiary: #334155;
+      --bd-text-primary: #f1f5f9;
+      --bd-text-secondary: #94a3b8;
+      --bd-text-muted: #64748b;
+      --bd-border: #334155;
+      --bd-border-focus: #22d3ee;
+      --bd-primary: #22d3ee;
+      --bd-primary-hover: #06b6d4;
+      --bd-primary-text: #0f172a;
+      --bd-overlay-bg: rgba(0, 0, 0, 0.6);
+      --bd-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.2);
+      --bd-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.3);
+      --bd-shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.4);
+      --bd-shadow-glow: 0 0 40px rgba(34, 211, 238, 0.15);
+      --bd-success: #34d399;
+      --bd-error: #f87171;
+    }
+
+    .bd-root {
+      font-family: var(--bd-font);
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    * {
+      box-sizing: border-box;
+      font-family: inherit;
+    }
+
+    /* Trigger Button */
+    .bd-trigger {
+      position: fixed;
+      bottom: 20px;
+      ${e};
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      border: none;
+      background: var(--bd-primary);
+      color: var(--bd-primary-text);
+      font-size: 24px;
+      cursor: pointer;
+      box-shadow:
+        var(--bd-shadow-md),
+        0 0 0 0 var(--bd-primary);
+      z-index: 999999;
+      transition: transform var(--bd-transition), box-shadow var(--bd-transition);
+    }
+
+    .bd-trigger:hover {
+      transform: scale(1.08);
+      box-shadow:
+        var(--bd-shadow-lg),
+        0 0 20px rgba(20, 184, 166, 0.3);
+    }
+
+    .bd-trigger:active {
+      transform: scale(0.96);
+    }
+
+    /* Dismissible close button */
+    .bd-trigger-close {
+      position: absolute;
+      top: -4px;
+      right: -4px;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      border: none;
+      background: var(--bd-text-primary);
+      color: var(--bd-bg-primary);
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 1;
+      cursor: pointer;
+      opacity: 0;
+      transform: scale(0.8);
+      transition: opacity var(--bd-transition), transform var(--bd-transition);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+      box-shadow: var(--bd-shadow-sm);
+    }
+
+    .bd-trigger:hover .bd-trigger-close {
+      opacity: 1;
+      transform: scale(1);
+    }
+
+    .bd-trigger-close:hover {
+      background: var(--bd-error);
+      color: white;
+    }
+
+    /* Modal Overlay */
+    .bd-overlay {
+      position: fixed;
+      inset: 0;
+      background: var(--bd-overlay-bg);
+      z-index: 1000000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      animation: bd-fadeIn 0.2s ease;
+    }
+
+    /* Modal */
+    .bd-modal {
+      background: var(--bd-bg-primary);
+      border-radius: var(--bd-radius-lg);
+      border: 1px solid var(--bd-border);
+      box-shadow: var(--bd-shadow-lg), var(--bd-shadow-glow);
+      max-width: 600px;
+      width: 90%;
+      max-height: 90vh;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      animation: bd-slideUp var(--bd-transition-slow);
+    }
+
+    /* Modal Header */
+    .bd-header {
+      padding: 16px 20px;
+      border-bottom: 1px solid var(--bd-border);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: var(--bd-bg-primary);
+      animation: bd-fadeIn 0.2s ease 0.05s both;
+    }
+
+    .bd-title {
+      margin: 0;
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      color: var(--bd-text-primary);
+    }
+
+    .bd-close {
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: transparent;
+      border: none;
+      border-radius: var(--bd-radius-sm);
+      font-size: 24px;
+      cursor: pointer;
+      color: var(--bd-text-secondary);
+      padding: 0;
+      line-height: 1;
+      transition: background var(--bd-transition), color var(--bd-transition);
+    }
+
+    .bd-close:hover {
+      background: var(--bd-bg-secondary);
+      color: var(--bd-text-primary);
+    }
+
+    /* Modal Body with staggered animation */
+    .bd-body {
+      padding: 20px;
+      overflow-y: auto;
+      flex: 1;
+    }
+
+    .bd-body > *:nth-child(1) { animation: bd-fadeIn 0.2s ease 0.1s both; }
+    .bd-body > *:nth-child(2) { animation: bd-fadeIn 0.2s ease 0.15s both; }
+    .bd-body > *:nth-child(3) { animation: bd-fadeIn 0.2s ease 0.2s both; }
+    .bd-body > *:nth-child(4) { animation: bd-fadeIn 0.2s ease 0.25s both; }
+    .bd-body > *:nth-child(5) { animation: bd-fadeIn 0.2s ease 0.3s both; }
+
+    /* Form Elements */
+    .bd-form-group {
+      margin-bottom: 16px;
+    }
+
+    .bd-label {
+      display: block;
+      margin-bottom: 6px;
+      font-weight: 500;
+      font-size: 13px;
+      color: var(--bd-text-secondary);
+      letter-spacing: 0.01em;
+    }
+
+    .bd-input, .bd-textarea {
+      width: 100%;
+      padding: 12px 14px;
+      background: var(--bd-bg-primary);
+      border: 1px solid var(--bd-border);
+      border-radius: var(--bd-radius-sm);
+      font-size: 14px;
+      color: var(--bd-text-primary);
+      transition: border-color var(--bd-transition), box-shadow var(--bd-transition);
+    }
+
+    .bd-input::placeholder, .bd-textarea::placeholder {
+      color: var(--bd-text-muted);
+    }
+
+    .bd-input:focus, .bd-textarea:focus {
+      outline: none;
+      border-color: var(--bd-border-focus);
+      box-shadow: 0 0 0 3px rgba(20, 184, 166, 0.15);
+    }
+
+    .bd-dark .bd-input:focus, .bd-dark .bd-textarea:focus {
+      box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.15);
+    }
+
+    .bd-textarea {
+      min-height: 100px;
+      resize: vertical;
+    }
+
+    /* Buttons */
+    .bd-btn {
+      padding: 11px 20px;
+      border-radius: var(--bd-radius-sm);
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all var(--bd-transition);
+      position: relative;
+    }
+
+    .bd-btn-primary {
+      background: var(--bd-primary);
+      color: var(--bd-primary-text);
+      border: none;
+      box-shadow: var(--bd-shadow-sm);
+    }
+
+    .bd-btn-primary:hover {
+      background: var(--bd-primary-hover);
+      box-shadow: var(--bd-shadow-md);
+    }
+
+    .bd-dark .bd-btn-primary:hover {
+      box-shadow: var(--bd-shadow-md), 0 0 20px rgba(34, 211, 238, 0.2);
+    }
+
+    .bd-btn-secondary {
+      background: var(--bd-bg-primary);
+      border: 1px solid var(--bd-border);
+      color: var(--bd-text-primary);
+    }
+
+    .bd-btn-secondary:hover {
+      background: var(--bd-bg-secondary);
+    }
+
+    .bd-btn:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
+    /* Loading States */
+    .bd-btn--loading {
+      color: transparent !important;
+      pointer-events: none;
+    }
+
+    .bd-btn--loading::after {
+      content: '';
+      position: absolute;
+      width: 16px;
+      height: 16px;
+      top: 50%;
+      left: 50%;
+      margin: -8px 0 0 -8px;
+      border: 2px solid currentColor;
+      border-color: var(--bd-primary-text) transparent var(--bd-primary-text) transparent;
+      border-radius: 50%;
+      animation: bd-spin 0.8s linear infinite;
+    }
+
+    .bd-spinner {
+      width: 20px;
+      height: 20px;
+      border: 2px solid var(--bd-border);
+      border-top-color: var(--bd-primary);
+      border-radius: 50%;
+      animation: bd-spin 0.8s linear infinite;
+    }
+
+    .bd-spinner--lg {
+      width: 32px;
+      height: 32px;
+      border-width: 3px;
+    }
+
+    .bd-loading-overlay {
+      position: absolute;
+      inset: 0;
+      background: var(--bd-bg-primary);
+      opacity: 0.95;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      z-index: 10;
+      border-radius: var(--bd-radius-lg);
+    }
+
+    .bd-loading-text {
+      font-size: 14px;
+      color: var(--bd-text-secondary);
+      font-weight: 500;
+    }
+
+    .bd-skeleton {
+      background: linear-gradient(
+        90deg,
+        var(--bd-bg-secondary) 0%,
+        var(--bd-bg-tertiary) 50%,
+        var(--bd-bg-secondary) 100%
+      );
+      background-size: 200% 100%;
+      animation: bd-shimmer 1.5s ease-in-out infinite;
+      border-radius: var(--bd-radius-sm);
+    }
+
+    /* Error States */
+    .bd-error-message {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 12px 14px;
+      background: rgba(239, 68, 68, 0.1);
+      border: 1px solid rgba(239, 68, 68, 0.2);
+      border-radius: var(--bd-radius-sm);
+      color: var(--bd-error);
+      font-size: 13px;
+      margin-bottom: 16px;
+    }
+
+    .bd-dark .bd-error-message {
+      background: rgba(248, 113, 113, 0.1);
+      border-color: rgba(248, 113, 113, 0.2);
+    }
+
+    .bd-error-message__icon {
+      flex-shrink: 0;
+      width: 16px;
+      height: 16px;
+    }
+
+    .bd-error-message__text {
+      flex: 1;
+      line-height: 1.4;
+    }
+
+    .bd-error-message__retry {
+      background: none;
+      border: none;
+      color: inherit;
+      font-weight: 600;
+      cursor: pointer;
+      text-decoration: underline;
+      padding: 0;
+      font-size: 13px;
+    }
+
+    .bd-input--error, .bd-textarea--error {
+      border-color: var(--bd-error) !important;
+    }
+
+    /* Success Modal */
+    .bd-success-content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      padding: 8px 0 16px;
+    }
+
+    .bd-success-icon {
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      background: var(--bd-success);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-bottom: 16px;
+    }
+
+    .bd-success-icon svg {
+      width: 28px;
+      height: 28px;
+      color: white;
+    }
+
+    .bd-success-issue {
+      margin: 0 0 12px;
+      color: var(--bd-text-primary);
+      font-size: 15px;
+    }
+
+    .bd-issue-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--bd-primary);
+      text-decoration: none;
+      font-weight: 500;
+      font-size: 14px;
+      padding: 8px 16px;
+      border-radius: var(--bd-radius-sm);
+      background: var(--bd-bg-secondary);
+      transition: background var(--bd-transition), color var(--bd-transition);
+    }
+
+    .bd-issue-link:hover {
+      background: var(--bd-bg-tertiary);
+      color: var(--bd-primary-hover);
+    }
+
+    .bd-issue-link svg {
+      flex-shrink: 0;
+    }
+
+    .bd-input--error:focus, .bd-textarea--error:focus {
+      box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15) !important;
+    }
+
+    .bd-field-error {
+      color: var(--bd-error);
+      font-size: 12px;
+      margin-top: 4px;
+    }
+
+    /* Actions */
+    .bd-actions {
+      display: flex;
+      gap: 12px;
+      justify-content: flex-end;
+      margin-top: 20px;
+    }
+
+    /* Tools Toolbar */
+    .bd-tools {
+      display: flex;
+      gap: 6px;
+      padding: 8px;
+      background: var(--bd-bg-secondary);
+      border: 1px solid var(--bd-border);
+      border-radius: var(--bd-radius-md);
+      margin-bottom: 12px;
+    }
+
+    .bd-tool {
+      padding: 8px 14px;
+      background: transparent;
+      border: none;
+      border-radius: var(--bd-radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--bd-text-secondary);
+      cursor: pointer;
+      transition: all var(--bd-transition);
+    }
+
+    .bd-tool:hover {
+      background: var(--bd-bg-tertiary);
+      color: var(--bd-text-primary);
+    }
+
+    .bd-tool.active {
+      background: var(--bd-bg-primary);
+      color: var(--bd-primary);
+      box-shadow: var(--bd-shadow-sm);
+    }
+
+    /* Preview */
+    .bd-preview {
+      border: 1px solid var(--bd-border);
+      border-radius: var(--bd-radius-md);
+      overflow: hidden;
+      margin-bottom: 16px;
+      box-shadow: var(--bd-shadow-sm);
+    }
+
+    .bd-preview img {
+      width: 100%;
+      display: block;
+    }
+
+    /* Toast Notifications */
+    .bd-toast {
+      position: fixed;
+      bottom: 100px;
+      right: 20px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 18px;
+      border-radius: var(--bd-radius-md);
+      color: white;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000001;
+      box-shadow: var(--bd-shadow-lg);
+      animation: bd-slideIn 0.3s ease;
+    }
+
+    .bd-toast.success {
+      background: var(--bd-success);
+    }
+
+    .bd-toast.error {
+      background: var(--bd-error);
+    }
+
+    /* Animations */
+    @keyframes bd-fadeIn {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    @keyframes bd-slideUp {
+      from { opacity: 0; transform: translateY(24px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+
+    @keyframes bd-slideIn {
+      from { transform: translateX(100%); opacity: 0; }
+      to { transform: translateX(0); opacity: 1; }
+    }
+
+    @keyframes bd-spin {
+      to { transform: rotate(360deg); }
+    }
+
+    @keyframes bd-shimmer {
+      0% { background-position: 200% 0; }
+      100% { background-position: -200% 0; }
+    }
+
+    /* Mobile Responsiveness */
+    @media (max-width: 640px) {
+      .bd-trigger {
+        width: 52px;
+        height: 52px;
+        bottom: 16px;
+        font-size: 22px;
+      }
+
+      .bd-overlay {
+        align-items: flex-end;
+      }
+
+      .bd-modal {
+        width: 100%;
+        max-width: 100%;
+        max-height: 95vh;
+        border-radius: var(--bd-radius-lg) var(--bd-radius-lg) 0 0;
+        animation: bd-slideUpMobile var(--bd-transition-slow);
+      }
+
+      .bd-header {
+        padding: 16px;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+      }
+
+      .bd-close {
+        width: 44px;
+        height: 44px;
+        font-size: 28px;
+      }
+
+      .bd-body {
+        padding: 16px;
+        padding-bottom: 32px;
+      }
+
+      .bd-btn {
+        padding: 14px 24px;
+        font-size: 16px;
+        min-height: 48px;
+      }
+
+      .bd-input, .bd-textarea {
+        padding: 14px;
+        font-size: 16px;
+        min-height: 48px;
+      }
+
+      .bd-textarea {
+        min-height: 120px;
+      }
+
+      .bd-actions {
+        flex-direction: column-reverse;
+        gap: 8px;
+      }
+
+      .bd-actions .bd-btn {
+        width: 100%;
+      }
+
+      .bd-tools {
+        flex-wrap: wrap;
+      }
+
+      .bd-tool {
+        flex: 1;
+        min-width: calc(50% - 4px);
+        justify-content: center;
+        padding: 12px;
+        text-align: center;
+      }
+
+      .bd-toast {
+        left: 16px;
+        right: 16px;
+        bottom: 80px;
+        justify-content: center;
+      }
+    }
+
+    @keyframes bd-slideUpMobile {
+      from { opacity: 0; transform: translateY(100%); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* Touch-friendly hover states */
+    @media (hover: none) {
+      .bd-trigger:hover {
+        transform: none;
+        box-shadow: var(--bd-shadow-md);
+      }
+
+      .bd-trigger:active {
+        transform: scale(0.95);
+      }
+
+      /* Always show close button on touch devices */
+      .bd-trigger-close {
+        opacity: 1;
+        transform: scale(1);
+      }
+
+      .bd-btn:hover {
+        background: inherit;
+      }
+
+      .bd-btn-primary:hover {
+        background: var(--bd-primary);
+      }
+
+      .bd-btn-primary:active {
+        background: var(--bd-primary-hover);
+      }
+
+      .bd-btn-secondary:hover {
+        background: var(--bd-bg-primary);
+      }
+
+      .bd-btn-secondary:active {
+        background: var(--bd-bg-secondary);
+      }
+    }
+
+    /* Safe area support for notched devices */
+    @supports (padding-bottom: env(safe-area-inset-bottom)) {
+      .bd-modal {
+        padding-bottom: env(safe-area-inset-bottom);
+      }
+    }
+
+    /* Reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+  `,o.appendChild(a);let i=document.createElement("div");return i.className=`bd-root${n?" bd-dark":""}`,o.appendChild(i),i}function h(o,r,e){let t=document.createElement("div");return t.className="bd-overlay",t.innerHTML=`
+    <div class="bd-modal">
+      <div class="bd-header">
+        <h2 class="bd-title">${r}</h2>
+        <button class="bd-close">&times;</button>
+      </div>
+      <div class="bd-body">
+        ${e}
+      </div>
+    </div>
+  `,o.appendChild(t),t}function P(o,r,e,t){return new Promise(n=>{let a=t?`
+        <p class="bd-success-issue">Issue <strong>#${r}</strong> has been created.</p>
+        <a href="${e}" target="_blank" rel="noopener noreferrer" class="bd-issue-link">
+          <svg viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
+            <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"/>
+          </svg>
+          View on GitHub
+        </a>
+      `:'<p class="bd-success-issue">Your feedback has been submitted successfully.</p>',i=h(o,"Feedback Submitted!",`
+        <div class="bd-success-content">
+          <div class="bd-success-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
+              <polyline points="22 4 12 14.01 9 11.01"/>
+            </svg>
+          </div>
+          ${a}
+        </div>
+        <div class="bd-actions">
+          <button class="bd-btn bd-btn-primary" data-action="done">Done</button>
+        </div>
+      `),d=i.querySelector(".bd-close"),c=i.querySelector('[data-action="done"]'),b=()=>{i.remove(),n()};d?.addEventListener("click",b),c?.addEventListener("click",b)})}var z="bugdrop_dismissed",W=null;function F(){try{return localStorage.getItem(z)==="true"}catch{return!1}}function j(){try{localStorage.setItem(z,"true")}catch{}}var f=document.currentScript,R=f?.dataset.theme,q={repo:f?.dataset.repo||"",apiUrl:f?.src.replace("/widget.js","/api")||"",position:f?.dataset.position||"bottom-right",theme:R||"auto",showName:f?.dataset.showName==="true",requireName:f?.dataset.requireName==="true",showEmail:f?.dataset.showEmail==="true",requireEmail:f?.dataset.requireEmail==="true",buttonDismissible:f?.dataset.buttonDismissible==="true"};q.repo?U(q):console.error("[BugDrop] Missing data-repo attribute");function U(o){let r=document.createElement("div");r.id="bugdrop-host",document.body.appendChild(r);let e=r.attachShadow({mode:"open"}),t=C(e,o);if(W=t,o.buttonDismissible&&F())return;let n=document.createElement("button");if(n.className="bd-trigger",n.innerHTML="\u{1F41B}",n.setAttribute("aria-label","Report a bug or send feedback"),o.buttonDismissible){let a=document.createElement("button");a.className="bd-trigger-close",a.innerHTML="\xD7",a.setAttribute("aria-label","Dismiss feedback button"),n.appendChild(a),a.addEventListener("click",i=>{i.stopPropagation(),j(),n.remove()})}t.appendChild(n),n.addEventListener("click",()=>Y(t,o))}async function Y(o,r){if(!await G(r)){O(o,r);return}let t=await X(o),n=null,a=null;if(t==="capture")n=await T(o);else if(t==="element"){let c=await S();c&&(n=await T(o,c),a=J(c))}let i=n;n&&(i=await V(o,n));let d=await K(o,i,r);d&&await D(o,r,{...d,screenshot:i,elementSelector:a})}async function T(o,r){let e=h(o,"Capturing...",`
+      <div style="display: flex; flex-direction: column; align-items: center; padding: 20px;">
+        <div class="bd-spinner bd-spinner--lg"></div>
+        <p class="bd-loading-text" style="margin-top: 12px;">Capturing screenshot...</p>
+      </div>
+    `);try{let t=await M(r);return e.remove(),t}catch{return e.remove(),new Promise(n=>{let a=h(o,"Capture Failed",`
+          <div class="bd-error-message">
+            <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-9.5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5.5zm0 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
+            </svg>
+            <span class="bd-error-message__text">Failed to capture screenshot. This might be due to browser restrictions.</span>
+          </div>
+          <div class="bd-actions">
+            <button class="bd-btn bd-btn-secondary" data-action="skip">Skip Screenshot</button>
+            <button class="bd-btn bd-btn-primary" data-action="retry">Try Again</button>
+          </div>
+        `),i=a.querySelector(".bd-close"),d=a.querySelector('[data-action="skip"]'),c=a.querySelector('[data-action="retry"]');i?.addEventListener("click",()=>{a.remove(),n(null)}),d?.addEventListener("click",()=>{a.remove(),n(null)}),c?.addEventListener("click",async()=>{a.remove();let b=await T(o,r);n(b)})})}}async function G(o){try{return(await(await fetch(`${o.apiUrl}/check/${o.repo}`)).json()).installed===!0}catch{return!1}}function O(o,r){let e=h(o,"Install Required",`
+      <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">BugDrop requires GitHub App installation to create issues.</p>
+      <div class="bd-actions">
+        <button class="bd-btn bd-btn-secondary" data-action="cancel">Cancel</button>
+        <a href="https://github.com/apps/YOUR_APP_NAME/installations/new" target="_blank" class="bd-btn bd-btn-primary" style="text-decoration: none;">Install App</a>
+      </div>
+    `),t=e.querySelector(".bd-close"),n=e.querySelector('[data-action="cancel"]');t?.addEventListener("click",()=>e.remove()),n?.addEventListener("click",()=>e.remove())}function X(o){return new Promise(r=>{let e=h(o,"Capture Screenshot",`
+        <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">Would you like to include a screenshot with your feedback?</p>
+        <div class="bd-actions">
+          <button class="bd-btn bd-btn-secondary" data-action="skip">Skip</button>
+          <button class="bd-btn bd-btn-secondary" data-action="element">Select Element</button>
+          <button class="bd-btn bd-btn-primary" data-action="capture">Full Page</button>
+        </div>
+      `),t=e.querySelector(".bd-close"),n=e.querySelector('[data-action="skip"]'),a=e.querySelector('[data-action="element"]'),i=e.querySelector('[data-action="capture"]');t?.addEventListener("click",()=>{e.remove(),r("skip")}),n?.addEventListener("click",()=>{e.remove(),r("skip")}),a?.addEventListener("click",()=>{e.remove(),r("element")}),i?.addEventListener("click",()=>{e.remove(),r("capture")})})}function V(o,r){return new Promise(e=>{let t=h(o,"Annotate Screenshot",`
+        <div class="bd-tools">
+          <button class="bd-tool active" data-tool="draw">\u270F\uFE0F Draw</button>
+          <button class="bd-tool" data-tool="arrow">\u27A1\uFE0F Arrow</button>
+          <button class="bd-tool" data-tool="rect">\u25A2 Rectangle</button>
+          <button class="bd-tool" data-action="undo">\u21B6 Undo</button>
+        </div>
+        <div id="annotation-canvas"></div>
+        <div class="bd-actions">
+          <button class="bd-btn bd-btn-secondary" data-action="skip">Skip Annotations</button>
+          <button class="bd-btn bd-btn-primary" data-action="done">Done</button>
+        </div>
+      `),n=t.querySelector("#annotation-canvas"),a=H(n,r),i=t.querySelectorAll("[data-tool]");i.forEach(m=>{m.addEventListener("click",p=>{let u=p.target,x=u.dataset.tool;x==="undo"?a.undo():x&&(i.forEach(y=>y.classList.remove("active")),u.classList.add("active"),a.setTool(x))})});let d=t.querySelector(".bd-close"),c=t.querySelector('[data-action="skip"]'),b=t.querySelector('[data-action="done"]');d?.addEventListener("click",()=>{a.destroy(),t.remove(),e(r)}),c?.addEventListener("click",()=>{a.destroy(),t.remove(),e(r)}),b?.addEventListener("click",()=>{let m=a.getImageData();a.destroy(),t.remove(),e(m)})})}function K(o,r,e){return new Promise(t=>{let n=r?`<div class="bd-preview"><img src="${r}" alt="Screenshot preview" /></div>`:"",a=e.showName?`
+          <div class="bd-form-group">
+            <label class="bd-label" for="name">Name${e.requireName?" *":""}</label>
+            <input type="text" id="name" class="bd-input" ${e.requireName?"required":""} placeholder="Your name" />
+          </div>
+        `:"",i=e.showEmail?`
+          <div class="bd-form-group">
+            <label class="bd-label" for="email">Email${e.requireEmail?" *":""}</label>
+            <input type="email" id="email" class="bd-input" ${e.requireEmail?"required":""} placeholder="your@email.com" />
+          </div>
+        `:"",d=h(o,"Send Feedback",`
+        ${n}
+        <form id="feedback-form">
+          ${a}
+          ${i}
+          <div class="bd-form-group">
+            <label class="bd-label" for="title">Title *</label>
+            <input type="text" id="title" class="bd-input" required placeholder="Brief description of the issue" />
+          </div>
+          <div class="bd-form-group">
+            <label class="bd-label" for="description">Description</label>
+            <textarea id="description" class="bd-textarea" placeholder="Additional details..."></textarea>
+          </div>
+          <div class="bd-actions">
+            <button type="button" class="bd-btn bd-btn-secondary" data-action="cancel">Cancel</button>
+            <button type="submit" class="bd-btn bd-btn-primary" id="submit-btn">Submit</button>
+          </div>
+        </form>
+      `),c=d.querySelector("#feedback-form"),b=d.querySelector("#name"),m=d.querySelector("#email"),p=d.querySelector("#title"),u=d.querySelector("#description"),x=d.querySelector(".bd-close"),y=d.querySelector('[data-action="cancel"]'),w=l=>{l.classList.remove("bd-input--error");let s=l.parentElement?.querySelector(".bd-field-error");s&&s.remove()};p?.addEventListener("input",()=>w(p)),b?.addEventListener("input",()=>w(b)),m?.addEventListener("input",()=>w(m)),x?.addEventListener("click",()=>{d.remove(),t(null)}),y?.addEventListener("click",()=>{d.remove(),t(null)}),c?.addEventListener("submit",l=>{l.preventDefault();let s=!1,g=(k,B)=>{if(k.classList.add("bd-input--error"),!k.parentElement?.querySelector(".bd-field-error")){let L=document.createElement("div");L.className="bd-field-error",L.textContent=B,k.parentElement?.appendChild(L)}s||(k.focus(),s=!0)};e.requireName&&b&&!b.value.trim()&&g(b,"Name is required"),e.requireEmail&&m&&!m.value.trim()&&g(m,"Email is required");let v=p.value.trim();v||g(p,"Title is required"),!s&&(d.remove(),t({title:v,description:u.value.trim(),name:b?.value.trim()||void 0,email:m?.value.trim()||void 0}))})})}async function D(o,r,e){let t=h(o,"Submitting...",`
+      <div style="display: flex; flex-direction: column; align-items: center; padding: 20px;">
+        <div class="bd-spinner bd-spinner--lg"></div>
+        <p class="bd-loading-text" style="margin-top: 12px;">Creating issue...</p>
+      </div>
+    `);try{let n=e.name||e.email?{name:e.name,email:e.email}:void 0,i=await(await fetch(`${r.apiUrl}/feedback`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({repo:r.repo,title:e.title,description:e.description,screenshot:e.screenshot,submitter:n,metadata:{url:window.location.href,userAgent:navigator.userAgent,viewport:{width:window.innerWidth,height:window.innerHeight},timestamp:new Date().toISOString(),elementSelector:e.elementSelector}})})).json();t.remove(),i.success?await P(o,i.issueNumber,i.issueUrl,i.isPublic??!1):I(o,r,e,i.error||"Failed to submit")}catch{t.remove(),I(o,r,e,"Network error. Please check your connection.")}}function I(o,r,e,t){let n=h(o,"Submission Failed",`
+      <div class="bd-error-message">
+        <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-9.5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5.5zm0 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
+        </svg>
+        <span class="bd-error-message__text">${t}</span>
+      </div>
+      <div class="bd-actions">
+        <button class="bd-btn bd-btn-secondary" data-action="cancel">Cancel</button>
+        <button class="bd-btn bd-btn-primary" data-action="retry">Try Again</button>
+      </div>
+    `),a=n.querySelector(".bd-close"),i=n.querySelector('[data-action="cancel"]'),d=n.querySelector('[data-action="retry"]');a?.addEventListener("click",()=>n.remove()),i?.addEventListener("click",()=>n.remove()),d?.addEventListener("click",async()=>{n.remove(),await D(o,r,e)})}function J(o){let r=[],e=o;for(;e&&e!==document.body;){let t=e.tagName.toLowerCase();if(e.id){t=`#${e.id}`,r.unshift(t);break}if(e.className){let a=(typeof e.className=="string"?e.className:e.className.baseVal||"").split(" ").filter(i=>i).slice(0,2);a.length&&(t+=`.${a.join(".")}`)}r.unshift(t),e=e.parentElement}return r.join(" > ")}})();

--- a/test/fixtures/legacy-compat/v1.53.1/widget.js
+++ b/test/fixtures/legacy-compat/v1.53.1/widget.js
@@ -1,0 +1,1637 @@
+"use strict";(()=>{function Tt(e,t){if(e.match(/^[a-z]+:\/\//i))return e;if(e.match(/^\/\//))return window.location.protocol+e;if(e.match(/^[a-z]+:/i))return e;let n=document.implementation.createHTMLDocument(),r=n.createElement("base"),o=n.createElement("a");return n.head.appendChild(r),n.body.appendChild(o),t&&(r.href=t),o.href=e,o.href}var Ct=(()=>{let e=0,t=()=>`0000${(Math.random()*36**4<<0).toString(36)}`.slice(-4);return()=>(e+=1,`u${t()}${e}`)})();function V(e){let t=[];for(let n=0,r=e.length;n<r;n++)t.push(e[n]);return t}var J=null;function Pe(e={}){return J||(e.includeStyleProperties?(J=e.includeStyleProperties,J):(J=V(window.getComputedStyle(document.documentElement)),J))}function Le(e,t){let r=(e.ownerDocument.defaultView||window).getComputedStyle(e).getPropertyValue(t);return r?parseFloat(r.replace("px","")):0}function Sr(e){let t=Le(e,"border-left-width"),n=Le(e,"border-right-width");return e.clientWidth+t+n}function Tr(e){let t=Le(e,"border-top-width"),n=Le(e,"border-bottom-width");return e.clientHeight+t+n}function Ze(e,t={}){let n=t.width||Sr(e),r=t.height||Tr(e);return{width:n,height:r}}function Lt(){let e,t;try{t=process}catch{}let n=t&&t.env?t.env.devicePixelRatio:null;return n&&(e=parseInt(n,10),Number.isNaN(e)&&(e=1)),e||window.devicePixelRatio||1}var W=16384;function Pt(e){(e.width>W||e.height>W)&&(e.width>W&&e.height>W?e.width>e.height?(e.height*=W/e.width,e.width=W):(e.width*=W/e.height,e.height=W):e.width>W?(e.height*=W/e.width,e.width=W):(e.width*=W/e.height,e.height=W))}function ee(e){return new Promise((t,n)=>{let r=new Image;r.onload=()=>{r.decode().then(()=>{requestAnimationFrame(()=>t(r))})},r.onerror=n,r.crossOrigin="anonymous",r.decoding="async",r.src=e})}async function Cr(e){return Promise.resolve().then(()=>new XMLSerializer().serializeToString(e)).then(encodeURIComponent).then(t=>`data:image/svg+xml;charset=utf-8,${t}`)}async function Mt(e,t,n){let r="http://www.w3.org/2000/svg",o=document.createElementNS(r,"svg"),i=document.createElementNS(r,"foreignObject");return o.setAttribute("width",`${t}`),o.setAttribute("height",`${n}`),o.setAttribute("viewBox",`0 0 ${t} ${n}`),i.setAttribute("width","100%"),i.setAttribute("height","100%"),i.setAttribute("x","0"),i.setAttribute("y","0"),i.setAttribute("externalResourcesRequired","true"),o.appendChild(i),i.appendChild(e),Cr(o)}var $=(e,t)=>{if(e instanceof t)return!0;let n=Object.getPrototypeOf(e);return n===null?!1:n.constructor.name===t.name||$(n,t)};function Lr(e){let t=e.getPropertyValue("content");return`${e.cssText} content: '${t.replace(/'|"/g,"")}';`}function Pr(e,t){return Pe(t).map(n=>{let r=e.getPropertyValue(n),o=e.getPropertyPriority(n);return`${n}: ${r}${o?" !important":""};`}).join(" ")}function Mr(e,t,n,r){let o=`.${e}:${t}`,i=n.cssText?Lr(n):Pr(n,r);return document.createTextNode(`${o}{${i}}`)}function Rt(e,t,n,r){let o=window.getComputedStyle(e,n),i=o.getPropertyValue("content");if(i===""||i==="none")return;let a=Ct();try{t.className=`${t.className} ${a}`}catch{return}let s=document.createElement("style");s.appendChild(Mr(a,n,o,r)),t.appendChild(s)}function zt(e,t,n){Rt(e,t,":before",n),Rt(e,t,":after",n)}var At="application/font-woff",It="image/jpeg",Rr={woff:At,woff2:At,ttf:"application/font-truetype",eot:"application/vnd.ms-fontobject",png:"image/png",jpg:It,jpeg:It,gif:"image/gif",tiff:"image/tiff",svg:"image/svg+xml",webp:"image/webp"};function zr(e){let t=/\.([^./]*?)$/g.exec(e);return t?t[1]:""}function te(e){let t=zr(e).toLowerCase();return Rr[t]||""}function Ar(e){return e.split(/,/)[1]}function de(e){return e.search(/^(data:)/)!==-1}function Je(e,t){return`data:${t};base64,${e}`}async function et(e,t,n){let r=await fetch(e,t);if(r.status===404)throw new Error(`Resource "${r.url}" not found`);let o=await r.blob();return new Promise((i,a)=>{let s=new FileReader;s.onerror=a,s.onloadend=()=>{try{i(n({res:r,result:s.result}))}catch(l){a(l)}},s.readAsDataURL(o)})}var Qe={};function Ir(e,t,n){let r=e.replace(/\?.*/,"");return n&&(r=e),/ttf|otf|eot|woff2?/i.test(r)&&(r=r.replace(/.*\//,"")),t?`[${t}]${r}`:r}async function ne(e,t,n){let r=Ir(e,t,n.includeQueryParams);if(Qe[r]!=null)return Qe[r];n.cacheBust&&(e+=(/\?/.test(e)?"&":"?")+new Date().getTime());let o;try{let i=await et(e,n.fetchRequestInit,({res:a,result:s})=>(t||(t=a.headers.get("Content-Type")||""),Ar(s)));o=Je(i,t)}catch(i){o=n.imagePlaceholder||"";let a=`Failed to fetch resource: ${e}`;i&&(a=typeof i=="string"?i:i.message),a&&console.warn(a)}return Qe[r]=o,o}async function Dr(e){let t=e.toDataURL();return t==="data:,"?e.cloneNode(!1):ee(t)}async function Fr(e,t){if(e.currentSrc){let i=document.createElement("canvas"),a=i.getContext("2d");i.width=e.clientWidth,i.height=e.clientHeight,a?.drawImage(e,0,0,i.width,i.height);let s=i.toDataURL();return ee(s)}let n=e.poster,r=te(n),o=await ne(n,r,t);return ee(o)}async function $r(e,t){var n;try{if(!((n=e?.contentDocument)===null||n===void 0)&&n.body)return await ue(e.contentDocument.body,t,!0)}catch{}return e.cloneNode(!1)}async function Br(e,t){return $(e,HTMLCanvasElement)?Dr(e):$(e,HTMLVideoElement)?Fr(e,t):$(e,HTMLIFrameElement)?$r(e,t):e.cloneNode(Dt(e))}var _r=e=>e.tagName!=null&&e.tagName.toUpperCase()==="SLOT",Dt=e=>e.tagName!=null&&e.tagName.toUpperCase()==="SVG";async function Nr(e,t,n){var r,o;if(Dt(t))return t;let i=[];return _r(e)&&e.assignedNodes?i=V(e.assignedNodes()):$(e,HTMLIFrameElement)&&(!((r=e.contentDocument)===null||r===void 0)&&r.body)?i=V(e.contentDocument.body.childNodes):i=V(((o=e.shadowRoot)!==null&&o!==void 0?o:e).childNodes),i.length===0||$(e,HTMLVideoElement)||await i.reduce((a,s)=>a.then(()=>ue(s,n)).then(l=>{l&&t.appendChild(l)}),Promise.resolve()),t}function Hr(e,t,n){let r=t.style;if(!r)return;let o=window.getComputedStyle(e);o.cssText?(r.cssText=o.cssText,r.transformOrigin=o.transformOrigin):Pe(n).forEach(i=>{let a=o.getPropertyValue(i);i==="font-size"&&a.endsWith("px")&&(a=`${Math.floor(parseFloat(a.substring(0,a.length-2)))-.1}px`),$(e,HTMLIFrameElement)&&i==="display"&&a==="inline"&&(a="block"),i==="d"&&t.getAttribute("d")&&(a=`path(${t.getAttribute("d")})`),r.setProperty(i,a,o.getPropertyPriority(i))})}function Or(e,t){$(e,HTMLTextAreaElement)&&(t.innerHTML=e.value),$(e,HTMLInputElement)&&t.setAttribute("value",e.value)}function Ur(e,t){if($(e,HTMLSelectElement)){let r=Array.from(t.children).find(o=>e.value===o.getAttribute("value"));r&&r.setAttribute("selected","")}}function Wr(e,t,n){return $(t,Element)&&(Hr(e,t,n),zt(e,t,n),Or(e,t),Ur(e,t)),t}async function jr(e,t){let n=e.querySelectorAll?e.querySelectorAll("use"):[];if(n.length===0)return e;let r={};for(let i=0;i<n.length;i++){let s=n[i].getAttribute("xlink:href");if(s){let l=e.querySelector(s),d=document.querySelector(s);!l&&d&&!r[s]&&(r[s]=await ue(d,t,!0))}}let o=Object.values(r);if(o.length){let i="http://www.w3.org/1999/xhtml",a=document.createElementNS(i,"svg");a.setAttribute("xmlns",i),a.style.position="absolute",a.style.width="0",a.style.height="0",a.style.overflow="hidden",a.style.display="none";let s=document.createElementNS(i,"defs");a.appendChild(s);for(let l=0;l<o.length;l++)s.appendChild(o[l]);e.appendChild(a)}return e}async function ue(e,t,n){return!n&&t.filter&&!t.filter(e)?null:Promise.resolve(e).then(r=>Br(r,t)).then(r=>Nr(e,r,t)).then(r=>Wr(e,r,t)).then(r=>jr(r,t))}var Ft=/url\((['"]?)([^'"]+?)\1\)/g,qr=/url\([^)]+\)\s*format\((["']?)([^"']+)\1\)/g,Vr=/src:\s*(?:url\([^)]+\)\s*format\([^)]+\)[,;]\s*)+/g;function Gr(e){let t=e.replace(/([.*+?^${}()|\[\]\/\\])/g,"\\$1");return new RegExp(`(url\\(['"]?)(${t})(['"]?\\))`,"g")}function Xr(e){let t=[];return e.replace(Ft,(n,r,o)=>(t.push(o),n)),t.filter(n=>!de(n))}async function Yr(e,t,n,r,o){try{let i=n?Tt(t,n):t,a=te(t),s;if(o){let l=await o(i);s=Je(l,a)}else s=await ne(i,a,r);return e.replace(Gr(t),`$1${s}$3`)}catch{}return e}function Kr(e,{preferredFontFormat:t}){return t?e.replace(Vr,n=>{for(;;){let[r,,o]=qr.exec(n)||[];if(!o)return"";if(o===t)return`src: ${r};`}}):e}function tt(e){return e.search(Ft)!==-1}async function Me(e,t,n){if(!tt(e))return e;let r=Kr(e,n);return Xr(r).reduce((i,a)=>i.then(s=>Yr(s,a,t,n)),Promise.resolve(r))}async function re(e,t,n){var r;let o=(r=t.style)===null||r===void 0?void 0:r.getPropertyValue(e);if(o){let i=await Me(o,null,n);return t.style.setProperty(e,i,t.style.getPropertyPriority(e)),!0}return!1}async function Zr(e,t){await re("background",e,t)||await re("background-image",e,t),await re("mask",e,t)||await re("-webkit-mask",e,t)||await re("mask-image",e,t)||await re("-webkit-mask-image",e,t)}async function Qr(e,t){let n=$(e,HTMLImageElement);if(!(n&&!de(e.src))&&!($(e,SVGImageElement)&&!de(e.href.baseVal)))return;let r=n?e.src:e.href.baseVal,o=await ne(r,te(r),t);await new Promise((i,a)=>{e.onload=i,e.onerror=t.onImageErrorHandler?(...l)=>{try{i(t.onImageErrorHandler(...l))}catch(d){a(d)}}:a;let s=e;s.decode&&(s.decode=i),s.loading==="lazy"&&(s.loading="eager"),n?(e.srcset="",e.src=o):e.href.baseVal=o})}async function Jr(e,t){let r=V(e.childNodes).map(o=>nt(o,t));await Promise.all(r).then(()=>e)}async function nt(e,t){$(e,Element)&&(await Zr(e,t),await Qr(e,t),await Jr(e,t))}function $t(e,t){let{style:n}=e;t.backgroundColor&&(n.backgroundColor=t.backgroundColor),t.width&&(n.width=`${t.width}px`),t.height&&(n.height=`${t.height}px`);let r=t.style;return r!=null&&Object.keys(r).forEach(o=>{n[o]=r[o]}),e}var Bt={};async function _t(e){let t=Bt[e];if(t!=null)return t;let r=await(await fetch(e)).text();return t={url:e,cssText:r},Bt[e]=t,t}async function Nt(e,t){let n=e.cssText,r=/url\(["']?([^"')]+)["']?\)/g,i=(n.match(/url\([^)]+\)/g)||[]).map(async a=>{let s=a.replace(r,"$1");return s.startsWith("https://")||(s=new URL(s,e.url).href),et(s,t.fetchRequestInit,({result:l})=>(n=n.replace(a,`url(${l})`),[a,l]))});return Promise.all(i).then(()=>n)}function Ht(e){if(e==null)return[];let t=[],n=/(\/\*[\s\S]*?\*\/)/gi,r=e.replace(n,""),o=new RegExp("((@.*?keyframes [\\s\\S]*?){([\\s\\S]*?}\\s*?)})","gi");for(;;){let l=o.exec(r);if(l===null)break;t.push(l[0])}r=r.replace(o,"");let i=/@import[\s\S]*?url\([^)]*\)[\s\S]*?;/gi,a="((\\s*?(?:\\/\\*[\\s\\S]*?\\*\\/)?\\s*?@media[\\s\\S]*?){([\\s\\S]*?)}\\s*?})|(([\\s\\S]*?){([\\s\\S]*?)})",s=new RegExp(a,"gi");for(;;){let l=i.exec(r);if(l===null){if(l=s.exec(r),l===null)break;i.lastIndex=s.lastIndex}else s.lastIndex=i.lastIndex;t.push(l[0])}return t}async function eo(e,t){let n=[],r=[];return e.forEach(o=>{if("cssRules"in o)try{V(o.cssRules||[]).forEach((i,a)=>{if(i.type===CSSRule.IMPORT_RULE){let s=a+1,l=i.href,d=_t(l).then(u=>Nt(u,t)).then(u=>Ht(u).forEach(m=>{try{o.insertRule(m,m.startsWith("@import")?s+=1:o.cssRules.length)}catch(y){console.error("Error inserting rule from remote css",{rule:m,error:y})}})).catch(u=>{console.error("Error loading remote css",u.toString())});r.push(d)}})}catch(i){let a=e.find(s=>s.href==null)||document.styleSheets[0];o.href!=null&&r.push(_t(o.href).then(s=>Nt(s,t)).then(s=>Ht(s).forEach(l=>{a.insertRule(l,a.cssRules.length)})).catch(s=>{console.error("Error loading remote stylesheet",s)})),console.error("Error inlining remote css file",i)}}),Promise.all(r).then(()=>(e.forEach(o=>{if("cssRules"in o)try{V(o.cssRules||[]).forEach(i=>{n.push(i)})}catch(i){console.error(`Error while reading CSS rules from ${o.href}`,i)}}),n))}function to(e){return e.filter(t=>t.type===CSSRule.FONT_FACE_RULE).filter(t=>tt(t.style.getPropertyValue("src")))}async function no(e,t){if(e.ownerDocument==null)throw new Error("Provided element is not within a Document");let n=V(e.ownerDocument.styleSheets),r=await eo(n,t);return to(r)}function Ot(e){return e.trim().replace(/["']/g,"")}function ro(e){let t=new Set;function n(r){(r.style.fontFamily||getComputedStyle(r).fontFamily).split(",").forEach(i=>{t.add(Ot(i))}),Array.from(r.children).forEach(i=>{i instanceof HTMLElement&&n(i)})}return n(e),t}async function Ut(e,t){let n=await no(e,t),r=ro(e);return(await Promise.all(n.filter(i=>r.has(Ot(i.style.fontFamily))).map(i=>{let a=i.parentStyleSheet?i.parentStyleSheet.href:null;return Me(i.cssText,a,t)}))).join(`
+`)}async function Wt(e,t){let n=t.fontEmbedCSS!=null?t.fontEmbedCSS:t.skipFonts?null:await Ut(e,t);if(n){let r=document.createElement("style"),o=document.createTextNode(n);r.appendChild(o),e.firstChild?e.insertBefore(r,e.firstChild):e.appendChild(r)}}async function oo(e,t={}){let{width:n,height:r}=Ze(e,t),o=await ue(e,t,!0);return await Wt(o,t),await nt(o,t),$t(o,t),await Mt(o,n,r)}async function io(e,t={}){let{width:n,height:r}=Ze(e,t),o=await oo(e,t),i=await ee(o),a=document.createElement("canvas"),s=a.getContext("2d"),l=t.pixelRatio||Lt(),d=t.canvasWidth||n,u=t.canvasHeight||r;return a.width=d*l,a.height=u*l,t.skipAutoScale||Pt(a),a.style.width=`${d}`,a.style.height=`${u}`,t.backgroundColor&&(s.fillStyle=t.backgroundColor,s.fillRect(0,0,a.width,a.height)),s.drawImage(i,0,0,a.width,a.height),a}async function jt(e,t={}){return(await io(e,t)).toDataURL()}var qt={triggerLabel:"Feedback",triggerAriaLabel:"Fehler melden oder Feedback senden",dismissButtonAriaLabel:"Feedback-Button ausblenden",pullTabAriaLabel:"Feedback-Button anzeigen",dragHandleTitle:"Feedback-Button verschieben",installRequiredTitle:"Installation erforderlich",connectionErrorTitle:"Verbindungsfehler",installRequiredMessage:"BugDrop ben\xF6tigt die Installation der GitHub-App, um Issues zu erstellen.",apiUnreachableMessage:"Die BugDrop-API ist nicht erreichbar. \xDCberpr\xFCfen Sie Ihre Netzwerkverbindung oder die URL des Script-Tags.",installApp:"App installieren",welcomeTitle:"Teilen Sie Ihr Feedback",welcomeHeadline:"Helfen Sie uns, besser zu werden, indem Sie Ihre Meinung teilen",welcomeBodyLine1:"Melden Sie Fehler, schlagen Sie Funktionen vor oder hinterlassen Sie Feedback.",welcomeBodyLine2:"Sie k\xF6nnen optional kommentierte Screenshots hinzuf\xFCgen.",getStarted:"Los geht\u2019s",feedbackFormTitle:"Feedback senden",categoryLabel:"Kategorie",categoryBug:"Fehler",categoryFeature:"Funktion",categoryQuestion:"Frage",nameLabel:"Name",namePlaceholder:"Ihr Name",emailLabel:"E-Mail",emailPlaceholder:"ihre@email.de",titleLabel:"Titel",titlePlaceholder:"Kurze Beschreibung des Problems oder Vorschlags",descriptionLabel:"Beschreibung",descriptionPlaceholder:"Geben Sie weitere Details, Schritte zur Reproduktion oder Kontext an...",screenshotAutoNote:"Diese Website h\xE4ngt beim Absenden automatisch einen Screenshot der gesamten Seite an, ohne eine Vorschau anzuzeigen. \xDCberpr\xFCfen Sie Ihre Seite vor dem Senden auf sensible Informationen.",screenshotAutoRedactionNote:"Einige von dieser Website als privat markierte Felder k\xF6nnen auf unterst\xFCtzten Seiten optisch maskiert werden, nicht markierte sensible Informationen k\xF6nnen jedoch weiterhin enthalten sein.",screenshotRequiredNote:"\u{1F4F8} Vor dem Absenden ist ein Screenshot erforderlich.",includeScreenshotLabel:"\u{1F4F8} Screenshot hinzuf\xFCgen",sendConsoleLogsLabel:"Konsolenprotokolle mitsenden",uploadsAriaLabel:"Uploads",uploadFilesAriaLabel:"Dateien hochladen",uploadButton:"Hochladen",uploadTooMany:e=>`Laden Sie bis zu ${e} Dateien hoch. Entfernen Sie eine Datei, bevor Sie eine weitere hinzuf\xFCgen.`,uploadUnsupportedType:"Dieser Dateityp wird nicht unterst\xFCtzt. Laden Sie ein Bild, ein PDF oder ein kurzes Video hoch.",uploadTooLarge:e=>`Die Datei ist zu gro\xDF. Laden Sie Dateien bis zu ${e} hoch.`,uploadReadError:"Diese Datei konnte nicht gelesen werden. Versuchen Sie es mit einer anderen.",removeAttachmentAriaLabel:e=>`${e} entfernen`,cancel:"Abbrechen",continueButton:"Weiter",submit:"Absenden",submittingTitle:"Wird gesendet...",creatingIssue:"Issue wird erstellt...",rateLimited:e=>`Zu viele \xDCbermittlungen. Bitte versuchen Sie es in ${e} Minute${e===1?"":"n"} erneut.`,submitFailedFallback:"Senden fehlgeschlagen",networkError:"Netzwerkfehler. Bitte \xFCberpr\xFCfen Sie Ihre Verbindung.",submissionFailedTitle:"Senden fehlgeschlagen",tryAgain:"Erneut versuchen",successTitle:"Feedback gesendet!",issueCreated:e=>`Issue ${e} wurde erstellt.`,feedbackSubmittedMessage:"Ihr Feedback wurde erfolgreich gesendet.",viewOnGitHub:"Auf GitHub ansehen",done:"Fertig",captureScreenshotTitle:"Screenshot erstellen",chooseWhatToCapture:"W\xE4hlen Sie aus, was erfasst werden soll:",viewportRedactionWarning:"Bei der Erfassung des sichtbaren Bereichs \xFCber den Browser k\xF6nnen private Felder nicht automatisch maskiert werden. W\xE4hlen Sie \u201EElement ausw\xE4hlen\u201C, um die automatische Maskierung beizubehalten, oder \xFCberpr\xFCfen und verdecken Sie sensible Bereiche vor dem Senden.",redactionReviewNote:"Diese Website hat einige Felder zur Schw\xE4rzung markiert. \xDCberpr\xFCfen Sie den Screenshot vor dem Senden.",pageTooComplexViewportNote:"Diese Seite ist zu komplex f\xFCr eine vollst\xE4ndige Erfassung oder eine Bereichserfassung. Erfassen Sie stattdessen den sichtbaren Bereich oder w\xE4hlen Sie ein bestimmtes Element aus.",pageTooComplexElementNote:"Diese Seite ist zu komplex f\xFCr eine vollst\xE4ndige Erfassung oder eine Bereichserfassung. W\xE4hlen Sie stattdessen ein bestimmtes Element aus.",fullPage:"Ganze Seite",captureViewport:"Sichtbaren Bereich erfassen",selectArea:"Bereich ausw\xE4hlen",selectElement:"Element ausw\xE4hlen",skipScreenshot:"Screenshot \xFCberspringen",areaPickerInstruction:"Ziehen Sie eine Auswahl um den zu erfassenden Bereich",areaPickerRedactionInstruction:"Ziehen Sie eine Auswahl um den zu erfassenden Bereich. Markierte private Felder k\xF6nnen maskiert werden, wenn sie darin enthalten sind.",elementPickerInstruction:"Klicken Sie auf ein beliebiges Element, um es zu erfassen",elementPickerTouchInstruction:"Tippen Sie auf ein beliebiges Element, um es zu erfassen",escToCancel:"ESC zum Abbrechen",capturingTitle:"Wird erfasst...",capturingScreenshot:"Screenshot wird erfasst...",captureFailedTitle:"Erfassung fehlgeschlagen",captureFailedMessage:"Der Screenshot konnte nicht erfasst werden. Die Seite ist m\xF6glicherweise zu komplex, oder Browsereinschr\xE4nkungen greifen.",chooseAnotherMethod:"Andere Methode w\xE4hlen",maskFailureTitle:"Datenschutz-Maskierung fehlgeschlagen",maskFailureMessage:"Die automatische Schw\xE4rzung privater Felder konnte nicht angewendet werden. Zum Schutz Ihrer Daten wurde dieser Screenshot verworfen. Sie k\xF6nnen Ihr Feedback weiterhin ohne Screenshot senden.",continueWithoutScreenshot:"Ohne Screenshot fortfahren",reviewScreenshotTitle:"Screenshot \xFCberpr\xFCfen",viewportRedactionUnavailableNote:"Bei diesem \xFCber den Browser erfassten sichtbaren Bereich konnten private Felder nicht automatisch maskiert werden. \xDCberpr\xFCfen und verdecken Sie sensible Bereiche vor dem Senden.",redactionCountNote:e=>e===1?`${e} privates Element wurde zur Schw\xE4rzung in diesem Screenshot markiert. \xDCberpr\xFCfen Sie ihn vor dem Senden.`:`${e} private Elemente wurden zur Schw\xE4rzung in diesem Screenshot markiert. \xDCberpr\xFCfen Sie ihn vor dem Senden.`,redactionLimitationsNote:"BugDrop hat nur die gemessenen markierten Bereiche abgedeckt. Es untersucht keine Pixel innerhalb eingebetteter oder gerenderter Inhalte wie iFrames, Canvas, Bildern, SVGs, Videos, CSS-Hintergr\xFCnden oder benutzerdefinierten Steuerelementen. Stellen Sie vor dem Senden sicher, dass das schwarze Feld den sensiblen Bereich vollst\xE4ndig abdeckt, oder nehmen Sie den Screenshot nach Markierung eines gr\xF6\xDFeren Bereichs erneut auf.",annotationInstruction:"Stellen Sie vor dem Senden sicher, dass keine sensiblen Informationen sichtbar sind. Verdecken Sie sensible Bereiche vor dem Absenden. Schw\xE4rzungen werden dauerhaft in das hochgeladene Bild eingebettet.",selectedElementNote:e=>`Ben\xF6tigen Sie mehr umgebenden Kontext? Passen Sie ${e} im BugDrop-Script-Tag an.`,toolDraw:"Zeichnen",toolArrow:"Pfeil",toolRectangle:"Rechteck",toolRedact:"Schw\xE4rzen",undo:"R\xFCckg\xE4ngig",retake:"Erneut aufnehmen",submitFeedback:"Feedback senden",captureTimeout:"Zeit\xFCberschreitung bei der Screenshot-Erfassung \u2014 die Seite ist m\xF6glicherweise zu komplex"};var rt={triggerLabel:"Feedback",triggerAriaLabel:"Report a bug or send feedback",dismissButtonAriaLabel:"Dismiss feedback button",pullTabAriaLabel:"Show feedback button",dragHandleTitle:"Drag feedback button",installRequiredTitle:"Install Required",connectionErrorTitle:"Connection Error",installRequiredMessage:"BugDrop requires GitHub App installation to create issues.",apiUnreachableMessage:"Unable to reach BugDrop API. Check your network connection or script tag URL.",installApp:"Install App",welcomeTitle:"Share Your Feedback",welcomeHeadline:"Help us improve by sharing your thoughts",welcomeBodyLine1:"Report bugs, suggest features, or leave feedback.",welcomeBodyLine2:"You can optionally include annotated screenshots.",getStarted:"Get Started",feedbackFormTitle:"Send Feedback",categoryLabel:"Category",categoryBug:"Bug",categoryFeature:"Feature",categoryQuestion:"Question",nameLabel:"Name",namePlaceholder:"Your name",emailLabel:"Email",emailPlaceholder:"your@email.com",titleLabel:"Title",titlePlaceholder:"Brief description of the issue or suggestion",descriptionLabel:"Description",descriptionPlaceholder:"Provide additional details, steps to reproduce, or context...",screenshotAutoNote:"This site will attach a full-page screenshot when you submit without showing a preview. Review your page for sensitive information before sending.",screenshotAutoRedactionNote:"Some fields this site marked private may be visually masked on supported pages, but unmarked sensitive information can still be included.",screenshotRequiredNote:"\u{1F4F8} A screenshot is required before submitting.",includeScreenshotLabel:"\u{1F4F8} Include a screenshot",sendConsoleLogsLabel:"Send Console Logs",uploadsAriaLabel:"Uploads",uploadFilesAriaLabel:"Upload files",uploadButton:"Upload",uploadTooMany:e=>`Upload up to ${e} files. Remove a file before adding another.`,uploadUnsupportedType:"That file type is not supported. Upload an image, PDF, or short video.",uploadTooLarge:e=>`File is too large. Upload files up to ${e}.`,uploadReadError:"Could not read that file. Try another one.",removeAttachmentAriaLabel:e=>`Remove ${e}`,cancel:"Cancel",continueButton:"Continue",submit:"Submit",submittingTitle:"Submitting...",creatingIssue:"Creating issue...",rateLimited:e=>`Too many submissions. Please try again in ${e} minute${e===1?"":"s"}.`,submitFailedFallback:"Failed to submit",networkError:"Network error. Please check your connection.",submissionFailedTitle:"Submission Failed",tryAgain:"Try Again",successTitle:"Feedback Submitted!",issueCreated:e=>`Issue ${e} has been created.`,feedbackSubmittedMessage:"Your feedback has been submitted successfully.",viewOnGitHub:"View on GitHub",done:"Done",captureScreenshotTitle:"Capture Screenshot",chooseWhatToCapture:"Choose what to capture:",viewportRedactionWarning:"Browser viewport capture cannot apply automatic private-field masks. Select Element to preserve automatic masking, or review and cover sensitive areas before sending.",redactionReviewNote:"This site marked some fields for redaction. Review the screenshot before sending.",pageTooComplexViewportNote:"This page is too complex for full-page or area capture. Capture the visible viewport or select a specific element instead.",pageTooComplexElementNote:"This page is too complex for full-page or area capture. Select a specific element instead.",fullPage:"Full Page",captureViewport:"Capture Viewport",selectArea:"Select Area",selectElement:"Select Element",skipScreenshot:"Skip Screenshot",areaPickerInstruction:"Draw a selection around the area to capture",areaPickerRedactionInstruction:"Draw a selection around the area to capture. Marked private fields may be masked if included.",elementPickerInstruction:"Click any element to capture it",elementPickerTouchInstruction:"Tap any element to capture it",escToCancel:"ESC to cancel",capturingTitle:"Capturing...",capturingScreenshot:"Capturing screenshot...",captureFailedTitle:"Capture Failed",captureFailedMessage:"Failed to capture screenshot. The page may be too complex or browser restrictions may apply.",chooseAnotherMethod:"Choose Another Method",maskFailureTitle:"Privacy masking failed",maskFailureMessage:"Automatic redaction of private fields could not be applied. To protect your data, this screenshot was discarded. You can still submit feedback without one.",continueWithoutScreenshot:"Continue without screenshot",reviewScreenshotTitle:"Review Screenshot",viewportRedactionUnavailableNote:"This browser viewport capture could not apply automatic private-field masks. Review and cover any sensitive areas before sending.",redactionCountNote:e=>`${e} private ${e===1?"item was":"items were"} marked for redaction in this screenshot. Review before sending.`,redactionLimitationsNote:"BugDrop only covered the measured marked boxes. It does not inspect pixels inside embedded or rendered content such as iframes, canvas, images, SVGs, videos, CSS backgrounds, or custom controls. Confirm the black box fully covers the sensitive region before sending, or retake after marking a larger wrapper.",annotationInstruction:"Check that no sensitive information is visible before sending. Cover sensitive areas before submitting. Redactions are baked into the uploaded image.",selectedElementNote:e=>`Need more surrounding context? Adjust ${e} on the BugDrop script tag.`,toolDraw:"Draw",toolArrow:"Arrow",toolRectangle:"Rectangle",toolRedact:"Redact",undo:"Undo",retake:"Retake",submitFeedback:"Submit Feedback",captureTimeout:"Screenshot capture timed out \u2014 the page may be too complex"};var Vt={triggerLabel:"Feedback",triggerAriaLabel:"Een fout melden of feedback versturen",dismissButtonAriaLabel:"Feedbackknop verbergen",pullTabAriaLabel:"Feedbackknop tonen",dragHandleTitle:"Feedbackknop verslepen",installRequiredTitle:"Installatie vereist",connectionErrorTitle:"Verbindingsfout",installRequiredMessage:"BugDrop vereist installatie van de GitHub-app om issues te kunnen aanmaken.",apiUnreachableMessage:"Kan de BugDrop-API niet bereiken. Controleer uw netwerkverbinding of de URL van de scripttag.",installApp:"App installeren",welcomeTitle:"Deel uw feedback",welcomeHeadline:"Help ons verbeteren door uw mening te delen",welcomeBodyLine1:"Meld fouten, stel functies voor of laat feedback achter.",welcomeBodyLine2:"U kunt optioneel schermafbeeldingen met aantekeningen toevoegen.",getStarted:"Aan de slag",feedbackFormTitle:"Feedback versturen",categoryLabel:"Categorie",categoryBug:"Fout",categoryFeature:"Suggestie",categoryQuestion:"Vraag",nameLabel:"Naam",namePlaceholder:"Uw naam",emailLabel:"E-mail",emailPlaceholder:"uw@email.nl",titleLabel:"Titel",titlePlaceholder:"Korte omschrijving van het probleem of de suggestie",descriptionLabel:"Omschrijving",descriptionPlaceholder:"Geef extra details, stappen om het te reproduceren of context...",screenshotAutoNote:"Deze site voegt bij het versturen automatisch een schermafbeelding van de volledige pagina toe, zonder voorbeeld. Controleer uw pagina op gevoelige informatie voordat u verstuurt.",screenshotAutoRedactionNote:"Sommige velden die deze site als priv\xE9 heeft gemarkeerd, kunnen op ondersteunde pagina\u2019s visueel worden gemaskeerd, maar niet-gemarkeerde gevoelige informatie kan nog steeds worden meegestuurd.",screenshotRequiredNote:"\u{1F4F8} Een schermafbeelding is vereist voordat u kunt versturen.",includeScreenshotLabel:"\u{1F4F8} Schermafbeelding toevoegen",sendConsoleLogsLabel:"Consolelogboeken meesturen",uploadsAriaLabel:"Uploads",uploadFilesAriaLabel:"Bestanden uploaden",uploadButton:"Uploaden",uploadTooMany:e=>`Upload maximaal ${e} bestanden. Verwijder een bestand voordat u er een toevoegt.`,uploadUnsupportedType:"Dat bestandstype wordt niet ondersteund. Upload een afbeelding, pdf of korte video.",uploadTooLarge:e=>`Het bestand is te groot. Upload bestanden tot ${e}.`,uploadReadError:"Kan dat bestand niet lezen. Probeer een ander bestand.",removeAttachmentAriaLabel:e=>`${e} verwijderen`,cancel:"Annuleren",continueButton:"Doorgaan",submit:"Versturen",submittingTitle:"Versturen...",creatingIssue:"Issue aanmaken...",rateLimited:e=>`Te veel inzendingen. Probeer het over ${e} ${e===1?"minuut":"minuten"} opnieuw.`,submitFailedFallback:"Versturen mislukt",networkError:"Netwerkfout. Controleer uw verbinding.",submissionFailedTitle:"Versturen mislukt",tryAgain:"Opnieuw proberen",successTitle:"Feedback verstuurd!",issueCreated:e=>`Issue ${e} is aangemaakt.`,feedbackSubmittedMessage:"Uw feedback is succesvol verstuurd.",viewOnGitHub:"Bekijken op GitHub",done:"Klaar",captureScreenshotTitle:"Schermafbeelding maken",chooseWhatToCapture:"Kies wat u wilt vastleggen:",viewportRedactionWarning:"Bij het vastleggen van het zichtbare deel via de browser kunnen priv\xE9velden niet automatisch worden gemaskeerd. Kies \u201CElement selecteren\u201D om automatische maskering te behouden, of controleer en dek gevoelige gebieden af voordat u verstuurt.",redactionReviewNote:"Deze site heeft enkele velden gemarkeerd voor redactie. Controleer de schermafbeelding voordat u verstuurt.",pageTooComplexViewportNote:"Deze pagina is te complex om volledig of per gebied vast te leggen. Leg het zichtbare deel vast of selecteer een specifiek element.",pageTooComplexElementNote:"Deze pagina is te complex om volledig of per gebied vast te leggen. Selecteer in plaats daarvan een specifiek element.",fullPage:"Volledige pagina",captureViewport:"Zichtbaar deel vastleggen",selectArea:"Gebied selecteren",selectElement:"Element selecteren",skipScreenshot:"Schermafbeelding overslaan",areaPickerInstruction:"Trek een selectie rond het gebied dat u wilt vastleggen",areaPickerRedactionInstruction:"Trek een selectie rond het gebied dat u wilt vastleggen. Gemarkeerde priv\xE9velden kunnen worden gemaskeerd als ze binnen de selectie vallen.",elementPickerInstruction:"Klik op een element om het vast te leggen",elementPickerTouchInstruction:"Tik op een element om het vast te leggen",escToCancel:"ESC om te annuleren",capturingTitle:"Vastleggen...",capturingScreenshot:"Schermafbeelding wordt gemaakt...",captureFailedTitle:"Opname mislukt",captureFailedMessage:"Kan geen schermafbeelding maken. De pagina is mogelijk te complex of de browser staat dit niet toe.",chooseAnotherMethod:"Kies een andere methode",maskFailureTitle:"Privacymaskering mislukt",maskFailureMessage:"Automatische redactie van priv\xE9velden kon niet worden toegepast. Om uw gegevens te beschermen is deze schermafbeelding verwijderd. U kunt uw feedback nog steeds zonder schermafbeelding versturen.",continueWithoutScreenshot:"Doorgaan zonder schermafbeelding",reviewScreenshotTitle:"Schermafbeelding controleren",viewportRedactionUnavailableNote:"Bij deze via de browser vastgelegde schermafbeelding konden priv\xE9velden niet automatisch worden gemaskeerd. Controleer en dek gevoelige gebieden af voordat u verstuurt.",redactionCountNote:e=>e===1?"1 priv\xE9-item is gemarkeerd voor redactie in deze schermafbeelding. Controleer voordat u verstuurt.":`${e} priv\xE9-items zijn gemarkeerd voor redactie in deze schermafbeelding. Controleer voordat u verstuurt.`,redactionLimitationsNote:"BugDrop heeft alleen de gemeten gemarkeerde vakken afgedekt. Het inspecteert geen pixels binnen ingesloten of gerenderde inhoud zoals iframes, canvas, afbeeldingen, SVG\u2019s, video\u2019s, CSS-achtergronden of aangepaste elementen. Controleer of het zwarte vak het gevoelige gebied volledig bedekt voordat u verstuurt, of maak de afbeelding opnieuw nadat u een groter element hebt gemarkeerd.",annotationInstruction:"Controleer of er geen gevoelige informatie zichtbaar is voordat u verstuurt. Dek gevoelige gebieden af voordat u indient. Redacties worden permanent in de ge\xFCploade afbeelding verwerkt.",selectedElementNote:e=>`Meer omringende context nodig? Pas ${e} aan op de BugDrop-scripttag.`,toolDraw:"Tekenen",toolArrow:"Pijl",toolRectangle:"Rechthoek",toolRedact:"Redigeren",undo:"Ongedaan maken",retake:"Opnieuw maken",submitFeedback:"Feedback versturen",captureTimeout:"Het maken van de schermafbeelding duurde te lang \u2014 de pagina is mogelijk te complex"};function ot(e){let t=e%10,n=e%100;return t>=2&&t<=4&&(n<12||n>14)}var Gt={triggerLabel:"Opinia",triggerAriaLabel:"Zg\u0142o\u015B b\u0142\u0105d lub wy\u015Blij opini\u0119",dismissButtonAriaLabel:"Ukryj przycisk opinii",pullTabAriaLabel:"Poka\u017C przycisk opinii",dragHandleTitle:"Przeci\u0105gnij przycisk opinii",installRequiredTitle:"Wymagana instalacja",connectionErrorTitle:"B\u0142\u0105d po\u0142\u0105czenia",installRequiredMessage:"BugDrop wymaga instalacji aplikacji GitHub, aby tworzy\u0107 zg\u0142oszenia.",apiUnreachableMessage:"Nie mo\u017Cna po\u0142\u0105czy\u0107 si\u0119 z API BugDrop. Sprawd\u017A po\u0142\u0105czenie sieciowe lub adres URL w tagu skryptu.",installApp:"Zainstaluj aplikacj\u0119",welcomeTitle:"Podziel si\u0119 opini\u0105",welcomeHeadline:"Pom\xF3\u017C nam si\u0119 rozwija\u0107, dziel\u0105c si\u0119 swoimi uwagami",welcomeBodyLine1:"Zg\u0142aszaj b\u0142\u0119dy, proponuj funkcje lub zostaw opini\u0119.",welcomeBodyLine2:"Opcjonalnie mo\u017Cesz do\u0142\u0105czy\u0107 zrzuty ekranu z adnotacjami.",getStarted:"Rozpocznij",feedbackFormTitle:"Wy\u015Blij opini\u0119",categoryLabel:"Kategoria",categoryBug:"B\u0142\u0105d",categoryFeature:"Propozycja",categoryQuestion:"Pytanie",nameLabel:"Imi\u0119 i nazwisko",namePlaceholder:"Twoje imi\u0119 i nazwisko",emailLabel:"E-mail",emailPlaceholder:"twoj@email.com",titleLabel:"Tytu\u0142",titlePlaceholder:"Kr\xF3tki opis problemu lub sugestii",descriptionLabel:"Opis",descriptionPlaceholder:"Podaj dodatkowe szczeg\xF3\u0142y, kroki do odtworzenia lub kontekst...",screenshotAutoNote:"Ta strona automatycznie do\u0142\u0105czy zrzut ca\u0142ej strony podczas wysy\u0142ania, bez pokazywania podgl\u0105du. Przed wys\u0142aniem sprawd\u017A, czy strona nie zawiera poufnych informacji.",screenshotAutoRedactionNote:"Niekt\xF3re pola oznaczone przez t\u0119 stron\u0119 jako prywatne mog\u0105 zosta\u0107 zamaskowane na obs\u0142ugiwanych stronach, ale nieoznaczone poufne informacje nadal mog\u0105 zosta\u0107 do\u0142\u0105czone.",screenshotRequiredNote:"\u{1F4F8} Zrzut ekranu jest wymagany przed wys\u0142aniem.",includeScreenshotLabel:"\u{1F4F8} Do\u0142\u0105cz zrzut ekranu",sendConsoleLogsLabel:"Wy\u015Blij logi konsoli",uploadsAriaLabel:"Za\u0142\u0105czniki",uploadFilesAriaLabel:"Prze\u015Blij pliki",uploadButton:"Prze\u015Blij",uploadTooMany:e=>`Mo\u017Cna przes\u0142a\u0107 maksymalnie ${e} ${ot(e)?"pliki":"plik\xF3w"}. Usu\u0144 plik, aby doda\u0107 kolejny.`,uploadUnsupportedType:"Ten typ pliku nie jest obs\u0142ugiwany. Prze\u015Blij obraz, plik PDF lub kr\xF3tki film.",uploadTooLarge:e=>`Plik jest za du\u017Cy. Prze\u015Blij pliki o rozmiarze do ${e}.`,uploadReadError:"Nie uda\u0142o si\u0119 odczyta\u0107 pliku. Spr\xF3buj z innym.",removeAttachmentAriaLabel:e=>`Usu\u0144 ${e}`,cancel:"Anuluj",continueButton:"Dalej",submit:"Wy\u015Blij",submittingTitle:"Wysy\u0142anie...",creatingIssue:"Tworzenie zg\u0142oszenia...",rateLimited:e=>`Zbyt wiele zg\u0142osze\u0144. Spr\xF3buj ponownie za ${e} ${e===1?"minut\u0119":ot(e)?"minuty":"minut"}.`,submitFailedFallback:"Nie uda\u0142o si\u0119 wys\u0142a\u0107",networkError:"B\u0142\u0105d sieci. Sprawd\u017A po\u0142\u0105czenie z internetem.",submissionFailedTitle:"Wysy\u0142anie nie powiod\u0142o si\u0119",tryAgain:"Spr\xF3buj ponownie",successTitle:"Opinia wys\u0142ana!",issueCreated:e=>`Utworzono zg\u0142oszenie ${e}.`,feedbackSubmittedMessage:"Twoja opinia zosta\u0142a pomy\u015Blnie wys\u0142ana.",viewOnGitHub:"Zobacz na GitHubie",done:"Gotowe",captureScreenshotTitle:"Zr\xF3b zrzut ekranu",chooseWhatToCapture:"Wybierz, co przechwyci\u0107:",viewportRedactionWarning:"Przechwytywanie widocznego obszaru przez przegl\u0105dark\u0119 nie pozwala automatycznie zamaskowa\u0107 p\xF3l prywatnych. Wybierz \u201EZaznacz element\u201D, aby zachowa\u0107 automatyczne maskowanie, albo sprawd\u017A i zakryj poufne obszary przed wys\u0142aniem.",redactionReviewNote:"Ta strona oznaczy\u0142a niekt\xF3re pola do zamazania. Sprawd\u017A zrzut ekranu przed wys\u0142aniem.",pageTooComplexViewportNote:"Ta strona jest zbyt z\u0142o\u017Cona, aby przechwyci\u0107 ca\u0142\u0105 stron\u0119 lub zaznaczony obszar. Przechwy\u0107 widoczny obszar albo zaznacz konkretny element.",pageTooComplexElementNote:"Ta strona jest zbyt z\u0142o\u017Cona, aby przechwyci\u0107 ca\u0142\u0105 stron\u0119 lub zaznaczony obszar. Zamiast tego zaznacz konkretny element.",fullPage:"Ca\u0142a strona",captureViewport:"Przechwy\u0107 widoczny obszar",selectArea:"Zaznacz obszar",selectElement:"Zaznacz element",skipScreenshot:"Pomi\u0144 zrzut ekranu",areaPickerInstruction:"Narysuj zaznaczenie wok\xF3\u0142 obszaru do przechwycenia",areaPickerRedactionInstruction:"Narysuj zaznaczenie wok\xF3\u0142 obszaru do przechwycenia. Pola oznaczone jako prywatne mog\u0105 zosta\u0107 zamaskowane, je\u015Bli znajd\u0105 si\u0119 w zaznaczeniu.",elementPickerInstruction:"Kliknij dowolny element, aby go przechwyci\u0107",elementPickerTouchInstruction:"Dotknij dowolny element, aby go przechwyci\u0107",escToCancel:"ESC, aby anulowa\u0107",capturingTitle:"Przechwytywanie...",capturingScreenshot:"Trwa przechwytywanie zrzutu ekranu...",captureFailedTitle:"Przechwytywanie nie powiod\u0142o si\u0119",captureFailedMessage:"Nie uda\u0142o si\u0119 przechwyci\u0107 zrzutu ekranu. Strona mo\u017Ce by\u0107 zbyt z\u0142o\u017Cona lub przegl\u0105darka na to nie pozwala.",chooseAnotherMethod:"Wybierz inn\u0105 metod\u0119",maskFailureTitle:"Maskowanie prywatno\u015Bci nie powiod\u0142o si\u0119",maskFailureMessage:"Nie uda\u0142o si\u0119 automatycznie zamaza\u0107 p\xF3l prywatnych. Aby chroni\u0107 Twoje dane, ten zrzut ekranu zosta\u0142 odrzucony. Nadal mo\u017Cesz wys\u0142a\u0107 opini\u0119 bez zrzutu ekranu.",continueWithoutScreenshot:"Kontynuuj bez zrzutu ekranu",reviewScreenshotTitle:"Sprawd\u017A zrzut ekranu",viewportRedactionUnavailableNote:"Na tym zrzucie przechwyconym przez przegl\u0105dark\u0119 nie uda\u0142o si\u0119 automatycznie zamaskowa\u0107 p\xF3l prywatnych. Sprawd\u017A i zakryj poufne obszary przed wys\u0142aniem.",redactionCountNote:e=>`${e} ${e===1?"prywatny element oznaczono":ot(e)?"prywatne elementy oznaczono":"prywatnych element\xF3w oznaczono"} do zamazania na tym zrzucie ekranu. Sprawd\u017A przed wys\u0142aniem.`,redactionLimitationsNote:"BugDrop zakrywa tylko zmierzone, oznaczone obszary. Nie analizuje pikseli wewn\u0105trz osadzonej lub renderowanej zawarto\u015Bci, takiej jak elementy iframe, canvas, obrazy, pliki SVG, filmy, t\u0142a CSS czy niestandardowe kontrolki. Przed wys\u0142aniem upewnij si\u0119, \u017Ce czarny prostok\u0105t w pe\u0142ni zakrywa poufny obszar, albo pon\xF3w zrzut po oznaczeniu wi\u0119kszego elementu.",annotationInstruction:"Przed wys\u0142aniem sprawd\u017A, czy nie wida\u0107 poufnych informacji. Zakryj poufne obszary przed przes\u0142aniem. Zamazania s\u0105 trwale zapisywane w przesy\u0142anym obrazie.",selectedElementNote:e=>`Potrzebujesz wi\u0119cej otaczaj\u0105cego kontekstu? Dostosuj ${e} w tagu skryptu BugDrop.`,toolDraw:"Rysuj",toolArrow:"Strza\u0142ka",toolRectangle:"Prostok\u0105t",toolRedact:"Zama\u017C",undo:"Cofnij",retake:"Pon\xF3w zrzut",submitFeedback:"Wy\u015Blij opini\u0119",captureTimeout:"Up\u0142yn\u0105\u0142 limit czasu przechwytywania zrzutu ekranu \u2014 strona mo\u017Ce by\u0107 zbyt z\u0142o\u017Cona"};var Xt=/[;{}<>]|\/\*|\*\/|@import|url\s*\(|<\/style/i,so=/^-?[_a-zA-Z][_a-zA-Z0-9-]*$/,lo=/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/,co=/^(?:rgb|rgba|hsl|hsla)\(\s*[-+.\d%]+\s*(?:,\s*[-+.\d%]+\s*){2,3}\)$/i;function H(e){return e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#39;")}function pe(e){let t=e?.trim();if(!t||t==="none")return t;try{let n=new URL(t,window.location.href);if(n.protocol==="https:"||n.protocol==="http:")return t}catch{return}}function B(e){let t=e?.trim();if(!(!t||Xt.test(t))&&(lo.test(t)||co.test(t)||so.test(t)||typeof CSS<"u"&&CSS.supports?.("color",t)))return t}function oe(e){let t=e?.trim();if(t){if(t==="inherit")return t;if(!Xt.test(t)&&/^[\w\s"',.-]+$/.test(t))return t}}function it(e){let t=e?.trim();if(!t||!/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(t))return;let n=Number(t);return Number.isFinite(n)?n:void 0}function G(e){let n=e?.trim()?.match(/^((?:0|[1-9]\d*)(?:\.\d+)?)(?:px)?$/);if(!n)return;let r=Number(n[1]);return Number.isFinite(r)?r:void 0}function Yt(e){let t=e?.trim();if(!t||!/^[1-9]\d*$/.test(t))return;let n=Number(t);return Number.isSafeInteger(n)?n:void 0}function Re(e){if(e==="none"||e==="soft"||e==="hard")return e}var Kt={en:rt,de:qt,nl:Vt,pl:Gt};function g(e){return H(e)}function Zt(e){if(!e)return"en";let t=e.toLowerCase().split(/[-_]/)[0];return Object.prototype.hasOwnProperty.call(Kt,t)?t:(console.warn(`[BugDrop] Unsupported data-locale "${e}"; falling back to English.`),"en")}var Qt=rt;function Jt(e){Qt=Kt[e]}function c(){return Qt}var uo=15e3;function me(e){let t,n=new Promise((r,o)=>{t=setTimeout(()=>o(new Error(c().captureTimeout)),uo)});return Promise.race([e,n]).finally(()=>clearTimeout(t))}var ie=class extends Error{constructor(t,n){super(t,n),this.name="MaskApplicationError"}},po="[data-bugdrop-mask], [data-bugdrop-redact], [data-bd-redact], [data-bugdrop-redacted]",mo='input[type="password"], input[autocomplete*="cc-number"], input[autocomplete*="cc-csc"], input[autocomplete*="cc-exp"]',en="iframe, canvas, img, svg, video",go=new Set(["CANVAS","IMG","SVG"]),bo=new Set(["VIDEO"]);function ze(e){return e.matches(po)?"developer-marked":e.matches(mo)?"sensitive-input":null}function Ae(e,t){let n=e.getBoundingClientRect();return n.width===0||n.height===0?null:{element:e,rect:{x:n.left+window.scrollX,y:n.top+window.scrollY,w:n.width,h:n.height},reason:t,strategy:"canvas-mask"}}function Ie(e){let t=[],n=[],r=ze(e);if(r){let o=Ae(e,r);return o&&(t.push(o),dt(e,n)),{targets:t,unsupportedSurfaces:n,redactionCount:t.length}}return lt(e,t,n),ct(e,t,n),{targets:t,unsupportedSurfaces:n,redactionCount:t.length}}function tn(e=document.body,t){let n=Ie(e).targets.map(r=>r.rect);return t?n.filter(r=>at(r,t)).length:n.length}function nn(e,t){let n=t?e.targets.filter(o=>at(o.rect,t)):e.targets,r=t?e.unsupportedSurfaces.filter(o=>at(o.rect,t)):e.unsupportedSurfaces;return{count:n.length,hasLimitations:r.length>0}}function at(e,t){return e.x<t.x+t.width&&e.x+e.w>t.x&&e.y<t.y+t.height&&e.y+e.h>t.y}function lt(e,t,n){for(let r of Array.from(e.children)){let o=ze(r);if(o){let i=Ae(r,o);i&&(t.push(i),dt(r,n));continue}lt(r,t,n),ct(r,t,n)}}function ct(e,t,n){let r=e.shadowRoot;if(r)for(let o of Array.from(r.children)){let i=ze(o);if(i){let a=Ae(o,i);a&&(t.push(a),dt(o,n));continue}lt(o,t,n),ct(o,t,n)}}function dt(e,t){st(e,t);for(let n of Array.from(e.querySelectorAll(en)))st(n,t);rn(e,t)}function st(e,t){let n=ho(e);if(!n)return;let r=Ae(e,ze(e)??"developer-marked");r&&t.push({tagName:e.tagName,reason:n,rect:r.rect})}function ho(e){let t=e.tagName.toUpperCase();return t==="IFRAME"?"embedded-document":go.has(t)?"pixel-content":bo.has(t)?"media-content":null}function rn(e,t){let n=e.shadowRoot;if(n)for(let r of Array.from(n.querySelectorAll(en)))st(r,t);for(let r of Array.from(e.children))rn(r,t)}function fo(e,t,n,r,o){let i=(e.x-n.x)*t,a=(e.y-n.y)*t,s=e.w*t,l=e.h*t,d=Math.max(0,Math.floor(i)-1),u=Math.max(0,Math.floor(a)-1),m=Math.min(r,Math.ceil(i+s)+1),y=Math.min(o,Math.ceil(a+l)+1);return{x:d,y:u,w:m-d,h:y-u}}async function ut(e,t,n,r={x:0,y:0}){if(t.length===0)return e;let o=await yo(e),i=document.createElement("canvas");i.width=o.naturalWidth||o.width,i.height=o.naturalHeight||o.height;let a=i.getContext("2d");if(!a)throw new ie("Failed to get canvas context for privacy masking");a.drawImage(o,0,0),a.fillStyle="#000";for(let s of t){let l=fo(s,n,r,i.width,i.height);l.w>0&&l.h>0&&a.fillRect(l.x,l.y,l.w,l.h)}return i.toDataURL("image/png")}function yo(e){return new Promise((t,n)=>{let r=new Image;r.onload=()=>t(r),r.onerror=()=>n(new ie("Failed to load image for privacy masking")),r.src=e})}var ge="#14b8a6";function ae(e){return e||ge}function De(e){return`color-mix(in srgb, ${e} 85%, black)`}function on(e){return e??0}function pt(){if(window.__bugdropMockViewportCapture)return window.__bugdropMockViewportCapture();if(!navigator.mediaDevices?.getDisplayMedia)return Promise.reject(new Error("Screen Capture API is not available"));let e={video:{displaySurface:"browser"},audio:!1,preferCurrentTab:!0};return me(navigator.mediaDevices.getDisplayMedia(e).then(t=>wo(t)))}async function wo(e){vo(e);let t=document.createElement("video");t.muted=!0,t.playsInline=!0;try{await xo(t,e);let n=t.videoWidth||window.innerWidth,r=t.videoHeight||window.innerHeight;if(!n||!r)throw new Error("Screen capture stream did not provide a video frame");let o=document.createElement("canvas");o.width=n,o.height=r;let i=o.getContext("2d");if(!i)throw new Error("Failed to get canvas context");return i.drawImage(t,0,0,n,r),o.toDataURL("image/png")}finally{for(let n of e.getTracks())n.stop();t.srcObject=null}}function vo(e){let[t]=e.getVideoTracks(),n=t?.getSettings().displaySurface;if(n&&n!=="browser"){for(let r of e.getTracks())r.stop();throw new Error("Please choose the current browser tab for viewport capture")}}async function xo(e,t){e.srcObject=t,await e.play().catch(()=>{}),!(e.requestVideoFrameCallback&&(await Promise.race([new Promise(n=>e.requestVideoFrameCallback?.(()=>n())),an(250)]),e.readyState>=HTMLMediaElement.HAVE_CURRENT_DATA))&&(e.readyState>=HTMLMediaElement.HAVE_CURRENT_DATA||await Promise.race([new Promise((n,r)=>{let o=()=>{a(),n()},i=()=>{a(),r(new Error("Failed to load screen capture stream"))},a=()=>{e.removeEventListener("loadeddata",o),e.removeEventListener("canplay",o),e.removeEventListener("error",i)};e.addEventListener("loadeddata",o),e.addEventListener("canplay",o),e.addEventListener("error",i)}),an(250)]))}function an(e){return new Promise(t=>setTimeout(t,e))}var sn=3e3,ln="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==",ko=1e4,Eo=sn;function Be(){return document.body.querySelectorAll("*").length}function K(){return Be()>=So()}function So(e=navigator.userAgent){return To(e)?Eo:ko}function To(e=navigator.userAgent){return/Safari\//.test(e)&&!/(Chrome|Chromium|CriOS|FxiOS|Edg|EdgiOS|OPR|Opera)\//.test(e)}function cn(e,t){if(e&&Be()>sn)return 1;let n=t??2;return Math.max(window.devicePixelRatio||1,n)}function dn(){let e=window.isSecureContext||location.protocol==="https:"||location.hostname==="localhost"||location.hostname==="127.0.0.1",t=typeof window.__bugdropMockViewportCapture=="function"||typeof navigator.mediaDevices?.getDisplayMedia=="function";return e&&t}async function un(e,t,n={}){let r=e||document.body,o=!e,i=Fe(e||document.body),a=n.highlightElement&&r.contains(n.highlightElement)?Fe(n.highlightElement):null,s=n.pixelRatio??cn(o,t),l=e?window.getComputedStyle(e):null,d=gn(),u={cacheBust:!1,imagePlaceholder:ln,pixelRatio:s,filter:mn,...l&&(l.marginLeft!=="0px"||l.marginRight!=="0px")?{style:{margin:`${l.marginTop} 0px ${l.marginBottom} 0px`}}:{}},m=Ie(r),y=e?{x:i.x,y:i.y}:{x:0,y:0},x=d(r,u),v=await me(x),T=await ut(v,m.targets.map(k=>k.rect),s,y);return $e(a?await bn(T,a,i,n.highlightStyle):T,m)}async function pn(e,t,n={}){let r=n.pixelRatio??cn(!0,t),o={x:e.x,y:e.y,w:e.width,h:e.height},i=n.highlightElement&&document.body.contains(n.highlightElement)?Fe(n.highlightElement):null,a=gn(),s={cacheBust:!1,imagePlaceholder:ln,pixelRatio:r,width:e.width,height:e.height,style:{transform:`translate(${-e.x}px, ${-e.y}px)`,transformOrigin:"top left",width:`${document.documentElement.scrollWidth}px`,height:`${document.documentElement.scrollHeight}px`},filter:mn},l=Ie(document.body),d=await me(a(document.body,s)),u=await ut(d,l.targets.map(m=>m.rect),r,{x:e.x,y:e.y});return $e(i?await bn(u,i,o,n.highlightStyle):u,l,e)}function se(e,t){return tn(e??document.body,t)}function mn(e){return!(e.id==="bugdrop-host"||Co(e)&&Lo(e))}function Co(e){return e.tagName?.toUpperCase()==="IMG"}function Lo(e){let t=(e.ownerDocument.defaultView??window).getComputedStyle(e);if(t.display==="none"||t.visibility==="hidden")return!0;let n=e.getBoundingClientRect();return n.width<=0||n.height<=0}function gn(){return jt}function $e(e,t,n){return{dataUrl:e,redaction:nn(t,n)}}async function bn(e,t,n,r={}){if(t.w<=0||t.h<=0)return e;let o=await zo(e),i=o.naturalWidth||o.width,a=o.naturalHeight||o.height,s=i/Math.max(1,n.w),l=a/Math.max(1,n.h),d=Math.max(1,(s+l)/2),u=Mo(r.borderWidth,d),y=2*d+u/2,x=(t.x-n.x)*s-y,v=(t.y-n.y)*l-y,T=t.w*s+y*2,k=t.h*l+y*2,z=Math.max(0,Math.ceil(-x)),R=Math.max(0,Math.ceil(-v)),P=Math.max(0,Math.ceil(x+T-i)),M=Math.max(0,Math.ceil(v+k-a)),A=document.createElement("canvas");A.width=i+z+P,A.height=a+R+M;let f=A.getContext("2d");if(!f)throw new Error("Failed to get canvas context for selected element highlight");f.drawImage(o,z,R);let C=Math.round(x+z),D=Math.round(v+R),I=Math.round(T),F=Math.round(k),O=Ro(r.radius,d),w=ae(r.accentColor);return Po(f,C,D,I,F,O),f.lineWidth=u,f.strokeStyle=w,f.stroke(),A.toDataURL("image/png")}function Po(e,t,n,r,o,i){let a=Math.max(0,Math.min(i,r/2,o/2));e.beginPath(),e.moveTo(t+a,n),e.lineTo(t+r-a,n),e.quadraticCurveTo(t+r,n,t+r,n+a),e.lineTo(t+r,n+o-a),e.quadraticCurveTo(t+r,n+o,t+r-a,n+o),e.lineTo(t+a,n+o),e.quadraticCurveTo(t,n+o,t,n+o-a),e.lineTo(t,n+a),e.quadraticCurveTo(t,n,t+a,n),e.closePath()}function Mo(e,t){let n=Number.parseFloat(e||"3");return Math.max(1,Math.round((Number.isFinite(n)?n:3)*t))}function Ro(e,t){let n=Number.parseFloat(e||"6");return Math.max(0,Math.round((Number.isFinite(n)?n:6)*t))}function Fe(e){let t=e.getBoundingClientRect();return{x:t.left+window.scrollX,y:t.top+window.scrollY,w:t.width,h:t.height}}function zo(e){return new Promise((t,n)=>{let r=new Image;r.onload=()=>t(r),r.onerror=()=>n(new Error("Failed to load image for selected element highlight")),r.src=e})}function _e(e){let t=e?.theme==="dark",n=G(e?.radius),r=G(e?.borderWidth),o=oe(e?.font);return{accent:ae(B(e?.accentColor)),fontFamily:e?.font==="inherit"?"system-ui, sans-serif":o||"'Space Grotesk', system-ui, sans-serif",radius:n!==void 0?`${n}px`:"6px",bw:r!==void 0?String(r):"3",tooltipBg:B(e?.bgColor)||(t?"#0f172a":"#1a1a1a"),tooltipText:B(e?.textColor)||"#f1f5f9",tooltipBorder:B(e?.borderColor)||(t?"#334155":"#333")}}var Ao=new Set(["alert","alertdialog","application","article","banner","button","cell","checkbox","columnheader","combobox","complementary","contentinfo","definition","dialog","directory","document","feed","figure","form","grid","gridcell","group","heading","img","link","list","listbox","listitem","log","main","marquee","math","menu","menubar","menuitem","menuitemcheckbox","menuitemradio","meter","navigation","none","note","option","presentation","progressbar","radio","radiogroup","region","row","rowgroup","rowheader","scrollbar","search","searchbox","separator","slider","spinbutton","status","switch","tab","table","tablist","tabpanel","term","textbox","timer","toolbar","tooltip","tree","treegrid","treeitem"]),Io=new Set(["button","checkbox","link","menuitem","menuitemcheckbox","menuitemradio","option","radio","searchbox","switch","tab","textbox"]),Do=new Set(["button","input","select","textarea"]);function hn(e){return Fo(e)??e}function Fo(e){let{body:t,documentElement:n}=e.ownerDocument,r=e;for(;r&&r!==t&&r!==n;){if($o(r))return r;r=r.parentElement}return null}function $o(e){if(e.getAttribute("aria-disabled")==="true")return!1;let t=e.tagName.toLowerCase();if(t==="a")return e.hasAttribute("href");if(Do.has(t))return!("disabled"in e&&e.disabled);if(t==="summary")return!0;let n=Bo(e);if(n&&Io.has(n))return!0;let r=e.getAttribute("tabindex");return r!==null&&Number.parseInt(r,10)>=0}function Bo(e){let t=e.getAttribute("role");if(!t)return null;for(let n of t.split(/\s+/)){let r=n.toLowerCase();if(Ao.has(r))return r}return null}var _o=new Set(["bugdrop-element-picker-overlay","bugdrop-element-picker-highlight","bugdrop-element-picker-tooltip","bugdrop-element-picker-cancel"]);function No(){let e=navigator.maxTouchPoints>0;return window.matchMedia&&window.matchMedia("(hover: none), (pointer: coarse), (any-pointer: coarse)").matches||e}function Ho(){let e=document.createElement("div");return e.id="bugdrop-element-picker-overlay",e.style.cssText=`
+    position: fixed;
+    inset: 0;
+    z-index: 2147483647;
+    cursor: crosshair;
+    touch-action: none;
+    user-select: none;
+    background: transparent;
+  `,e}function Oo(e){let t=document.createElement("div");return t.id="bugdrop-element-picker-highlight",t.style.cssText=`
+    position: fixed;
+    box-sizing: content-box;
+    pointer-events: none;
+    border: ${e.bw}px solid ${e.accent};
+    background: transparent;
+    z-index: 2147483645;
+    transition: all 0.05s ease-out;
+    box-shadow: none;
+    border-radius: ${e.radius};
+  `,t}function Uo(e,t){let n=document.createElement("div");if(n.id="bugdrop-element-picker-tooltip",n.style.cssText=`
+    position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: ${e.tooltipBg};
+    color: ${e.tooltipText};
+    padding: 14px 28px;
+    border-radius: ${e.radius};
+    font-family: ${e.fontFamily};
+    font-size: 14px;
+    font-weight: 500;
+    z-index: 2147483647;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border: ${e.bw}px solid ${e.tooltipBorder};
+  `,!t)return n.textContent=`${c().elementPickerInstruction} (${c().escToCancel})`,{tooltip:n,cancelButton:null};let r=Go(e.accent);return n.append(`${c().elementPickerTouchInstruction} (`,r,")"),{tooltip:n,cancelButton:r}}function Wo(e,t){let n=t.getBoundingClientRect();e.style.top=`${n.top-2}px`,e.style.left=`${n.left-2}px`,e.style.width=`${n.width+4}px`,e.style.height=`${n.height+4}px`,e.style.display="block"}function jo(e){e.overlay.addEventListener("pointerdown",e.onPointerDown),e.overlay.addEventListener("pointermove",e.onPointerMove),e.overlay.addEventListener("pointerup",e.onPointerUp),e.overlay.addEventListener("pointercancel",e.onPointerCancel),document.addEventListener("mousemove",e.onMouseMove,!0)}function qo(e){e.overlay.removeEventListener("pointerdown",e.onPointerDown),e.overlay.removeEventListener("pointermove",e.onPointerMove),e.overlay.removeEventListener("pointerup",e.onPointerUp),e.overlay.removeEventListener("pointercancel",e.onPointerCancel),document.removeEventListener("mousemove",e.onMouseMove,!0)}function fn(e){return new Promise(t=>{setTimeout(()=>{Vo(t,e)},50)})}function Vo(e,t){let{accent:n,fontFamily:r,radius:o,bw:i,tooltipBg:a,tooltipText:s,tooltipBorder:l}=_e(t),d=Ho();document.body.appendChild(d);let u=Oo({accent:n,bw:i,radius:o});document.body.appendChild(u);let{tooltip:m,cancelButton:y}=Uo({accent:n,fontFamily:r,radius:o,bw:i,tooltipBg:a,tooltipText:s,tooltipBorder:l},No());document.body.appendChild(m);let x=null,v=null,T=!1,k;function z(p){return p===d||p===u||p===m||_o.has(p.id)}function R(p,U){let q=d.style.pointerEvents;return d.style.pointerEvents="none",(()=>{try{return document.elementsFromPoint(p,U)}finally{d.style.pointerEvents=q}})().find(Ce=>!(z(Ce)||Ce.closest("#bugdrop-host")))}function P(p,U,q){let Y=R(p,U);return Y?hn(Y):q}function M(p){x=P(p.clientX,p.clientY,x),x&&Wo(u,x)}function A(p,U,q=!1){x=P(p,U,x),f(x,q)}function f(p,U=!1){T||(T=!0,E(U),e(p))}function C(p){v!==null||!p.isPrimary||(p.preventDefault(),p.stopPropagation(),v=p.pointerId,d.setPointerCapture?.(p.pointerId),x=P(p.clientX,p.clientY,x))}function D(p){v!==null&&p.pointerId!==v||(p.preventDefault(),p.stopPropagation(),M(p))}function I(p){v!==null&&p.pointerId!==v||(p.preventDefault(),p.stopPropagation(),v=null,d.releasePointerCapture?.(p.pointerId),A(p.clientX,p.clientY,!0))}function F(p){p.pointerId===v&&(v=null,d.releasePointerCapture?.(p.pointerId))}function O(p){if(T){if(document.removeEventListener("click",O,!0),p.target instanceof Element&&p.target.closest("#bugdrop-host"))return;p.preventDefault(),p.stopImmediatePropagation();return}if(p.preventDefault(),p.stopImmediatePropagation(),p.target instanceof Element&&p.target.id==="bugdrop-element-picker-cancel"){f(null);return}A(p.clientX,p.clientY)}function w(p){p.target instanceof Element&&p.target.id==="bugdrop-element-picker-cancel"||(p.type==="pointerdown"&&C(p),p.type==="pointermove"&&D(p),p.type==="pointerup"&&I(p),p.type==="pointercancel"&&F(p),p.preventDefault(),p.stopImmediatePropagation())}function h(p){p.key==="Escape"&&f(null)}function b(p){p.preventDefault(),p.stopPropagation(),f(null)}function E(p=!1){k!==void 0&&(window.clearTimeout(k),k=void 0),qo({overlay:d,onPointerDown:C,onPointerMove:D,onPointerUp:I,onPointerCancel:F,onMouseMove:M}),p?k=window.setTimeout(()=>{document.removeEventListener("click",O,!0),k=void 0},1e3):document.removeEventListener("click",O,!0),document.removeEventListener("keydown",h),N(),y?.removeEventListener("click",b),d.remove(),u.remove(),m.remove(),document.body.style.cursor=""}function L(){window.addEventListener("pointerdown",w,!0),window.addEventListener("pointermove",w,!0),window.addEventListener("pointerup",w,!0),window.addEventListener("pointercancel",w,!0)}function N(){window.removeEventListener("pointerdown",w,!0),window.removeEventListener("pointermove",w,!0),window.removeEventListener("pointerup",w,!0),window.removeEventListener("pointercancel",w,!0)}document.body.style.cursor="crosshair",L(),jo({overlay:d,onPointerDown:C,onPointerMove:D,onPointerUp:I,onPointerCancel:F,onMouseMove:M}),document.addEventListener("click",O,!0),document.addEventListener("keydown",h),y?.addEventListener("click",b)}function Go(e){let t=document.createElement("button");return t.id="bugdrop-element-picker-cancel",t.type="button",t.textContent=c().cancel,t.style.cssText=`
+    align-items: center;
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: ${e};
+    cursor: pointer;
+    display: inline-flex;
+    font: inherit;
+    font-weight: 700;
+    justify-content: center;
+    margin: -10px -12px;
+    min-height: 44px;
+    min-width: 44px;
+    padding: 10px 12px;
+    pointer-events: auto;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    touch-action: manipulation;
+    white-space: nowrap;
+    width: auto;
+  `,t}var yn=10;function wn(e,t){return new Promise(n=>{setTimeout(()=>{Xo(n,e,t)},50)})}function Xo(e,t,n){let{accent:r,fontFamily:o,radius:i,bw:a,tooltipBg:s,tooltipText:l,tooltipBorder:d}=_e(t),u=Yo();document.body.appendChild(u);let m=Ko({accent:r,bw:a,radius:i});document.body.appendChild(m);let y=n?.redactionsAvailable?c().areaPickerRedactionInstruction:c().areaPickerInstruction,x=Qo(),v=Zo({accent:r,fontFamily:o,radius:i,bw:a,tooltipBg:s,tooltipText:l,tooltipBorder:d},y,x);document.body.appendChild(v);let T=v.querySelector("#bugdrop-area-picker-cancel"),k=0,z=0,R=!1,P=null;function M(w,h,b,E){let L=Math.min(w,b),N=Math.min(h,E),p=Math.abs(b-w),U=Math.abs(E-h);m.style.left=`${L}px`,m.style.top=`${N}px`,m.style.width=`${p}px`,m.style.height=`${U}px`,m.style.display="block";let q=L+p,Y=N+U;u.style.clipPath=`polygon(
+      0% 0%, 0% 100%, ${L}px 100%, ${L}px ${N}px,
+      ${q}px ${N}px, ${q}px ${Y}px,
+      ${L}px ${Y}px, ${L}px 100%, 100% 100%, 100% 0%
+    )`}function A(w){P!==null||!w.isPrimary||(w.preventDefault(),k=w.clientX,z=w.clientY,R=!0,P=w.pointerId,u.setPointerCapture?.(w.pointerId))}function f(w){!R||w.pointerId!==P||(w.preventDefault(),M(k,z,w.clientX,w.clientY))}function C(w){if(!R||w.pointerId!==P)return;w.preventDefault(),R=!1,P=null,u.releasePointerCapture?.(w.pointerId);let h=Math.abs(w.clientX-k),b=Math.abs(w.clientY-z);if(h<yn||b<yn){m.style.display="none",u.style.clipPath="";return}let E=Math.min(k,w.clientX)+window.scrollX,L=Math.min(z,w.clientY)+window.scrollY;O(),e(new DOMRect(E,L,h,b))}function D(w){w.pointerId===P&&(R=!1,P=null,m.style.display="none",u.style.clipPath="")}function I(w){w.key==="Escape"&&(O(),e(null))}function F(){O(),e(null)}function O(){u.removeEventListener("pointerdown",A),document.removeEventListener("pointermove",f),document.removeEventListener("pointerup",C),document.removeEventListener("pointercancel",D),document.removeEventListener("keydown",I),T?.removeEventListener("click",F),u.remove(),m.remove(),v.remove()}u.addEventListener("pointerdown",A),document.addEventListener("pointermove",f),document.addEventListener("pointerup",C),document.addEventListener("pointercancel",D),document.addEventListener("keydown",I),T?.addEventListener("click",F)}function Yo(){let e=document.createElement("div");return e.id="bugdrop-area-picker-overlay",e.style.cssText=`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 2147483646;
+    cursor: crosshair;
+    touch-action: none;
+    user-select: none;
+  `,e}function Ko(e){let t=document.createElement("div");return t.id="bugdrop-area-picker-selection",t.style.cssText=`
+    position: fixed;
+    border: ${e.bw}px solid ${e.accent};
+    box-shadow: 0 0 0 4px color-mix(in srgb, ${e.accent} 30%, transparent);
+    border-radius: ${e.radius};
+    z-index: 2147483647;
+    pointer-events: none;
+    display: none;
+  `,t}function Zo(e,t,n){let r=document.createElement("div");if(r.id="bugdrop-area-picker-tooltip",r.style.cssText=`
+    position: fixed;
+    top: calc(env(safe-area-inset-top, 0px) + 20px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: ${e.tooltipBg};
+    color: ${e.tooltipText};
+    padding: 14px 28px;
+    border-radius: ${e.radius};
+    font-family: ${e.fontFamily};
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.5;
+    max-width: min(420px, calc(100vw - 40px));
+    box-sizing: border-box;
+    text-align: center;
+    z-index: 2147483647;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border: ${e.bw}px solid ${e.tooltipBorder};
+    pointer-events: none;
+  `,n){let o=document.createElement("button");o.id="bugdrop-area-picker-cancel",o.type="button",o.textContent=c().cancel,o.style.cssText=`
+      align-items: center;
+      appearance: none;
+      background: transparent;
+      border: 0;
+      color: ${e.accent};
+      cursor: pointer;
+      display: inline-flex;
+      font: inherit;
+      font-weight: 700;
+      justify-content: center;
+      margin: -10px -12px;
+      min-height: 44px;
+      min-width: 44px;
+      padding: 10px 12px;
+      pointer-events: auto;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+      touch-action: manipulation;
+      white-space: nowrap;
+      width: auto;
+    `,r.append(t," (",o,")")}else r.textContent=`${t} (${c().escToCancel})`;return r}function Qo(){let e=navigator.maxTouchPoints>0;return window.matchMedia&&window.matchMedia("(hover: none), (pointer: coarse), (any-pointer: coarse)").matches||e}var mt="#ff0000",Jo="#000000";var Ne=Math.PI/7,vn=2,xn=4,He=1;function kn(e,t){let n=document.createElement("canvas"),r=n.getContext("2d"),o="draw",i=!1,a=[],s=null,l=!1,d=[],u=new Image;u.onload=()=>{n.width=u.width,n.height=u.height,n.style.maxWidth="100%",n.style.height="auto",n.style.cursor="crosshair",r.drawImage(u,0,0),m()},u.src=t,e.appendChild(n);function m(){d.push(r.getImageData(0,0,n.width,n.height))}function y(h){r.putImageData(h,0,0)}function x(){return d[d.length-1]??null}function v(h,b){return Math.hypot(b.x-h.x,b.y-h.y)}function T(){window.removeEventListener("mouseup",w),i=!1,a=[],s=null,l=!1}function k(){s&&y(s),T()}function z(h){let b=n.getBoundingClientRect(),E=u.width/b.width,L=u.height/b.height,N=(h.clientX-b.left)*E,p=(h.clientY-b.top)*L;return{x:Math.max(0,Math.min(n.width,N)),y:Math.max(0,Math.min(n.height,p))}}function R(){let h=n.getBoundingClientRect(),b=Math.max(n.width/h.width,n.height/h.height,1);return Math.round(5.5*b)}function P(h,b){let E=R();r.beginPath(),r.moveTo(h.x,h.y),r.lineTo(b.x,b.y),r.strokeStyle=mt,r.lineWidth=E,r.lineCap="round",r.lineJoin="round",r.stroke()}function M(h,b){P(h,b);let E=Math.atan2(b.y-h.y,b.x-h.x),L=R()*5;r.beginPath(),r.moveTo(b.x,b.y),r.lineTo(b.x-L*Math.cos(E-Ne),b.y-L*Math.sin(E-Ne)),r.lineTo(b.x-L*Math.cos(E+Ne),b.y-L*Math.sin(E+Ne)),r.closePath(),r.fillStyle=mt,r.fill()}function A(h,b){r.strokeStyle=mt,r.lineWidth=R(),r.lineCap="round",r.lineJoin="round",r.strokeRect(h.x,h.y,b.x-h.x,b.y-h.y)}function f(h,b){let E=Math.min(h.x,b.x),L=Math.min(h.y,b.y),N=Math.abs(b.x-h.x),p=Math.abs(b.y-h.y);return{x:E,y:L,width:N,height:p}}function C(h,b){let{x:E,y:L,width:N,height:p}=f(h,b),U=Math.max(0,Math.floor(E)-He),q=Math.max(0,Math.floor(L)-He),Y=Math.min(n.width,Math.ceil(E+N)+He),Ce=Math.min(n.height,Math.ceil(L+p)+He);return{x:U,y:q,width:Math.max(0,Y-U),height:Math.max(0,Ce-q)}}function D(h,b){let{width:E,height:L}=C(h,b);return E>=xn&&L>=xn}function I(h,b){let{x:E,y:L,width:N,height:p}=C(h,b);r.fillStyle=Jo,r.fillRect(E,L,N,p)}function F(h){let b=x();b&&(i=!0,a=[z(h)],s=b,l=!1,window.addEventListener("mouseup",w))}function O(h){if(!i||!s)return;let b=z(h);o==="draw"?(P(a[a.length-1],b),a.push(b),l=l||v(a[0],b)>=vn):(y(s),o==="arrow"?M(a[0],b):o==="rect"?A(a[0],b):o==="redact"&&I(a[0],b))}function w(h){if(!i||!s){T();return}let b=z(h),E=a[0];if(!(o==="redact"?D(E,b):l||v(E,b)>=vn)){y(s),T();return}o==="arrow"?(y(s),M(E,b)):o==="rect"?(y(s),A(E,b)):o==="redact"?(y(s),I(E,b)):o==="draw"&&!l&&P(E,b),m(),T()}return n.addEventListener("mousedown",F),n.addEventListener("mousemove",O),n.addEventListener("mouseup",w),{setTool(h){k(),o=h},undo(){if(s){k();return}if(d.length<=1)return;T(),d.pop();let h=x();h&&y(h)},getImageData(){return n.toDataURL("image/png")},destroy(){T(),n.removeEventListener("mousedown",F),n.removeEventListener("mousemove",O),n.removeEventListener("mouseup",w),n.remove()}}}function ei(){return typeof window<"u"&&window.matchMedia&&window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light"}function Oe(e,t=ei){return e==="auto"?t():e}function Ue(e){return e==="light"||e==="dark"||e==="auto"}function be(e,t){e.classList.toggle("bd-dark",t==="dark")}function he(e,t,n){let r=n==="dark",o=B(t.accentColor);if(o){let u=o;e.style.setProperty("--bd-primary",u),e.style.setProperty("--bd-primary-hover",De(u)),e.style.setProperty("--bd-border-focus",u)}let i=B(t.bgColor);i&&(e.style.setProperty("--bd-bg-primary",i),r?(e.style.setProperty("--bd-bg-secondary",`color-mix(in srgb, ${i} 85%, white)`),e.style.setProperty("--bd-bg-tertiary",`color-mix(in srgb, ${i} 70%, white)`)):(e.style.setProperty("--bd-bg-secondary",`color-mix(in srgb, ${i} 93%, black)`),e.style.setProperty("--bd-bg-tertiary",`color-mix(in srgb, ${i} 85%, black)`)));let a=B(t.textColor);if(a){e.style.setProperty("--bd-text-primary",a);let u=i||(r?"#0f172a":"#fafaf9");e.style.setProperty("--bd-text-secondary",`color-mix(in srgb, ${a} 65%, ${u})`),e.style.setProperty("--bd-text-muted",`color-mix(in srgb, ${a} 40%, ${u})`)}let s=G(t.borderWidth)??null,l=B(t.borderColor)||null;if(s!==null||l!==null){let u=s!==null?`${s}px`:"1px",m=l||"var(--bd-border)";e.style.setProperty("--bd-border-width",u),l&&e.style.setProperty("--bd-border",m),e.style.setProperty("--bd-border-style",`var(--bd-border-width) solid ${m}`)}let d=Re(t.shadow)||null;if(d==="none")e.style.setProperty("--bd-shadow-sm","none"),e.style.setProperty("--bd-shadow-md","none"),e.style.setProperty("--bd-shadow-lg","none"),e.style.setProperty("--bd-shadow-glow","none");else if(d==="hard"){let u=l||(r?"#000":"#1a1a1a"),m=s!==null?"calc(var(--bd-border-width) + 2px)":"6px";e.style.setProperty("--bd-shadow-sm",`${u} 2px 2px 0 0`),e.style.setProperty("--bd-shadow-md",`${u} ${m} ${m} 0 0`),e.style.setProperty("--bd-shadow-lg",`${u} ${m} ${m} 0 0`),e.style.setProperty("--bd-shadow-glow","none")}}function En(e){if(typeof window>"u"||!window.matchMedia)return typeof console<"u"&&console.warn&&console.warn('[BugDrop] window.matchMedia unavailable; data-theme="auto" will not react to OS theme changes.'),()=>{};let t=window.matchMedia("(prefers-color-scheme: dark)"),n=r=>{try{e(r.matches?"dark":"light")}catch(o){console.warn("[BugDrop] Error applying system theme change:",o)}};return t.addEventListener("change",n),()=>t.removeEventListener("change",n)}var le=8,ti="(hover: none), (pointer: coarse)",ni="(max-width: 640px)";function ri(e,t,n){let r=pe(e);return!!(r&&r!=="none"&&r!=="#"&&n!=="never"&&(t||n==="always"))}function Sn(e,t){let n=t.position==="bottom-left"?"left: 0":"right: 0",r=Oe(t.theme),o=t.font==="inherit",i=t.font&&t.font!=="inherit"?oe(t.font):null,a=o||i?"":"@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap');",s=o?"inherit":i?`${i}, system-ui, sans-serif`:"'Space Grotesk', system-ui, sans-serif",l=G(t.radius)??null,d=l!==null?`${l}px`:"6px",u=l!==null?`${Math.round(l*1.4)}px`:"10px",m=l!==null?`${Math.round(l*2)}px`:"14px",y=G(t.borderWidth)??null,x=document.createElement("style");x.textContent=`
+    ${a}
+
+    :host {
+      /* Typography */
+      --bd-font: ${s};
+
+      /* Radius */
+      --bd-radius-sm: ${d};
+      --bd-radius-md: ${u};
+      --bd-radius-lg: ${m};
+
+      /* Border */
+      --bd-border-width: ${y!==null?`${y}px`:"1px"};
+
+      /* Transitions */
+      --bd-transition: 0.15s ease;
+      --bd-transition-slow: 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    /* Light Theme (Default) */
+    .bd-root {
+      --bd-bg-primary: #fafaf9;
+      --bd-bg-secondary: #f5f5f4;
+      --bd-bg-tertiary: #e7e5e4;
+      --bd-text-primary: #1c1917;
+      --bd-text-secondary: #57534e;
+      --bd-text-muted: #a8a29e;
+      --bd-border: #e7e5e4;
+      --bd-border-style: var(--bd-border-width) solid var(--bd-border);
+      --bd-border-focus: ${ge};
+      --bd-primary: ${ge};
+      --bd-primary-hover: ${De(ge)};
+      --bd-primary-text: #ffffff;
+      --bd-overlay-bg: rgba(0, 0, 0, 0.4);
+      --bd-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+      --bd-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+      --bd-shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.12);
+      --bd-shadow-glow: none;
+      --bd-success: #22c55e;
+      --bd-error: #ef4444;
+    }
+
+    /* Dark Theme */
+    .bd-root.bd-dark {
+      --bd-bg-primary: #0f172a;
+      --bd-bg-secondary: #1e293b;
+      --bd-bg-tertiary: #334155;
+      --bd-text-primary: #f1f5f9;
+      --bd-text-secondary: #94a3b8;
+      --bd-text-muted: #64748b;
+      --bd-border: #334155;
+      --bd-border-focus: #22d3ee;
+      --bd-primary: #22d3ee;
+      --bd-primary-hover: #06b6d4;
+      --bd-primary-text: #0f172a;
+      --bd-overlay-bg: rgba(0, 0, 0, 0.6);
+      --bd-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.2);
+      --bd-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.3);
+      --bd-shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.4);
+      --bd-shadow-glow: 0 0 40px rgba(34, 211, 238, 0.15);
+      --bd-success: #34d399;
+      --bd-error: #f87171;
+    }
+
+    .bd-root {
+      font-family: var(--bd-font);
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    * {
+      box-sizing: border-box;
+      font-family: inherit;
+    }
+
+    /* Trigger Button (edge label) */
+    .bd-trigger {
+      position: fixed;
+      bottom: 20px;
+      ${n};
+      height: 44px;
+      min-width: 0;
+      padding: 0 0 0 16px;
+      border-radius: ${l!==null?`${l*2}px 0 0 ${l*2}px`:"22px 0 0 22px"};
+      border: ${y!==null?"var(--bd-border-style)":"none"};
+      background: var(--bd-primary);
+      color: var(--bd-primary-text);
+      cursor: pointer;
+      box-shadow:
+        var(--bd-shadow-md),
+        0 0 0 0 var(--bd-primary);
+      z-index: 999999;
+      transition: transform var(--bd-transition), box-shadow var(--bd-transition), opacity var(--bd-transition);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      overflow: visible;
+      animation: bd-triggerSlideIn 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+      touch-action: none;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
+    .bd-trigger--left {
+      padding: 0 16px 0 0;
+      border-radius: ${l!==null?`0 ${l*2}px ${l*2}px 0`:"0 22px 22px 0"};
+    }
+
+    .bd-trigger--positioned {
+      animation: none;
+    }
+
+    .bd-trigger:hover {
+      transform: scale(1.03);
+      box-shadow:
+        var(--bd-shadow-lg),
+        0 0 20px color-mix(in srgb, var(--bd-primary) 30%, transparent);
+    }
+
+    .bd-trigger:active {
+      transform: scale(0.97);
+    }
+
+    .bd-trigger-icon {
+      font-size: 18px;
+      line-height: 1;
+    }
+
+    .bd-trigger-icon img {
+      width: 18px;
+      height: 18px;
+      object-fit: contain;
+      display: block;
+    }
+
+    .bd-trigger-label {
+      font-size: 14px;
+      font-weight: 600;
+      letter-spacing: 0;
+      white-space: nowrap;
+    }
+
+    .bd-trigger-drag-handle {
+      align-self: center;
+      width: 30px;
+      height: calc(100% - 8px);
+      margin: 4px;
+      border-radius: 7px;
+      background: transparent;
+      cursor: grab;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--bd-primary-text);
+      opacity: 0.95;
+      touch-action: none;
+    }
+
+    .bd-trigger--left .bd-trigger-drag-handle {
+      order: -1;
+    }
+
+    .bd-trigger-drag-handle:hover,
+    .bd-trigger-drag-handle:active,
+    .bd-trigger--dragging .bd-trigger-drag-handle {
+      background: color-mix(in srgb, var(--bd-primary-text) 18%, transparent);
+      opacity: 1;
+    }
+
+    .bd-trigger-drag-handle:hover {
+      cursor: grab;
+    }
+
+    .bd-trigger-drag-handle:active,
+    .bd-trigger--dragging .bd-trigger-drag-handle {
+      cursor: grabbing;
+    }
+
+    .bd-trigger-drag-handle svg {
+      display: block;
+      width: 14px;
+      height: 22px;
+      pointer-events: none;
+    }
+
+    @keyframes bd-triggerSlideIn {
+      from {
+        opacity: 0;
+        transform: translateY(20px) scale(0.9);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+
+    /* Pull Tab (shown after dismissal) */
+    .bd-pull-tab {
+      position: fixed;
+      bottom: 20px;
+      right: 0;
+      width: 24px;
+      height: 48px;
+      border-radius: 8px 0 0 8px;
+      border: none;
+      background: var(--bd-primary);
+      color: var(--bd-primary-text);
+      cursor: pointer;
+      box-shadow: -2px 4px 12px color-mix(in srgb, var(--bd-primary) 30%, transparent);
+      z-index: 999999;
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      animation: bd-pullTabSlideIn 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    .bd-pull-tab:hover {
+      width: 32px;
+      box-shadow: -4px 6px 16px color-mix(in srgb, var(--bd-primary) 40%, transparent);
+    }
+
+    .bd-pull-tab:active {
+      width: 28px;
+    }
+
+    .bd-pull-tab-chevron {
+      font-size: 16px;
+      font-weight: bold;
+      transition: transform 0.2s;
+    }
+
+    .bd-pull-tab:hover .bd-pull-tab-chevron {
+      transform: translateX(-2px);
+    }
+
+    /* Pull tab position for bottom-left */
+    .bd-pull-tab--left {
+      right: auto;
+      left: 0;
+      border-radius: 0 8px 8px 0;
+      box-shadow: 2px 4px 12px color-mix(in srgb, var(--bd-primary) 30%, transparent);
+    }
+
+    .bd-pull-tab--left:hover {
+      box-shadow: 4px 6px 16px color-mix(in srgb, var(--bd-primary) 40%, transparent);
+    }
+
+    .bd-pull-tab--left .bd-pull-tab-chevron {
+      transform: rotate(180deg);
+    }
+
+    .bd-pull-tab--left:hover .bd-pull-tab-chevron {
+      transform: rotate(180deg) translateX(-2px);
+    }
+
+    @media (max-width: 640px) {
+      .bd-pull-tab {
+        bottom: 16px;
+        height: 44px;
+        width: 22px;
+      }
+
+      .bd-pull-tab:hover {
+        width: 28px;
+      }
+    }
+
+    /* Touch devices - always slightly expanded */
+    @media (hover: none) {
+      .bd-pull-tab {
+        width: 28px;
+      }
+    }
+
+    /* Dismissible close button */
+    .bd-trigger-close {
+      position: absolute;
+      top: -4px;
+      right: 4px;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      border: none;
+      background: var(--bd-text-primary);
+      color: var(--bd-bg-primary);
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 1;
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transform: scale(0.8);
+      transition: opacity var(--bd-transition), transform var(--bd-transition);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+      box-shadow: var(--bd-shadow-sm);
+    }
+
+    .bd-trigger--left .bd-trigger-close {
+      right: auto;
+      left: 36px;
+    }
+
+    .bd-trigger--right .bd-trigger-close {
+      right: 36px;
+    }
+
+    .bd-trigger:hover .bd-trigger-close,
+    .bd-trigger-close:focus-visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: scale(1);
+    }
+
+    .bd-trigger-close:hover {
+      background: var(--bd-error);
+      color: white;
+    }
+
+    /* Modal Overlay */
+    .bd-overlay {
+      position: fixed;
+      inset: 0;
+      background: var(--bd-overlay-bg);
+      z-index: 1000000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      animation: bd-fadeIn 0.2s ease;
+    }
+
+    /* Modal */
+    .bd-modal {
+      background: var(--bd-bg-primary);
+      border-radius: var(--bd-radius-lg);
+      border: var(--bd-border-style);
+      box-shadow: var(--bd-shadow-lg), var(--bd-shadow-glow);
+      max-width: 600px;
+      width: 90%;
+      max-height: 90vh;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      animation: bd-slideUp var(--bd-transition-slow);
+    }
+
+    .bd-modal--positioned {
+      position: fixed;
+      margin: 0;
+      animation: none;
+    }
+
+    .bd-modal--dragging {
+      user-select: none;
+    }
+
+    .bd-modal--annotator {
+      width: min(96vw, 1100px);
+      max-width: 1100px;
+    }
+
+    /* Modal Header */
+    .bd-header {
+      position: relative;
+      padding: 16px 20px;
+      border-bottom: var(--bd-border-style);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: var(--bd-bg-primary);
+      animation: bd-fadeIn 0.2s ease 0.05s both;
+      cursor: grab;
+      user-select: none;
+      touch-action: none;
+    }
+
+    .bd-modal-drag-indicator {
+      position: absolute;
+      top: 6px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 28px;
+      height: 10px;
+      display: grid;
+      grid-template-columns: repeat(3, 4px);
+      grid-auto-rows: 4px;
+      gap: 3px 5px;
+      justify-content: center;
+      align-content: center;
+      color: var(--bd-text-muted);
+      opacity: 0.8;
+      pointer-events: none;
+    }
+
+    .bd-modal-drag-indicator span {
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background: currentColor;
+    }
+
+    .bd-modal--dragging .bd-header {
+      cursor: grabbing;
+    }
+
+    .bd-title {
+      margin: 0;
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      color: var(--bd-text-primary);
+    }
+
+    .bd-close {
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: transparent;
+      border: none;
+      border-radius: var(--bd-radius-sm);
+      font-size: 24px;
+      cursor: pointer;
+      color: var(--bd-text-secondary);
+      padding: 0;
+      line-height: 1;
+      transition: background var(--bd-transition), color var(--bd-transition);
+    }
+
+    .bd-close:hover {
+      background: var(--bd-bg-secondary);
+      color: var(--bd-text-primary);
+    }
+
+    /* Modal Body with staggered animation */
+    .bd-body {
+      padding: 20px;
+      overflow-y: auto;
+      flex: 1;
+    }
+
+    .bd-modal--annotator .bd-body {
+      padding-top: 0;
+    }
+
+    .bd-body > *:nth-child(1) { animation: bd-fadeIn 0.2s ease 0.1s both; }
+    .bd-body > *:nth-child(2) { animation: bd-fadeIn 0.2s ease 0.15s both; }
+    .bd-body > *:nth-child(3) { animation: bd-fadeIn 0.2s ease 0.2s both; }
+    .bd-body > *:nth-child(4) { animation: bd-fadeIn 0.2s ease 0.25s both; }
+    .bd-body > *:nth-child(5) { animation: bd-fadeIn 0.2s ease 0.3s both; }
+
+    .bd-version {
+      text-align: center;
+      padding: 4px 0;
+      font-size: 0.7rem;
+      color: var(--bd-text-secondary);
+      opacity: 0.5;
+    }
+
+    /* Form Elements */
+    .bd-form-group {
+      margin-bottom: 16px;
+    }
+
+    .bd-label {
+      display: block;
+      margin-bottom: 6px;
+      font-weight: 500;
+      font-size: 13px;
+      color: var(--bd-text-secondary);
+      letter-spacing: 0.01em;
+    }
+
+    .bd-input, .bd-textarea {
+      width: 100%;
+      padding: 12px 14px;
+      background: var(--bd-bg-primary);
+      border: var(--bd-border-style);
+      border-radius: var(--bd-radius-sm);
+      font-size: 14px;
+      color: var(--bd-text-primary);
+      transition: border-color var(--bd-transition), box-shadow var(--bd-transition);
+    }
+
+    .bd-input::placeholder, .bd-textarea::placeholder {
+      color: var(--bd-text-muted);
+    }
+
+    .bd-input:focus, .bd-textarea:focus {
+      outline: none;
+      border-color: var(--bd-border-focus);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--bd-border-focus) 15%, transparent);
+    }
+
+    .bd-textarea {
+      min-height: 100px;
+      resize: vertical;
+    }
+
+    /* Buttons */
+    .bd-btn {
+      padding: 11px 20px;
+      border-radius: var(--bd-radius-sm);
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all var(--bd-transition);
+      position: relative;
+    }
+
+    .bd-btn-primary {
+      background: var(--bd-primary);
+      color: var(--bd-primary-text);
+      border: none;
+      box-shadow: var(--bd-shadow-sm);
+    }
+
+    .bd-btn-primary:hover {
+      background: var(--bd-primary-hover);
+      box-shadow: var(--bd-shadow-md);
+    }
+
+    .bd-dark .bd-btn-primary:hover {
+      box-shadow: var(--bd-shadow-md), 0 0 20px rgba(34, 211, 238, 0.2);
+    }
+
+    .bd-btn-secondary {
+      background: var(--bd-bg-primary);
+      border: var(--bd-border-style);
+      color: var(--bd-text-primary);
+    }
+
+    .bd-btn-secondary:hover {
+      background: var(--bd-bg-secondary);
+    }
+
+    .bd-btn-quiet {
+      background: transparent;
+      border: none;
+      color: var(--bd-text-secondary);
+      padding-left: 12px;
+      padding-right: 12px;
+    }
+
+    .bd-btn-quiet:hover {
+      background: var(--bd-bg-secondary);
+      color: var(--bd-text-primary);
+    }
+
+    .bd-btn:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
+    .bd-evidence-block {
+      margin: 8px 0 16px;
+    }
+
+    .bd-evidence-row {
+      display: grid;
+      grid-template-columns: minmax(220px, 1fr) auto;
+      align-items: center;
+      gap: 14px;
+    }
+
+    .bd-screenshot-control {
+      min-height: 36px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding-top: 3px;
+    }
+
+    .bd-checkbox {
+      width: 18px;
+      height: 18px;
+      accent-color: var(--bd-primary);
+      cursor: pointer;
+      flex: 0 0 auto;
+    }
+
+    .bd-checkbox-label {
+      color: var(--bd-text-secondary);
+      cursor: pointer;
+      font-size: 0.95rem;
+      line-height: 1.35;
+      user-select: none;
+    }
+
+    .bd-upload-group {
+      min-width: 0;
+      justify-self: end;
+    }
+
+    .bd-upload-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .bd-upload-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      min-height: 32px;
+      padding: 6px 9px;
+      font-size: 13px;
+      white-space: nowrap;
+    }
+
+    .bd-upload-icon {
+      width: 14px;
+      height: 14px;
+      flex: 0 0 auto;
+    }
+
+    .bd-upload-input {
+      display: none;
+    }
+
+    .bd-upload-list {
+      display: grid;
+      gap: 6px;
+      margin-top: 10px;
+    }
+
+    .bd-upload-item {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto 28px;
+      align-items: center;
+      gap: 8px;
+      min-height: 34px;
+      padding: 5px 5px 5px 10px;
+      background: var(--bd-bg-secondary);
+      border: var(--bd-border-style);
+      border-radius: var(--bd-radius-sm);
+    }
+
+    .bd-upload-item__name {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--bd-text-primary);
+      font-size: 13px;
+    }
+
+    .bd-upload-item__meta {
+      color: var(--bd-text-secondary);
+      font-size: 12px;
+      white-space: nowrap;
+    }
+
+    .bd-upload-remove {
+      width: 28px;
+      height: 28px;
+      display: inline-grid;
+      place-items: center;
+      border: none;
+      border-radius: var(--bd-radius-sm);
+      background: transparent;
+      color: var(--bd-text-secondary);
+      cursor: pointer;
+      font-size: 20px;
+      line-height: 1;
+      transition: background var(--bd-transition), color var(--bd-transition);
+    }
+
+    .bd-upload-remove:hover {
+      background: var(--bd-bg-tertiary);
+      color: var(--bd-text-primary);
+    }
+
+    /* Loading States */
+    .bd-btn--loading {
+      color: transparent !important;
+      pointer-events: none;
+    }
+
+    .bd-btn--loading::after {
+      content: '';
+      position: absolute;
+      width: 16px;
+      height: 16px;
+      top: 50%;
+      left: 50%;
+      margin: -8px 0 0 -8px;
+      border: 2px solid currentColor;
+      border-color: var(--bd-primary-text) transparent var(--bd-primary-text) transparent;
+      border-radius: 50%;
+      animation: bd-spin 0.8s linear infinite;
+    }
+
+    .bd-spinner {
+      width: 20px;
+      height: 20px;
+      border: 2px solid var(--bd-border);
+      border-top-color: var(--bd-primary);
+      border-radius: 50%;
+      animation: bd-spin 0.8s linear infinite;
+    }
+
+    .bd-spinner--lg {
+      width: 32px;
+      height: 32px;
+      border-width: 3px;
+    }
+
+    .bd-loading-overlay {
+      position: absolute;
+      inset: 0;
+      background: var(--bd-bg-primary);
+      opacity: 0.95;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      z-index: 10;
+      border-radius: var(--bd-radius-lg);
+    }
+
+    .bd-loading-text {
+      font-size: 14px;
+      color: var(--bd-text-secondary);
+      font-weight: 500;
+    }
+
+    .bd-skeleton {
+      background: linear-gradient(
+        90deg,
+        var(--bd-bg-secondary) 0%,
+        var(--bd-bg-tertiary) 50%,
+        var(--bd-bg-secondary) 100%
+      );
+      background-size: 200% 100%;
+      animation: bd-shimmer 1.5s ease-in-out infinite;
+      border-radius: var(--bd-radius-sm);
+    }
+
+    /* Error States */
+    .bd-error-message {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 12px 14px;
+      background: rgba(239, 68, 68, 0.1);
+      border: 1px solid rgba(239, 68, 68, 0.2);
+      border-radius: var(--bd-radius-sm);
+      color: var(--bd-error);
+      font-size: 13px;
+      margin-bottom: 16px;
+    }
+
+    .bd-dark .bd-error-message {
+      background: rgba(248, 113, 113, 0.1);
+      border-color: rgba(248, 113, 113, 0.2);
+    }
+
+    .bd-error-message__icon {
+      flex-shrink: 0;
+      width: 16px;
+      height: 16px;
+    }
+
+    .bd-error-message__text {
+      flex: 1;
+      line-height: 1.4;
+    }
+
+    .bd-error-message__retry {
+      background: none;
+      border: none;
+      color: inherit;
+      font-weight: 600;
+      cursor: pointer;
+      text-decoration: underline;
+      padding: 0;
+      font-size: 13px;
+    }
+
+    .bd-input--error, .bd-textarea--error {
+      border-color: var(--bd-error) !important;
+    }
+
+    /* Success Modal */
+    .bd-success-content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      padding: 8px 0 16px;
+    }
+
+    .bd-success-icon {
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      background: var(--bd-success);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-bottom: 16px;
+    }
+
+    .bd-success-icon svg {
+      width: 28px;
+      height: 28px;
+      color: white;
+    }
+
+    .bd-success-issue {
+      margin: 0 0 12px;
+      color: var(--bd-text-primary);
+      font-size: 15px;
+    }
+
+    .bd-issue-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--bd-primary);
+      text-decoration: none;
+      font-weight: 500;
+      font-size: 14px;
+      padding: 8px 16px;
+      border-radius: var(--bd-radius-sm);
+      background: var(--bd-bg-secondary);
+      transition: background var(--bd-transition), color var(--bd-transition);
+    }
+
+    .bd-issue-link:hover {
+      background: var(--bd-bg-tertiary);
+      color: var(--bd-primary-hover);
+    }
+
+    .bd-issue-link svg {
+      flex-shrink: 0;
+    }
+
+    .bd-powered-by {
+      margin-top: 12px;
+      padding-top: 12px;
+      border-top: 1px solid var(--bd-border);
+      text-align: center;
+    }
+
+    .bd-powered-by a {
+      color: var(--bd-text-secondary);
+      text-decoration: none;
+      font-size: 12px;
+      transition: color var(--bd-transition);
+    }
+
+    .bd-powered-by a:hover {
+      color: var(--bd-text-primary);
+    }
+
+    .bd-input--error:focus, .bd-textarea--error:focus {
+      box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15) !important;
+    }
+
+    .bd-field-error {
+      color: var(--bd-error);
+      font-size: 12px;
+      margin-top: 4px;
+    }
+
+    /* Actions */
+    .bd-actions {
+      display: flex;
+      gap: 12px;
+      justify-content: flex-end;
+      margin-top: 20px;
+    }
+
+    .bd-success-actions {
+      justify-content: center;
+    }
+
+    .bd-screenshot-actions {
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    /* Tools Toolbar */
+    .bd-tools {
+      display: flex;
+      gap: 6px;
+      padding: 8px;
+      background: var(--bd-bg-secondary);
+      border: var(--bd-border-style);
+      border-radius: var(--bd-radius-md);
+      margin-bottom: 12px;
+    }
+
+    .bd-tool {
+      padding: 8px 14px;
+      background: transparent;
+      border: none;
+      border-radius: var(--bd-radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--bd-text-secondary);
+      cursor: pointer;
+      transition: all var(--bd-transition);
+    }
+
+    .bd-tool:hover {
+      background: var(--bd-bg-tertiary);
+      color: var(--bd-text-primary);
+    }
+
+    .bd-tool.active {
+      background: var(--bd-bg-primary);
+      color: var(--bd-primary);
+      box-shadow: var(--bd-shadow-sm);
+    }
+
+    .bd-annotation-stage {
+      min-height: 240px;
+      max-height: min(58vh, 620px);
+      padding: 18px;
+      border: 1px solid var(--bd-border, #e7e5e4);
+      border-radius: var(--bd-radius-md);
+      background:
+        linear-gradient(45deg, var(--bd-bg-secondary) 25%, transparent 25%),
+        linear-gradient(-45deg, var(--bd-bg-secondary) 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, var(--bd-bg-secondary) 75%),
+        linear-gradient(-45deg, transparent 75%, var(--bd-bg-secondary) 75%),
+        var(--bd-bg-primary);
+      background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+      background-size: 16px 16px;
+      box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--bd-border) 60%, transparent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: auto;
+    }
+
+    .bd-annotation-stage canvas {
+      display: block;
+      max-width: 100%;
+      max-height: calc(min(58vh, 620px) - 36px);
+      width: auto;
+      height: auto;
+      background: #ffffff;
+      box-shadow: var(--bd-shadow-md);
+    }
+
+    /* Preview */
+    .bd-preview {
+      border: var(--bd-border-style);
+      border-radius: var(--bd-radius-md);
+      overflow: hidden;
+      margin-bottom: 16px;
+      box-shadow: var(--bd-shadow-sm);
+    }
+
+    .bd-preview img {
+      width: 100%;
+      display: block;
+    }
+
+    /* Toast Notifications */
+    .bd-toast {
+      position: fixed;
+      bottom: 100px;
+      right: 20px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 18px;
+      border-radius: var(--bd-radius-md);
+      color: white;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000001;
+      box-shadow: var(--bd-shadow-lg);
+      animation: bd-slideIn 0.3s ease;
+    }
+
+    .bd-toast.success {
+      background: var(--bd-success);
+    }
+
+    .bd-toast.error {
+      background: var(--bd-error);
+    }
+
+    /* Animations */
+    @keyframes bd-fadeIn {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    @keyframes bd-slideUp {
+      from { opacity: 0; transform: translateY(24px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+
+    @keyframes bd-slideIn {
+      from { transform: translateX(100%); opacity: 0; }
+      to { transform: translateX(0); opacity: 1; }
+    }
+
+    @keyframes bd-pullTabSlideIn {
+      from { transform: translateX(100%); opacity: 0; }
+      to { transform: translateX(0); opacity: 1; }
+    }
+
+    /* Directional animations for dismiss/restore */
+    @keyframes bd-triggerSlideInFromRight {
+      from {
+        opacity: 0;
+        transform: translateX(100px) scale(0.8);
+      }
+      to {
+        opacity: 1;
+        transform: translateX(0) scale(1);
+      }
+    }
+
+    @keyframes bd-triggerSlideOutToRight {
+      from {
+        opacity: 1;
+        transform: translateX(0) scale(1);
+      }
+      to {
+        opacity: 0;
+        transform: translateX(100px) scale(0.8);
+      }
+    }
+
+    .bd-trigger--dismissing {
+      animation: bd-triggerSlideOutToRight 0.3s cubic-bezier(0.4, 0, 1, 1) forwards;
+    }
+
+    .bd-trigger--restoring {
+      animation: bd-triggerSlideInFromRight 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    @keyframes bd-spin {
+      to { transform: rotate(360deg); }
+    }
+
+    @keyframes bd-shimmer {
+      0% { background-position: 200% 0; }
+      100% { background-position: -200% 0; }
+    }
+
+    /* Mobile Responsiveness */
+    @media (max-width: 640px) {
+      .bd-trigger {
+        height: 40px;
+        padding: 0 0 0 14px;
+        bottom: 16px;
+        gap: 6px;
+      }
+
+      .bd-trigger--left {
+        padding: 0 14px 0 0;
+      }
+
+      .bd-trigger-drag-handle {
+        width: 28px;
+      }
+
+      .bd-trigger-icon {
+        font-size: 16px;
+      }
+
+      .bd-trigger-icon img {
+        width: 16px;
+        height: 16px;
+      }
+
+      .bd-trigger-label {
+        font-size: 13px;
+      }
+
+      .bd-overlay {
+        align-items: flex-end;
+      }
+
+      .bd-modal {
+        width: 100%;
+        max-width: 100%;
+        max-height: 95vh;
+        border-radius: var(--bd-radius-lg) var(--bd-radius-lg) 0 0;
+        animation: bd-slideUpMobile var(--bd-transition-slow);
+      }
+
+      .bd-modal--positioned {
+        position: static;
+        width: 100%;
+      }
+
+      .bd-modal--annotator {
+        width: calc(100% - 16px);
+        max-width: calc(100% - 16px);
+      }
+
+      .bd-header {
+        padding: 16px;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+      }
+
+      .bd-close {
+        width: 44px;
+        height: 44px;
+        font-size: 28px;
+      }
+
+      .bd-body {
+        padding: 16px;
+        padding-bottom: 32px;
+      }
+
+      .bd-btn {
+        padding: 14px 24px;
+        font-size: 16px;
+        min-height: 48px;
+      }
+
+      .bd-input, .bd-textarea {
+        padding: 14px;
+        font-size: 16px;
+        min-height: 48px;
+      }
+
+      .bd-category-option {
+        gap: 4px !important;
+        padding: 8px !important;
+        min-width: 0;
+      }
+
+      .bd-category-option span {
+        font-size: 0.85rem !important;
+        white-space: nowrap;
+      }
+
+      .bd-textarea {
+        min-height: 120px;
+      }
+
+      .bd-evidence-row {
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 8px;
+      }
+
+      .bd-upload-button {
+        min-height: 34px;
+        padding: 7px 10px;
+        font-size: 14px;
+      }
+
+      .bd-actions {
+        flex-direction: column-reverse;
+        gap: 8px;
+      }
+
+      .bd-actions .bd-btn {
+        width: 100%;
+      }
+
+      .bd-screenshot-actions {
+        flex-direction: column;
+      }
+
+      .bd-tools {
+        flex-wrap: wrap;
+      }
+
+      .bd-annotation-stage {
+        min-height: 180px;
+        max-height: 46vh;
+        padding: 12px;
+      }
+
+      .bd-annotation-stage canvas {
+        max-height: calc(46vh - 24px);
+      }
+
+      .bd-tool {
+        flex: 1;
+        min-width: calc(50% - 4px);
+        justify-content: center;
+        padding: 12px;
+        text-align: center;
+      }
+
+      .bd-toast {
+        left: 16px;
+        right: 16px;
+        bottom: 80px;
+        justify-content: center;
+      }
+    }
+
+    @keyframes bd-slideUpMobile {
+      from { opacity: 0; transform: translateY(100%); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* Touch-friendly hover states */
+    @media (hover: none) {
+      .bd-trigger:hover {
+        transform: none;
+        box-shadow: var(--bd-shadow-md);
+      }
+
+      .bd-trigger:active {
+        transform: scale(0.97);
+      }
+
+      /* Always show close button on touch devices */
+      .bd-trigger-close {
+        opacity: 1;
+        pointer-events: auto;
+        transform: scale(1);
+      }
+
+      .bd-header {
+        cursor: default;
+        user-select: auto;
+        touch-action: auto;
+      }
+
+      .bd-modal-drag-indicator {
+        display: none;
+      }
+
+      .bd-btn:hover {
+        background: inherit;
+      }
+
+      .bd-btn-primary:hover {
+        background: var(--bd-primary);
+      }
+
+      .bd-btn-primary:active {
+        background: var(--bd-primary-hover);
+      }
+
+      .bd-btn-secondary:hover {
+        background: var(--bd-bg-primary);
+      }
+
+      .bd-btn-secondary:active {
+        background: var(--bd-bg-secondary);
+      }
+    }
+
+    /* Safe area support for notched devices */
+    @supports (padding-bottom: env(safe-area-inset-bottom)) {
+      .bd-modal {
+        padding-bottom: env(safe-area-inset-bottom);
+      }
+    }
+
+    /* Reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+  `,e.appendChild(x);let v=document.createElement("div");return v.className="bd-root",be(v,r),he(v,t,r),e.appendChild(v),v}function fe(e){return`<p class="bd-redaction-note" style="margin: 0 0 12px; padding: 8px 12px; background: var(--bd-warning-bg, #fff8e1); border-radius: 6px; font-size: 13px; color: var(--bd-text-secondary);">${H(e)}</p>`}function _(e,t,n,r=!1,o=""){let i=document.createElement("div");i.className="bd-overlay";let a=["bd-modal",o].filter(Boolean).join(" "),s=r?'<div class="bd-version">BugDrop v1.53.1</div>':"";return i.innerHTML=`
+    <div class="${a}">
+      <div class="bd-header">
+        <span class="bd-modal-drag-indicator" aria-hidden="true">
+          <span></span><span></span><span></span>
+          <span></span><span></span><span></span>
+        </span>
+        <h2 class="bd-title">${H(t)}</h2>
+        <button class="bd-close">&times;</button>
+      </div>
+      <div class="bd-body">
+        ${n}
+      </div>
+      ${s}
+    </div>
+  `,e.appendChild(i),oi(i),i}function oi(e){if(typeof window.matchMedia!="function"||window.matchMedia(ti).matches)return;let t=e.querySelector(".bd-modal"),n=e.querySelector(".bd-header");if(!t||!n)return;let r=t,o=n,i=null,a=0,s=0,l=0,d=0,u=!1,m=null,y=()=>{u||(u=!0,R(),window.removeEventListener("resize",T),window.visualViewport?.removeEventListener("resize",T),m?.disconnect())};function x(f,C){let D=r.getBoundingClientRect(),I=Math.max(le,window.innerWidth-D.width-le),F=Math.max(le,window.innerHeight-D.height-le);return{left:Math.min(Math.max(f,le),I),top:Math.min(Math.max(C,le),F)}}function v(f,C){let D=x(f,C);r.style.left=`${D.left}px`,r.style.top=`${D.top}px`}function T(){if(!e.isConnected){y();return}if(!r.classList.contains("bd-modal--positioned"))return;if(window.matchMedia(ni).matches){z();return}k();let f=r.getBoundingClientRect();v(f.left,f.top)}function k(){r.style.removeProperty("width"),r.style.removeProperty("max-width");let f=r.getBoundingClientRect(),C=Math.floor(window.innerWidth*.9);r.style.width=`${Math.min(f.width,C)}px`,r.style.maxWidth="none"}function z(){r.classList.remove("bd-modal--positioned","bd-modal--dragging"),r.style.removeProperty("left"),r.style.removeProperty("top"),r.style.removeProperty("width"),r.style.removeProperty("max-width")}function R(){i!==null&&(i=null,r.classList.remove("bd-modal--dragging"),window.removeEventListener("pointermove",P),window.removeEventListener("pointerup",M),window.removeEventListener("pointercancel",A))}function P(f){i===f.pointerId&&v(l+f.clientX-a,d+f.clientY-s)}function M(f){i===f.pointerId&&R()}function A(f){i===f.pointerId&&R()}o.addEventListener("pointerdown",f=>{if(f.target.closest("button, a, input, textarea, select, label"))return;f.preventDefault();let C=r.getBoundingClientRect();i=f.pointerId,a=f.clientX,s=f.clientY,l=C.left,d=C.top,r.classList.add("bd-modal--positioned","bd-modal--dragging"),r.style.width=`${C.width}px`,r.style.maxWidth="none",v(l,d),o.setPointerCapture(f.pointerId),window.addEventListener("pointermove",P),window.addEventListener("pointerup",M),window.addEventListener("pointercancel",A)}),window.addEventListener("resize",T),window.visualViewport?.addEventListener("resize",T),e.parentNode&&(m=new MutationObserver(()=>{e.isConnected||y()}),m.observe(e.parentNode,{childList:!0}))}function Tn(e,t,n,r,o="public"){return new Promise(i=>{let a=pe(n),s=ri(n,r,o),l=s&&a?`<a href="${H(a)}" target="_blank" rel="noopener noreferrer" class="bd-issue-link">
+          <svg viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
+            <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"/>
+          </svg>
+          ${g(c().viewOnGitHub)}
+        </a>`:"",d=r||o==="always"&&s?`
+        <p class="bd-success-issue">${c().issueCreated(`<strong>#${t}</strong>`)}</p>
+        ${l}
+      `:`<p class="bd-success-issue">${g(c().feedbackSubmittedMessage)}</p>`,u=_(e,c().successTitle,`
+        <div class="bd-success-content">
+          <div class="bd-success-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
+              <polyline points="22 4 12 14.01 9 11.01"/>
+            </svg>
+          </div>
+          ${d}
+        </div>
+        <div class="bd-actions bd-success-actions">
+          <button class="bd-btn bd-btn-primary" data-action="done">${g(c().done)}</button>
+        </div>
+        <div class="bd-powered-by">
+          <a href="https://github.com/mean-weasel/bugdrop" target="_blank" rel="noopener noreferrer">Powered by BugDrop</a>
+        </div>
+      `,!0),m=u.querySelector(".bd-close"),y=u.querySelector('[data-action="done"]'),x=()=>{u.remove(),i()};m?.addEventListener("click",x),y?.addEventListener("click",x)})}function Cn(e,t,n=0,r){return new Promise(o=>{let i=[];r?.redactionUnavailable?i.push(c().viewportRedactionUnavailableNote):(n>0&&i.push(c().redactionCountNote(n)),r?.redactionLimitations&&i.push(c().redactionLimitationsNote));let a=i.length?fe(i.join(" ")):"",l=r?.selectedElementCapture?`
+        <p class="bd-selected-element-note" style="margin: -4px 0 12px; color: var(--bd-text-secondary); font-size: 13px;">
+          ${c().selectedElementNote('<a href="https://bugdrop.dev/docs/configuration#select-element-screenshots" target="_blank" rel="noopener noreferrer">data-element-context-max-area</a>')}
+        </p>
+      `:"",d=_(e,c().reviewScreenshotTitle,`
+        ${a}
+        <p style="margin: 0 0 12px; color: var(--bd-text-secondary); font-size: 13px;">
+          ${g(c().annotationInstruction)}
+        </p>
+        ${l}
+        <div class="bd-tools">
+          <button class="bd-tool active" data-tool="draw">\u270F\uFE0F ${g(c().toolDraw)}</button>
+          <button class="bd-tool" data-tool="arrow">\u27A1\uFE0F ${g(c().toolArrow)}</button>
+          <button class="bd-tool" data-tool="rect">\u25A2 ${g(c().toolRectangle)}</button>
+          <button class="bd-tool" data-tool="redact">${g(c().toolRedact)}</button>
+          <button class="bd-tool" data-action="undo">\u21B6 ${g(c().undo)}</button>
+        </div>
+        <div id="annotation-canvas" class="bd-annotation-stage"></div>
+        <div class="bd-actions">
+          <button class="bd-btn bd-btn-secondary" data-action="retake">${g(c().retake)}</button>
+          <button class="bd-btn bd-btn-primary" data-action="done">${g(c().submitFeedback)}</button>
+        </div>
+      `,!1,"bd-modal--annotator"),u=d.querySelector("#annotation-canvas"),m=kn(u,t),y=d.querySelectorAll("[data-tool]");y.forEach(z=>{z.addEventListener("click",R=>{let P=R.currentTarget,M=P.dataset.tool;M&&(y.forEach(A=>A.classList.remove("active")),P.classList.add("active"),m.setTool(M))})}),d.querySelector('[data-action="undo"]')?.addEventListener("click",()=>m.undo());let v=d.querySelector(".bd-close"),T=d.querySelector('[data-action="retake"]'),k=d.querySelector('[data-action="done"]');v?.addEventListener("click",()=>{m.destroy(),d.remove(),o("cancel")}),T?.addEventListener("click",()=>{m.destroy(),d.remove(),o("retake")}),k?.addEventListener("click",()=>{let z=m.getImageData();m.destroy(),d.remove(),o(z)})})}async function We(e,t,n,r){return je(e,()=>un(t,n,r?.captureOptions),r)}async function Ln(e,t,n,r){return je(e,()=>pn(t,n,r?.captureOptions),r)}async function je(e,t,n){let r=n?.showLoading===!1?null:_(e,c().capturingTitle,`
+            <div style="display: flex; flex-direction: column; align-items: center; padding: 20px;">
+              <div class="bd-spinner bd-spinner--lg"></div>
+              <p class="bd-loading-text" style="margin-top: 12px;">${g(c().capturingScreenshot)}</p>
+            </div>
+          `);try{r&&await ii();let i=await(typeof t=="function"?t():t);return r?.remove(),si(i)}catch(o){console.warn("[BugDrop] Screenshot capture failed:",o),r?.remove();let i=n?.allowSkip!==!1,a=n?.allowChooseAgain!==!1;return o instanceof ie?ai(e):new Promise(s=>{let l=_(e,c().captureFailedTitle,`
+          <div class="bd-error-message">
+            <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-9.5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5.5zm0 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
+            </svg>
+            <span class="bd-error-message__text">${g(c().captureFailedMessage)}</span>
+          </div>
+          <div class="bd-actions">
+            ${i?`<button class="bd-btn bd-btn-secondary" data-action="skip">${g(c().skipScreenshot)}</button>`:""}
+            ${a?`<button class="bd-btn bd-btn-primary" data-action="choose-again">${g(c().chooseAnotherMethod)}</button>`:""}
+          </div>
+        `,!0),d=l.querySelector(".bd-close"),u=l.querySelector('[data-action="skip"]'),m=l.querySelector('[data-action="choose-again"]');d?.addEventListener("click",()=>{l.remove(),s({kind:"cancelled"})}),u?.addEventListener("click",()=>{l.remove(),s({kind:"skipped"})}),m?.addEventListener("click",()=>{l.remove(),s({kind:"choose-again"})})})}}function ii(){return typeof requestAnimationFrame!="function"?new Promise(e=>setTimeout(e,0)):new Promise(e=>{requestAnimationFrame(()=>{requestAnimationFrame(()=>e())})})}function ai(e){return new Promise(t=>{let n=_(e,c().maskFailureTitle,`
+        <div class="bd-error-message">
+          <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-9.5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5.5zm0 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
+          </svg>
+          <span class="bd-error-message__text">${g(c().maskFailureMessage)}</span>
+        </div>
+        <div class="bd-actions">
+          <button class="bd-btn bd-btn-primary" data-action="skip">${g(c().continueWithoutScreenshot)}</button>
+        </div>
+      `,!0),r=n.querySelector(".bd-close"),o=n.querySelector('[data-action="skip"]');r?.addEventListener("click",()=>{n.remove(),t({kind:"cancelled"})}),o?.addEventListener("click",()=>{n.remove(),t({kind:"skipped"})})})}function si(e){return typeof e=="string"?{kind:"ok",dataUrl:e}:{kind:"ok",dataUrl:e.dataUrl,redaction:e.redaction}}function Rn(e,t){let n=e.getBoundingClientRect();if(!Mn(n))return e;let o=Math.max(1,window.innerWidth*window.innerHeight)*on(t.maxViewportAreaMultiplier),i=e,a=e.parentElement;for(;a&&a!==document.body&&a!==document.documentElement;){let s=a.getBoundingClientRect(),l=s.width*s.height;Mn(s)&&l<=o&&li(s,n)&&ci(s,n)&&(i=a),a=a.parentElement}return i}function Mn(e){return e.width>0&&e.height>0}function li(e,t){return e.left<=t.left&&e.top<=t.top&&e.right>=t.right&&e.bottom>=t.bottom}function ci(e,t){let n=e.width>=t.width+160,r=e.height>=t.height+160,o=t.width*t.height,i=e.width*e.height;return n||r||i>=o*4}function An(e){let t=[],n=e.ownerDocument.body,r=e;if(r===n)return qe(r);for(;r&&r!==n;){let o=qe(r);if(r.id){o=`#${ye(r.id)}`,t.unshift(o);break}let i=Dn(r).slice(0,2);i.length&&(o+=`.${i.map(ye).join(".")}`),t.unshift(o),r=r.parentElement}return t.join(" > ")}function In(e){let t=di(e),n=t.map(ui),r=t.map(gt);return mi(n,r,e)}function di(e){let t=[],n=e;for(;n;)t.unshift(n),n=n.parentElement;return t}function ui(e){let t=pi(e);return t.length<=128?t:gt(e)}function pi(e){let t=qe(e);e.id&&(t+=`#${ye(e.id)}`);let n=Dn(e).slice(0,3);return n.length>0&&(t+=`.${n.map(ye).join(".")}`),e.id||(t+=Fn(e)),t}function gt(e){return`${qe(e)}${Fn(e)}`}function Dn(e){return Array.from(e.classList).filter(Boolean)}function qe(e){return ye(e.localName||e.tagName.toLowerCase())}function mi(e,t,n){let r=e.join(" > ");return r.length<=1024?r:zn(e,n)||zn(t,n)||gt(n)}function zn(e,t){for(let n=e.length-1;n>=0;n-=1){let r=e.slice(n).join(" > ");if(!(r.length>1024)&&gi(r,t))return r}return null}function gi(e,t){try{return t.ownerDocument.querySelector(e)===t}catch{return!1}}function Fn(e){let t=bi(e);return t>1||hi(e)?`:nth-of-type(${t})`:""}function bi(e){let t=1,n=e.previousElementSibling;for(;n;)n.tagName===e.tagName&&(t+=1),n=n.previousElementSibling;return t}function hi(e){let t=e.previousElementSibling;for(;t;){if(t.tagName===e.tagName)return!0;t=t.previousElementSibling}for(t=e.nextElementSibling;t;){if(t.tagName===e.tagName)return!0;t=t.nextElementSibling}return!1}function ye(e){return typeof CSS<"u"&&typeof CSS.escape=="function"?CSS.escape(e):fi(e)}function fi(e){let t="";for(let n=0;n<e.length;n+=1){let r=e.charAt(n),o=e.charCodeAt(n),i=n===0,a=n===1,s=e.charCodeAt(0);if(o===0){t+="\uFFFD";continue}if(o>=1&&o<=31||o===127||i&&o>=48&&o<=57||a&&o>=48&&o<=57&&s===45){t+=`\\${o.toString(16)} `;continue}if(i&&o===45&&e.length===1){t+="\\-";continue}if(o>=128||o===45||o===95||o>=48&&o<=57||o>=65&&o<=90||o>=97&&o<=122){t+=r;continue}t+=`\\${r}`}return t}function $n(e,t){let n=K(),r=n&&dn(),o=t?.allowSkip!==!1,i="";return r?i=fe(c().viewportRedactionWarning):se()>0&&(i=fe(c().redactionReviewNote)),new Promise(a=>{let s=n?`<p style="margin: 0 0 12px; padding: 8px 12px; background: var(--bd-bg-secondary, #f5f5f5); border-radius: 6px; font-size: 13px; color: var(--bd-text-secondary);">${r?g(c().pageTooComplexViewportNote):g(c().pageTooComplexElementNote)}</p>`:"",l="";n?r&&(l=`<button class="bd-btn bd-btn-primary" data-action="viewport">${g(c().captureViewport)}</button>`):l=`<button class="bd-btn bd-btn-primary" data-action="capture">${g(c().fullPage)}</button>`;let d=_(e,c().captureScreenshotTitle,`
+        <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">${g(c().chooseWhatToCapture)}</p>
+        ${s}
+        ${i}
+        <div class="bd-actions bd-screenshot-actions">
+          ${l}
+          ${n?"":`<button class="bd-btn bd-btn-secondary" data-action="area">${g(c().selectArea)}</button>`}
+          <button class="bd-btn bd-btn-secondary" data-action="element">${g(c().selectElement)}</button>
+          ${o?`<button class="bd-btn bd-btn-quiet" data-action="skip">${g(c().skipScreenshot)}</button>`:""}
+        </div>
+      `),u=d.querySelector(".bd-close"),m=d.querySelector('[data-action="skip"]'),y=d.querySelector('[data-action="element"]'),x=d.querySelector('[data-action="area"]'),v=d.querySelector('[data-action="capture"]'),T=d.querySelector('[data-action="viewport"]');u?.addEventListener("click",()=>{d.remove(),a({kind:"cancel"})}),m?.addEventListener("click",()=>{d.remove(),a({kind:"skip"})}),y?.addEventListener("click",()=>{d.remove(),a({kind:"element"})}),x?.addEventListener("click",()=>{d.remove(),a({kind:"area"})}),v?.addEventListener("click",()=>{d.remove(),a({kind:"capture"})}),T?.addEventListener("click",()=>{d.remove();let k=pt();k.catch(()=>{}),a({kind:"viewport",capture:k})})})}async function Bn(e,t,n,r){if(t.screenshotMode==="auto")return wi(e,t);if(!n)return we();let o=t.screenshotMode==="required";for(;;){let i=await xi(e,t,o);if(i.kind==="returnToForm")return{...we(),returnToForm:!0};if(i.kind==="chooseAgain")continue;if(i.kind==="empty"){if(!o&&vi(i.reason)&&r(),o)continue;return{screenshot:null,elementSelector:i.elementSelector,fullElementSelector:i.fullElementSelector,returnToForm:!1}}let a=await Cn(e,i.screenshot,i.redactionCount,{redactionUnavailable:i.redactionUnavailable,...i.redactionLimitations?{redactionLimitations:!0}:{},...i.elementSelector?{selectedElementCapture:!0}:{}});if(a!=="retake")return a==="cancel"?{...we(),returnToForm:!0}:{screenshot:a,elementSelector:i.elementSelector,fullElementSelector:i.fullElementSelector,returnToForm:!1}}}async function wi(e,t){if(K())return we();let n=await We(e,void 0,t.screenshotScale,{allowChooseAgain:!1});return n.kind==="cancelled"?{...we(),returnToForm:!0}:{screenshot:n.kind==="ok"?n.dataUrl:null,elementSelector:null,fullElementSelector:null,returnToForm:!1}}function vi(e){return e==="explicit-skip"||e==="capture-failure-skip"}async function xi(e,t,n){let r=await $n(e,{allowSkip:!n});switch(r.kind){case"cancel":return{kind:"returnToForm"};case"skip":return Z("explicit-skip");case"viewport":return ki(e,r,n);case"capture":return Ei(e,t,n);case"element":return Si(e,t,n);case"area":return Ti(e,t,n);default:return Ci(r)}}async function ki(e,t,n){let r=await je(e,t.capture,{allowSkip:!n,showLoading:!1});return r.kind==="cancelled"?{kind:"returnToForm"}:r.kind==="choose-again"?{kind:"chooseAgain"}:r.kind==="skipped"?Z("capture-failure-skip"):{kind:"captured",screenshot:r.dataUrl,elementSelector:null,fullElementSelector:null,redactionCount:0,redactionUnavailable:!0,redactionLimitations:!1}}async function Ei(e,t,n){let r=await We(e,void 0,t.screenshotScale,{allowSkip:!n});return r.kind==="cancelled"?{kind:"returnToForm"}:r.kind==="choose-again"?{kind:"chooseAgain"}:r.kind==="skipped"?Z("capture-failure-skip"):{kind:"captured",screenshot:r.dataUrl,elementSelector:null,fullElementSelector:null,redactionCount:r.redaction?.count??0,redactionUnavailable:!1,redactionLimitations:r.redaction?.hasLimitations??!1}}async function Si(e,t,n){let r=await fn(_n(t));if(!r)return Z("selection-cancelled");let o={elementSelector:An(r),fullElementSelector:In(r)},i=Rn(r,{maxViewportAreaMultiplier:t.elementContextMaxArea}),a=await We(e,i,t.screenshotScale,{allowSkip:!n,captureOptions:{highlightElement:r,highlightStyle:{accentColor:t.accentColor,radius:t.radius,borderWidth:t.borderWidth},pixelRatio:1}});return a.kind==="cancelled"?{kind:"returnToForm"}:a.kind==="choose-again"?{kind:"chooseAgain"}:a.kind==="skipped"?Z("capture-failure-skip",o):{kind:"captured",screenshot:a.dataUrl,...o,redactionCount:a.redaction?.count??0,redactionUnavailable:!1,redactionLimitations:a.redaction?.hasLimitations??!1}}async function Ti(e,t,n){let r=await wn(_n(t),{redactionsAvailable:se()>0});if(!r)return Z("selection-cancelled");let o=await Ln(e,r,t.screenshotScale,{allowSkip:!n});return o.kind==="cancelled"?{kind:"returnToForm"}:o.kind==="choose-again"?{kind:"chooseAgain"}:o.kind==="skipped"?Z("capture-failure-skip"):{kind:"captured",screenshot:o.dataUrl,elementSelector:null,fullElementSelector:null,redactionCount:o.redaction?.count??0,redactionUnavailable:!1,redactionLimitations:o.redaction?.hasLimitations??!1}}function _n(e){return{accentColor:e.accentColor,font:e.font,radius:e.radius,borderWidth:e.borderWidth,bgColor:e.bgColor,textColor:e.textColor,borderColor:e.borderColor,theme:e.theme}}function we(){return{screenshot:null,...Nn(),returnToForm:!1}}function Z(e,t=Nn()){return{kind:"empty",reason:e,...t}}function Nn(){return{elementSelector:null,fullElementSelector:null}}function Ci(e){throw new Error(`Unhandled screenshot choice: ${JSON.stringify(e)}`)}function Hn(e,t=window){if(!e)return;let n=t[e];if(typeof n!="function"){console.warn(`[BugDrop] data-auth-token-provider "${e}" must reference a function.`);return}return n}async function bt(e){if(!e)return{};let t=await e();return t?{Authorization:t.startsWith("Bearer ")?t:`Bearer ${t}`}:{}}var Ve=String.raw`(?:"|')?\b(?:password|passwd|pwd|token|api[_-]?key|secret|authorization|auth|cookie)\b(?:"|')?`,Li=new RegExp(String.raw`(${Ve}\s*[:=]\s*)(["'])(?!Bearer\b)(?:\\[\s\S]|(?!\2)[^\\])*?\2`,"gi"),Pi=new RegExp(String.raw`(${Ve}\s*[:=]\s*)(["'])(?!Bearer\b)(?:\\[^\r\n]|(?!\2)[^\\\r\n])*(?=\r?\n|$)`,"gi"),Mi=new RegExp(String.raw`(${Ve}\s*[:=]\s*)(?:\[[^\]\r\n]*\]|\{[^\}\r\n]*\})`,"gi"),Ri=new RegExp(String.raw`(${Ve}\s*[:=]\s*)(?!Bearer\b)[^"',\s}&]+`,"gi"),zi=/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi,Ai=/\b[A-Za-z0-9+/_=-]{32,}\b/g;function On(e){return e.replace(zi,"Bearer [redacted]").replace(Mi,"$1[redacted]").replace(Li,"$1$2[redacted]$2").replace(Pi,"$1$2[redacted]").replace(Ri,"$1[redacted]").replace(Ai,"[redacted]")}var Ii=50,Di=1e3,Xe=[],Un=!1;function Wn(){Un||typeof window>"u"||typeof console>"u"||(Un=!0,Ge("log"),Ge("info"),Ge("warn"),Ge("error"),window.addEventListener("error",e=>{ht({level:"error",message:e.message||"Unhandled error",timestamp:new Date().toISOString(),sourceUrl:e.filename||void 0,lineNumber:e.lineno||void 0,columnNumber:e.colno||void 0})}),window.addEventListener("unhandledrejection",e=>{ht({level:"error",message:`Unhandled promise rejection: ${qn(e.reason)}`,timestamp:new Date().toISOString()})}))}function jn(){return Xe.map(e=>({...e}))}function Ge(e){let t=console[e];typeof t=="function"&&(console[e]=(...n)=>{ht({level:e,message:n.map(qn).join(" "),timestamp:new Date().toISOString(),...Fi()}),t.apply(console,n)})}function ht(e){for(Xe.push({...e,message:On(e.message).slice(0,Di)});Xe.length>Ii;)Xe.shift()}function qn(e){if(e instanceof Error)return e.stack||e.message;if(typeof e=="string")return e;try{return JSON.stringify(e)}catch{return String(e)}}function Fi(){let e=new Error().stack;if(!e)return{};for(let t of e.split(`
+`).slice(2)){if(t.includes("console-logs"))continue;let n=t.match(/\(?((?:https?:|file:|\/)[^():]+):(\d+):(\d+)\)?$/);if(n)return{sourceUrl:n[1],lineNumber:Number(n[2]),columnNumber:Number(n[3])}}return{}}function Vn(e){let t=!1,n=o=>{Ye(e,o)&&o.preventDefault()},r=o=>{if(!t&&$i(e,o)){if(o.type==="focusin"){o.stopImmediatePropagation();return}if(o.type==="focusout"){t=!0;try{Bi(o)}finally{t=!1}o.stopImmediatePropagation();return}o.stopImmediatePropagation()}};for(let o of["dismissableLayer.pointerDownOutside","dismissableLayer.interactOutside"])document.addEventListener(o,n,!0);window.addEventListener("focusin",r,!0),window.addEventListener("focusout",r,!0)}function Ye(e,t){let n=t.detail?.originalEvent;return(typeof n?.composedPath=="function"?n.composedPath():typeof t.composedPath=="function"?t.composedPath():[]).includes(e)?!0:(n?.target??t.target)===e}function $i(e,t){if(!(t instanceof FocusEvent)||t.type==="focusin")return Ye(e,t);if(t.type!=="focusout")return!1;let n=t.relatedTarget;return(n===e||n instanceof Node&&(e.shadowRoot?.contains(n)??!1))&&!Ye(e,t)}function Bi(e){let t=typeof e.composedPath=="function"?e.composedPath():[];for(let n of t)if(n instanceof HTMLElement&&(n.dispatchEvent(new FocusEvent("focusout",{bubbles:!1,composed:!1,relatedTarget:e instanceof FocusEvent?e.relatedTarget:null})),n===document.body))break}var Te="bugdrop_dismissed",_i="bugdrop_trigger_position_",tr="bugdrop_welcomed_",Ni="bugdrop_complex_screenshot_skipped_",Hi=10080*60*1e3,ke=8,Gn=16,Xn=5,Yn=5*1024*1024,nr=["image/png","image/jpeg","image/gif","image/webp","application/pdf","video/mp4","video/webm","video/quicktime"];function Oi(e){let t=[{name:"Edge",pattern:/Edg(?:e|A|iOS)?\/(\d+[\d.]*)/},{name:"Opera",pattern:/(?:OPR|Opera)\/(\d+[\d.]*)/},{name:"Chrome",pattern:/Chrome\/(\d+[\d.]*)/},{name:"Safari",pattern:/Version\/(\d+[\d.]*).*Safari/},{name:"Firefox",pattern:/Firefox\/(\d+[\d.]*)/}];for(let{name:n,pattern:r}of t){let o=e.match(r);if(o)return{name:n,version:o[1]||"unknown"}}return{name:"Unknown",version:"unknown"}}function Ui(e){let t=[{name:"iOS",pattern:/iPhone OS (\d+[_\d]*)/,versionIndex:1},{name:"iOS",pattern:/iPad.*OS (\d+[_\d]*)/,versionIndex:1},{name:"macOS",pattern:/Mac OS X (\d+[_.\d]*)/,versionIndex:1},{name:"Windows",pattern:/Windows NT (\d+\.\d+)/,versionIndex:1},{name:"Android",pattern:/Android (\d+[\d.]*)/,versionIndex:1},{name:"Linux",pattern:/Linux/,versionIndex:void 0},{name:"Chrome OS",pattern:/CrOS/,versionIndex:void 0}];for(let{name:n,pattern:r,versionIndex:o}of t){let i=e.match(r);if(i){let a=o!==void 0&&i[o]?i[o].replace(/_/g,"."):"";return{name:n,version:a}}}return{name:"Unknown",version:""}}function rr(e){try{let t=new URL(e);return`${t.origin}${t.pathname}`}catch{return e.split("?")[0].split("#")[0]}}function Wi(){let e=navigator.userAgent;return{browser:Oi(e),os:Ui(e),devicePixelRatio:window.devicePixelRatio||1,language:navigator.language||"unknown",url:rr(window.location.href)}}var ji=null,j=null,Ee=null,X=!1,qi=null,ce=!1;function Kn(e){try{let t=localStorage.getItem(Te);if(!t)return!1;if(t==="true")return!0;let n=parseInt(t,10);if(isNaN(n))return!1;if(e===void 0)return!0;let r=e*24*60*60*1e3;return Date.now()-n<r}catch{return!1}}function or(){try{localStorage.setItem(Te,Date.now().toString())}catch{}}function Vi(e){try{return localStorage.getItem(tr+e)!==null}catch{return!1}}function Gi(e){try{localStorage.setItem(tr+e,Date.now().toString())}catch{}}function kt(e){return`${Ni}${e}:${rr(window.location.href)}`}function Xi(e){try{let t=kt(e),n=localStorage.getItem(t);if(!n)return!1;let r=parseInt(n,10);return isNaN(r)||Date.now()-r>Hi?(localStorage.removeItem(t),!1):!0}catch{return!1}}function Yi(e){try{localStorage.setItem(kt(e),Date.now().toString())}catch{}}function Ki(e){try{localStorage.removeItem(kt(e))}catch{}}function Zi(e,t){K()&&(Yi(e.repo),t.includeScreenshot=!1)}function Qi(e){if(!e)return;let t;try{t=JSON.parse(e)}catch(o){let i=o instanceof Error?`: ${o.message}`:"";console.warn(`[BugDrop] Invalid data-category-labels JSON${i}. Using default GitHub labels.`);return}if(!t||typeof t!="object"||Array.isArray(t)){console.warn("[BugDrop] Invalid data-category-labels: expected a JSON object. Using default GitHub labels.");return}let n=["bug","feature","question"],r={};for(let[o,i]of Object.entries(t)){if(!n.includes(o)){console.warn(`[BugDrop] Invalid data-category-labels: unknown category "${o}" (expected ${n.join(", ")}). Ignoring.`);continue}typeof i=="string"||Array.isArray(i)&&i.every(a=>typeof a=="string")?r[o]=i:console.warn(`[BugDrop] Invalid data-category-labels: value for "${o}" must be a string or string array. Ignoring.`)}return Object.keys(r).length>0?r:void 0}var S=document.currentScript||document.querySelector('script[src*="bugdrop"][src*="widget"]');document.currentScript||console.warn("[BugDrop] document.currentScript is null \u2014 do not use async or defer on the BugDrop script tag.");var Se=S?.dataset.theme;Se&&!Ue(Se)&&console.warn(`[BugDrop] Invalid data-theme "${Se}". Expected "light", "dark", or "auto".`);var Ji=Zt(S?.dataset.locale||document.documentElement.lang),Zn=S?.dataset.requireName==="true",Qn=S?.dataset.requireEmail==="true",ve=S?.dataset.position;ve&&ve!=="bottom-right"&&ve!=="bottom-left"&&console.warn(`[BugDrop] Invalid data-position "${ve}". Expected "bottom-right" or "bottom-left".`);var ir=S?.dataset.dismissDuration,ar=Yt(ir);ir&&ar===void 0&&console.warn("[BugDrop] Invalid data-dismiss-duration. Expected a positive whole number of days.");var sr=S?.dataset.screenshotScale,lr=it(sr);sr&&lr===void 0&&console.warn("[BugDrop] Invalid data-screenshot-scale. Expected a non-negative number.");var cr=S?.dataset.elementContextMaxArea,dr=it(cr);cr&&dr===void 0&&console.warn("[BugDrop] Invalid data-element-context-max-area. Expected a non-negative number.");var ur=S?.dataset.shadow,pr=Re(ur);ur&&!pr&&console.warn('[BugDrop] Invalid data-shadow. Expected "soft", "hard", or "none".');var Q=S?.dataset.showIssueLink,mr=Q==="always"||Q==="never"?Q:"public";Q&&Q!=="public"&&Q!==mr&&console.warn(`[BugDrop] Invalid data-show-issue-link "${Q}". Expected "public", "always", or "never".`);var xe={repo:S?.dataset.repo||"",apiUrl:S?.src.replace(/\/widget(?:\.v[\d.]+)?\.js$/,"/api")||"",authTokenProvider:Hn(S?.dataset.authTokenProvider),position:ve==="bottom-left"?"bottom-left":"bottom-right",theme:Ue(Se)?Se:"auto",showName:S?.dataset.showName==="true"||Zn,requireName:Zn,showEmail:S?.dataset.showEmail==="true"||Qn,requireEmail:Qn,buttonDismissible:S?.dataset.buttonDismissible==="true",dismissDuration:ar,showRestore:S?.dataset.showRestore!=="false",showButton:S?.dataset.button!=="false",accentColor:B(S?.dataset.color),iconUrl:pe(S?.dataset.icon),label:S?.dataset.label||void 0,categoryLabels:Qi(S?.dataset.categoryLabels),font:oe(S?.dataset.font),radius:G(S?.dataset.radius)?.toString(),bgColor:B(S?.dataset.bg),textColor:B(S?.dataset.text),borderWidth:G(S?.dataset.borderWidth)?.toString(),borderColor:B(S?.dataset.borderColor),shadow:pr,welcome:(()=>{let e=S?.dataset.welcome;return e==="false"||e==="never"?"never":e==="always"?"always":"once"})(),screenshotMode:(()=>{let e=S?.dataset.screenshot;return e==="auto"||e==="required"?e:(e&&e!=="optional"&&console.warn(`[BugDrop] Invalid data-screenshot "${e}". Expected "optional", "auto", or "required".`),"optional")})(),screenshotScale:lr,elementContextMaxArea:dr,issueLinkVisibility:mr,sendConsoleLogs:S?.dataset.sendConsoleLogs==="true",locale:Ji};Jt(xe.locale);Wn();xe.repo?/^[^/]+\/[^/]+$/.test(xe.repo)?ra(xe):console.error(`[BugDrop] Invalid data-repo format "${xe.repo}". Expected "owner/repo" (e.g., "octocat/hello-world").`):console.error("[BugDrop] Missing data-repo attribute");function ea(e){return e.label!==void 0?e.label:c().triggerLabel}function gr(e,t){if(t.position==="bottom-left"&&e.appendChild(Jn()),t.iconUrl!=="none"){let r=document.createElement("span");if(r.className="bd-trigger-icon",t.iconUrl){let o=document.createElement("img");o.src=t.iconUrl,o.alt="";let i=document.createElement("span");i.textContent="\u{1F41B}",i.style.display="none",o.addEventListener("error",()=>{o.style.display="none",i.style.display=""}),r.append(o,i)}else r.textContent="\u{1F41B}";e.appendChild(r)}let n=document.createElement("span");n.className="bd-trigger-label",n.textContent=ea(t),e.appendChild(n),t.position!=="bottom-left"&&e.appendChild(Jn())}function Jn(){let e=document.createElement("span");return e.className="bd-trigger-drag-handle",e.setAttribute("aria-hidden","true"),e.title=c().dragHandleTitle,e.innerHTML=`
+    <svg viewBox="0 0 12 24" aria-hidden="true" focusable="false">
+      <circle cx="4" cy="5" r="1.5" fill="currentColor"></circle>
+      <circle cx="8" cy="5" r="1.5" fill="currentColor"></circle>
+      <circle cx="4" cy="9.5" r="1.5" fill="currentColor"></circle>
+      <circle cx="8" cy="9.5" r="1.5" fill="currentColor"></circle>
+      <circle cx="4" cy="14" r="1.5" fill="currentColor"></circle>
+      <circle cx="8" cy="14" r="1.5" fill="currentColor"></circle>
+      <circle cx="4" cy="18.5" r="1.5" fill="currentColor"></circle>
+      <circle cx="8" cy="18.5" r="1.5" fill="currentColor"></circle>
+    </svg>
+  `,e}function br(e,t=!1){let n=["bd-trigger",`bd-trigger--${e.position==="bottom-left"?"left":"right"}`];return t&&n.push("bd-trigger--restoring"),n.join(" ")}function hr(e){return`${_i}${e.repo}_${e.position}`}function ta(e){try{let t=localStorage.getItem(hr(e));if(!t)return null;let n=Number(t);return Number.isFinite(n)?n:null}catch{return null}}function Et(e,t){try{localStorage.setItem(hr(e),String(Math.round(t)))}catch{}}function na(e,t){let n=e.getBoundingClientRect(),r=Math.max(ke,window.innerHeight-n.height-ke);return Math.min(Math.max(t,ke),r)}function Ke(e,t){let n=na(e,t);return e.style.top=`${n}px`,e.style.bottom="auto",n}function fr(e,t){let n=ta(t);n!==null&&(e.classList.add("bd-trigger--positioned"),Ke(e,n))}function vt(e,t){if(!e.style.top)return;let n=e.getBoundingClientRect();if(n.width===0||n.height===0)return;let r=parseFloat(e.style.top);if(!Number.isFinite(r))return;let o=Ke(e,r);Et(t,o)}function yr(e,t){let n=()=>{if(!e.isConnected){r();return}vt(e,t)},r=()=>{window.removeEventListener("resize",n),window.visualViewport?.removeEventListener("resize",n)};window.addEventListener("resize",n),window.visualViewport?.addEventListener("resize",n)}function wr(e,t){let n=e.querySelector(".bd-trigger-drag-handle");if(!n)return;let r=null,o=0,i=0,a=!1,s=()=>{r!==null&&(r=null,e.classList.remove("bd-trigger--dragging"),window.removeEventListener("pointermove",l),window.removeEventListener("pointerup",d),window.removeEventListener("pointercancel",u),a&&(Et(t,e.getBoundingClientRect().top),window.setTimeout(()=>{ce=!1},0)))};function l(m){if(r!==m.pointerId)return;let y=i+m.clientY-o;Math.abs(m.clientY-o)>3&&(a=!0,ce=!0),Ke(e,y)}function d(m){r===m.pointerId&&s()}function u(m){r===m.pointerId&&s()}n.addEventListener("pointerdown",m=>{m.preventDefault(),m.stopPropagation();let y=e.getBoundingClientRect();r=m.pointerId,o=m.clientY,i=y.top,a=!1,e.classList.add("bd-trigger--dragging"),n.setPointerCapture(m.pointerId),window.addEventListener("pointermove",l),window.addEventListener("pointerup",d),window.addEventListener("pointercancel",u)}),n.addEventListener("click",m=>{m.preventDefault(),m.stopPropagation()})}function vr(e,t){e.addEventListener("keydown",n=>{if(n.target!==e||!["ArrowUp","ArrowDown","Home","End"].includes(n.key))return;n.preventDefault(),n.stopPropagation();let r=e.getBoundingClientRect(),o=window.innerHeight-r.height-ke,i=n.key==="ArrowUp"?r.top-Gn:n.key==="ArrowDown"?r.top+Gn:n.key==="Home"?ke:o;e.classList.add("bd-trigger--positioned"),Et(t,Ke(e,i))})}function xt(e,t){let n=document.createElement("div");n.className=t.position==="bottom-left"?"bd-pull-tab bd-pull-tab--left":"bd-pull-tab",n.innerHTML='<span class="bd-pull-tab-chevron">\u2039</span>',n.setAttribute("role","button"),n.setAttribute("tabindex","0"),n.setAttribute("aria-label",c().pullTabAriaLabel);let r=()=>{try{localStorage.removeItem(Te)}catch{}n.remove(),Ee=null,xr(e,t,!0)};return n.addEventListener("click",r),n.addEventListener("keydown",o=>{(o.key==="Enter"||o.key===" ")&&(o.preventDefault(),r())}),e.appendChild(n),Ee=n,n}function ra(e){if(qi=e,!e.buttonDismissible)try{localStorage.removeItem(Te)}catch{}let t=document.createElement("div");t.id="bugdrop-host",t.style.pointerEvents="auto",document.body.appendChild(t);let n=t.attachShadow({mode:"open"});Vn(t);for(let i of["keydown","keypress","keyup"])n.addEventListener(i,a=>{let s=a.target;(s.tagName==="INPUT"||s.tagName==="TEXTAREA")&&a.stopPropagation()});let r=Sn(n,e);if(ji=r,e.showButton&&!(e.buttonDismissible&&Kn(e.dismissDuration))){let i=document.createElement("button");if(i.className=br(e),gr(i,e),i.setAttribute("aria-label",c().triggerAriaLabel),e.buttonDismissible){let a=document.createElement("button");a.className="bd-trigger-close",a.textContent="\xD7",a.setAttribute("aria-label",c().dismissButtonAriaLabel),i.appendChild(a),a.addEventListener("click",s=>{s.stopPropagation(),or(),i.classList.remove("bd-trigger--restoring"),i.classList.add("bd-trigger--dismissing"),i.addEventListener("animationend",()=>{i.remove(),j=null,e.showRestore&&xt(r,e)},{once:!0})})}r.appendChild(i),j=i,fr(i,e),yr(i,e),wr(i,e),vr(i,e),i.addEventListener("click",()=>{if(ce){ce=!1;return}St(r,e)})}else e.showButton&&e.buttonDismissible&&e.showRestore&&Kn(e.dismissDuration)&&xt(r,e);oa(r,e),window.dispatchEvent(new CustomEvent("bugdrop:ready"))}function oa(e,t){let n=t.theme;window.BugDrop={open:()=>{X||St(e,t,{skipWelcome:!0})},close:()=>{if(X){let r=e.querySelector(".bd-modal");r&&r.remove(),X=!1}},hide:()=>{j&&(j.style.display="none")},show:()=>{try{localStorage.removeItem(Te)}catch{}Ee&&(Ee.remove(),Ee=null),j?(j.style.display="",vt(j,t),window.requestAnimationFrame(()=>{j&&vt(j,t)})):t.showButton&&xr(e,t)},isOpen:()=>X,isButtonVisible:()=>j!==null&&j.style.display!=="none",setTheme:r=>{if(!Ue(r)){console.warn(`[BugDrop] Invalid theme ${String(r)}. Expected 'light' | 'dark' | 'auto'.`);return}n=r;let o=Oe(r);be(e,o),he(e,t,o)}},En(r=>{n==="auto"&&(be(e,r),he(e,t,r))})}function xr(e,t,n=!1){let r=document.createElement("button");if(r.className=br(t,n),gr(r,t),r.setAttribute("aria-label",c().triggerAriaLabel),t.buttonDismissible){let o=document.createElement("button");o.className="bd-trigger-close",o.textContent="\xD7",o.setAttribute("aria-label",c().dismissButtonAriaLabel),r.appendChild(o),o.addEventListener("click",i=>{i.stopPropagation(),or(),r.classList.remove("bd-trigger--restoring"),r.classList.add("bd-trigger--dismissing"),r.addEventListener("animationend",()=>{r.remove(),j=null,t.showRestore&&xt(e,t)},{once:!0})})}e.appendChild(r),j=r,fr(r,t),yr(r,t),wr(r,t),vr(r,t),r.addEventListener("click",()=>{if(ce){ce=!1;return}St(e,t)})}async function St(e,t,n){if(X)return;X=!0;let{status:r,appName:o}=await ia(t);if(r==="not_installed"){er(e,t,void 0,o);return}if(r==="unreachable"){er(e,t,c().apiUnreachableMessage,o);return}if(!(n?.skipWelcome||t.welcome==="never"||t.welcome==="once"&&Vi(t.repo))){if(!await aa(e)){X=!1;return}t.welcome==="once"&&Gi(t.repo)}let a=null;for(;;){if(a=await sa(e,t,a),!a){X=!1;return}let s=a,l=await Bn(e,t,s.includeScreenshot,()=>Zi(t,s));if(!l.returnToForm){await Er(e,t,{title:a.title,description:a.description,category:a.category,name:a.name,email:a.email,screenshot:l.screenshot,attachments:a.attachments,elementSelector:l.elementSelector,fullElementSelector:l.fullElementSelector,selectedElementHighlightColor:l.elementSelector?ae(t.accentColor):null,sendConsoleLogs:a.sendConsoleLogs});break}}X=!1}async function ia(e){try{let t=await fetch(`${e.apiUrl}/check/${e.repo}`,{headers:await bt(e.authTokenProvider)});if(!t.ok)return{status:"unreachable"};let n=await t.json();return{status:n.installed===!0?"installed":"not_installed",appName:n.appName}}catch{return{status:"unreachable"}}}function er(e,t,n,r){let i=`https://github.com/apps/${r||(t.apiUrl.includes("bugdrop.neonwatty.workers.dev")?"neonwatty-bugdrop":t.apiUrl.replace(/https?:\/\//,"").replace(/\..*/,""))}/installations/new`,a=n||c().installRequiredMessage,s=n?c().connectionErrorTitle:c().installRequiredTitle,l=_(e,s,`
+      <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">${H(a)}</p>
+      <div class="bd-actions">
+        <button class="bd-btn bd-btn-secondary" data-action="cancel">${g(c().cancel)}</button>
+        ${n?"":`<a href="${i}" target="_blank" class="bd-btn bd-btn-primary" style="text-decoration: none;">${g(c().installApp)}</a>`}
+      </div>
+    `,!0),d=l.querySelector(".bd-close"),u=l.querySelector('[data-action="cancel"]');d?.addEventListener("click",()=>{l.remove(),X=!1}),u?.addEventListener("click",()=>{l.remove(),X=!1})}function aa(e){return new Promise(t=>{let n=_(e,c().welcomeTitle,`
+        <div style="text-align: center; padding: 8px 0 16px;">
+          <div style="font-size: 3rem; margin-bottom: 12px;">\u{1F4AC}</div>
+          <p style="margin: 0 0 12px; color: var(--bd-text-primary); font-size: 1.05rem; font-weight: 500;">
+            ${g(c().welcomeHeadline)}
+          </p>
+          <p style="margin: 0 0 8px; color: var(--bd-text-secondary); font-size: 0.95rem; line-height: 1.6;">
+            ${g(c().welcomeBodyLine1)}<br/>
+            ${g(c().welcomeBodyLine2)}
+          </p>
+        </div>
+        <div class="bd-actions" style="justify-content: center;">
+          <button class="bd-btn bd-btn-primary" data-action="continue">${g(c().getStarted)}</button>
+        </div>
+      `,!0),r=n.querySelector(".bd-close"),o=n.querySelector('[data-action="continue"]');r?.addEventListener("click",()=>{n.remove(),t(!1)}),o?.addEventListener("click",()=>{n.remove(),t(!0)})})}function sa(e,t,n){return new Promise(r=>{let o=t.showName?`
+          <div class="bd-form-group">
+            <label class="bd-label" for="name">${g(c().nameLabel)}${t.requireName?" *":""}</label>
+            <input type="text" id="name" class="bd-input" ${t.requireName?"required":""} placeholder="${g(c().namePlaceholder)}" value="${H(n?.name||"")}" />
+          </div>
+        `:"",i=t.showEmail?`
+          <div class="bd-form-group">
+            <label class="bd-label" for="email">${g(c().emailLabel)}${t.requireEmail?" *":""}</label>
+            <input type="email" id="email" class="bd-input" ${t.requireEmail?"required":""} placeholder="${g(c().emailPlaceholder)}" value="${H(n?.email||"")}" />
+          </div>
+        `:"",a=_(e,c().feedbackFormTitle,`
+        <form id="feedback-form">
+          <div class="bd-form-group">
+            <label class="bd-label">${g(c().categoryLabel)}</label>
+            <div class="bd-category-selector" style="display: flex; gap: 8px; margin-top: 6px;">
+              <label class="bd-category-option" style="flex: 1; display: flex; align-items: center; gap: 6px; padding: 8px 12px; border: var(--bd-border-style); border-radius: var(--bd-radius-sm); cursor: pointer; transition: all 0.15s ease;">
+                <input type="radio" name="category" value="bug" ${yt(n,"bug")} style="accent-color: var(--bd-primary);" />
+                <span style="font-size: 0.9rem;">\u{1F41B} ${g(c().categoryBug)}</span>
+              </label>
+              <label class="bd-category-option" style="flex: 1; display: flex; align-items: center; gap: 6px; padding: 8px 12px; border: var(--bd-border-style); border-radius: var(--bd-radius-sm); cursor: pointer; transition: all 0.15s ease;">
+                <input type="radio" name="category" value="feature" ${yt(n,"feature")} style="accent-color: var(--bd-primary);" />
+                <span style="font-size: 0.9rem;">\u2728 ${g(c().categoryFeature)}</span>
+              </label>
+              <label class="bd-category-option" style="flex: 1; display: flex; align-items: center; gap: 6px; padding: 8px 12px; border: var(--bd-border-style); border-radius: var(--bd-radius-sm); cursor: pointer; transition: all 0.15s ease;">
+                <input type="radio" name="category" value="question" ${yt(n,"question")} style="accent-color: var(--bd-primary);" />
+                <span style="font-size: 0.9rem;">\u2753 ${g(c().categoryQuestion)}</span>
+              </label>
+            </div>
+          </div>
+          <div class="bd-form-group">
+            <label class="bd-label" for="title">${g(c().titleLabel)} *</label>
+            <input type="text" id="title" class="bd-input" required placeholder="${g(c().titlePlaceholder)}" value="${H(n?.title||"")}" />
+          </div>
+          <div class="bd-form-group">
+            <label class="bd-label" for="description">${g(c().descriptionLabel)}</label>
+            <textarea id="description" class="bd-textarea" placeholder="${g(c().descriptionPlaceholder)}">${H(n?.description||"")}</textarea>
+          </div>
+          ${o}
+          ${i}
+          <div class="bd-evidence-block">
+            <div class="bd-evidence-row">
+              ${pa(t,n)}
+              ${la()}
+            </div>
+            <input type="file" id="attachment-upload" accept="${nr.join(",")}" multiple class="bd-upload-input" />
+            <div id="attachment-list" class="bd-upload-list" aria-live="polite">${n?.attachments.length,""}</div>
+            <p id="attachment-error" class="bd-field-error" hidden></p>
+            ${ma(t,n)}
+          </div>
+          <div class="bd-actions">
+            <button type="button" class="bd-btn bd-btn-secondary" data-action="cancel">${g(c().cancel)}</button>
+            <button type="submit" class="bd-btn bd-btn-primary" id="submit-btn">${t.screenshotMode==="auto"?g(c().submit):g(c().continueButton)}</button>
+          </div>
+        </form>
+      `),s=a.querySelector("#feedback-form"),l=a.querySelector("#name"),d=a.querySelector("#email"),u=a.querySelector("#title"),m=a.querySelector("#description"),y=a.querySelector("#include-screenshot"),x=a.querySelector("#attachment-upload"),v=a.querySelector('[data-action="choose-uploads"]'),T=a.querySelector("#attachment-list"),k=a.querySelector("#attachment-error"),z=a.querySelector("#send-console-logs"),R=a.querySelector(".bd-close"),P=a.querySelector('[data-action="cancel"]'),M=[...n?.attachments??[]],A=()=>{a.remove(),r(null)};R?.addEventListener("click",A),P?.addEventListener("click",A),s.addEventListener("submit",C=>{if(C.preventDefault(),!u.value.trim()){u.classList.add("bd-input--error"),u.focus();return}if(t.requireName&&l&&!l.value.trim()){l.classList.add("bd-input--error"),l.focus();return}if(t.requireEmail&&d&&!d.value.trim()){d.classList.add("bd-input--error"),d.focus();return}let I=a.querySelector('input[name="category"]:checked')?.value||"bug",F=t.screenshotMode==="optional"?y?.checked??!1:!0;t.screenshotMode==="optional"&&F&&Ki(t.repo),a.remove(),r({title:u.value.trim(),description:m.value.trim(),category:I,name:l?.value.trim()||void 0,email:d?.value.trim()||void 0,includeScreenshot:F,attachments:M,sendConsoleLogs:z.checked})}),u.addEventListener("input",()=>u.classList.remove("bd-input--error")),l?.addEventListener("input",()=>l.classList.remove("bd-input--error")),d?.addEventListener("input",()=>d.classList.remove("bd-input--error"));let f=()=>{da(T,M,C=>{M=M.filter((D,I)=>I!==C),f()})};v.addEventListener("click",()=>x.click()),x.addEventListener("change",async()=>{let C=Array.from(x.files??[]);x.value="",k.textContent="",k.hidden=!0;let D=Xn-M.length;if(C.length>D){ft(k,c().uploadTooMany(Xn));return}for(let I of C){let F=ca(I);if(F){ft(k,F);return}}try{let I=await Promise.all(C.map(ua));M=[...M,...I],f()}catch{ft(k,c().uploadReadError)}}),f()})}function la(){return`
+    <div class="bd-upload-group">
+      <div class="bd-upload-row" aria-label="${g(c().uploadsAriaLabel)}">
+        <button type="button" class="bd-btn bd-btn-secondary bd-upload-button" data-action="choose-uploads" aria-label="${g(c().uploadFilesAriaLabel)}">
+          <svg class="bd-upload-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <path d="M8 11V3" />
+            <path d="M4.5 6.5 8 3l3.5 3.5" />
+            <path d="M3 12.5h10" />
+          </svg>
+          ${g(c().uploadButton)}
+        </button>
+      </div>
+    </div>
+  `}function ca(e){return nr.includes(e.type)?e.size>Yn?c().uploadTooLarge(kr(Yn)):null:c().uploadUnsupportedType}function ft(e,t){e.textContent=t,e.hidden=!1}function da(e,t,n){e.innerHTML=t.map((r,o)=>`
+        <div class="bd-upload-item">
+          <span class="bd-upload-item__name">${H(r.name)}</span>
+          <span class="bd-upload-item__meta">${kr(r.size)}</span>
+          <button type="button" class="bd-upload-remove" data-index="${o}" aria-label="${g(c().removeAttachmentAriaLabel(r.name))}">&times;</button>
+        </div>
+      `).join(""),e.querySelectorAll(".bd-upload-remove").forEach(r=>{r.addEventListener("click",()=>{let o=Number(r.dataset.index);Number.isInteger(o)&&n(o)})})}function ua(e){return new Promise((t,n)=>{let r=new FileReader;r.addEventListener("load",()=>{if(typeof r.result!="string"){n(new Error("Could not read file."));return}t({name:e.name,type:e.type,size:e.size,dataUrl:r.result})}),r.addEventListener("error",()=>n(new Error("Could not read file."))),r.readAsDataURL(e)})}function kr(e){return e<1024?`${e} B`:e<1024*1024?`${Math.round(e/1024)} KB`:`${Math.round(e/(1024*1024)*10)/10} MB`}function pa(e,t){if(e.screenshotMode==="auto"){let r=se()>0?` ${g(c().screenshotAutoRedactionNote)}`:"";return`
+      <p style="margin: 8px 0 0; color: var(--bd-text-secondary); font-size: 0.95rem;">
+        ${g(c().screenshotAutoNote)}${r}
+      </p>
+    `}return e.screenshotMode==="required"?`
+      <p style="margin: 8px 0 0; color: var(--bd-text-secondary); font-size: 0.95rem;">
+        ${g(c().screenshotRequiredNote)}
+      </p>
+    `:`
+    <div class="bd-screenshot-control">
+      <input type="checkbox" id="include-screenshot" ${t?.includeScreenshot??(!K()||!Xi(e.repo))?"checked":""} class="bd-checkbox" />
+      <label for="include-screenshot" class="bd-checkbox-label">
+        ${g(c().includeScreenshotLabel)}
+      </label>
+    </div>
+  `}function ma(e,t){return`
+    <div class="bd-form-group" style="display: flex; align-items: center; gap: 10px; margin-top: 8px;">
+      <input type="checkbox" id="send-console-logs" ${t?.sendConsoleLogs??e.sendConsoleLogs?"checked":""} style="width: 18px; height: 18px; accent-color: var(--bd-primary); cursor: pointer;" />
+      <label for="send-console-logs" style="font-size: 0.95rem; color: var(--bd-text-secondary); cursor: pointer; user-select: none;">
+        ${g(c().sendConsoleLogsLabel)}
+      </label>
+    </div>
+  `}function yt(e,t){return(e?.category||"bug")===t?"checked":""}async function Er(e,t,n){let r=_(e,c().submittingTitle,`
+      <div style="display: flex; flex-direction: column; align-items: center; padding: 20px;">
+        <div class="bd-spinner bd-spinner--lg"></div>
+        <p class="bd-loading-text" style="margin-top: 12px;">${g(c().creatingIssue)}</p>
+      </div>
+    `);try{let o=n.name||n.email?{name:n.name,email:n.email}:void 0,i=Wi(),a=Be(),s=n.sendConsoleLogs?jn():void 0,l=await fetch(`${t.apiUrl}/feedback`,{method:"POST",headers:{"Content-Type":"application/json",...await bt(t.authTokenProvider)},body:JSON.stringify({repo:t.repo,title:n.title,description:n.description,category:n.category,categoryLabels:t.categoryLabels,screenshot:n.screenshot,attachments:n.attachments,consoleLogs:s,submitter:o,metadata:{url:i.url,userAgent:navigator.userAgent,viewport:{width:window.innerWidth,height:window.innerHeight},timestamp:new Date().toISOString(),elementSelector:n.elementSelector,fullElementSelector:n.fullElementSelector,selectedElementHighlightColor:n.selectedElementHighlightColor||void 0,domNodeCount:a,fullPageDisabled:K(),browser:i.browser,os:i.os,devicePixelRatio:i.devicePixelRatio,language:i.language}})});if(r.remove(),l.status===429){let u=l.headers.get("Retry-After"),m=u?Math.ceil(parseInt(u,10)/60):15;wt(e,t,n,c().rateLimited(m));return}let d=await l.json();d.success?await Tn(e,d.issueNumber,d.issueUrl,d.isPublic??!1,t.issueLinkVisibility):wt(e,t,n,d.error||c().submitFailedFallback)}catch{r.remove(),wt(e,t,n,c().networkError)}}function wt(e,t,n,r){let o=_(e,c().submissionFailedTitle,`
+      <div class="bd-error-message">
+        <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-9.5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5.5zm0 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
+        </svg>
+        <span class="bd-error-message__text">${H(r)}</span>
+      </div>
+      <div class="bd-actions">
+        <button class="bd-btn bd-btn-secondary" data-action="cancel">${g(c().cancel)}</button>
+        <button class="bd-btn bd-btn-primary" data-action="retry">${g(c().tryAgain)}</button>
+      </div>
+    `,!0),i=o.querySelector(".bd-close"),a=o.querySelector('[data-action="cancel"]'),s=o.querySelector('[data-action="retry"]');i?.addEventListener("click",()=>o.remove()),a?.addEventListener("click",()=>o.remove()),s?.addEventListener("click",async()=>{o.remove(),await Er(e,t,n)})}})();

--- a/test/githubIssueCanary.test.ts
+++ b/test/githubIssueCanary.test.ts
@@ -32,12 +32,15 @@ function issue(overrides: Partial<Issue> = {}): Issue {
     html_url: `https://github.com/${REPO}/issues/${number}`,
     title: canaryTitle(MARKER),
     body: [
-      '## Description',
+      '## Canary marker',
+      '',
       MARKER,
       '',
       '<details>',
       '<summary>System Info</summary>',
       '</details>',
+      '',
+      `<!-- bugdrop-submission: ci:${MARKER} -->`,
       '',
       '---',
       '*Submitted via [BugDrop](https://github.com/mean-weasel/bugdrop)*',
@@ -60,6 +63,8 @@ function jsonResponse(value: unknown, init: ResponseInit = {}): Response {
 function result(overrides: Record<string, unknown> = {}) {
   return {
     marker: MARKER,
+    kind: 'structured',
+    submissionId: `ci:${MARKER}`,
     issueNumber: 42,
     issueUrl: `https://github.com/${REPO}/issues/42`,
     workerSha: SHA,
@@ -127,6 +132,22 @@ describe('GitHub Issue canary discovery and verification', () => {
   it.each([
     ['wrong title', issue({ title: `${CANARY_TITLE_PREFIX} wrong` })],
     ['missing body marker', issue({ body: '## Description\nmissing marker' })],
+    [
+      'legacy body shape',
+      issue({ body: issue().body.replace('## Canary marker', '## Description') }),
+    ],
+    [
+      'wrong structured submission marker',
+      issue({
+        body: issue().body.replace(`<!-- bugdrop-submission: ci:${MARKER} -->`, '<!-- wrong -->'),
+      }),
+    ],
+    [
+      'wrong structured section value with marker retained in submission comment',
+      issue({
+        body: issue().body.replace(`## Canary marker\n\n${MARKER}`, '## Canary marker\n\nwrong'),
+      }),
+    ],
     ['unexpected labels', issue({ labels: [{ name: 'bug' }] })],
     ['wrong author', issue({ user: { login: 'someone-else' } })],
     ['closed before verification', issue({ state: 'closed' })],
@@ -167,6 +188,8 @@ describe('GitHub Issue canary discovery and verification', () => {
   it.each([
     ['missing result', undefined],
     ['wrong marker', result({ marker: 'wrong-marker' })],
+    ['wrong kind', result({ kind: 'legacy' })],
+    ['wrong submission ID', result({ submissionId: 'wrong' })],
     ['wrong number', result({ issueNumber: 99 })],
     ['wrong URL', result({ issueUrl: `https://github.com/${REPO}/issues/99` })],
     ['wrong Worker SHA', result({ workerSha: 'b'.repeat(40) })],

--- a/test/legacyCompatibility.test.ts
+++ b/test/legacyCompatibility.test.ts
@@ -1,0 +1,84 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { gzipSync } from 'node:zlib';
+import { describe, expect, it } from 'vitest';
+
+interface BundleFixture {
+  bundle: string;
+  sha256: string;
+  rawBytes: number;
+  gzipBytes: number;
+}
+
+interface CompatibilityManifest {
+  provenancePolicy: string;
+  bundleBudget: {
+    baselineTag: string;
+    maxGzipGrowthPercent: number;
+    baselineRawBytes: number;
+    baselineGzipBytes: number;
+    maxGzipBytes: number;
+  };
+  bundles: Record<string, BundleFixture>;
+  legacyBootstrap: {
+    hostId: string;
+    shadowRootMode: string;
+    readyEvent: {
+      target: string;
+      count: number;
+      bubbles: boolean;
+      cancelable: boolean;
+      detail: null;
+    };
+    storageKeys: string[];
+  };
+}
+
+const root = new URL('../', import.meta.url);
+const manifest = JSON.parse(
+  readFileSync(new URL('test/fixtures/legacy-compat/manifest.json', root), 'utf8')
+) as CompatibilityManifest;
+
+describe('immutable legacy compatibility fixtures', () => {
+  it.each(Object.entries(manifest.bundles))(
+    '%s matches its recorded bytes and hashes',
+    (_tag, fixture) => {
+      const bundle = readFileSync(new URL(fixture.bundle, root));
+
+      expect(bundle.byteLength).toBe(fixture.rawBytes);
+      expect(createHash('sha256').update(bundle).digest('hex')).toBe(fixture.sha256);
+      expect(gzipSync(bundle, { level: 9 }).byteLength).toBe(fixture.gzipBytes);
+    }
+  );
+
+  it('records an explicit reconstruction disclaimer and a deterministic v1.53.1 budget', () => {
+    expect(manifest.provenancePolicy).toContain('not claimed to be byte-identical');
+    expect(manifest.bundleBudget.baselineTag).toBe('v1.53.1');
+    expect(manifest.bundleBudget.maxGzipBytes).toBe(
+      Math.ceil(
+        manifest.bundleBudget.baselineGzipBytes *
+          (1 + manifest.bundleBudget.maxGzipGrowthPercent / 100)
+      )
+    );
+  });
+
+  it('freezes the observable bootstrap and persistence boundary', () => {
+    expect(manifest.legacyBootstrap).toEqual({
+      hostId: 'bugdrop-host',
+      shadowRootMode: 'open',
+      readyEvent: {
+        target: 'window',
+        count: 1,
+        bubbles: false,
+        cancelable: false,
+        detail: null,
+      },
+      storageKeys: [
+        'bugdrop_dismissed',
+        'bugdrop_trigger_position_<repo>',
+        'bugdrop_welcomed_<repo>',
+        'bugdrop_complex_screenshot_skipped_<repo>',
+      ],
+    });
+  });
+});

--- a/test/structuredFeedback.test.ts
+++ b/test/structuredFeedback.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { Env, StructuredFeedbackPayload } from '../src/types';
+import { createBugDropAuthTokenForTest } from '../src/lib/authToken';
+
+const mockGetInstallationToken = vi.fn();
+const mockCreateIssue = vi.fn();
+const mockIsRepoPublic = vi.fn();
+
+class TestGitHubLabelError extends Error {
+  readonly status: number;
+  constructor(message: string, status = 422) {
+    super(message);
+    this.name = 'GitHubLabelError';
+    this.status = status;
+  }
+}
+
+vi.mock('../src/lib/github', () => ({
+  getInstallationToken: (...arguments_: unknown[]) => mockGetInstallationToken(...arguments_),
+  createIssue: (...arguments_: unknown[]) => mockCreateIssue(...arguments_),
+  isRepoPublic: (...arguments_: unknown[]) => mockIsRepoPublic(...arguments_),
+  uploadScreenshotAsAsset: vi.fn(),
+  uploadAttachmentAsAsset: vi.fn(),
+  GitHubLabelError: TestGitHubLabelError,
+}));
+
+const validPayload: StructuredFeedbackPayload = {
+  kind: 'bugdrop.variant-submission',
+  schemaVersion: 1,
+  repo: 'testowner/testrepo',
+  variantId: 'export-review',
+  submissionId: 'submission-1234',
+  issue: {
+    title: '  Export   review — 5/5  ',
+    classification: 'feedback',
+    sections: [
+      { heading: 'Rating', value: '5/5 *great*' },
+      { heading: 'Comment', value: 'Fast and predictable.', format: 'quote' },
+      { heading: 'Optional', value: '   ' },
+    ],
+  },
+  metadata: {
+    url: 'https://example.test/export?token=secret#private',
+    userAgent: 'FrozenAgent/1.0',
+    viewport: { width: 1280, height: 720 },
+    timestamp: '2026-08-02T12:34:56.000Z',
+    browser: { name: 'Chrome', version: '126.0' },
+    os: { name: 'macOS', version: '14.5' },
+    devicePixelRatio: 2,
+    language: 'en-US',
+  },
+};
+
+const expectedBody = `## Rating
+
+5/5 \\*great\\*
+
+## Comment
+
+> Fast and predictable.
+
+<details>
+<summary>System Info</summary>
+
+| Property | Value |
+|----------|-------|
+| **Browser** | Chrome 126.0 |
+| **OS** | macOS 14.5 |
+| **Viewport** | 1280×720 @2x |
+| **Language** | en-US |
+| **Page** | https://example.test/export |
+| **Timestamp** | 2026-08-02T12:34:56.000Z |
+
+</details>
+
+<!-- bugdrop-submission: submission-1234 -->
+
+---
+*Submitted via [BugDrop](https://github.com/mean-weasel/bugdrop)*`;
+
+describe('structured feedback Worker contract', () => {
+  let app: Hono;
+  const env: Env = {
+    GITHUB_APP_ID: 'test-app-id',
+    GITHUB_PRIVATE_KEY: 'test-private-key',
+    ENVIRONMENT: 'test',
+    ALLOWED_ORIGINS: '*',
+    GITHUB_APP_NAME: 'test-bugdrop-app',
+    MAX_SCREENSHOT_SIZE_MB: '5',
+    ASSETS: {} as Fetcher,
+  };
+
+  beforeEach(async () => {
+    mockGetInstallationToken.mockReset().mockResolvedValue('test-token');
+    mockCreateIssue.mockReset().mockResolvedValue({
+      number: 42,
+      html_url: 'https://github.com/testowner/testrepo/issues/42',
+    });
+    mockIsRepoPublic.mockReset().mockResolvedValue(true);
+    const { default: api } = await import('../src/routes/api');
+    app = api;
+  });
+
+  async function submit(payload: unknown, overrideEnv: Env = env) {
+    const request = new Request('http://localhost/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    return app.fetch(request, overrideEnv);
+  }
+
+  it('creates one Issue from a normalized field-agnostic draft', async () => {
+    const response = await submit(validPayload);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      issueNumber: 42,
+      issueUrl: 'https://github.com/testowner/testrepo/issues/42',
+      isPublic: true,
+    });
+    expect(mockCreateIssue).toHaveBeenCalledWith(
+      'test-token',
+      'testowner',
+      'testrepo',
+      'Export review — 5/5',
+      expectedBody,
+      ['bugdrop']
+    );
+    expect(mockGetInstallationToken).toHaveBeenCalledOnce();
+  });
+
+  it('shares the existing auth-token boundary before GitHub access', async () => {
+    const protectedEnv = {
+      ...env,
+      AUTH_TOKEN_SECRET: 'structured-secret-with-at-least-32-bytes',
+    };
+
+    const response = await submit(validPayload, protectedEnv);
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'BugDrop auth token required' });
+    expect(mockGetInstallationToken).not.toHaveBeenCalled();
+  });
+
+  it('accepts a structured submission with a repo-bound existing auth token', async () => {
+    const protectedEnv = {
+      ...env,
+      AUTH_TOKEN_SECRET: 'structured-secret-with-at-least-32-bytes',
+    };
+    const now = Math.floor(Date.now() / 1000);
+    const token = await createBugDropAuthTokenForTest(
+      {
+        sub: 'structured-user',
+        repo: validPayload.repo,
+        iat: now,
+        exp: now + 300,
+        jti: 'structured-jti',
+      },
+      protectedEnv.AUTH_TOKEN_SECRET
+    );
+    const request = new Request('http://localhost/feedback', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(validPayload),
+    });
+
+    const response = await app.fetch(request, protectedEnv);
+
+    expect(response.status).toBe(200);
+    expect(mockCreateIssue).toHaveBeenCalledOnce();
+  });
+
+  it('resolves custom labels only from server-owned repo and variant configuration', async () => {
+    const response = await submit(validPayload, {
+      ...env,
+      VARIANT_LABELS: JSON.stringify({
+        'testowner/testrepo': { 'export-review': ['feedback', 'rating', 'feedback'] },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockCreateIssue.mock.calls[0][5]).toEqual(['feedback', 'rating', 'bugdrop']);
+    expect(await response.json()).not.toHaveProperty('labelMappingWarnings');
+  });
+
+  it('falls back to classification labels and surfaces unknown configured variants', async () => {
+    const payload = structuredClone(validPayload);
+    payload.issue.classification = 'feature';
+    const response = await submit(payload, {
+      ...env,
+      VARIANT_LABELS: JSON.stringify({
+        'testowner/testrepo': { 'another-variant': ['triage'] },
+      }),
+    });
+    const body = mockCreateIssue.mock.calls[0][4] as string;
+    const result = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockCreateIssue.mock.calls[0][5]).toEqual(['enhancement', 'bugdrop']);
+    expect(body).toContain('## Label mapping warning');
+    expect(result.labelMappingWarnings).toHaveLength(1);
+  });
+
+  it('retries a GitHub label rejection once with safe classification defaults', async () => {
+    mockCreateIssue
+      .mockRejectedValueOnce(new TestGitHubLabelError('invalid labels'))
+      .mockResolvedValueOnce({
+        number: 42,
+        html_url: 'https://github.com/testowner/testrepo/issues/42',
+      });
+    const payload = structuredClone(validPayload);
+    payload.issue.classification = 'bug';
+    const response = await submit(payload, {
+      ...env,
+      VARIANT_LABELS: JSON.stringify({
+        'testowner/testrepo': { 'export-review': ['custom-label'] },
+      }),
+    });
+    const result = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockCreateIssue).toHaveBeenCalledTimes(2);
+    expect(mockCreateIssue.mock.calls[0][5]).toEqual(['custom-label', 'bugdrop']);
+    expect(mockCreateIssue.mock.calls[1][5]).toEqual(['bug', 'bugdrop']);
+    expect(mockCreateIssue.mock.calls[1][4]).toContain('GitHub rejected configured labels');
+    expect(result.labelMappingWarnings).toHaveLength(1);
+  });
+
+  it.each([
+    ['unsupported schema', { ...validPayload, schemaVersion: 2 }],
+    ['raw labels', { ...validPayload, labels: ['privileged'] }],
+    ['label set', { ...validPayload, issue: { ...validPayload.issue, labelSet: 'admin' } }],
+    ['evidence', { ...validPayload, screenshot: 'data:image/png;base64,AAAA' }],
+    [
+      'duplicate headings',
+      {
+        ...validPayload,
+        issue: {
+          ...validPayload.issue,
+          sections: [
+            { heading: 'Same', value: 'one' },
+            { heading: 'same', value: 'two' },
+          ],
+        },
+      },
+    ],
+    [
+      'nested section value',
+      {
+        ...validPayload,
+        issue: {
+          ...validPayload.issue,
+          sections: [{ heading: 'Nested', value: { unsafe: true } }],
+        },
+      },
+    ],
+    [
+      'invalid metadata',
+      {
+        ...validPayload,
+        metadata: { ...validPayload.metadata, viewport: { width: NaN, height: 1 } },
+      },
+    ],
+  ])('rejects %s before any GitHub call', async (_name, payload) => {
+    const response = await submit(payload);
+
+    expect(response.status).toBe(400);
+    expect(mockGetInstallationToken).not.toHaveBeenCalled();
+    expect(mockCreateIssue).not.toHaveBeenCalled();
+  });
+
+  it('enforces the complete 32 KB payload bound independently of per-section bounds', async () => {
+    const payload = structuredClone(validPayload);
+    payload.issue.sections = Array.from({ length: 7 }, (_, index) => ({
+      heading: `Section ${index}`,
+      value: 'x'.repeat(5_000),
+      format: 'text' as const,
+    }));
+
+    const response = await submit(payload);
+    const result = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(result.error).toContain('32768 bytes');
+    expect(mockGetInstallationToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects escaped output beyond GitHub body limits before Issue creation', async () => {
+    const payload = structuredClone(validPayload);
+    payload.issue.sections = Array.from({ length: 6 }, (_, index) => ({
+      heading: `${'#'.repeat(100)}${index}`,
+      value: '*'.repeat(4_400),
+      format: 'text' as const,
+    }));
+    payload.metadata.url = `https://example.test/${'é'.repeat(1_900)}`;
+    expect(new TextEncoder().encode(JSON.stringify(payload)).byteLength).toBeLessThan(32 * 1_024);
+
+    const response = await submit(payload);
+    const result = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(result.error).toContain('65536 characters after formatting');
+    expect(mockCreateIssue).not.toHaveBeenCalled();
+  });
+
+  it('uses a fence longer than user backticks and never emits empty optional sections', async () => {
+    const payload = structuredClone(validPayload);
+    payload.issue.sections = [
+      { heading: 'Code', value: 'before ``` after', format: 'code' },
+      { heading: 'Empty', value: '\n\t' },
+    ];
+
+    const response = await submit(payload);
+    const body = mockCreateIssue.mock.calls[0][4] as string;
+
+    expect(response.status).toBe(200);
+    expect(body).toContain('````\nbefore ``` after\n````');
+    expect(body).not.toContain('## Empty');
+  });
+
+  it('does not report success for a non-canonical GitHub Issue result', async () => {
+    mockCreateIssue.mockResolvedValue({
+      number: 0,
+      html_url: 'https://attacker.test/not-an-issue',
+    });
+
+    const response = await submit(validPayload);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'GitHub returned an invalid Issue result' });
+  });
+});

--- a/test/variantConfig.test.ts
+++ b/test/variantConfig.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import type { VariantConfig } from '../src/widget/variants/public-types';
+import { validateAndFreezeVariantConfig } from '../src/widget/variants/validate-config';
+
+function config(): VariantConfig {
+  return {
+    id: 'export-review',
+    presentation: { kind: 'inline' },
+    content: { title: 'How was this export?' },
+    fields: [
+      { id: 'rating', type: 'rating', label: 'Rating', required: true, scale: 5 },
+      { id: 'message', type: 'longText', label: 'Comment', maxLength: 1_000 },
+    ],
+    issue: {
+      classification: 'feedback',
+      title: '[Export] {{rating}}/5 {{context.surface}}',
+      sections: [
+        { heading: 'Rating', field: 'rating', format: 'stars' },
+        { heading: 'Comment', field: 'message', omitWhenEmpty: true },
+      ],
+    },
+  };
+}
+
+describe('variant config validation', () => {
+  it('returns a deeply immutable copy', () => {
+    const source = config();
+    const frozen = validateAndFreezeVariantConfig(source);
+    source.content.title = 'mutated';
+
+    expect(frozen.content.title).toBe('How was this export?');
+    expect(Object.isFrozen(frozen)).toBe(true);
+    expect(Object.isFrozen(frozen.fields)).toBe(true);
+    expect(Object.isFrozen(frozen.fields[0])).toBe(true);
+  });
+
+  it.each([
+    ['reserved id', { ...config(), id: 'legacy' }],
+    ['invalid id', { ...config(), id: 'Export Review' }],
+    ['non-string id', { ...config(), id: null }],
+    ['unsupported config version', { ...config(), configVersion: 2 }],
+    ['duplicate fields', { ...config(), fields: [config().fields[0], config().fields[0]] }],
+    ['unknown title field', { ...config(), issue: { ...config().issue, title: '{{missing}}' } }],
+    [
+      'unknown section field',
+      {
+        ...config(),
+        issue: { ...config().issue, sections: [{ heading: 'Missing', field: 'missing' }] },
+      },
+    ],
+    ['unknown top-level property', { ...config(), unsafe: true }],
+    ['invalid presentation columns', { ...config(), presentation: { kind: 'inline', columns: 3 } }],
+    [
+      'invalid inline presentation property',
+      { ...config(), presentation: { kind: 'inline', size: 'wide' } },
+    ],
+    ['invalid appearance theme', { ...config(), appearance: { theme: 'sepia' } }],
+    ['invalid appearance accent', { ...config(), appearance: { accentColor: '' } }],
+    [
+      'invalid optional content copy',
+      { ...config(), content: { ...config().content, submitLabel: 42 } },
+    ],
+    [
+      'non-boolean required flag',
+      {
+        ...config(),
+        fields: [{ ...config().fields[0], required: 'false' }, config().fields[1]],
+      },
+    ],
+    [
+      'invalid field layout',
+      { ...config(), fields: [{ ...config().fields[0], layout: { span: 3 } }] },
+    ],
+    ['invalid long-text rows', { ...config(), fields: [{ ...config().fields[1], rows: 0 }] }],
+    ['null text bound', { ...config(), fields: [{ ...config().fields[1], minLength: null }] }],
+    ['invalid rating icon', { ...config(), fields: [{ ...config().fields[0], icon: 'heart' }] }],
+    [
+      'invalid choice display',
+      {
+        ...config(),
+        fields: [
+          {
+            id: 'choice',
+            type: 'singleChoice',
+            label: 'Choice',
+            options: [
+              { value: 'a', label: 'A' },
+              { value: 'b', label: 'B' },
+            ],
+            display: 'select',
+          },
+        ],
+      },
+    ],
+    [
+      'invalid section format',
+      {
+        ...config(),
+        issue: {
+          ...config().issue,
+          sections: [{ heading: 'Rating', field: 'rating', format: 'html' }],
+        },
+      },
+    ],
+    [
+      'null section format',
+      {
+        ...config(),
+        issue: {
+          ...config().issue,
+          sections: [{ heading: 'Rating', field: 'rating', format: null }],
+        },
+      },
+    ],
+    ['null sections', { ...config(), issue: { ...config().issue, sections: null } }],
+    [
+      'format incompatible with field type',
+      {
+        ...config(),
+        issue: {
+          ...config().issue,
+          sections: [{ heading: 'Comment', field: 'message', format: 'stars' }],
+        },
+      },
+    ],
+    [
+      'non-boolean omitWhenEmpty',
+      {
+        ...config(),
+        issue: {
+          ...config().issue,
+          sections: [{ heading: 'Comment', field: 'message', omitWhenEmpty: 'yes' }],
+        },
+      },
+    ],
+    [
+      'ambiguous section reference',
+      {
+        ...config(),
+        issue: {
+          ...config().issue,
+          sections: [{ heading: 'Both', field: 'rating', context: 'surface' }],
+        },
+      },
+    ],
+  ])('rejects %s synchronously', (_name, invalid) => {
+    expect(() => validateAndFreezeVariantConfig(invalid as VariantConfig)).toThrow(TypeError);
+  });
+});

--- a/test/variantIssueDraft.test.ts
+++ b/test/variantIssueDraft.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import type { VariantConfig } from '../src/widget/variants/public-types';
+import { compileIssueDraft } from '../src/widget/variants/issue-draft';
+
+const config: VariantConfig = {
+  id: 'next-integration-poll',
+  presentation: { kind: 'inline' },
+  content: { title: 'What next?' },
+  fields: [
+    { id: 'rating', type: 'rating', label: 'Rating', scale: 5, required: true },
+    {
+      id: 'choice',
+      type: 'singleChoice',
+      label: 'Choice',
+      required: true,
+      options: [
+        { value: 'gcp', label: 'Google Cloud' },
+        { value: 'azure', label: 'Microsoft Azure' },
+      ],
+    },
+    { id: 'detail', type: 'longText', label: 'Detail', maxLength: 500 },
+  ],
+  issue: {
+    classification: 'feature',
+    title: 'Vote — {{choice}} — {{context.surface}}',
+    sections: [
+      { heading: 'Rating', field: 'rating', format: 'stars' },
+      { heading: 'Choice', field: 'choice', format: 'choice' },
+      { heading: 'Detail', field: 'detail', omitWhenEmpty: true },
+      { heading: 'Surface', context: 'surface', format: 'code' },
+    ],
+  },
+};
+
+describe('variant Issue draft compilation', () => {
+  it('normalizes fields into the field-agnostic Worker draft', () => {
+    expect(
+      compileIssueDraft(config, { rating: 4, choice: 'gcp', detail: '  ' }, { surface: 'settings' })
+    ).toEqual({
+      title: 'Vote — gcp — settings',
+      classification: 'feature',
+      sections: [
+        { heading: 'Rating', value: '★★★★☆ (4/5)', format: 'text' },
+        { heading: 'Choice', value: 'Google Cloud', format: 'text' },
+        { heading: 'Surface', value: 'settings', format: 'code' },
+      ],
+    });
+  });
+
+  it('validates required, choice, rating, unknown-answer, and context boundaries', () => {
+    expect(() => compileIssueDraft(config, { choice: 'gcp' })).toThrow('rating is required');
+    expect(() =>
+      compileIssueDraft(
+        {
+          ...config,
+          fields: [{ id: 'detail', type: 'longText', label: 'Detail', required: true }],
+          issue: { title: 'Required text' },
+        },
+        { detail: '   ' }
+      )
+    ).toThrow('detail is required');
+    expect(() => compileIssueDraft(config, { rating: 6, choice: 'gcp' })).toThrow(
+      'rating from 1-5'
+    );
+    expect(() => compileIssueDraft(config, { rating: 5, choice: 'aws' })).toThrow(
+      'configured choice'
+    );
+    expect(() => compileIssueDraft(config, { rating: 5, choice: 'gcp', injected: true })).toThrow(
+      'Unknown BugDrop variant answer'
+    );
+    expect(() =>
+      compileIssueDraft(config, { rating: 5, choice: 'gcp' }, { invalidKey: true })
+    ).toThrow('Invalid context key');
+  });
+
+  it('keeps a visible placeholder unless an empty section is explicitly omitted', () => {
+    expect(
+      compileIssueDraft(
+        {
+          ...config,
+          issue: {
+            title: 'Optional sections',
+            sections: [
+              { heading: 'Visible empty', field: 'detail' },
+              { heading: 'Omitted empty', field: 'detail', omitWhenEmpty: true },
+            ],
+          },
+        },
+        { rating: 5, choice: 'gcp', detail: '' }
+      ).sections
+    ).toEqual([{ heading: 'Visible empty', value: 'Not provided.', format: 'text' }]);
+  });
+
+  it('bounds the compiled title after placeholder expansion', () => {
+    const longTitleConfig = {
+      ...config,
+      issue: { ...config.issue, title: '{{detail}}' },
+    };
+    const draft = compileIssueDraft(longTitleConfig, {
+      rating: 5,
+      choice: 'gcp',
+      detail: 'x'.repeat(500),
+    });
+
+    expect(draft.title).toHaveLength(256);
+  });
+});

--- a/test/variantPublicTypes.test.ts
+++ b/test/variantPublicTypes.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import type {
+  BugDropPublicAPI,
+  SubmissionResult,
+  VariantConfig,
+  VariantHandle,
+} from '../src/widget/public-api';
+
+describe('published variant API declarations', () => {
+  it('type-checks registration and headless submission without runtime imports', () => {
+    expectTypeOf<BugDropPublicAPI['registerVariant']>().parameter(0).toMatchTypeOf<VariantConfig>();
+    expectTypeOf<ReturnType<BugDropPublicAPI['registerVariant']>>().toEqualTypeOf<VariantHandle>();
+    expectTypeOf<ReturnType<VariantHandle['submit']>>().toEqualTypeOf<Promise<SubmissionResult>>();
+    expect(true).toBe(true);
+  });
+
+  it('resolves the public declarations from an actual packed package', () => {
+    const temporaryRoot = mkdtempSync(join(tmpdir(), 'bugdrop-types-'));
+    try {
+      const packOutput = execFileSync(
+        'npm',
+        ['pack', '--ignore-scripts', '--pack-destination', temporaryRoot, '--json'],
+        { cwd: process.cwd(), encoding: 'utf8' }
+      );
+      const [{ filename }] = JSON.parse(packOutput) as Array<{ filename: string }>;
+      const packageRoot = join(temporaryRoot, 'node_modules', 'bugdrop');
+      mkdirSync(packageRoot, { recursive: true });
+      execFileSync(
+        'tar',
+        ['-xzf', join(temporaryRoot, filename), '--strip-components=1', '-C', packageRoot],
+        { stdio: 'pipe' }
+      );
+      writeFileSync(
+        join(temporaryRoot, 'consumer.ts'),
+        [
+          "import type { BugDropPublicAPI, VariantConfig } from 'bugdrop';",
+          "import type { VariantHandle } from 'bugdrop/widget';",
+          "import type { SubmissionResult } from 'bugdrop/widget.js';",
+          'declare const api: BugDropPublicAPI;',
+          'declare const config: VariantConfig;',
+          'const handle: VariantHandle = api.registerVariant(config);',
+          'const result: Promise<SubmissionResult> = handle.submit({});',
+          'void result;',
+        ].join('\n')
+      );
+      execFileSync(
+        resolve('node_modules/.bin/tsc'),
+        [
+          '--noEmit',
+          '--strict',
+          '--module',
+          'ESNext',
+          '--moduleResolution',
+          'Bundler',
+          '--target',
+          'ES2022',
+          join(temporaryRoot, 'consumer.ts'),
+        ],
+        { cwd: temporaryRoot, stdio: 'pipe' }
+      );
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -38,6 +38,7 @@ preview_id = "ff8f3809037d4403befd09369a9f7e36"
 # GITHUB_APP_ID
 # GITHUB_PRIVATE_KEY
 # AUTH_TOKEN_SECRET  # Optional: set to require signed host-app auth tokens for /feedback
+# VARIANT_LABELS  # Optional: JSON object keyed by repo, then structured variant ID
 # BUGDROP_BOARD_TOKEN_SECRET  # Optional: enables /board embedded demo token signing
 
 # Preview environment for live E2E tests (deployed in merge queue)


### PR DESCRIPTION
## Summary

- freeze tag-reconstructed v1.1.0 and v1.53.1 legacy compatibility contracts and enforce the widget size budget
- add the field-agnostic structured Worker path with server-owned variant labels
- publish lazy headless `registerVariant().submit()` APIs and resolvable `.d.ts` declarations without rendered Phase 2 UI
- upgrade the existing single merge-group canary to submit and independently verify one structured GitHub Issue

## Compatibility

The current script-tag widget, legacy API, payload, response, Issue formatting, DOM, storage, and ready-event contracts remain intact. Variant work is lazy and only starts after explicit registration. No storage, service, or backend infrastructure is added.

## Verification

- `npm test` — 30 files, 442 tests
- `npm run typecheck`
- `npm run lint`
- `npm run knip`
- `node scripts/verify-legacy-compat.mjs`
- `bash test/ci-workflow-contract.test.sh`
- both tag-reconstructed bundles pass Chromium compatibility E2E
- isolated multi-registration and malformed-response browser tests pass
- rebuilt widget: 46,440 bytes gzip (52,597-byte ceiling)
- real-Issue canary suite lists exactly one zero-retry test

## Scope

Rendered modal and inline variant UXs remain explicitly deferred to Phase 2. This PR lands only the backward-compatible compatibility, contract, headless transport, and live-proof foundation.