### PR TITLE
fix: preserve canary attempt cleanup sentinel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
         run: |
           echo "BUGDROP_CANARY_MARKER=bugdrop-ci-canary:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${GITHUB_SHA}" >> "$GITHUB_ENV"
           echo "BUGDROP_CANARY_RESULT_FILE=test-results/issue-canary-result.json" >> "$GITHUB_ENV"
-          echo "BUGDROP_CANARY_ATTEMPT_FILE=test-results/issue-canary-attempted" >> "$GITHUB_ENV"
+          echo "BUGDROP_CANARY_ATTEMPT_FILE=$RUNNER_TEMP/bugdrop-canary-attempt-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
           echo "EXACT_WIDGET_FIXTURE_PATH=$RUNNER_TEMP/bugdrop-exact-preview-widget-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.js" >> "$GITHUB_ENV"
           echo "EXPECTED_WORKER_SHA=${GITHUB_SHA}" >> "$GITHUB_ENV"
           echo "EXPECTED_WIDGET_ORIGIN=https://bugdrop-preview.neonwatty.workers.dev" >> "$GITHUB_ENV"

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -153,6 +153,11 @@ sed -n "${cleanup_line},$((cleanup_line + 12))p" "$ci_workflow" | grep -Fq -- '-
   fail 'cleanup must not depend on the browser result file'
 grep -Fq ': > "$BUGDROP_CANARY_ATTEMPT_FILE"' <<< "$critical" ||
   fail 'the canary does not record that its browser action started'
+grep -Fq 'BUGDROP_CANARY_ATTEMPT_FILE=$RUNNER_TEMP/bugdrop-canary-attempt-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}' <<< "$critical" ||
+  fail 'the canary attempt sentinel must use an ephemeral run- and attempt-specific path'
+if grep -Fq 'BUGDROP_CANARY_ATTEMPT_FILE=test-results/' <<< "$critical"; then
+  fail 'the canary attempt sentinel must not live in Playwright outputDir'
+fi
 sed -n "${cleanup_line},$((cleanup_line + 12))p" "$ci_workflow" |
   grep -Fq 'if [ ! -f "$BUGDROP_CANARY_ATTEMPT_FILE" ]' ||
   fail 'current-marker cleanup does not distinguish a skipped canary from an attempted canary'


### PR DESCRIPTION
## Summary

- keep the canary-attempt sentinel in the ephemeral runner temp directory
- make its path unique to the GitHub run and attempt
- lock the safe location into the CI workflow contract

## Root cause

The merge-queue canary wrote its attempt sentinel under `test-results`, which is Playwright’s configured output directory. Playwright clears that directory before the browser test, so marker-specific cleanup could incorrectly conclude that no canary was attempted. The final reserved-prefix sweep still closed Issue #581 and proved that no matching Issue remained open.

## Verification

- `bash test/ci-workflow-contract.test.sh`
- `npm run format:check`
- `npm run typecheck` (pre-push)
- `git diff --check`

The merge-group run is the acceptance oracle: it must create and independently verify exactly one structured Issue, report that Issue in both `matchedNumbers` and `closedNumbers` during current-marker cleanup, and then report an empty final open-Issue sweep.