### PR TITLE
Add configurable feedback variants

### DIFF
--- a/docs/merge-queue-issue-canary.md
+++ b/docs/merge-queue-issue-canary.md
@@ -1,8 +1,8 @@
 # Merge-Queue Issue Canary Operations
 
 The CI workflow runs one real-Issue canary only for GitHub `merge_group` events. It uses the fixed
-Vercel preview venue, the shared `bugdrop-preview` Worker, the deployed widget's headless structured
-API, and the existing BugDrop GitHub App. Pull requests, manual and reusable live workflows, the
+Vercel preview venue, the shared `bugdrop-preview` Worker, the deployed widget's rendered CTA
+variant, and the existing BugDrop GitHub App. Pull requests, manual and reusable live workflows, the
 daily live workflow, and local Playwright commands do not select the canary. The Phase 0 run remains
 the retained live proof for the legacy form; the routine action was replaced rather than duplicated.
 
@@ -24,8 +24,13 @@ The marker format is:
 bugdrop-ci-canary:<run-id>:<run-attempt>:<full-merge-group-sha>
 ```
 
-The browser registers one headless canary variant and sends exactly one screenshot-free structured
-request. It asserts the discriminator, schema version, generic Issue draft, server-owned label
+Before the mutating canary, two nonmutating live tests render the inline star review and CTA text
+modal from the exact deployed widget bytes. Each intercepts its only feedback POST, prevents it from
+reaching the Worker, and asserts the complete normalized Issue draft and explicit-submit behavior.
+
+The canary browser then opens one rendered CTA modal and activates its explicit Submit button once,
+sending exactly one screenshot-free structured request. It asserts the discriminator, schema
+version, generic Issue draft, server-owned label
 boundary, submission ID, request origin, response origin, full Worker build SHA, positive Issue
 number, and canonical Issue URL. The server-side verifier independently lists repository Issues,
 rejects duplicates and pull requests, and checks the structured section, exact submission marker,

--- a/docs/website/javascript-api.mdx
+++ b/docs/website/javascript-api.mdx
@@ -142,12 +142,12 @@ If your code runs after the page is fully loaded and you want to check whether B
 
 This "check first, listen second" pattern is useful in single-page applications where your code might run at various points in the page lifecycle.
 
-## Headless Variants
+## Configurable Variants
 
-Use a registered variant when your application owns the UI but should reuse BugDrop's validation,
+Use a registered variant for a focused feedback experience while reusing BugDrop's validation,
 metadata, auth, Worker policy, and GitHub Issue creation. Registration validates synchronously and
 stores an immutable copy. The variant sidecar does no DOM, listener, observer, storage, or ID work
-until registration or submission requires it.
+until a variant is mounted or submitted.
 
 ```js
 const review = window.BugDrop.registerVariant({
@@ -168,6 +168,68 @@ const review = window.BugDrop.registerVariant({
   },
 });
 
+const mountedReview = review.mount(document.querySelector('#export-review-slot'), {
+  context: { surface: 'export-complete' },
+});
+
+// Later, restore the form to its initial state or remove this instance only.
+mountedReview.reset();
+mountedReview.unmount();
+```
+
+The inline renderer provides accessible short-text, long-text, and rating controls. Choosing a star
+changes only local form state; it never submits. A GitHub Issue is created only after the explicit
+Submit button succeeds.
+
+For a host-owned CTA, register a modal variant and call its handle instead of the legacy
+`BugDrop.open()` method:
+
+```js
+const providerQuestion = window.BugDrop.registerVariant({
+  id: 'cloud-provider-question',
+  presentation: { kind: 'modal', size: 'compact' },
+  content: {
+    title: 'Which cloud provider should we support next?',
+    description: 'Tell us what would fit your workflow.',
+    submitLabel: 'Send idea',
+    cancelLabel: 'Not now',
+  },
+  fields: [
+    {
+      id: 'response',
+      type: 'longText',
+      label: 'Your answer',
+      required: true,
+      minLength: 2,
+      maxLength: 1000,
+    },
+  ],
+  issue: {
+    classification: 'feature',
+    title: 'Cloud provider request — {{response}}',
+    sections: [{ heading: 'Requested provider or workflow', field: 'response' }],
+  },
+});
+
+document.querySelector('#provider-cta').addEventListener('click', () => {
+  const opened = providerQuestion.open({ context: { surface: 'studio-upload' } });
+  opened.result.then(outcome => console.log(outcome.status));
+});
+```
+
+The modal traps focus, closes on Escape, restores focus and page scrolling, and settles its result
+as `submitted`, `closed`, or `busy`. A variant requested while the legacy wizard is active returns
+`busy`. Opening the legacy wizard while a variant modal is active closes the variant first. The
+legacy `BugDrop.close()` method remains legacy-scoped.
+
+BugDrop's merge-queue preview checks render both this CTA modal and the inline star review from the
+exact deployed widget bytes. They assert each normalized draft without creating Issues, followed by
+one zero-retry rendered CTA canary that creates, independently verifies, closes, and sweeps one real
+GitHub Issue through the existing GitHub App.
+
+If your application owns the UI, the same immutable handle also supports headless submission:
+
+```js
 const result = await review.submit(
   { rating: 5, message: 'Fast and clear.' },
   { context: { surface: 'export-complete' } }
@@ -175,9 +237,8 @@ const result = await review.submit(
 console.log(result.issueNumber, result.issueUrl);
 ```
 
-Selecting or changing a value in host UI never submits. Only `submit()` sends a request. Rendered
-`open()` and `mount()` variants are not part of the Phase 1 headless foundation. TypeScript consumers
-can import `VariantConfig`, `VariantHandle`, and related declarations from the `bugdrop` package.
+TypeScript consumers can import `VariantConfig`, `VariantHandle`, `MountedVariant`, and related
+declarations from the `bugdrop` package.
 
 ## Keyboard Shortcut Example
 

--- a/e2e/variant-accessibility.radix.spec.ts
+++ b/e2e/variant-accessibility.radix.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from '@playwright/test';
+
+test('rating keyboard behavior requires explicit Submit', async ({ page }) => {
+  let submissionCount = 0;
+  await page.route('**/feedback', route => {
+    if (route.request().method() !== 'POST') return route.continue();
+    submissionCount += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        issueNumber: 301,
+        issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/301',
+        isPublic: false,
+      }),
+    });
+  });
+  await page.goto('/test/');
+  await expect
+    .poll(() => page.evaluate(() => typeof window.BugDrop?.registerVariant))
+    .toBe('function');
+  await page.evaluate(() => {
+    const slot = document.createElement('div');
+    slot.id = 'cross-browser-rating-slot';
+    document.body.appendChild(slot);
+    window
+      .BugDrop!.registerVariant({
+        id: 'cross-browser-rating',
+        presentation: { kind: 'inline' },
+        content: { title: 'Rate accessibility', submitLabel: 'Submit rating' },
+        fields: [{ id: 'rating', type: 'rating', label: 'Rating', required: true, scale: 5 }],
+        issue: { title: 'Accessibility rating {{rating}}' },
+      })
+      .mount(slot);
+  });
+
+  const host = page.locator('#cross-browser-rating-slot > [data-bugdrop-owned]');
+  const rating = host.getByRole('radiogroup', { name: 'Rating' });
+  const submit = host.getByRole('button', { name: 'Submit rating' });
+  await submit.click();
+  await expect(rating).toHaveAttribute('aria-invalid', 'true');
+  const first = rating.getByRole('radio', { name: '1 star' });
+  await expect(first).toBeFocused();
+  await first.press('ArrowRight');
+  const second = rating.getByRole('radio', { name: '2 stars' });
+  await expect(second).toBeFocused();
+  await expect(second).toHaveAttribute('aria-checked', 'true');
+  await second.press('Enter');
+  await second.press('Space');
+  expect(submissionCount).toBe(0);
+  await submit.click();
+  await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+  expect(submissionCount).toBe(1);
+});
+
+test('modal focus is contained and Escape restores the host page', async ({ page }) => {
+  await page.goto('/test/');
+  await expect
+    .poll(() => page.evaluate(() => typeof window.BugDrop?.registerVariant))
+    .toBe('function');
+  await page.evaluate(() => {
+    document.body.style.overflow = 'clip';
+    const cta = document.createElement('button');
+    cta.id = 'cross-browser-modal-cta';
+    cta.textContent = 'Open provider question';
+    document.body.appendChild(cta);
+    const handle = window.BugDrop!.registerVariant({
+      id: 'cross-browser-modal',
+      presentation: { kind: 'modal', size: 'compact' },
+      content: { title: 'Provider question', submitLabel: 'Send', cancelLabel: 'Not now' },
+      fields: [{ id: 'response', type: 'longText', label: 'Your answer', required: true }],
+      issue: { title: 'Provider {{response}}' },
+    });
+    cta.addEventListener('click', () => {
+      const opened = handle.open();
+      opened.result.then(outcome => {
+        (
+          window as Window & {
+            __crossBrowserModalOutcome?: string;
+          }
+        ).__crossBrowserModalOutcome = outcome.status;
+      });
+    });
+  });
+
+  const cta = page.getByRole('button', { name: 'Open provider question' });
+  await cta.focus();
+  await page.keyboard.press('Enter');
+  const host = page.locator('body > [data-bugdrop-owned]');
+  await expect(host.getByRole('dialog', { name: 'Provider question' })).toBeVisible();
+  await expect(host.getByRole('textbox', { name: 'Your answer' })).toBeFocused();
+  await host.getByRole('button', { name: 'Not now' }).focus();
+  await page.keyboard.press('Tab');
+  await expect(host.getByRole('button', { name: 'Close' })).toBeFocused();
+  await page.keyboard.press('Escape');
+  await expect(host).toHaveCount(0);
+  await expect(cta).toBeFocused();
+  await expect.poll(() => page.evaluate(() => document.body.style.overflow)).toBe('clip');
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as Window & { __crossBrowserModalOutcome?: string }).__crossBrowserModalOutcome
+      )
+    )
+    .toBe('closed');
+});

--- a/e2e/variant-inline.spec.ts
+++ b/e2e/variant-inline.spec.ts
@@ -1,0 +1,225 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('rendered inline variants', () => {
+  test('submits an exact star-review draft only after explicit Submit and supports reset', async ({
+    page,
+  }) => {
+    const submissions: Array<Record<string, unknown>> = [];
+    await page.route('**/api/feedback', route => {
+      submissions.push(route.request().postDataJSON() as Record<string, unknown>);
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          issueNumber: 104,
+          issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/104',
+          isPublic: true,
+        }),
+      });
+    });
+    await page.goto('/test/?private=redacted#secret');
+    await page.locator('#bugdrop-host').locator('css=.bd-trigger').waitFor();
+    await page.evaluate(() => {
+      const slot = document.createElement('div');
+      slot.id = 'export-review-slot';
+      document.body.appendChild(slot);
+      const handle = window.BugDrop!.registerVariant({
+        id: 'export-review-rendered',
+        presentation: { kind: 'inline' },
+        content: {
+          title: 'How was this export?',
+          description: 'Your feedback helps us improve exports.',
+          submitLabel: 'Submit review',
+          successTitle: 'Thanks for the review!',
+        },
+        fields: [
+          {
+            id: 'rating',
+            type: 'rating',
+            label: 'Rating',
+            required: true,
+            scale: 5,
+            icon: 'star',
+          },
+          {
+            id: 'message',
+            type: 'longText',
+            label: 'Anything else?',
+            maxLength: 1000,
+          },
+        ],
+        issue: {
+          classification: 'feedback',
+          title: '[Export review] {{rating}}/5',
+          sections: [
+            { heading: 'Rating', field: 'rating', format: 'stars' },
+            { heading: 'Comment', field: 'message', omitWhenEmpty: true },
+          ],
+        },
+      });
+      const mounted = handle.mount(slot, {
+        context: { surface: 'export-complete' },
+        initialAnswers: { rating: 2 },
+      });
+      (
+        window as Window & {
+          __renderedReview?: { reset(): void; unmount(): void; instanceId: string };
+        }
+      ).__renderedReview = mounted;
+    });
+
+    const host = page.locator('#export-review-slot > [data-bugdrop-owned]');
+    await expect(host).toHaveAttribute('data-bugdrop-instance', /export-review-rendered-/);
+    const rating = host.getByRole('radiogroup', { name: 'Rating' });
+    await expect(rating.getByRole('radio', { name: '2 stars' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    await rating.getByRole('radio', { name: '4 stars' }).click();
+    expect(submissions).toHaveLength(0);
+    await host.getByRole('textbox', { name: 'Anything else?' }).fill('  Fast and clear.  ');
+    expect(submissions).toHaveLength(0);
+    await host.getByRole('button', { name: 'Submit review' }).click();
+    await expect(host.getByRole('heading', { name: 'Thanks for the review!' })).toBeVisible();
+
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0]).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      repo: 'mean-weasel/bugdrop-widget-test',
+      variantId: 'export-review-rendered',
+      issue: {
+        title: '[Export review] 4/5',
+        classification: 'feedback',
+        sections: [
+          { heading: 'Rating', value: '★★★★☆ (4/5)', format: 'text' },
+          { heading: 'Comment', value: 'Fast and clear.', format: 'text' },
+        ],
+      },
+      metadata: { url: 'http://localhost:8787/test/' },
+    });
+    expect(submissions[0]?.submissionId).toEqual(expect.any(String));
+    expect(submissions[0]).not.toHaveProperty('labels');
+    expect(submissions[0]).not.toHaveProperty('fields');
+
+    await page.evaluate(() => {
+      (
+        window as Window & {
+          __renderedReview?: { reset(): void };
+        }
+      ).__renderedReview?.reset();
+    });
+    await expect(host.getByRole('heading', { name: 'How was this export?' })).toBeVisible();
+    await expect(rating.getByRole('radio', { name: '2 stars' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    await expect(host.getByRole('textbox', { name: 'Anything else?' })).toHaveValue('');
+    await host.getByRole('button', { name: 'Submit review' }).click();
+    await expect(host.getByRole('heading', { name: 'Thanks for the review!' })).toBeVisible();
+    expect(submissions).toHaveLength(2);
+    expect(submissions[1]).toMatchObject({
+      issue: {
+        title: '[Export review] 2/5',
+        sections: [{ heading: 'Rating', value: '★★☆☆☆ (2/5)', format: 'text' }],
+      },
+    });
+    expect(submissions[1]?.submissionId).not.toBe(submissions[0]?.submissionId);
+  });
+
+  test('focuses invalid rating, supports keyboard selection, and never submits on selection', async ({
+    page,
+  }) => {
+    let submissionCount = 0;
+    await page.route('**/api/feedback', route => {
+      submissionCount += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          issueNumber: 105,
+          issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/105',
+          isPublic: false,
+        }),
+      });
+    });
+    await page.goto('/test/');
+    await page.locator('#bugdrop-host').locator('css=.bd-trigger').waitFor();
+    await page.evaluate(() => {
+      const slot = document.createElement('div');
+      slot.id = 'keyboard-review-slot';
+      document.body.appendChild(slot);
+      window
+        .BugDrop!.registerVariant({
+          id: 'keyboard-review',
+          presentation: { kind: 'inline' },
+          content: { title: 'Rate keyboard support', submitLabel: 'Send rating' },
+          fields: [
+            { id: 'rating', type: 'rating', label: 'Rating', required: true, scale: 5 },
+            { id: 'tag', type: 'shortText', label: 'Optional tag' },
+          ],
+          issue: { title: 'Keyboard rating {{rating}}' },
+        })
+        .mount(slot);
+    });
+
+    const host = page.locator('#keyboard-review-slot > [data-bugdrop-owned]');
+    const submit = host.getByRole('button', { name: 'Send rating' });
+    const rating = host.getByRole('radiogroup', { name: 'Rating' });
+    const first = rating.getByRole('radio', { name: '1 star' });
+    await submit.click();
+    expect(submissionCount).toBe(0);
+    await expect(rating).toHaveAttribute('aria-invalid', 'true');
+    await expect(first).toBeFocused();
+
+    await first.press('ArrowRight');
+    await expect(rating.getByRole('radio', { name: '2 stars' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    expect(submissionCount).toBe(0);
+    await host.getByRole('textbox', { name: 'Optional tag' }).fill('keyboard');
+    await host.getByRole('textbox', { name: 'Optional tag' }).press('Enter');
+    expect(submissionCount).toBe(0);
+    await submit.click();
+    await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+    expect(submissionCount).toBe(1);
+    await expect(host.getByRole('link', { name: 'View GitHub Issue' })).toBeHidden();
+  });
+
+  test('keeps two mounted reviews isolated and disposes only the requested instance', async ({
+    page,
+  }) => {
+    await page.goto('/test/');
+    await page.locator('#bugdrop-host').locator('css=.bd-trigger').waitFor();
+    const instances = await page.evaluate(() => {
+      const firstSlot = document.createElement('div');
+      firstSlot.id = 'first-review-slot';
+      const secondSlot = document.createElement('div');
+      secondSlot.id = 'second-review-slot';
+      document.body.append(firstSlot, secondSlot);
+      const handle = window.BugDrop!.registerVariant({
+        id: 'multi-review',
+        presentation: { kind: 'inline' },
+        content: { title: 'Multi review' },
+        fields: [{ id: 'rating', type: 'rating', label: 'Rating', required: true }],
+        issue: { title: 'Multi {{rating}}' },
+      });
+      const first = handle.mount(firstSlot, { initialAnswers: { rating: 1 } });
+      const second = handle.mount(secondSlot, { initialAnswers: { rating: 5 } });
+      first.unmount();
+      return { first: first.instanceId, second: second.instanceId };
+    });
+
+    expect(instances.first).not.toBe(instances.second);
+    await expect(page.locator('#first-review-slot > [data-bugdrop-owned]')).toHaveCount(0);
+    const second = page.locator('#second-review-slot > [data-bugdrop-owned]');
+    await expect(second).toHaveAttribute('data-bugdrop-instance', instances.second);
+    await expect(second.getByRole('radio', { name: '5 stars' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+  });
+});

--- a/e2e/variant-modal.radix.spec.ts
+++ b/e2e/variant-modal.radix.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+
+test('variant modal remains interactive inside Radix-style host dismissal and focus traps', async ({
+  page,
+}) => {
+  await page.goto('/test/welcome-disabled.html');
+  await expect
+    .poll(() => page.evaluate(() => typeof window.BugDrop?.registerVariant))
+    .toBe('function');
+  await page.evaluate(() => {
+    const hostDialog = document.createElement('div');
+    hostDialog.id = 'host-dialog';
+    hostDialog.tabIndex = -1;
+    document.body.appendChild(hostDialog);
+    hostDialog.focus();
+    (window as Window & { __variantHostDismissed?: boolean }).__variantHostDismissed = false;
+    document.addEventListener(
+      'pointerdown',
+      event => {
+        const owned = document.querySelector('[data-bugdrop-owned]');
+        if (!owned || !event.composedPath().includes(owned)) return;
+        const outside = new CustomEvent('dismissableLayer.pointerDownOutside', {
+          cancelable: true,
+          detail: { originalEvent: event },
+        });
+        document.dispatchEvent(outside);
+        if (!outside.defaultPrevented) {
+          (window as Window & { __variantHostDismissed?: boolean }).__variantHostDismissed = true;
+        }
+      },
+      true
+    );
+    document.addEventListener(
+      'focusin',
+      event => {
+        const owned = document.querySelector('[data-bugdrop-owned]');
+        if (owned && event.composedPath().includes(owned)) hostDialog.focus();
+      },
+      true
+    );
+    const handle = window.BugDrop!.registerVariant({
+      id: 'radix-provider-question',
+      presentation: { kind: 'modal', size: 'compact' },
+      content: { title: 'Which provider?', submitLabel: 'Send' },
+      fields: [{ id: 'response', type: 'longText', label: 'Your answer', required: true }],
+      issue: { title: 'Provider {{response}}' },
+    });
+    handle.open();
+  });
+
+  const host = page.locator('body > [data-bugdrop-owned]');
+  const answer = host.getByRole('textbox', { name: 'Your answer' });
+  await answer.click();
+  await answer.fill('OpenStack');
+  await expect(answer).toHaveValue('OpenStack');
+  await expect.poll(() => page.evaluate(() => document.activeElement?.id)).not.toBe('host-dialog');
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as Window & { __variantHostDismissed?: boolean }).__variantHostDismissed
+      )
+    )
+    .toBe(false);
+});

--- a/e2e/variant-modal.spec.ts
+++ b/e2e/variant-modal.spec.ts
@@ -1,0 +1,192 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function ready(page: Page) {
+  await page.goto('/test/welcome-disabled.html?private=redacted#secret');
+  await expect
+    .poll(() => page.evaluate(() => typeof window.BugDrop?.registerVariant))
+    .toBe('function');
+}
+
+async function registerProviderQuestion(page: Page) {
+  await page.evaluate(() => {
+    const cta = document.createElement('button');
+    cta.id = 'provider-cta';
+    cta.textContent = 'Request a provider';
+    document.body.appendChild(cta);
+    const handle = window.BugDrop!.registerVariant({
+      id: 'provider-question-rendered',
+      presentation: { kind: 'modal', size: 'compact' },
+      content: {
+        title: 'Which cloud provider should we support next?',
+        description: 'Tell us what would fit your workflow.',
+        submitLabel: 'Send idea',
+        cancelLabel: 'Not now',
+        successTitle: 'Thanks for the idea!',
+      },
+      fields: [
+        {
+          id: 'response',
+          type: 'longText',
+          label: 'Your answer',
+          required: true,
+          minLength: 2,
+          maxLength: 1000,
+        },
+      ],
+      issue: {
+        classification: 'feature',
+        title: 'Cloud provider request — {{response}}',
+        sections: [
+          { heading: 'Requested provider or workflow', field: 'response' },
+          { heading: 'Surface', context: 'surface', format: 'code' },
+        ],
+      },
+    });
+    cta.addEventListener('click', () => {
+      const opened = handle.open({ context: { surface: 'studio-upload' } });
+      (window as Window & { __providerOpened?: typeof opened }).__providerOpened = opened;
+    });
+  });
+}
+
+test.describe('rendered CTA modal variant', () => {
+  test('creates the exact draft only after explicit Submit and settles submitted', async ({
+    page,
+  }) => {
+    const submissions: Array<Record<string, unknown>> = [];
+    await page.route('**/api/feedback', route => {
+      submissions.push(route.request().postDataJSON() as Record<string, unknown>);
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          issueNumber: 206,
+          issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/206',
+          isPublic: true,
+        }),
+      });
+    });
+    await ready(page);
+    await registerProviderQuestion(page);
+    await page.getByRole('button', { name: 'Request a provider' }).click();
+
+    const host = page.locator('body > [data-bugdrop-owned]');
+    const dialog = host.getByRole('dialog', {
+      name: 'Which cloud provider should we support next?',
+    });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute('aria-modal', 'true');
+    const answer = host.getByRole('textbox', { name: 'Your answer' });
+    await expect(answer).toBeFocused();
+    await answer.fill('  Oracle Cloud for regulated workloads  ');
+    await answer.press('Enter');
+    expect(submissions).toHaveLength(0);
+    await host.getByRole('button', { name: 'Send idea' }).click();
+    await expect(host.getByRole('heading', { name: 'Thanks for the idea!' })).toBeVisible();
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0]).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      repo: 'mean-weasel/bugdrop-widget-test',
+      variantId: 'provider-question-rendered',
+      issue: {
+        title: 'Cloud provider request — Oracle Cloud for regulated workloads',
+        classification: 'feature',
+        sections: [
+          {
+            heading: 'Requested provider or workflow',
+            value: 'Oracle Cloud for regulated workloads',
+            format: 'text',
+          },
+          { heading: 'Surface', value: 'studio-upload', format: 'code' },
+        ],
+      },
+      metadata: { url: 'http://localhost:8787/test/welcome-disabled' },
+    });
+    await expect
+      .poll(() =>
+        page.evaluate(async () => {
+          const opened = (
+            window as Window & {
+              __providerOpened?: { result: Promise<{ status: string }> };
+            }
+          ).__providerOpened;
+          return (await opened?.result)?.status;
+        })
+      )
+      .toBe('submitted');
+  });
+
+  test('focuses errors, traps focus, restores focus/scroll, and closes on Escape', async ({
+    page,
+  }) => {
+    await ready(page);
+    await registerProviderQuestion(page);
+    await page.evaluate(() => {
+      document.body.style.overflow = 'clip';
+    });
+    const cta = page.getByRole('button', { name: 'Request a provider' });
+    await cta.click();
+    const host = page.locator('body > [data-bugdrop-owned]');
+    const answer = host.getByRole('textbox', { name: 'Your answer' });
+    await host.getByRole('button', { name: 'Send idea' }).click();
+    await expect(answer).toHaveAttribute('aria-invalid', 'true');
+    await expect(answer).toBeFocused();
+    await host.getByRole('button', { name: 'Not now' }).focus();
+    await page.keyboard.press('Tab');
+    await expect(host.getByRole('button', { name: 'Close' })).toBeFocused();
+    await page.keyboard.press('Escape');
+    await expect(host).toHaveCount(0);
+    await expect(cta).toBeFocused();
+    await expect.poll(() => page.evaluate(() => document.body.style.overflow)).toBe('clip');
+    await expect
+      .poll(() =>
+        page.evaluate(async () => {
+          const opened = (
+            window as Window & {
+              __providerOpened?: { result: Promise<{ status: string }> };
+            }
+          ).__providerOpened;
+          return (await opened?.result)?.status;
+        })
+      )
+      .toBe('closed');
+  });
+
+  test('follows legacy arbitration in both directions without broadening legacy close', async ({
+    page,
+  }) => {
+    await page.route('**/api/check**', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"installed":true}' })
+    );
+    await ready(page);
+    await registerProviderQuestion(page);
+    await page.evaluate(() => window.BugDrop!.open());
+    const legacyModal = page.locator('#bugdrop-host').locator('css=.bd-modal');
+    await expect(legacyModal).toBeVisible();
+    const busy = await page.evaluate(async () => {
+      const cta = document.getElementById('provider-cta')!;
+      cta.click();
+      const opened = (
+        window as Window & {
+          __providerOpened?: { result: Promise<{ status: string }> };
+        }
+      ).__providerOpened!;
+      return (await opened.result).status;
+    });
+    expect(busy).toBe('busy');
+    await expect(page.locator('body > [data-bugdrop-owned]')).toHaveCount(0);
+    await expect(legacyModal).toBeVisible();
+
+    await page.evaluate(() => window.BugDrop!.close());
+    await page.evaluate(() => document.getElementById('provider-cta')!.click());
+    const variantHost = page.locator('body > [data-bugdrop-owned]');
+    await expect(variantHost.getByRole('dialog')).toBeVisible();
+    await page.evaluate(() => window.BugDrop!.close());
+    await expect(variantHost).toHaveCount(1);
+    await page.evaluate(() => window.BugDrop!.open());
+    await expect(variantHost).toHaveCount(0);
+    await expect(legacyModal).toBeVisible();
+  });
+});

--- a/e2e/variant.live.spec.ts
+++ b/e2e/variant.live.spec.ts
@@ -1,0 +1,165 @@
+import { expect, type Page, type Request } from '@playwright/test';
+import {
+  assertExactPreviewWidgetResponse,
+  test,
+  waitForPreviewWidgetResponse,
+} from './live-preview-widget';
+
+const expectedWidgetOrigin = process.env.EXPECTED_WIDGET_ORIGIN;
+const expectedWidgetSha256 = process.env.EXPECTED_WIDGET_SHA256;
+const venuePath = process.env.LIVE_VENUE_PATH || (process.env.LIVE_TARGET ? '/' : '/test/');
+
+if (process.env.VERCEL_AUTOMATION_BYPASS_SECRET) {
+  test.beforeEach(async ({ context }) => {
+    await context.route('**/*.vercel.app/**', route =>
+      route.continue({
+        headers: {
+          ...route.request().headers(),
+          'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET!,
+        },
+      })
+    );
+  });
+}
+
+async function loadExactWidget(page: Page) {
+  const widgetResponse = expectedWidgetOrigin
+    ? waitForPreviewWidgetResponse(page, expectedWidgetOrigin)
+    : undefined;
+  await page.goto(venuePath);
+  await expect
+    .poll(() => page.evaluate(() => typeof window.BugDrop?.registerVariant))
+    .toBe('function');
+  if (widgetResponse && expectedWidgetSha256) {
+    await assertExactPreviewWidgetResponse(await widgetResponse, expectedWidgetSha256);
+  }
+}
+
+async function interceptOneSubmission(page: Page) {
+  const submissions: Request[] = [];
+  await page.route('**/feedback', route => {
+    const request = route.request();
+    if (request.method() !== 'POST') return route.continue();
+    const requestUrl = new URL(request.url());
+    expect(requestUrl.pathname).toBe('/api/feedback');
+    if (expectedWidgetOrigin) expect(requestUrl.origin).toBe(expectedWidgetOrigin);
+    submissions.push(request);
+    if (submissions.length > 1) return route.abort('blockedbyclient');
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        issueNumber: 901,
+        issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/901',
+        isPublic: false,
+      }),
+    });
+  });
+  return submissions;
+}
+
+test.describe('rendered variants on the deployed widget', () => {
+  test('renders and submits the exact inline star-review draft', async ({ page }) => {
+    const submissions = await interceptOneSubmission(page);
+    await loadExactWidget(page);
+    await page.evaluate(() => {
+      const slot = document.createElement('div');
+      slot.id = 'live-review-slot';
+      document.body.appendChild(slot);
+      window
+        .BugDrop!.registerVariant({
+          id: 'live-export-review',
+          presentation: { kind: 'inline' },
+          content: { title: 'How was this export?', submitLabel: 'Submit review' },
+          fields: [
+            { id: 'rating', type: 'rating', label: 'Rating', required: true, scale: 5 },
+            { id: 'message', type: 'longText', label: 'Anything else?', maxLength: 1000 },
+          ],
+          issue: {
+            classification: 'feedback',
+            title: '[Live export review] {{rating}}/5',
+            sections: [
+              { heading: 'Rating', field: 'rating', format: 'stars' },
+              { heading: 'Comment', field: 'message', omitWhenEmpty: true },
+            ],
+          },
+        })
+        .mount(slot);
+    });
+    const host = page.locator('#live-review-slot > [data-bugdrop-owned]');
+    await host.getByRole('radio', { name: '4 stars' }).click();
+    await host.getByRole('textbox', { name: 'Anything else?' }).fill('Exact preview review');
+    expect(submissions).toHaveLength(0);
+    await host.getByRole('button', { name: 'Submit review' }).click();
+    await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0].postDataJSON()).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      variantId: 'live-export-review',
+      issue: {
+        title: '[Live export review] 4/5',
+        classification: 'feedback',
+        sections: [
+          { heading: 'Rating', value: '★★★★☆ (4/5)', format: 'text' },
+          { heading: 'Comment', value: 'Exact preview review', format: 'text' },
+        ],
+      },
+    });
+  });
+
+  test('opens and submits the exact CTA text-modal draft', async ({ page }) => {
+    const submissions = await interceptOneSubmission(page);
+    await loadExactWidget(page);
+    await page.evaluate(() => {
+      const cta = document.createElement('button');
+      cta.id = 'live-provider-cta';
+      cta.textContent = 'Request a provider';
+      document.body.appendChild(cta);
+      const handle = window.BugDrop!.registerVariant({
+        id: 'live-provider-question',
+        presentation: { kind: 'modal', size: 'compact' },
+        content: {
+          title: 'Which cloud provider should we support next?',
+          submitLabel: 'Send idea',
+        },
+        fields: [
+          {
+            id: 'response',
+            type: 'longText',
+            label: 'Your answer',
+            required: true,
+            minLength: 2,
+          },
+        ],
+        issue: {
+          classification: 'feature',
+          title: 'Live provider request — {{response}}',
+          sections: [{ heading: 'Requested provider', field: 'response' }],
+        },
+      });
+      cta.addEventListener('click', () => handle.open());
+      cta.click();
+    });
+    const host = page.locator('body > [data-bugdrop-owned]');
+    await expect(
+      host.getByRole('dialog', { name: 'Which cloud provider should we support next?' })
+    ).toBeVisible();
+    await host.getByRole('textbox', { name: 'Your answer' }).fill('OpenStack');
+    expect(submissions).toHaveLength(0);
+    await host.getByRole('button', { name: 'Send idea' }).click();
+    await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0].postDataJSON()).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      variantId: 'live-provider-question',
+      issue: {
+        title: 'Live provider request — OpenStack',
+        classification: 'feature',
+        sections: [{ heading: 'Requested provider', value: 'OpenStack', format: 'text' }],
+      },
+    });
+  });
+});

--- a/e2e/widget.issue-canary.spec.ts
+++ b/e2e/widget.issue-canary.spec.ts
@@ -28,11 +28,10 @@ type FeedbackResult = {
 
 test.describe.configure({ mode: 'serial', retries: 0 });
 
-test('headless structured preview widget creates one real Issue with exact deployment identity', async ({
+test('rendered CTA preview widget creates one real Issue with exact deployment identity', async ({
   page,
 }) => {
   const environment = requireCanaryEnvironment();
-  const submissionId = `ci:${environment.marker}`;
   await installVercelBypass(page);
 
   const widgetResponsePromise = waitForPreviewWidgetResponse(
@@ -57,6 +56,7 @@ test('headless structured preview widget creates one real Issue with exact deplo
   );
 
   const feedbackPosts: Request[] = [];
+  let canarySubmissionId: string | undefined;
   let rejectedRequest: string | undefined;
   await page.route('**/feedback', async route => {
     const outgoing = route.request();
@@ -77,13 +77,14 @@ test('headless structured preview widget creates one real Issue with exact deplo
     }
 
     const payload = outgoing.postDataJSON() as Record<string, unknown>;
+    expect(payload.submissionId).toEqual(expect.any(String));
+    canarySubmissionId = String(payload.submissionId);
     expect(payload.repo).toBe(TEST_REPO);
     expect(payload).toMatchObject({
       kind: 'bugdrop.variant-submission',
       schemaVersion: 1,
       repo: TEST_REPO,
       variantId: 'merge-queue-canary',
-      submissionId,
       issue: {
         title: `${TITLE_PREFIX} ${environment.marker}`,
         classification: 'bug',
@@ -105,13 +106,13 @@ test('headless structured preview widget creates one real Issue with exact deplo
       responseUrl.pathname === '/api/feedback'
     );
   });
-  const result = await page.evaluate(
-    async ({ marker, submissionId, titlePrefix }) => {
+  await page.evaluate(
+    ({ titlePrefix }) => {
       if (!window.BugDrop) throw new Error('BugDrop API is unavailable');
       const handle = window.BugDrop.registerVariant({
         id: 'merge-queue-canary',
-        presentation: { kind: 'inline' },
-        content: { title: 'Merge-queue canary' },
+        presentation: { kind: 'modal', size: 'compact' },
+        content: { title: 'Merge-queue canary', submitLabel: 'Create canary Issue' },
         fields: [{ id: 'marker', type: 'longText', label: 'Marker', required: true }],
         issue: {
           classification: 'bug',
@@ -119,10 +120,43 @@ test('headless structured preview widget creates one real Issue with exact deplo
           sections: [{ heading: 'Canary marker', field: 'marker' }],
         },
       });
-      return handle.submit({ marker }, { submissionId });
+      const opened = handle.open({ context: { canary: true } });
+      (
+        window as Window & {
+          __bugdropCanaryOpened?: typeof opened;
+        }
+      ).__bugdropCanaryOpened = opened;
     },
-    { marker: environment.marker, submissionId, titlePrefix: TITLE_PREFIX }
+    { titlePrefix: TITLE_PREFIX }
   );
+  const canaryHost = page.locator('body > [data-bugdrop-owned]');
+  await expect(canaryHost.getByRole('dialog', { name: 'Merge-queue canary' })).toBeVisible();
+  const markerInput = canaryHost.getByRole('textbox', { name: 'Marker' });
+  await markerInput.fill(environment.marker);
+  await expect(markerInput).toHaveValue(environment.marker);
+  expect(feedbackPosts).toHaveLength(0);
+  await canaryHost.getByRole('button', { name: 'Create canary Issue' }).click();
+  const result = await page.evaluate(async () => {
+    const opened = (
+      window as Window & {
+        __bugdropCanaryOpened?: {
+          result: Promise<
+            | {
+                status: 'submitted';
+                result: { issueNumber: number; issueUrl: string; isPublic: boolean };
+              }
+            | { status: 'closed' | 'busy' }
+          >;
+        };
+      }
+    ).__bugdropCanaryOpened;
+    if (!opened) throw new Error('Rendered canary modal handle is unavailable');
+    const outcome = await opened.result;
+    if (outcome.status !== 'submitted') {
+      throw new Error(`Rendered canary ended with ${outcome.status}`);
+    }
+    return outcome.result;
+  });
   const feedbackResponse = await feedbackResponsePromise;
 
   const feedbackUrl = new URL(feedbackResponse.url());
@@ -144,6 +178,7 @@ test('headless structured preview widget creates one real Issue with exact deplo
   await page.waitForTimeout(1_000);
   expect(rejectedRequest).toBeUndefined();
   expect(feedbackPosts).toHaveLength(1);
+  expect(canarySubmissionId).toMatch(/^submission-/);
 
   await mkdir(dirname(environment.resultFile), { recursive: true });
   await writeFile(
@@ -151,7 +186,8 @@ test('headless structured preview widget creates one real Issue with exact deplo
     `${JSON.stringify({
       marker: environment.marker,
       kind: 'structured',
-      submissionId,
+      presentation: 'modal',
+      submissionId: canarySubmissionId,
       issueNumber,
       issueUrl,
       workerSha: environment.expectedWorkerSha,

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -22,6 +22,7 @@ declare global {
       width: number;
       height: number;
     };
+    __ownedCaptureFilter?: boolean[];
   }
 }
 
@@ -3827,6 +3828,78 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     });
     return () => count;
   }
+
+  test('full-page capture excludes owned variants', async ({ page }) => {
+    await mockHtmlToImage(
+      page,
+      `function(el, opts) {
+        window.__captureOpts = opts;
+        window.__ownedCaptureFilter = Array.from(document.querySelectorAll('[data-bugdrop-owned]'))
+          .map(function(root) { return opts.filter(root); });
+        return Promise.resolve('${STUB_PNG}');
+      }`
+    );
+    await page.goto('/test/');
+    await page.locator('#bugdrop-host').locator('css=.bd-trigger').waitFor();
+    await page.evaluate(() => {
+      for (const rating of [1, 5]) {
+        const slot = document.createElement('div');
+        document.body.appendChild(slot);
+        window
+          .BugDrop!.registerVariant({
+            id: `capture-review-${rating}`,
+            presentation: { kind: 'inline' },
+            content: { title: 'Capture review' },
+            fields: [{ id: 'rating', type: 'rating', label: 'Rating' }],
+            issue: { title: 'Capture {{rating}}' },
+          })
+          .mount(slot, { initialAnswers: { rating } });
+      }
+    });
+
+    await navigateToFullPageCapture(page);
+    await expect
+      .poll(() => page.evaluate(() => window.__ownedCaptureFilter))
+      .toEqual([false, false]);
+  });
+
+  test('element picker excludes owned variants', async ({ page }) => {
+    await page.goto('/test/');
+    await page.locator('#bugdrop-host').locator('css=.bd-trigger').waitFor();
+    await page.evaluate(() => {
+      const underlay = document.createElement('div');
+      underlay.id = 'capture-underlay';
+      Object.assign(underlay.style, { width: '500px', minHeight: '260px', padding: '20px' });
+      document.body.prepend(underlay);
+      window
+        .BugDrop!.registerVariant({
+          id: 'picker-review',
+          presentation: { kind: 'inline' },
+          content: { title: 'Picker review' },
+          fields: [{ id: 'rating', type: 'rating', label: 'Rating' }],
+          issue: { title: 'Picker {{rating}}' },
+        })
+        .mount(underlay, { initialAnswers: { rating: 3 } });
+    });
+    const host = await navigateToScreenshotOptions(page);
+    await host.locator('css=[data-action="element"]').click();
+    await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible();
+    const variant = page.locator('#capture-underlay > [data-bugdrop-owned]');
+    const box = await variant.boundingBox();
+    expect(box).not.toBeNull();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    const highlight = page.locator('#bugdrop-element-picker-highlight');
+    await expect(highlight).toBeVisible();
+    const highlightBox = await highlight.boundingBox();
+    const underlayBox = await page.locator('#capture-underlay').boundingBox();
+    expect(highlightBox).not.toBeNull();
+    expect(underlayBox).not.toBeNull();
+    expect(Math.abs(highlightBox!.width - underlayBox!.width)).toBeLessThanOrEqual(12);
+    expect(Math.abs(highlightBox!.height - underlayBox!.height)).toBeLessThanOrEqual(12);
+    expect(highlightBox!.width).toBeGreaterThan(box!.width);
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#bugdrop-element-picker-overlay')).toHaveCount(0);
+  });
 
   async function trackFeedbackPayloads(page: Page) {
     const payloads: Array<Record<string, unknown>> = [];

--- a/scripts/github-issue-canary.mjs
+++ b/scripts/github-issue-canary.mjs
@@ -469,9 +469,7 @@ function validateBrowserResult({ failures, result, marker, expectedSha, candidat
   }
   if (result.marker !== marker) failures.push('Browser result marker does not match');
   if (result.kind !== 'structured') failures.push('Browser result kind is not structured');
-  if (result.submissionId !== `ci:${marker}`) {
-    failures.push('Browser result submission ID does not match the canary marker');
-  }
+  validateBrowserSubmissionId({ failures, result, marker });
   if (!Number.isInteger(result.issueNumber) || result.issueNumber <= 0) {
     failures.push('Browser result Issue number is not a positive integer');
   }
@@ -487,15 +485,32 @@ function validateBrowserResultReference({ failures, result, marker, expectedSha,
   }
   if (result.marker !== marker) failures.push('Browser result marker does not match');
   if (result.kind !== 'structured') failures.push('Browser result kind is not structured');
-  if (result.submissionId !== `ci:${marker}`) {
-    failures.push('Browser result submission ID does not match the canary marker');
-  }
+  validateBrowserSubmissionId({ failures, result, marker });
   if (!Number.isInteger(result.issueNumber) || result.issueNumber <= 0) {
     failures.push('Browser result Issue number is not a positive integer');
   } else if (result.issueUrl !== canonicalIssueUrl(repo, result.issueNumber)) {
     failures.push('Browser result Issue URL is not canonical');
   }
   if (result.workerSha !== expectedSha) failures.push('Browser result Worker SHA differs');
+}
+
+function validateBrowserSubmissionId({ failures, result, marker }) {
+  if (result.presentation === 'modal') {
+    if (!isRenderedSubmissionId(result.submissionId)) {
+      failures.push('Browser result submission ID is not a rendered submission identity');
+    }
+    return;
+  }
+  if (result.submissionId !== `ci:${marker}`) {
+    failures.push('Browser result submission ID does not match the canary marker');
+  }
+}
+
+function isRenderedSubmissionId(value) {
+  return (
+    typeof value === 'string' &&
+    /^submission-(?:[0-9a-f]{32}|[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})$/i.test(value)
+  );
 }
 
 function normalizeLabels(labels) {

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -31,6 +31,7 @@ import {
 } from './console-logs';
 import { escapeWidgetText, resolveLocale, setLocale, t, type SupportedLocale } from './i18n';
 import { installRadixDialogCompatibility } from './radix-compat';
+import { closeActiveVariantModal } from './variants/modal-coordinator';
 import { resolveAccentColor } from '../defaults';
 import type { BugDropPublicAPI } from './variants/public-types';
 import { createVariantManager, type VariantManager } from './variants/manager';
@@ -968,11 +969,14 @@ function exposeBugDropAPI(root: HTMLElement, config: WidgetConfig) {
     // The sidecar is created only on the first registration. Legacy-only pages
     // do not allocate variant maps, IDs, DOM, listeners, observers, or storage.
     registerVariant: variantConfig => {
-      variantManager ??= createVariantManager({
-        repo: config.repo,
-        apiUrl: config.apiUrl,
-        authTokenProvider: config.authTokenProvider,
-      });
+      variantManager ??= createVariantManager(
+        {
+          repo: config.repo,
+          apiUrl: config.apiUrl,
+          authTokenProvider: config.authTokenProvider,
+        },
+        { isLegacyModalOpen: () => _isModalOpen }
+      );
       return variantManager.register(variantConfig);
     },
   };
@@ -1053,6 +1057,8 @@ async function openFeedbackFlow(
   if (_isModalOpen) {
     return;
   }
+
+  closeActiveVariantModal();
 
   // Mark modal as open
   _isModalOpen = true;

--- a/src/widget/mask.ts
+++ b/src/widget/mask.ts
@@ -73,6 +73,9 @@ function createTarget(el: Element, reason: RedactionReason): RedactionTarget | n
 export function createRedactionSnapshot(root: Element): RedactionSnapshot {
   const targets: RedactionTarget[] = [];
   const unsupportedSurfaces: UnsupportedRedactionSurface[] = [];
+  if (isBugDropOwnedNode(root)) {
+    return { targets, unsupportedSurfaces, redactionCount: 0 };
+  }
   const rootReason = getRedactionReason(root);
 
   if (rootReason) {
@@ -143,6 +146,7 @@ function walk(
   unsupportedSurfaces: UnsupportedRedactionSurface[]
 ): void {
   for (const child of Array.from(node.children)) {
+    if (isBugDropOwnedNode(child)) continue;
     const reason = getRedactionReason(child);
     if (reason) {
       const target = createTarget(child, reason);
@@ -291,3 +295,4 @@ function loadImage(dataUrl: string): Promise<HTMLImageElement> {
     img.src = dataUrl;
   });
 }
+import { isBugDropOwnedNode } from './owned-roots';

--- a/src/widget/owned-roots.ts
+++ b/src/widget/owned-roots.ts
@@ -1,0 +1,28 @@
+const BUGDROP_OWNED_SELECTOR = '#bugdrop-host, [data-bugdrop-owned]';
+
+export function isBugDropOwnedNode(node: unknown): boolean {
+  if (node instanceof ShadowRoot) return isBugDropOwnedNode(node.host);
+  if (!(node instanceof Element)) return false;
+  if (node.matches(BUGDROP_OWNED_SELECTOR) || node.closest(BUGDROP_OWNED_SELECTOR)) return true;
+  const root = node.getRootNode();
+  return root instanceof ShadowRoot && isBugDropOwnedNode(root.host);
+}
+
+export async function withBugDropOwnedRootsHidden<T>(action: () => Promise<T>): Promise<T> {
+  const roots = Array.from(document.querySelectorAll<HTMLElement>(BUGDROP_OWNED_SELECTOR));
+  const styles = roots.map(root => ({
+    root,
+    value: root.style.getPropertyValue('visibility'),
+    priority: root.style.getPropertyPriority('visibility'),
+  }));
+
+  for (const { root } of styles) root.style.setProperty('visibility', 'hidden', 'important');
+  try {
+    return await action();
+  } finally {
+    for (const { root, value, priority } of styles) {
+      if (value) root.style.setProperty('visibility', value, priority);
+      else root.style.removeProperty('visibility');
+    }
+  }
+}

--- a/src/widget/picker.ts
+++ b/src/widget/picker.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines, max-lines-per-function */
 import { resolvePickerStyle, type PickerStyle, type ResolvedPickerStyle } from './picker-style';
 import { getSelectionTarget } from './picker-target';
+import { isBugDropOwnedNode } from './owned-roots';
 import { t } from './i18n';
 
 export { resolvePickerStyle, type PickerStyle };
@@ -175,7 +176,7 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
 
     return elementsAtPoint.find(el => {
       if (isPickerChrome(el)) return false;
-      if (el.closest('#bugdrop-host')) return false;
+      if (isBugDropOwnedNode(el)) return false;
       return true;
     });
   }
@@ -238,7 +239,7 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
   function onClick(e: MouseEvent) {
     if (resolved) {
       document.removeEventListener('click', onClick, true);
-      if (e.target instanceof Element && e.target.closest('#bugdrop-host')) return;
+      if (isBugDropOwnedNode(e.target)) return;
       e.preventDefault();
       e.stopImmediatePropagation();
       return;

--- a/src/widget/radix-compat.ts
+++ b/src/widget/radix-compat.ts
@@ -5,14 +5,25 @@
  * would dismiss its own dialogs or yank focus back.
  */
 
-export function installRadixDialogCompatibility(host: HTMLElement): void {
-  // Guards replayHostFocusOut: the synthetic focusout events it dispatches
-  // propagate a capture phase from window and would re-enter keepBugDropFocus
-  // with the same in-widget relatedTarget, replaying forever (stack overflow).
-  let replayingFocusOut = false;
+const ownedRoots = new Set<HTMLElement>();
+let installed = false;
+let replayingFocusOut = false;
 
+export function installRadixDialogCompatibility(host: HTMLElement): () => void {
+  ownedRoots.add(host);
+  if (!installed) installGlobalCompatibilityListeners();
+  let disposed = false;
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    ownedRoots.delete(host);
+  };
+}
+
+function installGlobalCompatibilityListeners(): void {
+  installed = true;
   const preventBugDropDismissal = (event: Event) => {
-    if (isBugDropInteraction(host, event)) {
+    if (isBugDropInteraction(event)) {
       event.preventDefault();
     }
   };
@@ -21,7 +32,7 @@ export function installRadixDialogCompatibility(host: HTMLElement): void {
       return;
     }
 
-    if (isBugDropFocusEvent(host, event)) {
+    if (isBugDropFocusEvent(event)) {
       if (event.type === 'focusin') {
         event.stopImmediatePropagation();
         return;
@@ -52,7 +63,7 @@ export function installRadixDialogCompatibility(host: HTMLElement): void {
   window.addEventListener('focusout', keepBugDropFocus, true);
 }
 
-function isBugDropInteraction(host: HTMLElement, event: Event): boolean {
+function isBugDropInteraction(event: Event): boolean {
   const originalEvent = (event as CustomEvent<{ originalEvent?: Event }>).detail?.originalEvent;
   const path =
     typeof originalEvent?.composedPath === 'function'
@@ -61,20 +72,18 @@ function isBugDropInteraction(host: HTMLElement, event: Event): boolean {
         ? event.composedPath()
         : [];
 
-  if (path.includes(host)) {
-    return true;
-  }
-
-  return (originalEvent?.target ?? event.target) === host;
+  return Array.from(ownedRoots).some(
+    host => path.includes(host) || (originalEvent?.target ?? event.target) === host
+  );
 }
 
-function isBugDropFocusEvent(host: HTMLElement, event: Event): boolean {
+function isBugDropFocusEvent(event: Event): boolean {
   if (!(event instanceof FocusEvent)) {
-    return isBugDropInteraction(host, event);
+    return isBugDropInteraction(event);
   }
 
   if (event.type === 'focusin') {
-    return isBugDropInteraction(host, event);
+    return isBugDropInteraction(event);
   }
 
   if (event.type !== 'focusout') {
@@ -82,10 +91,12 @@ function isBugDropFocusEvent(host: HTMLElement, event: Event): boolean {
   }
 
   const nextFocusedNode = event.relatedTarget;
-  const nextFocusIsBugDrop =
-    nextFocusedNode === host ||
-    (nextFocusedNode instanceof Node && (host.shadowRoot?.contains(nextFocusedNode) ?? false));
-  return nextFocusIsBugDrop && !isBugDropInteraction(host, event);
+  const nextFocusIsBugDrop = Array.from(ownedRoots).some(
+    host =>
+      nextFocusedNode === host ||
+      (nextFocusedNode instanceof Node && (host.shadowRoot?.contains(nextFocusedNode) ?? false))
+  );
+  return nextFocusIsBugDrop && !isBugDropInteraction(event);
 }
 
 function replayHostFocusOut(event: Event): void {

--- a/src/widget/screenshot.ts
+++ b/src/widget/screenshot.ts
@@ -10,6 +10,7 @@ import {
   type RedactionSummary,
 } from './mask';
 import { resolveAccentColor } from '../defaults';
+import { isBugDropOwnedNode } from './owned-roots';
 export { cropScreenshot } from './crop-screenshot';
 export { beginViewportCapture } from './viewport-capture';
 
@@ -200,7 +201,7 @@ export function getRedactionCount(element?: Element, rect?: DOMRect): number {
 }
 
 function shouldIncludeCaptureNode(node: HTMLElement): boolean {
-  if (node.id === 'bugdrop-host') return false;
+  if (isBugDropOwnedNode(node)) return false;
 
   if (isHtmlImage(node) && isInvisibleOrZeroSize(node)) {
     return false;

--- a/src/widget/variants/answer-validation.ts
+++ b/src/widget/variants/answer-validation.ts
@@ -1,0 +1,86 @@
+import type { VariantField } from './public-types';
+
+type NormalizedVariantAnswer = string | number;
+
+export class VariantAnswerError extends TypeError {
+  constructor(
+    public readonly fieldId: string | null,
+    message: string
+  ) {
+    super(message);
+    this.name = 'VariantAnswerError';
+  }
+}
+
+export function assertKnownVariantAnswerKeys(
+  fields: ReadonlyArray<VariantField>,
+  answers: Record<string, unknown>
+): void {
+  if (!isObject(answers)) {
+    throw new VariantAnswerError(null, 'BugDrop variant answers must be an object');
+  }
+  const knownFields = new Set(fields.map(field => field.id));
+  const unknown = Object.keys(answers).find(key => !knownFields.has(key));
+  if (unknown) {
+    throw new VariantAnswerError(null, `Unknown BugDrop variant answer: ${unknown}`);
+  }
+}
+
+export function normalizeVariantAnswers(
+  fields: ReadonlyArray<VariantField>,
+  answers: Record<string, unknown>
+): Record<string, NormalizedVariantAnswer> {
+  assertKnownVariantAnswerKeys(fields, answers);
+  return Object.fromEntries(
+    fields.map(field => [field.id, normalizeVariantAnswer(field, answers[field.id])])
+  );
+}
+
+function normalizeVariantAnswer(field: VariantField, raw: unknown): NormalizedVariantAnswer {
+  if (field.type === 'shortText' || field.type === 'longText') {
+    if (raw === undefined || raw === null || raw === '') {
+      if (field.required) throw fieldError(field, `Answer ${field.id} is required`);
+      return '';
+    }
+    if (typeof raw !== 'string') {
+      throw fieldError(field, `Answer ${field.id} must be text`);
+    }
+    const value = raw.trim();
+    if (field.required && !value) throw fieldError(field, `Answer ${field.id} is required`);
+    const minimum = field.minLength ?? 0;
+    const maximum = field.maxLength ?? (field.type === 'shortText' ? 500 : 5_000);
+    if (value.length < minimum || value.length > maximum) {
+      throw fieldError(field, `Answer ${field.id} must be ${minimum}-${maximum} characters`);
+    }
+    return value;
+  }
+
+  if (field.type === 'rating') {
+    const scale = field.scale ?? 5;
+    if (raw === undefined || raw === null || raw === '') {
+      if (field.required) throw fieldError(field, `Answer ${field.id} is required`);
+      return '';
+    }
+    if (!Number.isInteger(raw) || (raw as number) < 1 || (raw as number) > scale) {
+      throw fieldError(field, `Answer ${field.id} must be a rating from 1-${scale}`);
+    }
+    return raw as number;
+  }
+
+  if (raw === undefined || raw === null || raw === '') {
+    if (field.required) throw fieldError(field, `Answer ${field.id} is required`);
+    return '';
+  }
+  if (typeof raw !== 'string' || !field.options.some(option => option.value === raw)) {
+    throw fieldError(field, `Answer ${field.id} must be a configured choice`);
+  }
+  return raw;
+}
+
+function fieldError(field: VariantField, message: string): VariantAnswerError {
+  return new VariantAnswerError(field.id, message);
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/widget/variants/fields/index.ts
+++ b/src/widget/variants/fields/index.ts
@@ -1,0 +1,12 @@
+import type { VariantField } from '../public-types';
+import { createLongTextController } from './long-text';
+import { createRatingController } from './rating';
+import { createShortTextController } from './short-text';
+import type { FieldController } from './types';
+
+export function createFieldController(field: VariantField, instanceId: string): FieldController {
+  if (field.type === 'shortText') return createShortTextController(field, instanceId);
+  if (field.type === 'longText') return createLongTextController(field, instanceId);
+  if (field.type === 'rating') return createRatingController(field, instanceId);
+  throw new Error('BugDrop single-choice rendering is not available in Phase 2');
+}

--- a/src/widget/variants/fields/long-text.ts
+++ b/src/widget/variants/fields/long-text.ts
@@ -1,0 +1,28 @@
+import type { LongTextField } from '../public-types';
+import { applyTextControlAttributes, createFieldScaffold } from './shared';
+import type { FieldController } from './types';
+
+export function createLongTextController(
+  field: LongTextField,
+  instanceId: string
+): FieldController {
+  const scaffold = createFieldScaffold(field, instanceId);
+  const textarea = document.createElement('textarea');
+  textarea.rows = field.rows ?? 4;
+  applyTextControlAttributes(textarea, field, scaffold);
+
+  return {
+    field,
+    element: scaffold.wrapper,
+    getValue: () => textarea.value,
+    setValue(value) {
+      textarea.value = typeof value === 'string' ? value : '';
+    },
+    setError: message => scaffold.setError(textarea, message),
+    setDisabled: disabled => {
+      textarea.disabled = disabled;
+    },
+    focus: () => textarea.focus(),
+    dispose() {},
+  };
+}

--- a/src/widget/variants/fields/rating.ts
+++ b/src/widget/variants/fields/rating.ts
@@ -1,0 +1,109 @@
+import type { RatingField } from '../public-types';
+import { createFieldScaffold } from './shared';
+import type { FieldController } from './types';
+
+export function createRatingController(field: RatingField, instanceId: string): FieldController {
+  const scaffold = createFieldScaffold(field, instanceId);
+  const scale = field.scale ?? 5;
+  const group = document.createElement('div');
+  group.id = scaffold.controlId;
+  group.className = 'bdv-rating';
+  group.setAttribute('role', 'radiogroup');
+  group.setAttribute('aria-labelledby', scaffold.labelId);
+  group.setAttribute('aria-required', String(field.required ?? false));
+  if (scaffold.describedBy) group.setAttribute('aria-describedby', scaffold.describedBy);
+
+  const buttons: HTMLButtonElement[] = [];
+  let selected: number | null = null;
+
+  const renderSelection = () => {
+    for (const [index, button] of buttons.entries()) {
+      const value = index + 1;
+      const active = selected !== null && value <= selected;
+      button.classList.toggle('bdv-rating-option--active', active);
+      button.setAttribute('aria-checked', String(value === selected));
+      button.tabIndex = value === (selected ?? 1) ? 0 : -1;
+    }
+  };
+  const select = (value: number, focus = false) => {
+    selected = value;
+    renderSelection();
+    if (focus) buttons[value - 1]?.focus();
+  };
+  const listeners: Array<{
+    button: HTMLButtonElement;
+    click: () => void;
+    keydown: (event: KeyboardEvent) => void;
+  }> = [];
+
+  for (let value = 1; value <= scale; value += 1) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'bdv-rating-option';
+    button.setAttribute('role', 'radio');
+    button.setAttribute('aria-label', `${value} ${value === 1 ? 'star' : 'stars'}`);
+    button.textContent = field.icon === 'number' ? String(value) : '★';
+    const click = () => select(value);
+    const keydown = (event: KeyboardEvent) => {
+      let next: number | null = null;
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        next = value === scale ? 1 : value + 1;
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        next = value === 1 ? scale : value - 1;
+      } else if (event.key === 'Home') {
+        next = 1;
+      } else if (event.key === 'End') {
+        next = scale;
+      } else if (event.key === 'Enter' || event.key === ' ') {
+        next = value;
+      }
+      if (next === null) return;
+      event.preventDefault();
+      select(next, true);
+    };
+    button.addEventListener('click', click);
+    button.addEventListener('keydown', keydown);
+    listeners.push({ button, click, keydown });
+    buttons.push(button);
+    group.appendChild(button);
+  }
+  scaffold.wrapper.insertBefore(group, scaffold.wrapper.querySelector('.bdv-error'));
+
+  if (field.lowLabel || field.highLabel) {
+    const labels = document.createElement('div');
+    labels.className = 'bdv-rating-labels';
+    const low = document.createElement('span');
+    low.textContent = field.lowLabel ?? '';
+    const high = document.createElement('span');
+    high.textContent = field.highLabel ?? '';
+    labels.append(low, high);
+    scaffold.wrapper.insertBefore(labels, scaffold.wrapper.querySelector('.bdv-error'));
+  }
+  renderSelection();
+
+  return {
+    field,
+    element: scaffold.wrapper,
+    getValue: () => selected ?? '',
+    setValue(value) {
+      selected =
+        Number.isInteger(value) && (value as number) >= 1 && (value as number) <= scale
+          ? (value as number)
+          : null;
+      renderSelection();
+    },
+    setError: message => scaffold.setError(group, message),
+    setDisabled(disabled) {
+      for (const button of buttons) button.disabled = disabled;
+    },
+    focus() {
+      buttons[(selected ?? 1) - 1]?.focus();
+    },
+    dispose() {
+      for (const listener of listeners) {
+        listener.button.removeEventListener('click', listener.click);
+        listener.button.removeEventListener('keydown', listener.keydown);
+      }
+    },
+  };
+}

--- a/src/widget/variants/fields/shared.ts
+++ b/src/widget/variants/fields/shared.ts
@@ -1,0 +1,76 @@
+import type { VariantField } from '../public-types';
+import type { FieldScaffold } from './types';
+
+export function createFieldScaffold(field: VariantField, instanceId: string): FieldScaffold {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'bdv-field';
+  wrapper.dataset.bugdropField = field.id;
+  wrapper.dataset.span = String(field.layout?.span ?? 1);
+
+  const controlId = `${instanceId}-${field.id}`;
+  const labelId = `${controlId}-label`;
+  const helpId = `${controlId}-help`;
+  const errorId = `${controlId}-error`;
+
+  const label = document.createElement('label');
+  label.className = 'bdv-label';
+  label.id = labelId;
+  label.htmlFor = controlId;
+  label.textContent = field.label;
+  if (field.required) {
+    const required = document.createElement('span');
+    required.className = 'bdv-required';
+    required.textContent = ' *';
+    required.setAttribute('aria-hidden', 'true');
+    label.appendChild(required);
+  }
+  wrapper.appendChild(label);
+
+  const describedBy: string[] = [];
+  if (field.helpText) {
+    const help = document.createElement('div');
+    help.className = 'bdv-help';
+    help.id = helpId;
+    help.textContent = field.helpText;
+    wrapper.appendChild(help);
+    describedBy.push(helpId);
+  }
+
+  const error = document.createElement('div');
+  error.className = 'bdv-error';
+  error.id = errorId;
+  error.hidden = true;
+  error.setAttribute('aria-live', 'polite');
+  wrapper.appendChild(error);
+  describedBy.push(errorId);
+
+  return {
+    wrapper,
+    label,
+    controlId,
+    labelId,
+    describedBy: describedBy.join(' ') || null,
+    setError(target, message) {
+      error.textContent = message ?? '';
+      error.hidden = !message;
+      if (message) target.setAttribute('aria-invalid', 'true');
+      else target.removeAttribute('aria-invalid');
+    },
+  };
+}
+
+export function applyTextControlAttributes(
+  control: HTMLInputElement | HTMLTextAreaElement,
+  field: Extract<VariantField, { type: 'shortText' | 'longText' }>,
+  scaffold: FieldScaffold
+): void {
+  control.id = scaffold.controlId;
+  control.className = 'bdv-input';
+  control.required = field.required ?? false;
+  control.setAttribute('aria-required', String(field.required ?? false));
+  if (scaffold.describedBy) control.setAttribute('aria-describedby', scaffold.describedBy);
+  if (field.placeholder) control.placeholder = field.placeholder;
+  control.minLength = field.minLength ?? 0;
+  control.maxLength = field.maxLength ?? (field.type === 'shortText' ? 500 : 5_000);
+  scaffold.wrapper.insertBefore(control, scaffold.wrapper.querySelector('.bdv-error'));
+}

--- a/src/widget/variants/fields/short-text.ts
+++ b/src/widget/variants/fields/short-text.ts
@@ -1,0 +1,28 @@
+import type { ShortTextField } from '../public-types';
+import { applyTextControlAttributes, createFieldScaffold } from './shared';
+import type { FieldController } from './types';
+
+export function createShortTextController(
+  field: ShortTextField,
+  instanceId: string
+): FieldController {
+  const scaffold = createFieldScaffold(field, instanceId);
+  const input = document.createElement('input');
+  input.type = 'text';
+  applyTextControlAttributes(input, field, scaffold);
+
+  return {
+    field,
+    element: scaffold.wrapper,
+    getValue: () => input.value,
+    setValue(value) {
+      input.value = typeof value === 'string' ? value : '';
+    },
+    setError: message => scaffold.setError(input, message),
+    setDisabled: disabled => {
+      input.disabled = disabled;
+    },
+    focus: () => input.focus(),
+    dispose() {},
+  };
+}

--- a/src/widget/variants/fields/types.ts
+++ b/src/widget/variants/fields/types.ts
@@ -1,0 +1,21 @@
+import type { VariantField } from '../public-types';
+
+export interface FieldController {
+  readonly field: VariantField;
+  readonly element: HTMLElement;
+  getValue(): unknown;
+  setValue(value: unknown): void;
+  setError(message: string | null): void;
+  setDisabled(disabled: boolean): void;
+  focus(): void;
+  dispose(): void;
+}
+
+export interface FieldScaffold {
+  readonly wrapper: HTMLDivElement;
+  readonly label: HTMLLabelElement;
+  readonly controlId: string;
+  readonly labelId: string;
+  readonly describedBy: string | null;
+  setError(target: HTMLElement, message: string | null): void;
+}

--- a/src/widget/variants/form.ts
+++ b/src/widget/variants/form.ts
@@ -1,0 +1,236 @@
+import {
+  assertKnownVariantAnswerKeys,
+  normalizeVariantAnswers,
+  VariantAnswerError,
+} from './answer-validation';
+import { createFieldController } from './fields';
+import type {
+  HeadlessSubmitOptions,
+  SubmissionResult,
+  VariantConfig,
+  VariantContext,
+} from './public-types';
+
+interface VariantFormOptions {
+  config: Readonly<VariantConfig>;
+  instanceId: string;
+  context?: VariantContext;
+  initialAnswers?: Record<string, unknown>;
+  submit(
+    answers: Record<string, unknown>,
+    options: HeadlessSubmitOptions
+  ): Promise<SubmissionResult>;
+  cancel?: { label: string; onCancel(): void };
+  onSubmitted?(result: SubmissionResult): void;
+}
+
+interface VariantFormController {
+  readonly element: HTMLElement;
+  reset(): void;
+  dispose(): void;
+}
+
+export function createVariantForm(options: VariantFormOptions): VariantFormController {
+  const { config, instanceId } = options;
+  const context = { ...(options.context ?? {}) };
+  const initialAnswers = { ...(options.initialAnswers ?? {}) };
+  assertKnownVariantAnswerKeys(config.fields, initialAnswers);
+
+  const surface = document.createElement('section');
+  surface.className = 'bdv-surface';
+  const titleId = `${instanceId}-title`;
+  surface.setAttribute('aria-labelledby', titleId);
+
+  const header = document.createElement('div');
+  header.className = 'bdv-header';
+  const title = document.createElement('h2');
+  title.className = 'bdv-title';
+  title.id = titleId;
+  title.textContent = config.content.title;
+  header.appendChild(title);
+  if (config.content.description) {
+    const description = document.createElement('p');
+    description.className = 'bdv-description';
+    description.textContent = config.content.description;
+    header.appendChild(description);
+  }
+  surface.appendChild(header);
+
+  const form = document.createElement('form');
+  form.className = 'bdv-form';
+  form.noValidate = true;
+  const fieldsElement = document.createElement('div');
+  fieldsElement.className = 'bdv-fields';
+  const controllers = config.fields.map(field => createFieldController(field, instanceId));
+  for (const controller of controllers) fieldsElement.appendChild(controller.element);
+  form.appendChild(fieldsElement);
+
+  const actions = document.createElement('div');
+  actions.className = 'bdv-actions';
+  const submitButton = document.createElement('button');
+  submitButton.type = 'submit';
+  submitButton.className = 'bdv-submit';
+  submitButton.textContent = config.content.submitLabel ?? 'Submit';
+  actions.appendChild(submitButton);
+  let cancelButton: HTMLButtonElement | undefined;
+  if (options.cancel) {
+    cancelButton = document.createElement('button');
+    cancelButton.type = 'button';
+    cancelButton.className = 'bdv-cancel';
+    cancelButton.textContent = options.cancel.label;
+    cancelButton.addEventListener('click', options.cancel.onCancel);
+    actions.appendChild(cancelButton);
+  }
+  form.appendChild(actions);
+
+  const status = document.createElement('p');
+  status.className = 'bdv-status';
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+  form.appendChild(status);
+  surface.appendChild(form);
+
+  const { success, successLink } = createSuccessState(config);
+  surface.appendChild(success);
+
+  let submissionId = createRuntimeId('submission');
+  let busy = false;
+  let disposed = false;
+
+  const setBusy = (value: boolean) => {
+    busy = value;
+    form.setAttribute('aria-busy', String(value));
+    submitButton.disabled = value;
+    if (cancelButton) cancelButton.disabled = value;
+    for (const controller of controllers) controller.setDisabled(value);
+  };
+  const clearErrors = () => {
+    status.textContent = '';
+    status.removeAttribute('data-kind');
+    for (const controller of controllers) controller.setError(null);
+  };
+  const applyInitialAnswers = () => {
+    for (const controller of controllers) {
+      controller.setValue(initialAnswers[controller.field.id] ?? '');
+    }
+  };
+  const collectAnswers = () =>
+    Object.fromEntries(controllers.map(controller => [controller.field.id, controller.getValue()]));
+
+  const handleSubmit = async (event: SubmitEvent) => {
+    event.preventDefault();
+    if (busy || disposed) return;
+    clearErrors();
+
+    let answers: Record<string, string | number>;
+    try {
+      answers = normalizeVariantAnswers(config.fields, collectAnswers());
+    } catch (error) {
+      if (error instanceof VariantAnswerError && error.fieldId) {
+        const controller = controllers.find(candidate => candidate.field.id === error.fieldId);
+        controller?.setError(readableFieldError(error));
+        controller?.focus();
+      } else {
+        status.textContent = error instanceof Error ? error.message : 'Please check your response.';
+        status.dataset.kind = 'error';
+      }
+      return;
+    }
+
+    setBusy(true);
+    status.textContent = 'Submitting…';
+    try {
+      const result = await options.submit(answers, { context, submissionId });
+      if (disposed) return;
+      setBusy(false);
+      successLink.hidden = !result.isPublic;
+      if (result.isPublic) successLink.href = result.issueUrl;
+      form.hidden = true;
+      success.hidden = false;
+      success.focus();
+      options.onSubmitted?.(result);
+    } catch (error) {
+      if (disposed) return;
+      status.textContent = error instanceof Error ? error.message : 'Failed to submit feedback.';
+      status.dataset.kind = 'error';
+      setBusy(false);
+    }
+  };
+  const preventImplicitSubmit = (event: KeyboardEvent) => {
+    if (
+      event.key === 'Enter' &&
+      event.target instanceof HTMLInputElement &&
+      event.target.type !== 'submit'
+    ) {
+      event.preventDefault();
+    }
+  };
+  form.addEventListener('submit', handleSubmit);
+  form.addEventListener('keydown', preventImplicitSubmit);
+  applyInitialAnswers();
+
+  return {
+    element: surface,
+    reset() {
+      if (busy || disposed) return;
+      submissionId = createRuntimeId('submission');
+      clearErrors();
+      applyInitialAnswers();
+      success.hidden = true;
+      successLink.removeAttribute('href');
+      form.hidden = false;
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      form.removeEventListener('submit', handleSubmit);
+      form.removeEventListener('keydown', preventImplicitSubmit);
+      if (cancelButton && options.cancel) {
+        cancelButton.removeEventListener('click', options.cancel.onCancel);
+      }
+      for (const controller of controllers) controller.dispose();
+    },
+  };
+}
+
+export function createRuntimeId(prefix: string): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return `${prefix}-${globalThis.crypto.randomUUID()}`;
+  }
+  if (typeof globalThis.crypto?.getRandomValues !== 'function') {
+    throw new Error(
+      'BugDrop rendered variants require a cryptographically secure random generator'
+    );
+  }
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
+  return `${prefix}-${Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+function createSuccessState(config: Readonly<VariantConfig>) {
+  const success = document.createElement('div');
+  success.className = 'bdv-success';
+  success.hidden = true;
+  success.tabIndex = -1;
+  const title = document.createElement('h3');
+  title.className = 'bdv-success-title';
+  title.textContent = config.content.successTitle ?? 'Thanks for your feedback!';
+  const message = document.createElement('p');
+  message.className = 'bdv-success-message';
+  message.textContent = config.content.successMessage ?? 'Your response was submitted.';
+  const successLink = document.createElement('a');
+  successLink.className = 'bdv-success-link';
+  successLink.textContent = 'View GitHub Issue';
+  successLink.target = '_blank';
+  successLink.rel = 'noopener noreferrer';
+  success.append(title, message, successLink);
+  return { success, successLink };
+}
+
+function readableFieldError(error: VariantAnswerError): string {
+  if (!error.fieldId) return error.message;
+  const prefix = `Answer ${error.fieldId} `;
+  const detail = error.message.startsWith(prefix)
+    ? error.message.slice(prefix.length)
+    : error.message;
+  return detail.charAt(0).toUpperCase() + detail.slice(1);
+}

--- a/src/widget/variants/issue-draft.ts
+++ b/src/widget/variants/issue-draft.ts
@@ -4,6 +4,7 @@ import type {
   VariantField,
   VariantIssueSection,
 } from './public-types';
+import { normalizeVariantAnswers } from './answer-validation';
 
 interface CompiledIssueDraft {
   title: string;
@@ -17,7 +18,7 @@ export function compileIssueDraft(
   context: VariantContext = {}
 ): CompiledIssueDraft {
   validateContext(context);
-  const normalizedAnswers = normalizeAnswers(config.fields, answers);
+  const normalizedAnswers = normalizeVariantAnswers(config.fields, answers);
   const title = config.issue.title
     .replace(/{{\s*([^{}]+?)\s*}}/g, (_match, reference: string) => {
       const value = reference.startsWith('context.')
@@ -47,57 +48,6 @@ export function compileIssueDraft(
     ...(config.issue.classification ? { classification: config.issue.classification } : {}),
     sections,
   };
-}
-
-function normalizeAnswers(
-  fields: ReadonlyArray<VariantField>,
-  answers: Record<string, unknown>
-): Record<string, string | number> {
-  if (!isObject(answers)) throw new TypeError('BugDrop variant answers must be an object');
-  const knownFields = new Set(fields.map(field => field.id));
-  const unknown = Object.keys(answers).find(key => !knownFields.has(key));
-  if (unknown) throw new TypeError(`Unknown BugDrop variant answer: ${unknown}`);
-
-  const normalized: Record<string, string | number> = {};
-  for (const field of fields) {
-    const raw = answers[field.id];
-    if (field.type === 'shortText' || field.type === 'longText') {
-      if (raw === undefined || raw === null || raw === '') {
-        if (field.required) throw new TypeError(`Answer ${field.id} is required`);
-        normalized[field.id] = '';
-        continue;
-      }
-      if (typeof raw !== 'string') throw new TypeError(`Answer ${field.id} must be text`);
-      const value = raw.trim();
-      if (field.required && !value) throw new TypeError(`Answer ${field.id} is required`);
-      const minimum = field.minLength ?? 0;
-      const maximum = field.maxLength ?? (field.type === 'shortText' ? 500 : 5_000);
-      if (value.length < minimum || value.length > maximum) {
-        throw new TypeError(`Answer ${field.id} must be ${minimum}-${maximum} characters`);
-      }
-      normalized[field.id] = value;
-    } else if (field.type === 'rating') {
-      const scale = field.scale ?? 5;
-      if (raw === undefined || raw === null || raw === '') {
-        if (field.required) throw new TypeError(`Answer ${field.id} is required`);
-        normalized[field.id] = '';
-      } else if (!Number.isInteger(raw) || (raw as number) < 1 || (raw as number) > scale) {
-        throw new TypeError(`Answer ${field.id} must be a rating from 1-${scale}`);
-      } else {
-        normalized[field.id] = raw as number;
-      }
-    } else {
-      if (raw === undefined || raw === null || raw === '') {
-        if (field.required) throw new TypeError(`Answer ${field.id} is required`);
-        normalized[field.id] = '';
-      } else if (typeof raw !== 'string' || !field.options.some(option => option.value === raw)) {
-        throw new TypeError(`Answer ${field.id} must be a configured choice`);
-      } else {
-        normalized[field.id] = raw;
-      }
-    }
-  }
-  return normalized;
 }
 
 function resolveSectionValue(

--- a/src/widget/variants/manager.ts
+++ b/src/widget/variants/manager.ts
@@ -1,4 +1,11 @@
-import type { VariantConfig, VariantHandle } from './public-types';
+import type {
+  VariantConfig,
+  VariantHandle,
+  VariantMountOptions,
+  VariantOpenOptions,
+} from './public-types';
+import { mountInlineVariant } from './presentations/inline';
+import { createBusyOpenedVariant, openModalVariant } from './presentations/modal';
 import { validateAndFreezeVariantConfig } from './validate-config';
 import { submitVariant, type VariantTransportConfig } from './submission';
 
@@ -6,7 +13,10 @@ export interface VariantManager {
   register(config: VariantConfig): VariantHandle;
 }
 
-export function createVariantManager(transport: VariantTransportConfig): VariantManager {
+export function createVariantManager(
+  transport: VariantTransportConfig,
+  runtime: { isLegacyModalOpen(): boolean } = { isLegacyModalOpen: () => false }
+): VariantManager {
   const variants = new Map<string, Readonly<VariantConfig>>();
 
   return {
@@ -19,11 +29,26 @@ export function createVariantManager(transport: VariantTransportConfig): Variant
 
       return Object.freeze({
         id: normalized.id,
-        open() {
-          throw new Error('BugDrop rendered variants are not available in the headless foundation');
+        open(options?: VariantOpenOptions) {
+          if (normalized.presentation.kind !== 'modal') {
+            throw new TypeError('BugDrop open() requires a modal variant');
+          }
+          if (runtime.isLegacyModalOpen()) return createBusyOpenedVariant(normalized.id);
+          return openModalVariant({
+            config: normalized,
+            options,
+            submit: (answers, submitOptions) =>
+              submitVariant(transport, normalized, answers, submitOptions),
+          });
         },
-        mount() {
-          throw new Error('BugDrop rendered variants are not available in the headless foundation');
+        mount(target: HTMLElement, options?: VariantMountOptions) {
+          return mountInlineVariant({
+            config: normalized,
+            target,
+            options,
+            submit: (answers, submitOptions) =>
+              submitVariant(transport, normalized, answers, submitOptions),
+          });
         },
         submit(answers: Record<string, unknown>, options = {}) {
           return submitVariant(transport, normalized, answers, options);

--- a/src/widget/variants/modal-coordinator.ts
+++ b/src/widget/variants/modal-coordinator.ts
@@ -1,0 +1,16 @@
+interface ActiveVariantModal {
+  close(): void;
+}
+
+let activeVariantModal: ActiveVariantModal | undefined;
+
+export function closeActiveVariantModal(): void {
+  activeVariantModal?.close();
+}
+
+export function setActiveVariantModal(modal: ActiveVariantModal): () => void {
+  activeVariantModal = modal;
+  return () => {
+    if (activeVariantModal === modal) activeVariantModal = undefined;
+  };
+}

--- a/src/widget/variants/presentations/inline.ts
+++ b/src/widget/variants/presentations/inline.ts
@@ -1,0 +1,63 @@
+import { assertKnownVariantAnswerKeys } from '../answer-validation';
+import { createRuntimeId, createVariantForm } from '../form';
+import type {
+  MountedVariant,
+  VariantConfig,
+  VariantMountOptions,
+  SubmissionResult,
+} from '../public-types';
+import { createStyledVariantRoot } from '../styles';
+import { installRadixDialogCompatibility } from '../../radix-compat';
+
+interface InlineMountOptions {
+  config: Readonly<VariantConfig>;
+  target: HTMLElement;
+  options?: VariantMountOptions;
+  submit(
+    answers: Record<string, unknown>,
+    options: { context?: VariantMountOptions['context']; submissionId?: string }
+  ): Promise<SubmissionResult>;
+}
+
+export function mountInlineVariant(input: InlineMountOptions): MountedVariant {
+  if (!(input.target instanceof HTMLElement)) {
+    throw new TypeError('BugDrop inline variant target must be an HTMLElement');
+  }
+  if (input.config.presentation.kind !== 'inline') {
+    throw new TypeError('BugDrop mount() requires an inline variant');
+  }
+  assertKnownVariantAnswerKeys(input.config.fields, input.options?.initialAnswers ?? {});
+
+  const instanceId = createRuntimeId(input.config.id);
+  const host = document.createElement('div');
+  host.dataset.bugdropOwned = '';
+  host.dataset.bugdropInstance = instanceId;
+  const shadow = host.attachShadow({ mode: 'open' });
+  const disposeRadix = installRadixDialogCompatibility(host);
+  const styled = createStyledVariantRoot(shadow, input.config, 'inline');
+  const form = createVariantForm({
+    config: input.config,
+    instanceId,
+    context: input.options?.context,
+    initialAnswers: input.options?.initialAnswers,
+    submit: input.submit,
+  });
+  styled.root.appendChild(form.element);
+  input.target.appendChild(host);
+
+  let unmounted = false;
+  return Object.freeze({
+    instanceId,
+    reset() {
+      if (!unmounted) form.reset();
+    },
+    unmount() {
+      if (unmounted) return;
+      unmounted = true;
+      form.dispose();
+      disposeRadix();
+      styled.dispose();
+      host.remove();
+    },
+  });
+}

--- a/src/widget/variants/presentations/modal.ts
+++ b/src/widget/variants/presentations/modal.ts
@@ -1,0 +1,159 @@
+import { assertKnownVariantAnswerKeys } from '../answer-validation';
+import { createRuntimeId, createVariantForm } from '../form';
+import { closeActiveVariantModal, setActiveVariantModal } from '../modal-coordinator';
+import type {
+  OpenedVariant,
+  SubmissionResult,
+  VariantConfig,
+  VariantOpenOptions,
+  VariantOutcome,
+} from '../public-types';
+import { createStyledVariantRoot } from '../styles';
+import { installRadixDialogCompatibility } from '../../radix-compat';
+
+interface ModalOpenInput {
+  config: Readonly<VariantConfig>;
+  options?: VariantOpenOptions;
+  submit(
+    answers: Record<string, unknown>,
+    options: { context?: VariantOpenOptions['context']; submissionId?: string }
+  ): Promise<SubmissionResult>;
+}
+
+export function openModalVariant(input: ModalOpenInput): OpenedVariant {
+  if (input.config.presentation.kind !== 'modal') {
+    throw new TypeError('BugDrop open() requires a modal variant');
+  }
+  assertKnownVariantAnswerKeys(input.config.fields, input.options?.initialAnswers ?? {});
+  closeActiveVariantModal();
+
+  const instanceId = createRuntimeId(input.config.id);
+  const previousFocus =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const previousOverflow = document.body.style.getPropertyValue('overflow');
+  const previousOverflowPriority = document.body.style.getPropertyPriority('overflow');
+  const host = document.createElement('div');
+  host.dataset.bugdropOwned = '';
+  host.dataset.bugdropInstance = instanceId;
+  Object.assign(host.style, { position: 'fixed', inset: '0', zIndex: '2147483646' });
+  const shadow = host.attachShadow({ mode: 'open' });
+  const styled = createStyledVariantRoot(shadow, input.config, 'modal');
+  const overlay = document.createElement('div');
+  overlay.className = 'bdv-overlay';
+  styled.root.appendChild(overlay);
+
+  let resolveOutcome!: (outcome: VariantOutcome) => void;
+  const result = new Promise<VariantOutcome>(resolve => {
+    resolveOutcome = resolve;
+  });
+  let settled = false;
+  let closed = false;
+  let unregisterActive = () => {};
+  const settle = (outcome: VariantOutcome) => {
+    if (settled) return;
+    settled = true;
+    resolveOutcome(outcome);
+  };
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    settle({ status: 'closed' });
+    unregisterActive();
+    shadow.removeEventListener('keydown', handleKeydown);
+    overlay.removeEventListener('pointerdown', handleBackdropPointerDown);
+    form.dispose();
+    disposeRadix();
+    styled.dispose();
+    host.remove();
+    restoreBodyOverflow(previousOverflow, previousOverflowPriority);
+    if (previousFocus?.isConnected) previousFocus.focus();
+  };
+
+  const form = createVariantForm({
+    config: input.config,
+    instanceId,
+    context: input.options?.context,
+    initialAnswers: input.options?.initialAnswers,
+    submit: input.submit,
+    cancel: { label: input.config.content.cancelLabel ?? 'Cancel', onCancel: close },
+    onSubmitted: submission => settle({ status: 'submitted', result: submission }),
+  });
+  form.element.setAttribute('role', 'dialog');
+  form.element.setAttribute('aria-modal', 'true');
+  form.element.dataset.size = input.config.presentation.size ?? 'default';
+
+  const closeButton = document.createElement('button');
+  closeButton.type = 'button';
+  closeButton.className = 'bdv-close';
+  closeButton.setAttribute('aria-label', 'Close');
+  closeButton.textContent = '×';
+  closeButton.addEventListener('click', close, { once: true });
+  form.element.prepend(closeButton);
+  overlay.appendChild(form.element);
+
+  function handleKeydown(event: Event) {
+    if (!(event instanceof KeyboardEvent)) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const focusable = getFocusable(form.element);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      form.element.focus();
+      return;
+    }
+    const active = shadow.activeElement;
+    const first = focusable[0];
+    const last = focusable.at(-1)!;
+    if (event.shiftKey && (active === first || !form.element.contains(active))) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+  function handleBackdropPointerDown(event: PointerEvent) {
+    if (event.target === overlay) close();
+  }
+
+  document.body.style.setProperty('overflow', 'hidden');
+  document.body.appendChild(host);
+  const disposeRadix = installRadixDialogCompatibility(host);
+  shadow.addEventListener('keydown', handleKeydown);
+  overlay.addEventListener('pointerdown', handleBackdropPointerDown);
+  const opened = Object.freeze({ instanceId, result, close });
+  unregisterActive = setActiveVariantModal(opened);
+  queueMicrotask(() => {
+    if (closed) return;
+    const preferred = form.element.querySelector<HTMLElement>(
+      'textarea:not(:disabled), input:not(:disabled), [role="radio"][tabindex="0"]'
+    );
+    (preferred ?? getFocusable(form.element)[0] ?? form.element).focus();
+  });
+  return opened;
+}
+
+export function createBusyOpenedVariant(variantId: string): OpenedVariant {
+  return Object.freeze({
+    instanceId: createRuntimeId(variantId),
+    result: Promise.resolve<VariantOutcome>({ status: 'busy' }),
+    close() {},
+  });
+}
+
+function getFocusable(root: HTMLElement): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'button:not(:disabled), input:not(:disabled), textarea:not(:disabled), select:not(:disabled), a[href], [tabindex]:not([tabindex="-1"])'
+    )
+  ).filter(element => !element.hidden && element.getAttribute('aria-hidden') !== 'true');
+}
+
+function restoreBodyOverflow(value: string, priority: string): void {
+  if (value) document.body.style.setProperty('overflow', value, priority);
+  else document.body.style.removeProperty('overflow');
+}

--- a/src/widget/variants/styles.ts
+++ b/src/widget/variants/styles.ts
@@ -1,0 +1,227 @@
+import { sanitizeCssColor } from '../sanitize';
+import { attachSystemThemeListener, resolveTheme } from '../theme';
+import type { VariantConfig } from './public-types';
+
+interface StyledVariantRoot {
+  readonly root: HTMLDivElement;
+  dispose(): void;
+}
+
+export function createStyledVariantRoot(
+  shadow: ShadowRoot,
+  config: Readonly<VariantConfig>,
+  presentation: 'inline' | 'modal'
+): StyledVariantRoot {
+  const style = document.createElement('style');
+  style.textContent = VARIANT_CSS;
+  shadow.appendChild(style);
+
+  const root = document.createElement('div');
+  root.className = 'bdv-root';
+  root.dataset.presentation = presentation;
+  if (config.presentation.kind === 'modal') {
+    root.dataset.size = config.presentation.size ?? 'default';
+  }
+  root.dataset.density = config.appearance?.density ?? 'comfortable';
+  root.dataset.columns = String(config.presentation.columns ?? 1);
+  const accent = sanitizeCssColor(config.appearance?.accentColor);
+  if (accent) root.style.setProperty('--bdv-accent', accent);
+  shadow.appendChild(root);
+
+  const mode = config.appearance?.theme ?? 'auto';
+  const applyTheme = (resolved: 'light' | 'dark') => {
+    root.classList.toggle('bdv-dark', resolved === 'dark');
+  };
+  applyTheme(resolveTheme(mode));
+  const detachTheme = mode === 'auto' ? attachSystemThemeListener(applyTheme) : () => {};
+
+  return {
+    root,
+    dispose() {
+      detachTheme();
+      style.remove();
+      root.remove();
+    },
+  };
+}
+
+const VARIANT_CSS = `
+  :host {
+    --bdv-accent: #2563eb;
+    display: block;
+    color-scheme: light;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; }
+
+  .bdv-root {
+    --bdv-bg: #ffffff;
+    --bdv-bg-muted: #f8fafc;
+    --bdv-text: #0f172a;
+    --bdv-text-muted: #64748b;
+    --bdv-border: #cbd5e1;
+    --bdv-danger: #b91c1c;
+    --bdv-success: #047857;
+    color: var(--bdv-text);
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+  }
+
+  .bdv-root.bdv-dark {
+    --bdv-bg: #0f172a;
+    --bdv-bg-muted: #1e293b;
+    --bdv-text: #f8fafc;
+    --bdv-text-muted: #94a3b8;
+    --bdv-border: #475569;
+    --bdv-danger: #fca5a5;
+    --bdv-success: #6ee7b7;
+    color-scheme: dark;
+  }
+
+  .bdv-surface {
+    position: relative;
+    width: 100%;
+    border: 1px solid var(--bdv-border);
+    border-radius: 14px;
+    background: var(--bdv-bg);
+    color: var(--bdv-text);
+    padding: 24px;
+    box-shadow: 0 8px 28px rgb(15 23 42 / 10%);
+  }
+
+  .bdv-root[data-density="compact"] .bdv-surface { padding: 16px; }
+  .bdv-header { margin-bottom: 20px; }
+  .bdv-title { margin: 0; font-size: 1.25rem; line-height: 1.3; }
+  .bdv-description { margin: 8px 0 0; color: var(--bdv-text-muted); }
+
+  .bdv-fields {
+    display: grid;
+    grid-template-columns: repeat(var(--bdv-columns, 1), minmax(0, 1fr));
+    gap: 18px;
+  }
+  .bdv-root[data-columns="2"] .bdv-fields { --bdv-columns: 2; }
+  .bdv-field[data-span="2"] { grid-column: span 2; }
+  .bdv-field { min-width: 0; }
+  .bdv-label { display: block; margin-bottom: 6px; font-weight: 650; }
+  .bdv-required { color: var(--bdv-danger); }
+  .bdv-help { margin: -2px 0 7px; color: var(--bdv-text-muted); font-size: 0.875rem; }
+  .bdv-error { margin-top: 6px; color: var(--bdv-danger); font-size: 0.875rem; }
+
+  .bdv-input {
+    width: 100%;
+    min-height: 44px;
+    border: 1px solid var(--bdv-border);
+    border-radius: 9px;
+    background: var(--bdv-bg);
+    color: var(--bdv-text);
+    padding: 10px 12px;
+    font: inherit;
+  }
+  textarea.bdv-input { min-height: 108px; resize: vertical; }
+  .bdv-input:focus-visible,
+  .bdv-rating-option:focus-visible,
+  .bdv-submit:focus-visible,
+  .bdv-cancel:focus-visible,
+  .bdv-close:focus-visible,
+  .bdv-success-link:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--bdv-accent) 35%, transparent);
+    outline-offset: 2px;
+  }
+  [aria-invalid="true"] { border-color: var(--bdv-danger); }
+
+  .bdv-rating { display: flex; flex-wrap: wrap; gap: 6px; }
+  .bdv-rating-option {
+    width: 44px;
+    height: 44px;
+    border: 1px solid var(--bdv-border);
+    border-radius: 9px;
+    background: var(--bdv-bg-muted);
+    color: var(--bdv-text-muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: 1.4rem;
+    line-height: 1;
+  }
+  .bdv-rating-option:hover,
+  .bdv-rating-option--active { color: var(--bdv-accent); border-color: var(--bdv-accent); }
+  .bdv-rating-option:disabled { cursor: wait; opacity: 0.65; }
+  .bdv-rating-labels {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 5px;
+    color: var(--bdv-text-muted);
+    font-size: 0.8rem;
+  }
+
+  .bdv-actions { display: flex; align-items: center; gap: 12px; margin-top: 20px; }
+  .bdv-submit {
+    min-height: 44px;
+    border: 0;
+    border-radius: 9px;
+    background: var(--bdv-accent);
+    color: #ffffff;
+    cursor: pointer;
+    padding: 10px 18px;
+    font: inherit;
+    font-weight: 700;
+  }
+  .bdv-cancel {
+    min-height: 44px;
+    border: 1px solid var(--bdv-border);
+    border-radius: 9px;
+    background: var(--bdv-bg);
+    color: var(--bdv-text);
+    cursor: pointer;
+    padding: 10px 18px;
+    font: inherit;
+    font-weight: 650;
+  }
+  .bdv-cancel:disabled { cursor: wait; opacity: 0.65; }
+  .bdv-overlay {
+    display: grid;
+    min-height: 100%;
+    place-items: center;
+    overflow: auto;
+    padding: max(20px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right))
+      max(20px, env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left));
+    background: rgb(15 23 42 / 56%);
+  }
+  .bdv-root[data-presentation="modal"] { height: 100%; }
+  .bdv-root[data-presentation="modal"] .bdv-surface { max-width: 560px; }
+  .bdv-root[data-size="compact"] .bdv-surface { max-width: 440px; }
+  .bdv-root[data-size="wide"] .bdv-surface { max-width: 760px; }
+  .bdv-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    display: grid;
+    width: 44px;
+    height: 44px;
+    place-items: center;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--bdv-text-muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: 1.6rem;
+    line-height: 1;
+  }
+  .bdv-close:hover { background: var(--bdv-bg-muted); color: var(--bdv-text); }
+  .bdv-root[data-presentation="modal"] .bdv-header { padding-right: 36px; }
+  .bdv-submit:disabled { cursor: wait; opacity: 0.65; }
+  .bdv-status { min-height: 1.5em; margin: 12px 0 0; color: var(--bdv-text-muted); }
+  .bdv-status[data-kind="error"] { color: var(--bdv-danger); }
+  .bdv-success { outline: none; }
+  .bdv-success-title { margin: 0; color: var(--bdv-success); font-size: 1.2rem; }
+  .bdv-success-message { margin: 8px 0 0; color: var(--bdv-text-muted); }
+  .bdv-success-link { display: inline-block; margin-top: 14px; color: var(--bdv-accent); }
+
+  @media (max-width: 640px) {
+    .bdv-root[data-columns="2"] .bdv-fields { --bdv-columns: 1; }
+    .bdv-field[data-span="2"] { grid-column: span 1; }
+    .bdv-surface { padding: 18px; }
+    .bdv-root[data-presentation="modal"] .bdv-surface { max-width: none; }
+  }
+`;

--- a/src/widget/viewport-capture.ts
+++ b/src/widget/viewport-capture.ts
@@ -1,4 +1,5 @@
 import { withCaptureTimeout } from './capture-timeout';
+import { withBugDropOwnedRootsHidden } from './owned-roots';
 
 type DisplayMediaOptionsWithCurrentTab = DisplayMediaStreamOptions & {
   preferCurrentTab?: boolean;
@@ -15,9 +16,11 @@ declare global {
 }
 
 export function beginViewportCapture(): Promise<string> {
-  if (window.__bugdropMockViewportCapture) {
-    return window.__bugdropMockViewportCapture();
-  }
+  return withBugDropOwnedRootsHidden(beginVisibleViewportCapture);
+}
+
+function beginVisibleViewportCapture(): Promise<string> {
+  if (window.__bugdropMockViewportCapture) return window.__bugdropMockViewportCapture();
 
   if (!navigator.mediaDevices?.getDisplayMedia) {
     return Promise.reject(new Error('Screen Capture API is not available'));

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -7,6 +7,8 @@ ci_workflow="$repo_root/.github/workflows/ci.yml"
 live_workflow="$repo_root/.github/workflows/live-tests.yml"
 canary_spec="$repo_root/e2e/widget.issue-canary.spec.ts"
 live_spec="$repo_root/e2e/widget.live.spec.ts"
+variant_live_spec="$repo_root/e2e/variant.live.spec.ts"
+variant_accessibility_spec="$repo_root/e2e/variant-accessibility.radix.spec.ts"
 live_radix_spec="$repo_root/e2e/widget.live-radix.spec.ts"
 cross_browser_live_spec="$repo_root/e2e/widget.cross-browser-live.spec.ts"
 exact_widget_fixture="$repo_root/e2e/live-preview-widget.ts"
@@ -186,8 +188,21 @@ require_literal "$canary_spec" "response.request().method() === 'POST'"
 require_literal "$canary_spec" 'responseUrl.origin === environment.expectedWidgetOrigin'
 require_literal "$canary_spec" "responseUrl.pathname === '/api/feedback'"
 require_literal "$canary_spec" 'expect(feedbackUrl.origin).toBe(environment.expectedWidgetOrigin)'
+require_literal "$canary_spec" "presentation: { kind: 'modal', size: 'compact' }"
+require_literal "$canary_spec" 'const opened = handle.open('
+require_literal "$canary_spec" 'await markerInput.fill(environment.marker)'
+require_literal "$canary_spec" "getByRole('button', { name: 'Create canary Issue' }).click()"
+require_absent "$canary_spec" 'return handle.submit('
 require_literal "$live_spec" "page.route('**/feedback'"
 require_literal "$live_spec" 'installExactPreviewWidgetFromEnvironment(context)'
+require_literal "$variant_live_spec" "from './live-preview-widget'"
+require_literal "$variant_live_spec" "page.route('**/feedback'"
+require_literal "$variant_live_spec" 'renders and submits the exact inline star-review draft'
+require_literal "$variant_live_spec" 'opens and submits the exact CTA text-modal draft'
+require_literal "$variant_live_spec" 'assertExactPreviewWidgetResponse'
+require_literal "$variant_accessibility_spec" 'rating keyboard behavior requires explicit Submit'
+require_literal "$variant_accessibility_spec" 'modal focus is contained and Escape restores the host page'
+require_literal "$variant_accessibility_spec" "expect(submissionCount).toBe(0)"
 for live_browser_spec in "$live_spec" "$live_radix_spec" "$cross_browser_live_spec"; do
   require_literal "$live_browser_spec" "from './live-preview-widget'"
 done

--- a/test/githubIssueCanary.test.ts
+++ b/test/githubIssueCanary.test.ts
@@ -12,6 +12,7 @@ const REPO = 'mean-weasel/bugdrop-widget-test';
 const MARKER = `bugdrop-ci-canary:123:1:${'a'.repeat(40)}`;
 const SHA = 'a'.repeat(40);
 const TOKEN = 'synthetic-redaction-sentinel-not-a-credential';
+const RENDERED_SUBMISSION_ID = 'submission-95a970ec-e4fa-41da-9a29-f4b62fb941ca';
 const noWait = vi.fn(async () => {});
 
 type Issue = {
@@ -72,6 +73,14 @@ function result(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function renderedResult(overrides: Record<string, unknown> = {}) {
+  return result({
+    presentation: 'modal',
+    submissionId: RENDERED_SUBMISSION_ID,
+    ...overrides,
+  });
+}
+
 function issueFetch(
   matches: Issue[],
   direct: Issue = matches[0]
@@ -127,6 +136,48 @@ describe('GitHub Issue canary discovery and verification', () => {
 
     expect(verified.number).toBe(42);
     expect(verified.html_url).toBe(`https://github.com/${REPO}/issues/42`);
+  });
+
+  it('verifies a rendered modal result with its runtime submission identity', async () => {
+    const renderedIssue = issue({
+      body: issue().body.replace(`ci:${MARKER}`, RENDERED_SUBMISSION_ID),
+    });
+    const fetchImpl = issueFetch([renderedIssue]);
+
+    const verified = await verifyCanaryIssue({
+      fetchImpl,
+      repo: REPO,
+      token: TOKEN,
+      marker: MARKER,
+      expectedSha: SHA,
+      result: renderedResult(),
+      sleepImpl: noWait,
+    });
+
+    expect(verified.number).toBe(42);
+  });
+
+  it.each([
+    ['missing rendered identity', renderedResult({ submissionId: undefined })],
+    ['non-rendered identity', renderedResult({ submissionId: `ci:${MARKER}` })],
+    ['malformed rendered identity', renderedResult({ submissionId: 'submission-not-random' })],
+  ])('rejects a rendered modal result with %s', async (_name, browserResult) => {
+    const renderedIssue = issue({
+      body: issue().body.replace(`ci:${MARKER}`, RENDERED_SUBMISSION_ID),
+    });
+    const fetchImpl = issueFetch([renderedIssue]);
+
+    await expect(
+      verifyCanaryIssue({
+        fetchImpl,
+        repo: REPO,
+        token: TOKEN,
+        marker: MARKER,
+        expectedSha: SHA,
+        result: browserResult,
+        sleepImpl: noWait,
+      })
+    ).rejects.toThrow('rendered submission identity');
   });
 
   it.each([

--- a/test/mask.test.ts
+++ b/test/mask.test.ts
@@ -57,6 +57,21 @@ describe('collectMaskRects — explicit attribute', () => {
     expect(collectMaskRects(document.body)).toEqual([]);
   });
 
+  it('does not inspect BugDrop-owned light or shadow DOM', () => {
+    const owned = document.createElement('div');
+    owned.dataset.bugdropOwned = '';
+    const lightInput = withRect(document.createElement('input'), 0, 0, 100, 30);
+    lightInput.type = 'password';
+    const shadowInput = withRect(document.createElement('input'), 0, 40, 100, 30);
+    shadowInput.type = 'password';
+    owned.appendChild(lightInput);
+    owned.attachShadow({ mode: 'open' }).appendChild(shadowInput);
+    document.body.appendChild(owned);
+
+    expect(collectMaskRects(document.body)).toEqual([]);
+    expect(createRedactionSnapshot(owned).redactionCount).toBe(0);
+  });
+
   it('returns rect for a single masked div', () => {
     const div = withRect(document.createElement('div'), 10, 20, 100, 50);
     div.setAttribute('data-bugdrop-mask', '');

--- a/test/ownedRoots.test.ts
+++ b/test/ownedRoots.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { isBugDropOwnedNode, withBugDropOwnedRootsHidden } from '../src/widget/owned-roots';
+
+describe('BugDrop-owned roots', () => {
+  beforeEach(() => document.body.replaceChildren());
+
+  it('recognizes legacy, variant, and open-shadow descendants without claiming host content', () => {
+    const legacy = document.createElement('div');
+    legacy.id = 'bugdrop-host';
+    const variant = document.createElement('div');
+    variant.dataset.bugdropOwned = '';
+    const shadowChild = document.createElement('button');
+    variant.attachShadow({ mode: 'open' }).appendChild(shadowChild);
+    const hostContent = document.createElement('button');
+    document.body.append(legacy, variant, hostContent);
+
+    expect(isBugDropOwnedNode(legacy)).toBe(true);
+    expect(isBugDropOwnedNode(variant)).toBe(true);
+    expect(isBugDropOwnedNode(shadowChild)).toBe(true);
+    expect(isBugDropOwnedNode(hostContent)).toBe(false);
+  });
+
+  it('restores exact visibility styles after successful and failed viewport work', async () => {
+    const first = document.createElement('div');
+    first.id = 'bugdrop-host';
+    first.style.setProperty('visibility', 'visible', 'important');
+    const second = document.createElement('div');
+    second.dataset.bugdropOwned = '';
+    document.body.append(first, second);
+
+    await expect(
+      withBugDropOwnedRootsHidden(async () => {
+        expect(getComputedStyle(first).visibility).toBe('hidden');
+        expect(getComputedStyle(second).visibility).toBe('hidden');
+        throw new Error('capture failed');
+      })
+    ).rejects.toThrow('capture failed');
+    expect(first.style.getPropertyValue('visibility')).toBe('visible');
+    expect(first.style.getPropertyPriority('visibility')).toBe('important');
+    expect(second.style.getPropertyValue('visibility')).toBe('');
+  });
+});

--- a/test/variantFields.test.ts
+++ b/test/variantFields.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import {
+  VariantAnswerError,
+  normalizeVariantAnswers,
+} from '../src/widget/variants/answer-validation';
+import { createFieldController } from '../src/widget/variants/fields';
+import type { VariantField } from '../src/widget/variants/public-types';
+
+describe('rendered variant field controllers', () => {
+  it('normalizes rendered and headless answers through the same field errors', () => {
+    const fields: VariantField[] = [
+      { id: 'rating', type: 'rating', label: 'Rating', required: true, scale: 5 },
+      { id: 'message', type: 'longText', label: 'Message', maxLength: 10 },
+    ];
+
+    expect(normalizeVariantAnswers(fields, { rating: 4, message: '  useful  ' })).toEqual({
+      rating: 4,
+      message: 'useful',
+    });
+    try {
+      normalizeVariantAnswers(fields, { rating: '', message: '' });
+      throw new Error('Expected required rating to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(VariantAnswerError);
+      expect(error).toMatchObject({ fieldId: 'rating', message: 'Answer rating is required' });
+    }
+  });
+
+  it('renders short and long text controls with bounded accessible state', () => {
+    const short = createFieldController(
+      {
+        id: 'summary',
+        type: 'shortText',
+        label: 'Summary',
+        helpText: 'Keep it brief',
+        required: true,
+        maxLength: 40,
+      },
+      'instance-1'
+    );
+    const long = createFieldController(
+      { id: 'detail', type: 'longText', label: 'Detail', rows: 6, maxLength: 500 },
+      'instance-1'
+    );
+    document.body.append(short.element, long.element);
+
+    short.setValue('Cloudflare');
+    long.setValue('More context');
+    expect(short.getValue()).toBe('Cloudflare');
+    expect(long.getValue()).toBe('More context');
+    expect(short.element.querySelector('input')).toMatchObject({ required: true, maxLength: 40 });
+    expect(long.element.querySelector('textarea')).toMatchObject({ rows: 6, maxLength: 500 });
+
+    short.setError('Is required');
+    expect(short.element.querySelector('input')?.getAttribute('aria-invalid')).toBe('true');
+    expect(short.element.querySelector('.bdv-error')?.textContent).toBe('Is required');
+    short.setError(null);
+    expect(short.element.querySelector('input')?.hasAttribute('aria-invalid')).toBe(false);
+  });
+
+  it('supports pointer and keyboard rating selection without a form submit control', () => {
+    const rating = createFieldController(
+      {
+        id: 'rating',
+        type: 'rating',
+        label: 'Rating',
+        required: true,
+        scale: 5,
+        lowLabel: 'Poor',
+        highLabel: 'Excellent',
+      },
+      'instance-2'
+    );
+    document.body.appendChild(rating.element);
+    const buttons = Array.from(rating.element.querySelectorAll('button'));
+    expect(buttons).toHaveLength(5);
+    expect(buttons.every(button => button.type === 'button')).toBe(true);
+
+    buttons[2]?.click();
+    expect(rating.getValue()).toBe(3);
+    buttons[2]?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(rating.getValue()).toBe(4);
+    expect(buttons[3]?.getAttribute('aria-checked')).toBe('true');
+
+    rating.setDisabled(true);
+    expect(buttons.every(button => button.disabled)).toBe(true);
+    rating.setValue('invalid');
+    expect(rating.getValue()).toBe('');
+    rating.dispose();
+  });
+});

--- a/test/variantManager.test.ts
+++ b/test/variantManager.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createVariantManager } from '../src/widget/variants/manager';
+import type { VariantConfig } from '../src/widget/variants/public-types';
+
+const reviewConfig: VariantConfig = {
+  id: 'export-review',
+  presentation: { kind: 'inline' },
+  content: { title: 'How was this export?', submitLabel: 'Submit review' },
+  fields: [
+    { id: 'rating', type: 'rating', label: 'Rating', required: true, scale: 5 },
+    { id: 'message', type: 'longText', label: 'Anything else?', maxLength: 1000 },
+  ],
+  issue: { title: 'Review {{rating}}/5' },
+};
+
+const modalConfig: VariantConfig = {
+  id: 'provider-question',
+  presentation: { kind: 'modal', size: 'compact' },
+  content: { title: 'Which provider?', cancelLabel: 'Not now' },
+  fields: [{ id: 'response', type: 'longText', label: 'Your answer', required: true }],
+  issue: { title: 'Provider {{response}}' },
+};
+
+describe('rendered variant manager', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('keeps registration lazy and mounts one owned isolated child', () => {
+    const manager = createVariantManager({
+      repo: 'owner/repo',
+      apiUrl: 'https://example.test/api',
+    });
+    const handle = manager.register(reviewConfig);
+    expect(document.querySelectorAll('[data-bugdrop-owned]')).toHaveLength(0);
+
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const mounted = handle.mount(target, { initialAnswers: { rating: 2, message: 'Initial' } });
+    const host = target.querySelector<HTMLElement>('[data-bugdrop-owned]');
+    expect(host?.dataset.bugdropInstance).toBe(mounted.instanceId);
+    expect(host?.shadowRoot?.querySelector('[role="radiogroup"]')).not.toBeNull();
+    expect(host?.shadowRoot?.querySelector('textarea')).toMatchObject({ value: 'Initial' });
+
+    const selected = host?.shadowRoot?.querySelector('[role="radio"][aria-checked="true"]');
+    expect(selected?.getAttribute('aria-label')).toBe('2 stars');
+    mounted.unmount();
+    mounted.unmount();
+    expect(target.childElementCount).toBe(0);
+  });
+
+  it('isolates repeated mounts and restores initial state on reset', () => {
+    const manager = createVariantManager({
+      repo: 'owner/repo',
+      apiUrl: 'https://example.test/api',
+    });
+    const handle = manager.register(reviewConfig);
+    const firstTarget = document.createElement('div');
+    const secondTarget = document.createElement('div');
+    document.body.append(firstTarget, secondTarget);
+    const first = handle.mount(firstTarget, { initialAnswers: { rating: 1 } });
+    const second = handle.mount(secondTarget, { initialAnswers: { rating: 5 } });
+    expect(first.instanceId).not.toBe(second.instanceId);
+
+    firstTarget
+      .querySelector<HTMLElement>('[data-bugdrop-owned]')
+      ?.shadowRoot?.querySelector<HTMLButtonElement>('[aria-label="4 stars"]')
+      ?.click();
+    first.reset();
+    expect(
+      firstTarget
+        .querySelector<HTMLElement>('[data-bugdrop-owned]')
+        ?.shadowRoot?.querySelector('[aria-checked="true"]')
+        ?.getAttribute('aria-label')
+    ).toBe('1 star');
+    expect(
+      secondTarget
+        .querySelector<HTMLElement>('[data-bugdrop-owned]')
+        ?.shadowRoot?.querySelector('[aria-checked="true"]')
+        ?.getAttribute('aria-label')
+    ).toBe('5 stars');
+  });
+
+  it('rejects modal mount and unknown initial answers without leaking a host', () => {
+    const manager = createVariantManager({
+      repo: 'owner/repo',
+      apiUrl: 'https://example.test/api',
+    });
+    const inline = manager.register(reviewConfig);
+    const modal = manager.register({
+      ...reviewConfig,
+      id: 'provider-question',
+      presentation: { kind: 'modal' },
+    });
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    expect(() => inline.mount(target, { initialAnswers: { injected: true } })).toThrow(
+      'Unknown BugDrop variant answer'
+    );
+    expect(() => modal.mount(target)).toThrow('requires an inline variant');
+    expect(target.childElementCount).toBe(0);
+  });
+
+  it('opens an accessible modal and restores focus, scroll, and result exactly once', async () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+    document.body.style.overflow = 'clip';
+    const manager = createVariantManager({ repo: 'owner/repo', apiUrl: '/api' });
+    const opened = manager.register(modalConfig).open({ initialAnswers: { response: 'Fly' } });
+    const host = document.querySelector<HTMLElement>('[data-bugdrop-owned]');
+    const dialog = host?.shadowRoot?.querySelector<HTMLElement>('[role="dialog"]');
+
+    expect(host?.dataset.bugdropInstance).toBe(opened.instanceId);
+    expect(dialog?.getAttribute('aria-modal')).toBe('true');
+    expect(host?.shadowRoot?.querySelector<HTMLTextAreaElement>('textarea')?.value).toBe('Fly');
+    expect(document.body.style.overflow).toBe('hidden');
+    opened.close();
+    opened.close();
+    await expect(opened.result).resolves.toEqual({ status: 'closed' });
+    expect(document.querySelector('[data-bugdrop-owned]')).toBeNull();
+    expect(document.body.style.overflow).toBe('clip');
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('returns busy over a legacy modal and replaces an active variant through cancellation', async () => {
+    let legacyOpen = true;
+    const manager = createVariantManager(
+      { repo: 'owner/repo', apiUrl: '/api' },
+      { isLegacyModalOpen: () => legacyOpen }
+    );
+    const handle = manager.register(modalConfig);
+    const busy = handle.open();
+    await expect(busy.result).resolves.toEqual({ status: 'busy' });
+    expect(document.querySelector('[data-bugdrop-owned]')).toBeNull();
+
+    legacyOpen = false;
+    const first = handle.open();
+    const second = handle.open();
+    await expect(first.result).resolves.toEqual({ status: 'closed' });
+    expect(document.querySelectorAll('[data-bugdrop-owned]')).toHaveLength(1);
+    expect(document.body.style.overflow).toBe('hidden');
+    second.close();
+  });
+});


### PR DESCRIPTION
## Summary

- add an inline one-to-five-star review with an optional comment and explicit Submit
- add a host-triggered CTA modal for focused text responses
- share field controllers, validation, issue-draft compilation, lifecycle, and owned-root isolation across rendered and headless variants
- preserve legacy widget behavior, capture boundaries, Radix coexistence, lazy startup, and multiple-instance isolation

## Merge-queue proof

- render and submit both UX variants against the exact pinned preview widget bytes without creating Issues
- run one zero-retry rendered CTA canary through the existing GitHub App
- independently verify the resulting Issue fields, close it, and sweep for zero matching open Issues

## Local verification

- `npm run validate` — 33 files, 453 tests
- `npm run verify:legacy-compat`
- `npm run knip`
- `bash test/ci-workflow-contract.test.sh`
- focused Chromium, Firefox, and WebKit rendered accessibility/coexistence suites
- widget bundle remains under the established gzip budget
