### PR TITLE
docs: plan weekly manual release cadence

### DIFF
--- a/docs/goals/weekly-manual-release-cadence/goal.md
+++ b/docs/goals/weekly-manual-release-cadence/goal.md
@@ -1,0 +1,95 @@
+# Weekly Manual Release Cadence
+
+## Objective
+
+Produce a decision-complete specification and a detailed, verification-driven implementation plan for replacing BugDrop's push-to-main semantic-release/deploy coupling with a controlled weekly manual release process. This is a planning-only tranche: do not modify release workflows, dependencies, product code, GitHub settings, Cloudflare state, tags, or releases.
+
+## Original Request
+
+On a fresh worktree off GitHub main, start with a specification for moving away from semantic-release to a weekly release cadence with a manually dispatched GitHub workflow, then convert that specification into a detailed implementation plan using GoalBuddyPrep.
+
+## Intake Summary
+
+- Input shape: `existing_plan`
+- Audience: BugDrop maintainers and the engineers who will implement and operate releases.
+- Authority: `requested`
+- Proof type: `artifact`
+- Completion proof: A reviewed release-cadence specification and a reviewed implementation plan exist in this goal's `notes/` directory, resolve the known release-safety decisions, cite current repository evidence, define migration/rollback/verification, and leave product and deployment state unchanged.
+- Goal oracle: A final Judge audit can trace every owner concern and every verified current-system risk to an explicit decision in the specification and a bounded implementation/verification step in the plan.
+- Likely misfire: Producing a generic workflow checklist that changes only the trigger while preserving hidden automatic deployments, branch-selection hazards, incomplete-stack releases, non-idempotent retries, broken pinned assets, or post-publication failure ambiguity.
+- Blind spots considered: Manual dispatch does not by itself prevent incomplete stacks; dispatch permits branch selection; production actions are not atomic across GitHub and Cloudflare; current no-release pushes still deploy; old exact-version assets disappear; `GITHUB_TOKEN` suppresses release-event notification workflows; production lacks a concurrency/environment gate and deployed SHA identity; package/changelog versions are stale.
+- Existing plan facts: Preserve the evidence-backed audit and validate it against the fresh `main` snapshot before writing the specification. The intended sequence is specification first, Judge review second, detailed implementation plan third, and final audit last.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`For every release concern in the original request and prior audit, the approved specification contains an explicit policy/acceptance criterion and the approved implementation plan contains a sequenced work package, exact verification, failure handling, and rollback or deferral; a final audit confirms no release implementation or external mutation occurred.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, or a plausible-looking workflow sketch is not enough. The goal finishes only when a final Judge/PM audit maps receipts and both artifacts back to this oracle and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`existing_plan`
+
+## Current Tranche
+
+This is explicitly plan-only. Revalidate the current release architecture and live evidence, write a decision-complete specification, review it skeptically, convert the approved specification into a detailed implementation plan with bounded work packages and verification, and perform a final completeness audit. Stop before implementation or external configuration changes.
+
+## Non-Negotiable Constraints
+
+- Work only in the fresh worktree and branch created for this planning effort.
+- Do not modify product code, workflows, dependencies, lockfiles, repository settings, GitHub environments, secrets, Cloudflare state, tags, releases, or notifications.
+- Revalidate current facts from the fresh `origin/main` snapshot before treating the earlier audit as authoritative.
+- Treat weekly as an operator cadence and manual dispatch as the release authority unless the specification explicitly presents and resolves a competing scheduled-approval design.
+- Do not claim manual dispatch alone prevents incomplete stacked work; specify an immutable target and a release-readiness control.
+- Preserve preview CI and docs-sync behavior unless the specification explicitly justifies a change.
+- Address idempotency, concurrency, permissions, environment approval, failure ordering, rollback, deployed identity, notifications, release notes, stale package/changelog metadata, and exact-version asset retention.
+- Separate repository changes from GitHub/Cloudflare operator configuration steps in the implementation plan.
+- Every acceptance criterion must have observable verification.
+
+## Stop Rule
+
+Stop only when a final audit proves the full planning outcome is complete. This goal must not continue into implementation; implementation requires a separate owner-approved goal or request.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. It does not mean tiny.
+
+A good task is the largest safe useful planning slice: evidence map, complete specification, complete implementation plan, or final audit. Do not split sections into isolated micro-tasks unless a material uncertainty blocks the larger artifact.
+
+## Board Health
+
+The PM owns board health. If the board looks stale, misleading, offline, or inconsistent, run the bundled checker:
+
+```bash
+node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.4.2/skills/goal-prep/scripts/check-goal-state.mjs docs/goals/weekly-manual-release-cadence
+```
+
+If the local board is running, compare `state.yaml` to the live board API. Repair only GoalBuddy control files during prep.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/weekly-manual-release-cadence/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/weekly-manual-release-cadence/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter and the GoalBuddy execution contract.
+2. Read `state.yaml` and work only on its active task.
+3. Re-check the original request, prior audit facts, constraints, oracle, and likely misfire.
+4. Assign Scout, Judge, Worker, or PM according to the task card.
+5. Record a compact receipt and update the board.
+6. Continue through specification, review, implementation planning, and final audit without entering implementation.
+7. Before stopping, run GoalBuddy's `check-can-stop.mjs` gate.

--- a/docs/goals/weekly-manual-release-cadence/goal.md
+++ b/docs/goals/weekly-manual-release-cadence/goal.md
@@ -2,31 +2,33 @@
 
 ## Objective
 
-Produce a decision-complete specification and a detailed, verification-driven implementation plan for replacing BugDrop's push-to-main semantic-release/deploy coupling with a controlled weekly manual release process. This is a planning-only tranche: do not modify release workflows, dependencies, product code, GitHub settings, Cloudflare state, tags, or releases.
+Complete the first implementation tranche after the production safety freeze: use the already-open documentation-only planning PR as the post-freeze canary, prove that merging it cannot start a production release, create a fresh worktree from the resulting `main`, and implement the read-only deterministic planning and identity engine from Work Package 1.
+
+This tranche must not wire a production workflow, dispatch the freeze workflow, deploy production, create or modify tags or GitHub Releases, change repository settings, or use production credentials.
 
 ## Original Request
 
-On a fresh worktree off GitHub main, start with a specification for moving away from semantic-release to a weekly release cadence with a manually dispatched GitHub workflow, then convert that specification into a detailed implementation plan using GoalBuddyPrep.
+Move BugDrop away from push-triggered semantic-release toward a controlled weekly manual release process. After approving the specification and detailed implementation plan, begin the migration, merge the production safety freeze through the queue, and prepare the next step.
 
 ## Intake Summary
 
 - Input shape: `existing_plan`
-- Audience: BugDrop maintainers and the engineers who will implement and operate releases.
-- Authority: `requested`
-- Proof type: `artifact`
-- Completion proof: A reviewed release-cadence specification and a reviewed implementation plan exist in this goal's `notes/` directory, resolve the known release-safety decisions, cite current repository evidence, define migration/rollback/verification, and leave product and deployment state unchanged.
-- Goal oracle: A final Judge audit can trace every owner concern and every verified current-system risk to an explicit decision in the specification and a bounded implementation/verification step in the plan.
-- Likely misfire: Producing a generic workflow checklist that changes only the trigger while preserving hidden automatic deployments, branch-selection hazards, incomplete-stack releases, non-idempotent retries, broken pinned assets, or post-publication failure ambiguity.
-- Blind spots considered: Manual dispatch does not by itself prevent incomplete stacks; dispatch permits branch selection; production actions are not atomic across GitHub and Cloudflare; current no-release pushes still deploy; old exact-version assets disappear; `GITHUB_TOKEN` suppresses release-event notification workflows; production lacks a concurrency/environment gate and deployed SHA identity; package/changelog versions are stale.
-- Existing plan facts: Preserve the evidence-backed audit and validate it against the fresh `main` snapshot before writing the specification. The intended sequence is specification first, Judge review second, detailed implementation plan third, and final audit last.
+- Audience: BugDrop maintainers and release implementers.
+- Authority: `approved` for the bounded repository work and canary merge described by this tranche; production and operator cutover remain unauthorized.
+- Proof type: `test` plus GitHub audit evidence.
+- Completion proof: Planning PR #262 merges through the queue as a documentation-only canary with zero production-release runs; a fresh worktree starts from that exact `main`; the Work Package 1 planning/identity engine passes its focused adversarial tests and repository gates; and a final Judge audit maps the result to the approved plan without finding production side effects.
+- Goal oracle: GitHub shows the freeze still active and no production workflow run for the canary merge, while deterministic WP1 tests prove immutable controller/candidate identity, SemVer/frontier modeling, completed/partial-plan handling, canonical identities, and stale revalidation.
+- Likely misfire: Treating the already-observed freeze merge as the required documentation-only canary, implementing only happy-path SemVer calculation, trusting candidate-controlled release code, using mutable or abbreviated SHAs, reading nondeterministic runtime values inside identities, or beginning workflow/deployment wiring before the engine is reviewed.
+- Blind spots considered: PR #262 is still open and must land before its board is available on `main`; WP1 must operate on older main ancestors that lack release helpers; GitHub tags, Releases, drafts, and ancestry can disagree; network uncertainty must fail closed; same-version retries must distinguish complete, partial, changed, and contained plans; production remains intentionally disabled.
+- Existing plan facts: WP0 merged as PR #263 at `57317afd387f057706ca8e36383957a774218bba`. The approved implementation plan requires a documentation-only post-freeze canary before engine work and defines exact WP1 files, cases, verification, rollback, and acceptance-criterion coverage.
 
 ## Goal Oracle
 
-The oracle for this goal is:
+The oracle for this tranche is:
 
-`For every release concern in the original request and prior audit, the approved specification contains an explicit policy/acceptance criterion and the approved implementation plan contains a sequenced work package, exact verification, failure handling, and rollback or deferral; a final audit confirms no release implementation or external mutation occurred.`
+`PR #262 merges through the queue without any Production Release run; the freeze remains dispatch-only and read-only on main; WP1 is implemented from the post-canary main snapshot entirely within its approved scope; all focused adversarial tests and repository gates pass; and a final skeptical audit finds no production or publication side effect.`
 
-The PM must keep comparing task receipts to this oracle. Planning, discovery, or a plausible-looking workflow sketch is not enough. The goal finishes only when a final Judge/PM audit maps receipts and both artifacts back to this oracle and records `full_outcome_complete: true`.
+The PM must test this oracle after the canary, after implementation, and at final audit. A green happy path, local-only proof, an open PR, or a plausible data model is not enough.
 
 ## Goal Kind
 
@@ -34,39 +36,41 @@ The PM must keep comparing task receipts to this oracle. Planning, discovery, or
 
 ## Current Tranche
 
-This is explicitly plan-only. Revalidate the current release architecture and live evidence, write a decision-complete specification, review it skeptically, convert the approved specification into a detailed implementation plan with bounded work packages and verification, and perform a final completeness audit. Stop before implementation or external configuration changes.
+1. Queue and monitor documentation-only planning PR #262 as the required post-freeze canary.
+2. Prove from GitHub Actions and the merge SHA that no production-release workflow started and the freeze remains intact.
+3. Create a fresh WP1 worktree and `codex/` branch from the resulting `origin/main`.
+4. Revalidate the approved WP1 Worker package against that snapshot.
+5. Implement and skeptically review the deterministic planning and identity engine.
+6. Stop after a final tranche audit; Work Packages 2–8 require a later continuation.
 
 ## Non-Negotiable Constraints
 
-- Work only in the fresh worktree and branch created for this planning effort.
-- Do not modify product code, workflows, dependencies, lockfiles, repository settings, GitHub environments, secrets, Cloudflare state, tags, releases, or notifications.
-- Revalidate current facts from the fresh `origin/main` snapshot before treating the earlier audit as authoritative.
-- Treat weekly as an operator cadence and manual dispatch as the release authority unless the specification explicitly presents and resolves a competing scheduled-approval design.
-- Do not claim manual dispatch alone prevents incomplete stacked work; specify an immutable target and a release-readiness control.
-- Preserve preview CI and docs-sync behavior unless the specification explicitly justifies a change.
-- Address idempotency, concurrency, permissions, environment approval, failure ordering, rollback, deployed identity, notifications, release notes, stale package/changelog metadata, and exact-version asset retention.
-- Separate repository changes from GitHub/Cloudflare operator configuration steps in the implementation plan.
-- Every acceptance criterion must have observable verification.
+- Never dispatch `.github/workflows/deploy.yml` merely to prove the freeze.
+- The canary is PR #262 only; it may contain only `docs/goals/weekly-manual-release-cadence/**`.
+- If any production-release run starts for the canary merge, cancel it if possible, preserve evidence, and stop before WP1.
+- Start WP1 from the exact post-canary `origin/main`, not the stale planning or WP0 branches.
+- Keep production disabled. Do not edit release workflows, live-test/Discord workflows, Wrangler configuration, product deployment code, secrets, environments, repository variables, tags, Releases, or Cloudflare state.
+- WP1 may change only the files named by its approved Worker task. Stop if another file is required.
+- Controller and candidate identities must be full immutable main-history SHAs; candidate content must not control credentialed release logic.
+- Identity code must be deterministic and must not read clocks, run IDs, artifact IDs, or ambient environment values directly.
+- Network/API ambiguity must produce a typed non-mutating failure, never an inferred empty state.
+- Preserve the manual read-only production freeze throughout this tranche.
 
 ## Stop Rule
 
-Stop only when a final audit proves the full planning outcome is complete. This goal must not continue into implementation; implementation requires a separate owner-approved goal or request.
+Stop only when a final Judge or PM audit records that the canary proof and WP1 implementation satisfy this tranche's oracle. Do not continue into static assets, deployment, publication, workflow wiring, dependency cleanup, or operator cutover.
 
 ## Slice Sizing
 
-Safe means bounded, explicit, verified, and reversible. It does not mean tiny.
-
-A good task is the largest safe useful planning slice: evidence map, complete specification, complete implementation plan, or final audit. Do not split sections into isolated micro-tasks unless a material uncertainty blocks the larger artifact.
+The documentation canary is a small but mandatory safety gate. WP1 is one coherent Worker slice: schemas, canonical identity, planning/frontier/state modeling, fixtures, tests, and repository integration should be implemented and reviewed together rather than split into helper-sized tasks.
 
 ## Board Health
 
-The PM owns board health. If the board looks stale, misleading, offline, or inconsistent, run the bundled checker:
+The PM owns board health. If the board looks stale, misleading, offline, or inconsistent, run:
 
 ```bash
 node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.4.2/skills/goal-prep/scripts/check-goal-state.mjs docs/goals/weekly-manual-release-cadence
 ```
-
-If the local board is running, compare `state.yaml` to the live board API. Repair only GoalBuddy control files during prep.
 
 ## Canonical Board
 
@@ -88,8 +92,8 @@ On every `/goal` continuation:
 
 1. Read this charter and the GoalBuddy execution contract.
 2. Read `state.yaml` and work only on its active task.
-3. Re-check the original request, prior audit facts, constraints, oracle, and likely misfire.
-4. Assign Scout, Judge, Worker, or PM according to the task card.
-5. Record a compact receipt and update the board.
-6. Continue through specification, review, implementation planning, and final audit without entering implementation.
-7. Before stopping, run GoalBuddy's `check-can-stop.mjs` gate.
+3. Re-check the tranche oracle, the approved specification/plan, and the production-freeze boundary.
+4. Assign PM, Judge, or Worker according to the task card; use only one active task.
+5. Record a compact receipt with exact SHAs, commands, checks, and external evidence.
+6. Stop immediately on unexpected production activity or required scope expansion.
+7. Before completion, run GoalBuddy's stop gate and the final audit task.

--- a/docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md
+++ b/docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md
@@ -1,0 +1,494 @@
+# BugDrop Weekly Manual Release Specification
+
+Status: Proposed for implementation planning
+
+Repository snapshot: `mean-weasel/bugdrop@12b139c49b157a0decf5570c723fe2935149e5f4`
+
+Specification scope: release policy and target behavior; no implementation is performed by this document
+
+## Problem
+
+BugDrop currently treats every push to `main` as both a release opportunity and a production deployment. Conventional commit text determines whether semantic-release creates a version, but deployment runs after semantic-release even when no version is created. Release publication and production deployment happen before the workflow's live-production verification.
+
+This creates four owner-visible problems:
+
+1. A partially merged pull-request stack can be released as soon as one release-worthy commit reaches `main`.
+2. Maintainers cannot choose a release window independently of merge timing.
+3. A red workflow does not reliably mean that publication or deployment did not happen.
+4. The documented exact-version widget contract is not durable: prior exact assets disappear after a later deployment.
+
+The goal is not merely to replace `push` with `workflow_dispatch`. The goal is a release system in which timing, source, version, approval, effects, retries, and recovery are all explicit and observable.
+
+### Terminology
+
+- **Merge**: admission of a commit to `main` after the existing merge-queue checks.
+- **Candidate**: one immutable 40-character commit SHA in the ancestry of GitHub `main` selected for possible release.
+- **Request plan**: the pre-build, read-only result that binds the candidate, previous release, next version, included changes, notes, and expected artifact names.
+- **Release plan**: the post-verification immutable result that binds one request plan to the hashes and provenance of the artifacts that were actually built and verified.
+- **Core release**: production deployment, production verification, immutable tag, and published GitHub Release for one candidate/version pair.
+- **Notification**: the Discord announcement after core release success. It is recoverable communication, not part of the core release transaction.
+- **Weekly release**: the normal operator cadence. It is a human process, not an automatic cron publication.
+- **Emergency release**: an out-of-cadence invocation of the same guarded workflow and policy.
+
+## Outcomes
+
+The implemented release system must make the following statements true:
+
+1. Merging to `main` never publishes a version and never deploys production.
+2. A core release can begin only from an explicit manual dispatch and a protected production approval.
+3. The source is an immutable, reviewed SHA from `main` history, not whichever commit is at the branch tip when a later job starts.
+4. The version is an explicit human SemVer decision, calculated deterministically from the previous stable release without semantic commit analysis, except that an exact completed request is recognized before that now-advanced frontier is recalculated.
+5. One release plan has at most one source SHA and one version, and a version can never be rebound to another SHA.
+6. Preflight failure has no production, tag, release, or notification side effects.
+7. Production verification proves both deployed Worker source identity and deployed widget bytes.
+8. A failed provisional deployment is rolled back and is not advertised as a published release.
+9. A retry resumes or safely no-ops; it never increments, republishes, redeploys, or renotifies accidentally.
+10. Exact widget URLs released after cutover remain immutable and available after later releases.
+11. GitHub Releases become the canonical public release history; repository metadata no longer pretends that `package.json` or the stale hand-maintained changelog is current release authority.
+12. Existing merge-queue preview CI, daily live monitoring, and path-filtered docs synchronization remain operational and independent.
+
+### Audience
+
+- Maintainers deciding when and what to release.
+- Reviewers approving a production release candidate.
+- Engineers implementing and testing release automation.
+- Operators recovering a failed or partially completed release.
+- Widget consumers relying on latest, major, minor, or exact URLs.
+
+## Current State Evidence
+
+The following are verified facts at the repository snapshot, not target-state proposals.
+
+### Trigger and job ordering
+
+- `.github/workflows/deploy.yml:8-10` triggers on every push to `main`.
+- Its dependency chain is `semantic-release -> Cloudflare deploy -> live production tests`.
+- The release job has `contents`, `issues`, and `pull-requests` write permission.
+- The production deploy job has no GitHub Environment and no concurrency group.
+- GitHub's repository API reported zero configured environments.
+
+### Release and version behavior
+
+- `.releaserc.json` explicitly enables commit analysis, release-note generation, and GitHub publication only.
+- No npm, changelog, or git-prepare semantic-release plugin is active.
+- `package.json` says `1.14.0`, the hand-maintained `CHANGELOG.md` stops at `1.11.0`, and live production reported `1.55.0` during validation.
+- `scripts/build-widget.js` accepts `VERSION` or falls back to `package.json`, then emits only current latest, major, minor, and exact files.
+- Generated widget files and `versions.json` are gitignored.
+
+### Observed failure semantics
+
+- [Run 30724408445](https://github.com/mean-weasel/bugdrop/actions/runs/30724408445) logged “no relevant changes,” then built the current source as the previous version and deployed a new Cloudflare Worker version. A non-release push therefore still deploys.
+- [Run 30765978738](https://github.com/mean-weasel/bugdrop/actions/runs/30765978738) published `v1.55.0` and successfully deployed production before live E2E failed. Its overall result is red after public effects occurred.
+- The two preceding production workflows had the same publish/deploy-before-live-failure shape.
+- The repository had 121 published releases, 96 since April 1, 25 calendar days with multiple releases, and as many as 12 releases in one day.
+
+### Production identity and retention
+
+- Production `/api/health` reported `environment: development` and no `buildSha`.
+- Preview CI already deploys with `BUILD_SHA` and polls for the exact preview environment and SHA.
+- Production `versions.json` reported `1.55.0` during validation.
+- `widget.v1.55.0.js` returned 200, while `widget.v1.54.1.js`, `widget.v1.54.0.js`, `widget.v1.53.1.js`, and `widget.v1.1.0.js` returned 404.
+- `CHANGELOG.md` nevertheless describes exact URLs as the strict-control option.
+
+### Notification and independent workflows
+
+- `.github/workflows/discord-release.yml` listens for `release.published` and supports a separate manual dispatch.
+- GitHub states that events caused by `GITHUB_TOKEN` do not normally create another workflow run; only one recent release-event Discord run was present. The target system must not rely on a release event caused by its own `GITHUB_TOKEN`. See [GitHub's `GITHUB_TOKEN` event rules](https://docs.github.com/en/actions/concepts/security/github_token).
+- `.github/workflows/sync-docs.yml` independently synchronizes `docs/website/**` on main pushes. It does not require production release coupling.
+- `.github/workflows/ci.yml` owns merge-queue preview deployment and candidate checks. Its preview behavior must remain independent.
+
+## Release Policy
+
+### RP-01: manual authority, weekly cadence
+
+The production release workflow must have `workflow_dispatch` as its only event trigger. It must not declare `push`, `pull_request`, `merge_group`, `release`, or `schedule` triggers.
+
+“Weekly” is the normal operator ritual: a maintainer prepares one candidate during the agreed weekly window. A reminder may exist outside the release workflow, but no timer may tag, publish, deploy, or notify.
+
+An emergency release uses the same workflow, checks, approval, concurrency, and recovery. It differs only by a required `release_reason=emergency` input and a non-empty operator rationale recorded in the workflow summary and GitHub Release notes.
+
+### RP-02: dispatch inputs
+
+The manual workflow requires:
+
+- `target_sha`: exactly 40 lowercase hexadecimal characters.
+- `bump`: a choice of `patch`, `minor`, or `major`.
+- `release_reason`: a choice of `weekly` or `emergency`.
+- `rationale`: required non-whitespace text for emergencies and optional text for weekly releases.
+- `dry_run`: boolean, default `true` for initial rollout and later changed to `false` only after the cutover proof is accepted.
+- `notes`: optional bounded text appended to generated notes; it cannot replace the generated compare/PR inventory.
+
+The operator chooses the SemVer impact through `bump`. Commit prefixes no longer grant release authority or choose the version.
+
+### RP-03: dispatch ref guard
+
+GitHub's manual-run UI lets an operator choose a branch, and its API accepts a `ref`. See [GitHub's manual workflow documentation](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow?tool=webui).
+
+The workflow must fail before checkout of release source or access to production secrets unless its workflow ref is exactly `refs/heads/main`. The workflow definition is therefore always taken from protected `main`; a feature branch cannot alter and run its own release logic.
+
+This ref guard does not define the released source. `target_sha` defines the released source.
+
+### RP-04: operator and approver authority
+
+Dispatch requires GitHub write access. Production-mutating jobs must additionally reference a `production` GitHub Environment with:
+
+- selected deployment branch `main` only;
+- required reviewer protection;
+- environment-scoped Cloudflare credentials and Discord webhook access where used;
+- administrative bypass disabled;
+- self-review prevention enabled when at least two eligible maintainers exist.
+
+If the repository has only one eligible maintainer, the owner may explicitly configure self-review as a documented operational exception. The workflow summary must still present the complete immutable plan before approval, and the dispatch plus environment approval remain two distinct actions.
+
+GitHub environments can gate jobs, restrict branches, and withhold secrets until approval. See [GitHub's environment documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments).
+
+### RP-05: one serialized production lane
+
+Every core release invocation must use one repository-wide concurrency group, `bugdrop-production-release`, with in-progress cancellation disabled and queued runs preserved.
+
+Concurrency serialization does not establish release order by itself. Each run must revalidate the latest published version and existing tag state after entering the serialized, approved mutation job. A queued plan that became stale must stop and require a new dry run; it must not silently recalculate a different version.
+
+GitHub documents both single-running concurrency and queued pending runs. See [GitHub's concurrency documentation](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).
+
+### RP-06: least privilege
+
+Workflow-level permissions default to `contents: read`. Planning, build, and verification jobs remain read-only. Only the publication job receives `contents: write`, and only after production verification. Issue and pull-request write permissions are removed unless an implementation proves a necessary behavior that cannot be achieved with generated notes alone.
+
+Cloudflare and Discord credentials live in the protected environment or another least-privilege environment appropriate to their job. No secret is available to dry-run, planning, or candidate-build jobs.
+
+## Release Candidate
+
+### RC-01: immutable source validation
+
+Before building, the workflow must fetch full history and tags and prove all of the following:
+
+1. `target_sha` exists as a commit.
+2. The exact commit is reachable from the current remote `main`.
+3. The tag belonging to the previous published stable GitHub Release is an ancestor of `target_sha`.
+4. `target_sha` is strictly later than the previous release; an empty compare is a no-op error.
+5. No later stable release already contains `target_sha`.
+6. The candidate's required merge-queue checks are present and successful, or an explicitly equivalent release preflight suite is successful.
+
+A target may be an earlier ancestor of the current `main` tip. This permits a maintainer to release the last known releasable main commit when newer main work is intentionally held. The workflow must prominently report excluded newer main commits so approval cannot mistake the candidate for the current tip.
+
+The workflow must never accept a pull-request head, merge-group pseudo-ref, arbitrary branch head, abbreviated SHA, tag name, or mutable symbolic ref as release source.
+
+### RC-02: release-readiness attestation
+
+Manual timing alone is not release readiness. The pre-build request plan must list:
+
+- previous release tag and SHA;
+- candidate SHA and commit timestamp;
+- current `main` SHA at planning time;
+- whether the candidate is behind current `main` and by how many commits;
+- every merged pull request and first-line commit message in the compare range;
+- changed top-level paths;
+- computed next version;
+- generated release notes and optional operator notes;
+- expected mutable aliases and exact asset name;
+- planned verification commands and expected artifact names;
+- release reason and rationale.
+
+After State 2, the finalized release plan adds the verification results, widget/static hashes, manifest hash, Worker source-tree/lockfile digest, provenance hash, and release-plan identity. Approval is an explicit attestation to that finalized release plan: the entire compare range is coherent, stacked work included in the candidate is complete, intentionally excluded main commits are acceptable, the bump is correct, the verified hashes and provenance identify the intended candidate, and the release window is authorized.
+
+Feature flags or merge discipline remain the preferred protection against unreleasable intermediate states on `main`; release automation cannot infer product completeness from commit topology.
+
+### RC-03: deterministic version calculation
+
+Before calculating the published release frontier or a next version, the workflow performs a read-only **completed-plan lookup**. After validating the dispatch syntax, workflow ref, and exact target commit's reachability from remote `main`, it inventories authoritative published stable GitHub Releases and their resolved refs. It first searches for a Release targeted exactly at `target_sha`; only if none exists does it check whether a later published Release target already contains `target_sha` in its ancestry. Tags or drafts without a published Release remain partial-publication evidence handled below and can never prove completion.
+
+A published Release proves an exact completed request only when all of the following hold:
+
+1. It is the unique published stable Release for `target_sha`, and its tag resolves to that SHA.
+2. Its machine-readable identity marker agrees with its downloaded canonical release content payload, final release plan, and checksums; recomputing the canonical payload SHA-256 reproduces the stored release-plan identity, and every required release asset name and hash agrees with those records.
+3. The stored request identity and normalized original request fields exactly match the current repository, workflow ref, `target_sha`, `bump`, `release_reason`, rationale, and operator notes. `dry_run` remains an execution control rather than release content and does not change this comparison.
+4. The stored previous tag, selected version/tag, generated notes, artifact identities, and protocol versions are internally consistent with that published Release. The lookup uses these stored values to authenticate the already completed plan; it does not recalculate them from the now-advanced frontier.
+
+An exact match is a **post-success core no-op** before checkout, build, production approval, secret access, or any mutation. The run records the matched release URL, tag, target, request identity, and release-plan identity in its own audit summary, then exits core release successfully. It performs no deployment, tag creation, Release creation or edit, asset upload, rollback, or automatic notification. A failed or omitted prior announcement may be retried only through the explicit notification-only path.
+
+If a published Release exists at the same target but any input or authenticated content differs, is missing, is ambiguous, or is inconsistent, the workflow fails closed; one source SHA may not acquire another version or release plan. If no exact-target Release exists but a later published Release already contains the target, the request is **already contained** and fails the no-op-range check without calculating a new version. Only a target with neither an exact published Release nor containment by a later published Release may proceed to frontier calculation. Thus the completed-plan lookup cannot weaken no-op-range rejection or treat a merely similar request as completed.
+
+The **published release frontier** is the highest SemVer GitHub Release that is published (not a draft or prerelease), has a valid stable `vMAJOR.MINOR.PATCH` tag, has a tag/ref that resolves to the Release's target commit, and is reachable from `target_sha`. It is determined from authoritative GitHub Release and ref state, not merely the newest local tag or `git describe` output. Historical published Releases may retain their existing lightweight tags.
+
+An otherwise stable tag without a matching published Release, or a matching draft Release, is a detected partial-publication state and does not advance the published release frontier. Planning must inventory stable tags, published Releases, and drafts separately so it cannot mistake a tag-only failure for a completed release.
+
+The selected bump produces exactly:
+
+- patch: `vM.m.(p+1)`;
+- minor: `vM.(m+1).0`;
+- major: `v(M+1).0.0`.
+
+The helper must reject malformed, prerelease, build-metadata, duplicate, unreachable, or conflicting published releases/tags. The computed next tag must not already exist unless it points to the same target and, for a tag created by this workflow, its annotated tag message contains the exact versioned release-plan identity marker required by State 6. A pre-existing lightweight tag without a matching published Release, an annotation mismatch, a tag at another SHA, or an unrelated draft fails closed. It must never cause the workflow to silently increment to a later version.
+
+Planning produces a stable **request identity** derived from repository, workflow ref, target SHA, previous tag, next tag, bump, release reason, rationale, generated notes, and operator notes. It deliberately excludes artifact hashes because no release artifact exists yet.
+
+After candidate verification, the workflow produces a canonical deterministic **release content payload**. It contains the request identity; widget/static-artifact and versions-manifest hashes; Worker source-tree, lockfile, Wrangler-version, and deployment-configuration digests; and the versioned verification-contract identifier with its deterministic pass/fail result. The payload uses a specified canonical serialization (stable field names and ordering, normalized text, and no implicit current time). It expressly excludes its own hash and every execution-specific value, including GitHub run ID/attempt, artifact IDs or expiry, approval actor/time, job timing, deployment observations, Cloudflare result IDs, publication/notification results, and recovery results.
+
+The immutable **release-plan identity** is the SHA-256 of those canonical payload bytes. It is neither self-referential nor derived from an execution/audit document. The final release plan contains the canonical payload and its identity. Production approval must display and approve that finalized identity, its content fields, and its hashes. Jobs exchange these recorded outputs rather than recalculating them from mutable repository state.
+
+Every run or rerun also maintains a separate append-only **audit envelope** that references the release-plan identity and records execution-specific evidence: GitHub run ID/attempt, artifact IDs and retention state, verification logs, approval result, observed production baseline and deployment, publication, notification, cancellation, and recovery outcomes. The audit envelope is required provenance but never changes the release-plan identity. A resumed plan therefore retains one deterministic content identity while each execution remains independently attributable.
+
+The request identity is useful for detecting repeated requests; it is not sufficient authority to mutate production. Only a finalized release-plan identity may enter production approval or mutation.
+
+### RC-04: notes
+
+Release notes are generated from merged pull requests and the compare range rather than relying on conventional commit prefixes. A repository release-notes configuration may categorize or exclude PRs, but the workflow summary always includes an unfiltered compare link and complete included PR list.
+
+Operator-supplied notes are appended under an “Operator notes” heading. Emergency rationale is included under an “Emergency release” heading. Generated provenance includes the exact target SHA and artifact SHA-256.
+
+## Release Lifecycle
+
+The core workflow is a state machine. The completed-plan lookup is a pre-State-1 terminal guard: an authenticated exact completed request exits as a core no-op, while a conflict or already-contained target fails closed. States 1 and 2 are joined by the request identity. A later state may be entered only when the prior state's evidence exists for the same finalized release-plan identity.
+
+### State 1: planned
+
+After the completed-plan lookup determines that the request is neither completed nor disallowed, the workflow validates the remaining pre-build portions of RP-02, RP-03, and RC-01 through RC-04. It writes the proposed request plan and request identity to the GitHub Actions job summary and uploads a machine-readable request-plan artifact.
+
+This state does not claim candidate verification or artifact hashes. Both dry-run and live invocations continue to State 2.
+
+### State 2: candidate verified
+
+The workflow checks out `target_sha`, installs the lockfile exactly, and runs release-focused verification. At minimum this includes:
+
+- existing repository check suites relevant to workflow validity;
+- legacy compatibility provenance verification;
+- unit tests;
+- TypeScript builds;
+- a production widget build with the explicit planned version;
+- an assertion that production test hooks are absent;
+- SHA-256 generation for every release artifact;
+- confirmation that successful required merge-queue checks cover the candidate.
+
+The verified widget/static artifact set, versions manifest, request plan, final release plan, hashes, and current audit envelope are uploaded once and used downstream. The final release plan binds the request identity to the deterministic release content payload and release-plan identity. The separate audit envelope binds this run's verification evidence and artifact records to that identity.
+
+The build-once promotion guarantee applies to widget/static release bytes: mutation jobs must not rebuild those bytes. The current Wrangler deployment model bundles the Worker during deploy, so this specification does not claim binary equality between a preflight Worker build and the deployed Worker. Candidate verification must build/check the Worker from the exact target checkout and lockfile. Production deployment must use the installed, pinned Wrangler toolchain against that same immutable source and lockfile, without source mutation, and must record the source/lockfile digest plus `BUILD_SHA`. The implementation must validate the installed Wrangler version's exact capabilities; it may strengthen this to prebuilt Worker-artifact promotion only if a supported mechanism is proven and tested.
+
+`dry_run=true` stops successfully after this state. It never references the production environment, reads production secrets, or performs an external mutation. Its final summary contains the same finalized release-plan identity, artifact hashes, and verification evidence that a live run would present for approval.
+
+### State 3: approved and revalidated
+
+The production mutation job enters the serialized concurrency lane and waits on the protected `production` environment. The approval view must identify the finalized release-plan identity and artifact hashes, not merely the pre-build request. After approval and before using secrets, it re-fetches remote tags/releases and proves that the plan remains current. This revalidation repeats the completed-plan lookup before consulting the advanced frontier: if a concurrent run published the exact authenticated plan, this run exits as the same post-success core no-op with no automatic notification; a same-target mismatch or merely already-contained target fails closed.
+
+If another release changed the previous-version frontier, if the planned version now belongs to another SHA, or if the candidate is no longer reachable from `main`, the run stops before mutation. It does not rebase, recalculate, or bump in place.
+
+### State 4: provisionally deployed
+
+Before deployment the workflow records an authoritative rollback baseline: the currently active Cloudflare deployment/version ID, previously published BugDrop tag, live widget and manifest hashes, current aliases, and live health response. The first cutover release uses this as a **bootstrap baseline** because current production does not expose a build SHA: its rollback proof is the recorded Cloudflare version/deployment ID plus the prior widget/manifest hashes and health response. After the first successful cutover, every baseline must additionally contain `environment=production`, the prior `buildSha`, tag, and asset hashes.
+
+It then deploys the verified widget/static artifacts and bundles the Worker once during the provisional production deploy from the exact target source and lockfile with:
+
+- explicit release version;
+- `BUILD_SHA=target_sha`;
+- `ENVIRONMENT=production`;
+- a deployment annotation containing release-plan identity and tag.
+
+The deployment must verify the source-tree/lockfile digest immediately before invoking pinned Wrangler and must not regenerate widget/static release bytes. Unless the implementation proves a supported prebuilt Worker mechanism, the integrity claim for the Worker is exact source, lockfile, toolchain, configuration, and deployed `BUILD_SHA`, not byte-for-byte equivalence to a preflight Worker bundle.
+
+At this point the candidate may briefly serve production traffic but is not yet a published GitHub Release.
+
+### State 5: production verified
+
+Verification must prove, against production:
+
+1. `/api/health` reports `environment=production`.
+2. `/api/health.buildSha` equals `target_sha`.
+3. `widget.js` hash equals the verified artifact hash.
+4. The new exact URL exists and has the same hash.
+5. Mutable major and minor aliases expected for the version have the same hash.
+6. Every retained post-cutover exact URL sampled by the retention contract still exists with its recorded immutable hash.
+7. `versions.json` identifies the planned version and retained exact releases.
+8. Live production E2E receives the explicit candidate SHA, version, origin, and expected artifact hash; it does not infer identity through `git describe`.
+
+### State 6: published
+
+Only after State 5 succeeds may the workflow assemble and publish the GitHub Release. It uses a versioned, deterministic publication protocol:
+
+1. Create the new tag as an annotated tag at `target_sha`. Its canonical annotation includes the tag/version, target SHA, release-plan identity, canonical content-payload hash, and protocol version. Future workflow-created tags are immutable; retries inspect them but never move or replace them.
+2. Create the GitHub Release as a draft whose body contains the same machine-readable identity marker. Draft creation does not advance the published release frontier.
+3. Upload the exact widget bundle, versions manifest, canonical release content payload, final release plan, execution audit envelope, and checksums. Re-list every required asset, reject unexpected name/hash conflicts, download or hash-read each asset, and prove the complete set before publication.
+4. Publish the already complete draft in one explicit final action. Only that transition advances the published release frontier and permits notification.
+
+Creation and resumption are conditional and idempotent:
+
+- no tag or Release: create the annotated tag, assemble the draft, verify it, and publish;
+- matching annotated tag with no Release (**tag-only** state): retain the tag, create and verify the identity-matched draft, then publish;
+- matching annotated tag and matching draft, including a partially uploaded draft: reconcile only missing exact assets, fail on any conflicting asset, verify the complete draft, then publish;
+- a published Release whose tag, target SHA, identity marker, notes provenance, and artifact hashes all match: core publication is a no-op success;
+- a lightweight orphan tag, identity/SHA mismatch, unrelated draft, duplicate Release, unexpected asset, or published mismatch: fail closed without moving, deleting, overwriting, or silently incrementing anything.
+
+The published assets are the canonical forward archive for reconstructing later deployments and auditing exact URLs.
+
+### State 7: notified
+
+After publication, the workflow invokes Discord notification explicitly using the published tag; it does not wait for a suppressed `release.published` event. Notification reuse should share the existing payload implementation rather than duplicate it.
+
+Notification success completes the normal path. Notification failure produces a visible degraded-notification warning and retry instruction but does not roll back, retag, republish, or redeploy a verified core release.
+
+## Failure Semantics
+
+### FS-01: before production mutation
+
+Validation, notes, checkout, install, check, test, build, artifact, approval rejection, or stale-plan failure has no tag, GitHub Release, production deployment, or Discord side effect. The run may be retried with the same inputs after correcting the cause.
+
+### FS-02: deployment command failure
+
+If the production deployment command reports failure, the workflow must inspect authoritative Cloudflare state rather than assuming nothing changed. If the candidate is active or partially active, it attempts rollback to the recorded previous deployment and verifies the complete rollback baseline. For the bootstrap cutover this means the previous Cloudflare version/deployment ID, widget/manifest hashes, aliases, and health response even though no prior build SHA exists; later releases also verify the prior production build SHA and tag. No tag or Release is published.
+
+### FS-03: production verification failure
+
+If health identity, artifact hash, retention checks, or live E2E fail after provisional deployment, the workflow automatically attempts rollback to the recorded previous deployment. Rollback success is verified against the complete recorded baseline, using the bootstrap proof for the first cutover and production build SHA/tag/hash proof thereafter. No tag, GitHub Release, or notification is created.
+
+Rollback failure is a critical terminal state. The workflow must surface both intended and observed production identities, Cloudflare version identifiers, failed verification, and manual recovery command/runbook. It must not continue publication.
+
+### FS-04: publication failure after verified deployment
+
+If annotated-tag creation, draft assembly, asset verification, or final publication fails after production verification, the workflow treats production as provisional and attempts rollback to the recorded previous deployment. It retains an identity-matched tag or draft as durable resumable evidence; routine recovery never deletes or moves the tag. A later retry first inspects tag, draft/published Release, assets, and production state and never assumes the failed API call had no effect.
+
+If publication actually succeeded despite a lost response, the retry recognizes the exact matching published Release and complete assets and continues without duplication. If only the tag or draft exists and rollback restored the previous version, that partial state does not advance the published release frontier: the same request deterministically selects the same version, reproduces the same release-plan identity, redeploys and verifies, and then resumes the bounded missing publication steps. Any mismatch fails closed rather than selecting a later version.
+
+### FS-05: notification failure
+
+Notification is not transactional with the core release. Failure records a warning containing the published release URL and the existing notification-only retry path. It never changes core release success and never triggers a release/deploy rerun.
+
+### FS-06: duplicate and concurrent dispatch
+
+Two dispatches may calculate the same next version before entering concurrency. The first approved run that completes publication advances the frontier. Before treating that advanced frontier as stale-plan failure, the second repeats the completed-plan lookup. An exact authenticated plan exits as a post-success core no-op; any input/content mismatch fails closed. It must not automatically select the subsequent version.
+
+Two identical dispatches for the same request identity may build independently, but they are the same release plan only if every deterministic release content field and the release-plan identity match. Their run IDs, attempts, artifact storage records, timing, and audit envelopes remain distinct and do not prevent a safe identity match. One may complete while the other recognizes an exact published match and exits core release as a no-op. Notification idempotency must prevent an automatic duplicate announcement; explicit notification-only retries are operator-authorized.
+
+Within the same workflow run or GitHub rerun, downstream jobs reuse the uploaded immutable artifacts when they remain available and append that attempt's observations to the audit envelope. A new dispatch with the same request identity may rebuild widget/static assets only from the exact source, lockfile, toolchain, and plan-supplied deterministic inputs; it may resume the same release plan only when the canonical release content payload and every hash reproduce the prior finalized identity exactly. Its new audit envelope references that existing identity without being folded into it. Missing or expired artifacts may never be silently replaced. The workflow must either rebuild and prove exact content-identity equality or create a new finalized release plan requiring approval. A mismatch fails closed or produces a new plan; it cannot inherit an earlier approval.
+
+Until a supported prebuilt Worker mechanism is proven, each production deploy attempt bundles the Worker from the same immutable source/lockfile and pinned toolchain. Resumption proves Worker integrity with the recorded source-tree/lockfile digest and resulting live `BUILD_SHA`, while widget/static artifacts retain byte-for-byte identity.
+
+### FS-07: cancellation
+
+Production release runs are never canceled by a newer run. Cancellation before production mutation is side-effect free.
+
+A user-requested cancellation during or after mutation creates an **ambiguous critical state** until authoritative inspection proves either the candidate state or the complete previous rollback baseline. An `always()` recovery/finalization job must be configured to inspect production and attempt the appropriate verification or rollback, but GitHub cancellation can prevent or interrupt cleanup, so this path is best effort rather than a guarantee. If automated finalization does not complete, the run must surface the intended candidate, recorded baseline, last observed Cloudflare state, and exact operator runbook/manual recovery steps. No operator may treat the run as cleanly canceled until that inspection and recovery evidence is recorded.
+
+### FS-08: rollback policy
+
+Rollback restores service; it does not rewrite Git history or reuse a released version.
+
+- Before tag/Release publication, a rolled-back plan may retry the same version and SHA.
+- After publication, rollback is a new production action recorded against the existing release; a corrected source requires a new higher SemVer release.
+- Tags are immutable and are never moved or deleted as routine recovery.
+- A dedicated rollback dispatch may redeploy a previously published release artifact, but it requires the production environment, serialization, explicit target release, observed-state verification, and an operator rationale.
+
+The implementation plan must validate the exact supported Cloudflare rollback mechanism and command against the installed Wrangler version before encoding it in automation.
+
+## Artifact Retention
+
+### AR-01: URL semantics
+
+- `widget.js` is mutable and points to the newest successfully published production release.
+- `widget.vMAJOR.js` is mutable within that major line.
+- `widget.vMAJOR.MINOR.js` is mutable within that minor line.
+- `widget.vMAJOR.MINOR.PATCH.js` is immutable and must remain byte-for-byte available after every later deployment.
+
+Aliases update only when the corresponding core release reaches production-verified state. A rolled-back or unpublished candidate cannot advance them.
+
+### AR-02: canonical archive
+
+Every post-cutover GitHub Release stores the exact bundle and checksum as release assets. Before a later deploy, the workflow stages all supported post-cutover exact assets from their canonical release assets plus the new verified exact bundle, verifies each checksum, and deploys the complete retained set with current aliases.
+
+The production manifest records, for each retained exact version, its filename, target SHA, SHA-256, publication timestamp, and archive URL. Timestamp values are fixed deterministic inputs in the request plan (for example, the candidate commit timestamp or another predeclared normalized value), never the current clock at rebuild time. Rebuilding the same request may resume the same release plan only if the manifest and every other static artifact reproduce the finalized hashes exactly.
+
+### AR-03: historical gap
+
+The retention guarantee is prospective from the cutover release. Existing 404 historical versions must not be represented as available.
+
+A separate, explicitly labeled backfill may reconstruct selected historical versions from tags and lockfiles with provenance. It must not claim byte identity with unavailable historical deployments unless a stored hash or original artifact proves it. Backfill is not required to cut over the safer release cadence, but the manifest and documentation must disclose the boundary.
+
+### AR-04: release artifact integrity
+
+The release workflow deploys the widget/static bytes verified before approval and later attaches those same bytes to the GitHub Release. It must not rebuild those bytes between verification, deployment, retention staging, and publication. Hash mismatch at any boundary fails closed.
+
+Worker integrity is separately proven by the immutable target source, lockfile, pinned Wrangler toolchain/configuration, source-tree/lockfile digest, and live `BUILD_SHA`. The implementation plan must not describe a prebuilt Worker bundle as promotable unless it first validates and tests an exact supported Wrangler mechanism.
+
+## Notifications and Metadata
+
+### NM-01: Discord
+
+The existing Discord payload behavior is retained and made reusable by the core release workflow. The manual notification-only path remains for retry and dry-run inspection.
+
+An automatic release announcement is sent exactly once per published release plan. The notification records the GitHub Release URL and tag. Optional custom text, image, and allow-listed user mention behavior remain available only through bounded inputs.
+
+### NM-02: canonical release history
+
+GitHub Releases and immutable tags are the canonical release history. Release notes include target SHA, compare link, PR inventory, artifact hashes, and emergency rationale when applicable.
+
+`CHANGELOG.md` is not revived as an automatically committed per-release file. It is updated once during migration to identify its historical coverage and link to GitHub Releases for current history.
+
+### NM-03: package metadata
+
+BugDrop does not currently publish through npm. `package.json` must stop presenting an old production release as authoritative. The migration changes its version to a clearly documented development sentinel and prevents the widget release workflow from deriving production identity from it.
+
+Production builds require an explicit valid planned version. Local development builds may use a visible `dev` identity. Any future npm publication is a separate product/distribution decision and must introduce its own package-version lifecycle.
+
+### NM-04: production deployment identity
+
+Production must report `ENVIRONMENT=production` and the exact deployed `BUILD_SHA`. GitHub Actions must reference a named production environment so GitHub records deployment history and exposes approval/audit data.
+
+The deterministic release content payload and final release plan record target SHA, tag, artifact hashes, and the immutable build/configuration inputs defined by RC-03. Separately, workflow summaries and the append-only audit envelope record GitHub run ID/attempt, artifact storage/retention records, previous and new Cloudflare versions, approval result, production verification observations, publication result, notification result, cancellation, and rollback/recovery result if applicable. Publication attaches both documents so content identity is reproducible without losing execution provenance.
+
+## Acceptance Criteria
+
+| ID    | Requirement                                                                 | Authoritative proof                                                                                                      |
+| ----- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| AC-01 | Main merges cannot release or deploy production.                           | Workflow contract test proves no production workflow has `push`, `pull_request`, `merge_group`, `release`, or `schedule`. |
+| AC-02 | Only manual dispatch can start release planning.                            | Workflow event inspection and a GitHub Actions dry-run invocation.                                                       |
+| AC-03 | A non-main dispatch ref is rejected before secrets or mutation.             | Negative workflow test/fixture and a real dry run from a temporary branch.                                               |
+| AC-04 | Candidate source is one full SHA reachable from remote main.                | Unit/contract tests for valid tip, valid ancestor, branch head, abbreviated SHA, unreachable SHA, and pseudo-ref.         |
+| AC-05 | Approval reports included/excluded stack work and final candidate identity. | Approval summary fixture contains the finalized release-plan identity, full compare, PR inventory, main-tip delta, paths, version, rationale, notes, verification evidence, and hashes. |
+| AC-06 | SemVer comes from explicit bump and the reachable published frontier.       | Table-driven helper tests for patch/minor/major, malformed/unreachable/conflicting releases/tags, drafts, orphan tags, and no-op ranges. |
+| AC-07 | Dry run completes candidate verification without secrets or mutation.       | A real dry run reaches State 2, finalizes the release plan, and leaves no tag, Release, deployment, notification, environment access, or secret access. |
+| AC-08 | Widget/static release bytes are built once and promoted unchanged.           | Static-artifact SHA-256 is identical at build, upload/download, deploy, live readback, retention staging, and Release asset. |
+| AC-09 | Production access is approval-gated and serialized.                         | GitHub environment configuration audit and workflow contract for concurrency, queueing, and no cancellation.              |
+| AC-10 | A stale queued plan fails rather than recalculates.                         | Concurrency integration test with two planned versions and observed zero mutation from the stale run.                     |
+| AC-11 | Production identifies environment and source.                               | Live `/api/health` equals `production` and the approved 40-character target SHA.                                          |
+| AC-12 | Live tests use explicit plan identity, not `git describe`.                  | Workflow contract and live-test invocation prove explicit version, SHA, origin, and widget hash are passed together.      |
+| AC-13 | Publication occurs only after production verification.                     | Dependency/order contract and a forced live-test failure prove no tag or Release is created.                              |
+| AC-14 | Publication is complete, idempotent, and tags are immutable.                | Tests cover annotated tag, identity-bound draft, verified complete assets, final publish, identical no-op, conflicts, and absence of any tag move/delete path. |
+| AC-15 | Deployment or verification failure restores the complete prior baseline.    | Bootstrap drill verifies prior Cloudflare ID, widget/manifest hashes, aliases, and health without requiring a missing old build SHA; later drill also verifies production build SHA/tag. |
+| AC-16 | Publication failure is inspected and recovered safely.                     | Lost-response simulations at tag, draft, asset, and publish boundaries prove retry recognizes actual state, rolls back provisional production, and resumes without duplicate/moved publication. |
+| AC-17 | Notification does not depend on `release.published`.                       | Core workflow invokes reusable notification directly; absence of a release-event child run does not block notification.  |
+| AC-18 | Notification-only failure is independently retryable.                      | Forced webhook failure leaves core release intact and provides a successful tag-scoped notification-only retry.           |
+| AC-19 | Exact assets remain available and immutable after a later release.          | Release N+1 drill reads release N exact URL, matches its recorded hash, and confirms aliases advance to N+1.               |
+| AC-20 | Historical retention boundary is truthful.                                 | Manifest/docs distinguish retained post-cutover versions from unavailable or provenance-reconstructed historical files.  |
+| AC-21 | Package/changelog metadata no longer claims current release authority.      | Source inspection shows development sentinel and historical changelog notice/link; production build rejects missing version. |
+| AC-22 | Preview CI, scheduled live monitoring, and docs sync remain independent.     | Existing workflow contract tests plus trigger/diff audit show their behavior was not coupled to manual production release. |
+| AC-23 | Permissions are least-privilege.                                            | Workflow permission audit shows write only in post-verification publication and secrets only behind appropriate environment. |
+| AC-24 | Emergency releases use the same safety path.                                | Emergency dry-run and release fixture prove identical gates plus mandatory rationale in summary and notes.                |
+| AC-25 | A release operator can recover every terminal state.                        | Reviewed runbook exercises dry-run, stale plan, preflight fail, deploy fail, verify fail, publish fail, notify fail, retry, and rollback. |
+| AC-26 | Request identity and release-plan identity are created at the correct times. | Contract/unit test proves the request identity exists before build, deterministic artifact/content fields finalize a distinct release-plan identity after State 2, and approval binds only the latter. |
+| AC-27 | Worker deployment identity is honest and reproducible.                      | Preflight/deploy audit proves exact target source, lockfile, pinned Wrangler/configuration, source digest, and live build SHA; no unsupported prebuilt-bundle claim exists. |
+| AC-28 | Retry and artifact expiry cannot substitute different release bytes.        | Rerun reuses immutable artifacts; expired-artifact test rebuilds deterministically and requires exact content-identity equality or a new plan and approval. |
+| AC-29 | Cancellation after mutation is treated as an ambiguous critical state.      | Cancellation drill proves no auto-cancel, best-effort finalization, authoritative state inspection, and runbook recovery when cleanup is interrupted. |
+| AC-30 | Deterministic content identity is separate from complete execution audit.   | Canonicalization tests prove reordered/equivalent content hashes identically, any content change changes identity, run ID/attempt and observations do not; two dispatches resume one identity with distinct complete audit envelopes. |
+| AC-31 | Partial publication cannot drift the SemVer frontier.                       | A tag-only and partial-draft drill proves the next plan remains the same version/identity, resumes exact missing steps, and fails conflicts instead of silently incrementing. |
+| AC-32 | An exact post-success rerun no-ops before the advanced frontier.            | Tests publish a release, rerun its exact normalized request, and prove the completed-plan lookup authenticates stored content then performs no build, approval, secret access, deploy, tag/Release/asset mutation, or automatic notification; variants with changed bump/reason/rationale/notes, missing or conflicting content, the same SHA under another plan, and a target already contained only by a later release all fail closed without calculating another version. |
+
+## Non-Goals
+
+- Automatically deciding whether a partially merged feature is product-complete.
+- Automatically publishing every week when no maintainer authorizes a candidate.
+- Replacing the existing merge queue, preview Worker, preview live tests, or daily production monitoring.
+- Publishing BugDrop to npm or introducing an npm distribution channel.
+- Reconstructing every historical exact widget as a prerequisite for cadence cutover.
+- Changing widget APIs, feedback behavior, GitHub App behavior, tenant configuration, or product data.
+- Moving or deleting historical Git tags to make release history appear cleaner.
+- Making GitHub and Cloudflare transactions mathematically atomic; the requirement is explicit state, verification, compensating rollback, and idempotent recovery.
+- Treating Discord delivery as a reason to roll back a healthy published core release.
+
+## Open Decisions
+
+No architecture-blocking decision remains for implementation planning. The following values are operator configuration, not unresolved release semantics:
+
+1. The named user/team configured as production required reviewer.
+2. Whether the repository currently has enough eligible maintainers to enable self-review prevention immediately; the target policy is to enable it whenever two maintainers are available.
+3. The agreed weekly calendar window and reminder mechanism outside the release workflow.
+4. The first release designated as the exact-asset retention cutover boundary.
+5. Which historical exact versions, if any, receive a separately proven provenance backfill.
+
+The implementation plan must represent those as explicit operator checklist entries and must not silently choose identities, dates, or unsupported historical bytes.

--- a/docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md
+++ b/docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md
@@ -1,0 +1,638 @@
+# BugDrop Weekly Manual Release Implementation Plan
+
+Status: Proposed for implementation after specification approval
+
+Specification: `T002-release-cadence-spec.md`, approved by T013
+
+Repository basis: `mean-weasel/bugdrop@12b139c49b157a0decf5570c723fe2935149e5f4`
+
+Scope of this document: repository work, operator configuration, validation, and cutover sequencing; no implementation or external mutation is performed here
+
+## Target Architecture
+
+### Architecture delta
+
+| Concern | Current main | Target state |
+| --- | --- | --- |
+| Production trigger | Every push to `main` in `.github/workflows/deploy.yml` | `workflow_dispatch` only; normal weekly and emergency releases use the same path |
+| Release authority | Conventional commit analysis by semantic-release | Maintainer-selected immutable main-history SHA, explicit bump, readiness summary, and protected approval |
+| Release tooling | Workflow and product share one checkout | Immutable trusted controller SHA supplies release logic/config; separate candidate checkout supplies only selected product source/dependencies |
+| Version frontier | Local tags and `git describe` | Highest consistent published stable GitHub Release reachable from the candidate, with partial tags/drafts tracked separately |
+| Build identity | Production build infers the newest tag | Request identity before build; deterministic release-plan identity after static hashes and Worker inputs exist |
+| Static assets | Current version rebuilt during deploy; old exact files disappear | Candidate static package built once; retained exact assets restored from checksum-verified GitHub Release assets |
+| Worker integrity | Wrangler bundles whichever checkout the job has | Exact target checkout, lockfile, pinned Wrangler/configuration digest, `BUILD_SHA`, and production health proof |
+| Approval and serialization | None | `production` GitHub Environment plus `bugdrop-production-release`, `queue: max`, and no in-progress cancellation |
+| Failure order | Publish, deploy, then live-test | Plan, verify, approve, capture baseline, provisional deploy, verify live, assemble/publish Release, notify |
+| Recovery | Red run may already have effects | Authoritative state inspection, verified rollback, deterministic resumption, and explicit ambiguous-cancellation handling |
+| Notification | Assumed `release.published` child workflow | Direct reusable invocation after matching published Release; notification-only retry remains separate |
+| Public history | GitHub Releases plus stale package/changelog claims | GitHub Releases/tags canonical; package version is a development sentinel and changelog is explicitly historical |
+
+### Target release state machine
+
+```mermaid
+flowchart TD
+    A["Manual dispatch on main"] --> B["Guard syntax, ref, full SHA, main ancestry"]
+    B --> C{"Exact completed plan?"}
+    C -->|yes| N["Proven core no-op; no auto-notification"]
+    C -->|conflict or already contained| X["Fail closed"]
+    C -->|no| D["Resolve published frontier and request plan"]
+    D --> E["Checkout exact SHA; verify and build static package once"]
+    E --> F["Finalize content payload, release-plan identity, audit envelope"]
+    F --> G{"Dry run?"}
+    G -->|yes| Y["Publish summary/artifacts only"]
+    G -->|no| H["Environment approval and serialized revalidation"]
+    H --> I["Capture rollback baseline and deploy provisionally"]
+    I --> J{"Production identity, hashes, retention, E2E pass?"}
+    J -->|no| R["Inspect and roll back; verify prior baseline"]
+    J -->|yes| K["Annotated tag; assemble and verify draft Release"]
+    K --> L{"Draft publication succeeds?"}
+    L -->|no| R
+    L -->|yes| M["Published Release becomes frontier"]
+    M --> O["Direct Discord notification"]
+```
+
+### Identity and evidence objects
+
+Implementation must use versioned JSON schemas and canonical UTF-8 serialization with recursively sorted keys, normalized line endings, and no implicit current clock.
+
+1. `request-plan.json` contains normalized dispatch inputs, exact repository/workflow ref, immutable controller SHA, candidate target/main/frontier SHAs, previous/next tags, compare/PR inventory, notes, deterministic timestamp inputs, and a request identity. It exists before build.
+2. `release-content.json` contains only deterministic content: request identity, static package/file hashes, manifest hash, controller/candidate source and lockfile digests, pinned controller esbuild/Wrangler versions, effective staging/configuration digests, and verification-contract version/result.
+3. `release-plan.json` contains `sha256(canonical release-content.json)` as the release-plan identity. It must not contain that identity inside the hashed payload.
+4. `audit-envelope.<run>-<attempt>.json` references the release-plan identity and records run/attempt, artifact IDs/retention, approval, Cloudflare observations, publication, notification, cancellation, and recovery. Execution fields never affect content identity.
+5. `checksums.txt` covers every Release asset and every deployed static file using a deterministic order and SHA-256.
+
+The GitHub Actions artifact name must contain the release-plan identity and use a documented retention period long enough to span the normal weekly retry window. A rerun uses the same artifact IDs when available. A new dispatch may claim the same plan only after an exact canonical content/hash reproduction.
+
+### Trusted controller and candidate separation
+
+Every nontrivial job uses two immutable, credential-free checkouts with `persist-credentials: false`:
+
+- The **controller checkout** is pinned to GitHub's immutable workflow/controller SHA (`github.workflow_sha` for a new plan), not the moving `main` ref. It contains the reviewed release helpers, schemas, workflow contracts, canonical production configuration, and pinned release toolchain.
+- The **candidate checkout** is pinned to `target_sha` in a different directory. It supplies product `src/`, widget source, `package.json`, and lockfile only. An older main ancestor is not assumed to contain any new release helper, workflow, or hardened production configuration.
+
+GitHub documents `github.workflow_sha` as the commit SHA for the workflow file; the implementation contract must assert it is non-empty/full-length and record it. See [GitHub contexts](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context).
+
+New-plan planning and content identity record the controller SHA and both checkout tree/lockfile digests. Release helpers execute from the controller checkout and receive the candidate directory as explicit data. Candidate tests may execute only in preflight jobs with no write token or production secret. Candidate lifecycle/release scripts never run in the protected mutation job.
+
+The protected job constructs a fresh immutable staging tree outside both checkouts: verified candidate product source/package metadata plus the audited controller production config and controller-pinned tool binaries. Candidate dependencies are installed without lifecycle scripts if required for bundling; the implementation must prove this supports the current dependency tree. Static building invokes the controller-pinned esbuild against candidate widget source. Wrangler runs from the controller lockfile against the recorded staging tree. The workflow hashes the staging manifest immediately before deploy and never mutates candidate source.
+
+The exact supported Wrangler `--config`/working-directory/module-resolution arrangement remains an Operator WP7 capability gate. If direct separation is unsupported, the implementation may use the described content-addressed staging tree only after a non-production proof shows it bundles candidate source and controller configuration exactly; it may not fall back to running the candidate's deploy script.
+
+For a tag/draft partial retry after `main` has changed, the stored release plan selects its original controller SHA. The current workflow definition remains from protected `main`, verifies that stored controller commit is the recorded main-history commit and that its protocol is supported, then checks out that exact controller to reproduce the plan. It must not silently substitute the current controller. Published completed-plan lookup may use a current backwards-compatible reader because it performs no mutation. Keep compatibility fixtures for every still-resumable protocol; if the stored controller/protocol cannot be authenticated or executed safely, stop in a critical manual-recovery state rather than creating a different identity.
+
+This separation is the **credential isolation** boundary: candidate files and processes never receive `GITHUB_TOKEN` with write scope, Cloudflare credentials, Discord credentials, or environment approval data. Only controller commands named by the workflow receive the minimum secret on the exact step that needs it.
+
+### Workflow job boundaries
+
+The replacement `.github/workflows/deploy.yml` remains the single production owner and uses workflow-level concurrency so the lock covers revalidation through publication and recovery. Planning-only dry runs may queue behind a live release; predictability is more important than saving a few minutes.
+
+| Job | Permissions and secrets | Responsibility |
+| --- | --- | --- |
+| `guard-and-plan` | `contents: read`; no environment/secrets | Pin controller SHA, validate workflow ref/inputs, authenticate completed plans, inspect authoritative Release/ref state, and calculate the request plan |
+| `verify-candidate` | `contents: read`; no environment/secrets | Create controller checkout and candidate checkout, verify candidate/tests, build through controller tooling, stage retained assets, and emit checksums/Worker inputs/final plan/audit artifact |
+| `dry-run-summary` | `contents: read`; no environment/secrets | Prove State 2 completed and exit without environment access or mutation |
+| `core-release` | `contents: write`; protected `production` environment; environment-scoped Cloudflare and test secrets | Revalidate, capture baseline, deploy exact static package and Worker source, verify production/E2E, publish or roll back, write final audit evidence |
+| `notify` | `contents: read`; notification-scoped webhook | Call the shared notification implementation only after an exact published Release result |
+| `finalize-cancelled` | `contents: read`; protected production recovery credentials | Best-effort authoritative inspection after cancellation; never claims cleanup is guaranteed |
+
+`core-release` must create both checkouts with `persist-credentials: false`, re-hash them against the plan, and execute only controller paths. Although the job needs `contents: write`, the token is passed to no shell or candidate-SHA code before verified publication steps. No third-party action runs after production credentials or the write token becomes available. Issue and pull-request write permission are absent.
+
+The implementation must recheck the current GitHub Actions concurrency schema in CI. GitHub currently documents `queue: max` as retaining up to 100 pending runs and disallowing its combination with `cancel-in-progress: true`; the contract test must prevent removal of `queue: max` or addition of cancellation. See [GitHub concurrency](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).
+
+## Migration Strategy
+
+### Delivery units
+
+Use three repository pull requests and one operator-controlled cutover:
+
+1. **PR A — production safety freeze.** Stop main pushes from invoking semantic-release or Cloudflare. Leave an explicit manually dispatched “release migration frozen” workflow that cannot mutate production. This is the fastest risk reduction and is independently reversible, but rollback must never restore automatic push deployment.
+2. **PR B — release engine and deterministic artifacts.** Add pure/testable release helpers, strict build modes, retention packaging, publication-state modeling, production verification, and unit/contract tests. Keep production disabled.
+3. **PR C — guarded workflow and documentation.** Install the full manual workflow, reusable live-test/Discord paths, metadata cleanup, operator runbook, and a repository-variable kill switch defaulting off.
+4. **Operator cutover.** Configure environments/rules/secrets, validate Cloudflare rollback capability, run dry/failure drills, enable the kill switch, and perform one supervised bootstrap release.
+
+Every PR must pass the existing merge queue. PR B and PR C may be stacked for review, but PR C must not merge until PR B is on `main`; neither can restore an automatic production trigger.
+
+### Non-negotiable migration gates
+
+- No production release is possible between PR A and successful operator cutover except an explicitly documented manual Cloudflare recovery action.
+- `RELEASE_PRODUCTION_ENABLED` is absent/`false` by default. The workflow always allows State 2 dry runs; a live request fails before environment/secrets unless the variable is exactly `true`.
+- The installed Wrangler version and Cloudflare account must prove version inspection and rollback behavior before live enablement. Help text is not proof; use a non-production deployment and rollback/readback drill.
+- The first production release uses the bootstrap baseline because current health omits `buildSha` and reports `development`.
+- Routine rollback freezes releases and restores the previous Cloudflare version; it never reintroduces push-triggered release or moves/deletes a tag.
+
+## Repository Change Inventory
+
+### Existing files to modify
+
+| File | Planned change |
+| --- | --- |
+| `.github/workflows/deploy.yml` | PR A freezes the old path; PR C replaces it with dispatch-only guarded state machine, concurrency, permissions, environment, artifacts, publication, recovery, and direct notification dependency |
+| `.github/workflows/live-tests.yml` | Add explicit release-call inputs for SHA, version, widget origin/hash, exact URL, and manifest hash; remove production reliance on `git describe`; preserve scheduled monitoring and preview behavior |
+| `.github/workflows/discord-release.yml` | Add `workflow_call`; remove reliance on `release.published`; preserve manual tag retry/dry run and bounded custom fields |
+| `.github/workflows/ci.yml` | Stop preview build identity from using the latest tag; pass explicit development/preview identity while preserving preview deployment and merge-queue checks |
+| `test/ci-workflow-contract.test.sh` | Preserve existing preview assertions and add production trigger, ref guard, permissions, environment, concurrency, ordering, explicit live identity, and notification contracts |
+| `scripts/build-widget.js` | Introduce strict release/development modes, validate stable SemVer in release mode, require deterministic timestamp input, emit only declared outputs, and never fall back to package version for production |
+| `package.json` | Remove semantic-release, set documented development sentinel, add release-helper/test scripts; retain commitlint because commit style may remain without release authority |
+| `package-lock.json` | Lockfile update caused only by semantic-release removal and any explicitly approved test/runtime dependency |
+| `knip.json` | Remove semantic-release ignore entries and add new release helper entry points |
+| `Makefile` | Add deterministic release-plan/build/contract targets; make production build require explicit inputs while keeping local development simple |
+| `wrangler.toml` | Add explicit `[env.production]` name/routes/vars as applicable; production workflow still passes `BUILD_SHA`; keep preview config behavior unchanged |
+| `src/routes/api.ts` | No semantic change expected: retain existing optional `buildSha`; change only if implementation needs stricter production validation surfaced by tests |
+| `test/api.test.ts` | Add/retain proof that production health reports exact `environment` and `buildSha`; do not make development/preview behavior regress |
+| `CHANGELOG.md` | Mark entries through 1.11.0 as historical and link GitHub Releases as canonical current history; do not resume per-release commits |
+| `CLAUDE.md` | Replace semantic-release/conventional-bump guidance with manual weekly release/runbook guidance while retaining conventional commits as a collaboration convention |
+| `docs/website/version-pinning.mdx` | Explain prospective exact-asset retention boundary and never claim unavailable historical bytes |
+
+### New repository files
+
+| File | Responsibility |
+| --- | --- |
+| `.github/release.yml` | Generated Release-note categories/exclusions while preserving an unfiltered compare/PR inventory in provenance |
+| `scripts/release/canonical-json.mjs` | Canonical serialization and SHA-256 primitives; no GitHub or clock access |
+| `scripts/release/plan.mjs` | Input/ref/source/controller validation, completed-plan lookup, frontier/partial-state modeling, SemVer calculation, request plan, and stale revalidation; API/state adapters injectable for tests |
+| `scripts/release/static-assets.mjs` | Controller-driven candidate build orchestration, prior Release-asset download/checksum validation, retained tree/aliases/manifest creation, tar/archive validation, and checksums |
+| `scripts/release/publication.mjs` | Inspect annotated tag/draft/published states, create identity-bound annotated tag/draft, reconcile exact assets, read-verify completeness, and final publish |
+| `scripts/release/production-state.mjs` | Normalize Cloudflare version/deployment observations, capture bootstrap/normal baselines, verify candidate or prior baseline, and emit recovery evidence; exact CLI adapter added only after capability proof |
+| `scripts/release/verify-live.mjs` | Poll health, latest/exact/aliases/retained hashes, and manifest against explicit plan inputs; no `git describe` or mutable-main inference |
+| `scripts/discord-release.mjs` | Extract and test existing release lookup, payload, allow-listed mention, dry-run, and webhook behavior for both reusable and manual workflows |
+| `test/release/canonical-json.test.ts` | Canonicalization, identity sensitivity/exclusions, and no-self-reference tests |
+| `test/release/plan.test.ts` | Source/ref/controller/frontier/completed-plan/partial-state/SemVer/stale/concurrent/idempotency tables |
+| `test/release/static-assets.test.ts` | Release/dev build modes, deterministic manifest, retention, corruption, expiry/rebuild, aliases, hooks, and archive tests |
+| `test/release/publication.test.ts` | No-tag, tag-only, draft, partial assets, published, lost-response, and every conflict transition |
+| `test/release/production-state.test.ts` | Bootstrap/normal baseline, ambiguous deploy result, rollback verification, and cancellation state tests with fixtures |
+| `test/release/verify-live.test.ts` | Health/SHA/hash/manifest/retention success and mismatch tests |
+| `test/release-workflow-contract.test.sh` | Dedicated manual-release workflow syntax/trigger/permission/environment/concurrency/dependency/secret/order contract |
+| `test/fixtures/release/*.json` | Sanitized GitHub/Cloudflare/manifest state fixtures; never real tokens or private payloads |
+| `docs/releasing.md` | Weekly/emergency operator runbook, terminal-state decision table, rollback/cancellation recovery, notification-only retry, and evidence checklist |
+
+Do not add generated `public/widget*.js`, `versions.json`, workflow artifacts, Cloudflare state, tokens, or real production responses to git.
+
+## Work Package 0 — Freeze Automatic Production
+
+**Objective:** make merges incapable of releasing or deploying before the larger migration lands.
+
+**Dependencies:** none.
+
+**Allowed scope:** `.github/workflows/deploy.yml`, `test/release-workflow-contract.test.sh`, and the test target registration in `Makefile`/`package.json` if required.
+
+**Changes:**
+
+1. Replace `on.push.branches: [main]` with `workflow_dispatch` only.
+2. Replace semantic-release/deploy/live jobs temporarily with one read-only freeze job that explains the migration and exits without checking out target code, using secrets, creating tags/Releases, or invoking Wrangler.
+3. Add a contract test proving there is no `push`, `pull_request`, `merge_group`, `release`, or `schedule` production trigger and no semantic-release/Wrangler production command.
+4. Keep preview CI, scheduled live monitoring, and docs sync untouched.
+
+**Verification:**
+
+```sh
+bash test/release-workflow-contract.test.sh
+bash test/ci-workflow-contract.test.sh
+npm run check:actions-node24
+git diff --check
+```
+
+After merge, inspect the Actions workflow trigger and merge a documentation-only canary PR; prove no Deploy run starts. Do not trigger a production deploy merely to test absence.
+
+**Failure handling:** if workflow validation fails, keep the existing PR unmerged. If an unexpected production run starts after merge, cancel it before deployment if possible, set the repository kill switch false/absent, inspect Cloudflare state, and follow the existing-state recovery checklist.
+
+**Rollback:** revert only the malformed freeze implementation to a corrected manual no-op workflow. Never restore `push` production deployment.
+
+**Exit proof:** AC-01, AC-02, and preservation half of AC-22 pass before starting engine work.
+
+## Work Package 1 — Deterministic Planning and Identity Engine
+
+**Objective:** implement all read-only decisions as testable Node modules before wiring production.
+
+**Dependencies:** WP0 merged.
+
+**Allowed scope:** `scripts/release/canonical-json.mjs`, `scripts/release/plan.mjs`, `test/release/canonical-json.test.ts`, `test/release/plan.test.ts`, fixtures, `.github/release.yml`, `package.json`, `Makefile`, and `knip.json`.
+
+**Changes:**
+
+1. Define versioned schemas for normalized dispatch fields, request plan, release content, final plan, audit envelope, and publication marker.
+2. Resolve and record immutable controller SHA from the workflow context before either checkout. Reject non-main workflow refs; validate exactly 40 lowercase hex characters, fetch remote main/tags/Releases, and use `merge-base --is-ancestor` against `origin/main` for candidate and required controller/history checks.
+3. Model published Releases, resolved refs, orphan/lightweight/annotated tags, drafts, and target ancestry separately.
+4. Perform completed-plan lookup before frontier calculation. Verify downloaded plan/content/checksum assets and tag marker; exact match yields a typed no-op, while changed/same/contained targets fail.
+5. Calculate the published frontier and explicit patch/minor/major result without conventional commit analysis. Never silently increment past a partial next tag.
+6. Query the compare/PR data, retain a complete unfiltered list, generate categorized notes, and record excluded newer-main commits.
+7. Produce deterministic request identity, content identity, and separate audit envelope, including controller/candidate provenance without execution fields. Inject clocks/API adapters; pure identity code must never read `Date.now()`, environment run IDs, or artifact IDs.
+8. Implement stale revalidation for frontier/tag/draft/main changes after queue wait and stored-controller selection for a recognized partial plan.
+
+**Tests and verification:**
+
+```sh
+npx vitest run test/release/canonical-json.test.ts test/release/plan.test.ts
+node scripts/release/plan.mjs --help
+npm run typecheck
+npm run lint
+npm run knip
+git diff --check
+```
+
+Table tests must include valid tip/older main ancestor whose tree lacks all release helpers, abbreviated/mixed-case/unreachable SHA, non-main ref, mutable/wrong controller SHA, empty range, malformed/prerelease/build-metadata tags, divergent Release/ref, orphan tags, drafts, exact completed plan, corrupt/missing identity assets, already-contained SHA, concurrent winner, stale frontier, and a partial plan whose original controller differs from current main.
+
+**Failure handling:** network/API uncertainty is a typed non-mutating failure, never “no releases.” Multiple candidates or inconsistent GitHub objects fail closed and include object IDs/URLs without secrets.
+
+**Rollback:** remove the new unused helpers/tests if abandoned; WP0 remains frozen.
+
+**Exit proof:** AC-03, AC-04, AC-05, AC-06, AC-10, AC-14 planning cases, AC-26, AC-30, AC-31, and AC-32 unit proofs pass.
+
+## Work Package 2 — Deterministic Static Assets and Retention
+
+**Objective:** build one verified static deployment package and make prospective exact URLs durable.
+
+**Dependencies:** WP1 schemas and plan outputs.
+
+**Allowed scope:** `scripts/build-widget.js`, `scripts/release/static-assets.mjs`, related tests/fixtures, `package.json`, `Makefile`, `.github/workflows/ci.yml`, and `test/ci-workflow-contract.test.sh`.
+
+**Changes:**
+
+1. Add explicit build mode and source/output directory arguments so the controller script can build candidate source without importing candidate release code. `release` requires a valid planned stable version and fixed normalized timestamp; `development` uses a visible non-release identity and cannot emit authoritative release metadata.
+2. Remove production fallback to `package.json`. Release mode fails for missing/invalid version, missing timestamp, test hooks, unexpected output, or dirty output directory.
+3. Build the new widget once with controller-pinned esbuild against the candidate checkout; record exact, latest, major, and minor aliases as byte-identical copies.
+4. Download every post-cutover retained exact asset and checksum from its published GitHub Release. Reject missing, duplicate, unexpected, or corrupt assets. Do not represent historical 404 versions.
+5. Construct `versions.json` deterministically from the declared cutover boundary and fixed plan values. Package the complete `public/` tree and checksums once for downstream upload/download, Cloudflare deployment, live readback, and Release assets.
+6. Define retry semantics: same run uses immutable artifact ID; new dispatch rebuilds only with identical pinned inputs and must reproduce every hash before reuse.
+7. Change preview CI from `git describe` to an explicit development identity without changing preview URLs, `BUILD_SHA`, environment polling, exact widget fixture, canary behavior, or required checks. Preview does not need the dual release checkout because it deploys its own merge-group candidate and has no release credentials.
+
+**Tests and verification:**
+
+```sh
+npx vitest run test/release/static-assets.test.ts
+bash test/ci-workflow-contract.test.sh
+BUGDROP_BUILD_MODE=release BUGDROP_VERSION=1.56.0 BUGDROP_RELEASE_TIMESTAMP=2026-08-02T00:00:00Z npm run build:widget
+shasum -a 256 public/widget.js public/widget.v1.56.0.js
+make check
+git diff --check
+```
+
+Run the release build twice from clean controller/candidate/staging directories with the same inputs and compare recursive file names/hashes. Use an older candidate fixture that lacks `scripts/release/**` and prove the controller still builds it. Change one timestamp/source/tool/controller input and prove content identity changes. Corrupt one prior asset and prove packaging stops.
+
+**Failure handling:** any missing archive/hash fails before approval. Artifact expiry triggers deterministic rebuild-and-compare or a new plan/approval; it never substitutes bytes.
+
+**Rollback:** revert build-mode changes and keep WP0 frozen. Never cut over exact retention until two-build reproducibility and N/N+1 fixture tests pass.
+
+**Exit proof:** AC-07 build half, AC-08, AC-19, AC-20, AC-21 build half, AC-22 preview proof, and AC-28 pass.
+
+## Work Package 3 — Worker, Live Verification, and Notification Components
+
+**Objective:** make production identity and notification explicit and reusable without yet enabling a release.
+
+**Dependencies:** WP1–WP2.
+
+**Allowed scope:** `wrangler.toml`, `scripts/release/production-state.mjs`, `scripts/release/verify-live.mjs`, `scripts/discord-release.mjs`, related tests, `.github/workflows/live-tests.yml`, `.github/workflows/discord-release.yml`, `src/routes/api.ts`/`test/api.test.ts` only if tests expose a gap.
+
+**Changes:**
+
+1. Pin and record Wrangler/esbuild from the controller lockfile; separately hash the candidate tree/package lock and compute the effective staging/configuration digest.
+2. Add explicit controller-owned production configuration and require deploy-time `BUILD_SHA=target_sha` plus `ENVIRONMENT=production`. Prove the staged Wrangler entry point and module resolution use candidate source/dependencies. Do not claim prebuilt Worker byte promotion unless Operator WP7 proves a supported Wrangler mechanism.
+3. Implement baseline normalization for current bootstrap state and future identified state. Capture Cloudflare version/deployment ID, live health, widget/manifest/alias hashes, and prior published tag.
+4. Implement live verifier inputs for expected SHA, version, origin, widget hash, exact/alias names, retained manifest/hashes, and timeout. It must never call `git describe`.
+5. Refactor live-tests workflow calls to require explicit release identity. Scheduled production monitoring observes and reports current live identity without pretending a checkout tag is expected identity. Preview keeps its existing explicit SHA/hash path.
+6. Extract Discord payload/send logic. Add `workflow_call` and keep manual tag-scoped dry-run/retry. Remove `release.published` as an automatic authority. Deduplicate automatic sends by release-plan identity/tag.
+
+**Capability gate and verification:**
+
+```sh
+npx wrangler --version
+npx wrangler deployments --help
+npx wrangler versions --help
+npx vitest run test/release/production-state.test.ts test/release/verify-live.test.ts
+bash test/ci-workflow-contract.test.sh
+npm run validate
+git diff --check
+```
+
+The Wrangler help commands only identify candidate operations. Operator WP7 must prove the exact list/rollback/deploy commands, controller-config/candidate-source staging layout, module resolution, and JSON fields against preview or another non-production Worker using the locked controller version. Record the accepted command shape in `docs/releasing.md`; if no verifiable rollback or checkout separation is available, block cutover.
+
+**Failure handling:** unknown Cloudflare JSON/state returns “ambiguous,” never success. A Discord failure returns a tag-scoped retry instruction and cannot invoke deploy/publication.
+
+**Rollback:** revert component/workflow changes while WP0 remains frozen. Preview and scheduled monitoring must pass their original contracts before merge.
+
+**Exit proof:** AC-11, AC-12, AC-17, AC-18, AC-22, and AC-27 component proofs pass.
+
+## Work Package 4 — Publication and Recovery Engine
+
+**Objective:** implement the post-verification GitHub state machine and compensating recovery as pure/tested transitions.
+
+**Dependencies:** identities/static package from WP1–WP2 and Cloudflare state model from WP3.
+
+**Allowed scope:** `scripts/release/publication.mjs`, publication/production-state tests and fixtures, and runbook draft.
+
+**Changes:**
+
+1. Inspect tag ref/object, tag annotation, draft/published Releases, body marker, target, assets, and checksums before every action.
+2. Create a canonical annotated tag only at the target SHA with protocol/version/identity marker; never force, move, or delete it.
+3. Create/reuse an identity-matched draft. Reconcile only absent exact assets, reject name/hash/content conflicts, download/read-verify the complete required set, then publish the draft explicitly.
+4. Treat published exact match as no-op. Treat lightweight orphan, wrong SHA/identity, unrelated draft, duplicate Release, unexpected asset, or published mismatch as conflict.
+5. Model lost responses for every mutation by re-reading authoritative state.
+6. Emit typed outcomes consumed by the workflow: `published`, `already-published`, `partial-resumable`, `conflict`, or `unknown-critical`.
+
+**Tests and verification:**
+
+```sh
+npx vitest run test/release/publication.test.ts test/release/production-state.test.ts
+npm run typecheck
+npm run lint
+git diff --check
+```
+
+Use a fake GitHub adapter that can apply a mutation and then throw to simulate lost responses. Assert the second attempt never duplicates, overwrites, moves, deletes, or increments.
+
+**Failure handling:** before publication, deployment is provisional. A publication failure triggers prior-baseline rollback handling; identity-matched partial GitHub objects remain for exact retry. A published matching result wins over a lost client response and must not be rolled back as unpublished.
+
+**Rollback:** helpers are unused until WP5; remove them if necessary. Never “clean up” test-discovered production tags.
+
+**Exit proof:** AC-13, AC-14, AC-16, AC-30, and AC-31 transition proofs pass.
+
+## Work Package 5 — Full Manual Workflow and Contracts
+
+**Objective:** replace the freeze with the complete workflow while production remains killed off.
+
+**Dependencies:** WP1–WP4 green; T013 spec unchanged.
+
+**Allowed scope:** `.github/workflows/deploy.yml`, release/live/Discord workflows, release scripts/tests, workflow contract tests, `Makefile`, and package scripts.
+
+**Changes:**
+
+1. Add only the specified dispatch inputs and an immediate `github.ref == refs/heads/main` guard.
+2. Pin `controller_sha` from immutable workflow context. Set workflow-level `contents: read`; declare `bugdrop-production-release`, `queue: max`, and `cancel-in-progress: false`.
+3. Implement the target jobs and immutable artifact handoffs. Every job creates separate controller and candidate checkouts at explicit SHAs; no job checks out mutable main or executes candidate release helpers.
+4. `dry_run=true` completes State 2 and never references `production`, secrets, Cloudflare, tag/Release write, or Discord.
+5. A live run additionally requires `vars.RELEASE_PRODUCTION_ENABLED == 'true'`, then protected environment approval and stale/completed-plan revalidation.
+6. In `core-release`, recreate both credential-free checkouts, download/hash-check the static package, verify controller/candidate/staging digests, capture baseline, and invoke controller-pinned Wrangler once against the immutable candidate-source staging tree.
+7. Run explicit live verification/E2E before any GitHub publication. On deploy/verify/publication failure, inspect state, attempt the validated rollback, and verify the complete bootstrap/normal baseline.
+8. Publish through WP4 only after live success. Pass write token only to named controller publication steps; neither checkout persists credentials and no candidate command receives any secret.
+9. Notify directly only for a newly/matchingly published core result. Exact post-success and concurrent-winner no-ops do not auto-notify.
+10. Add `always()` finalization for mutation attempts, explicitly labeling cancellation cleanup best effort and ambiguous states critical.
+
+**Contract verification:**
+
+```sh
+bash test/release-workflow-contract.test.sh
+bash test/ci-workflow-contract.test.sh
+npm run check:actions-node24
+npm run validate
+make build-all
+git diff --check
+```
+
+Parse the workflow with an Actions-aware YAML/schema checker. The contract must assert triggers, input types/default, main-ref guard before checkout, immutable workflow/controller SHA, distinct controller/candidate paths and refs, `persist-credentials: false`, full candidate SHA validation, workflow-level queue, job permissions, no issue/PR write, environment only on mutation/recovery jobs, kill switch, dependency ordering, credential isolation from candidate commands, no `git describe`, explicit live inputs, no release-event notification dependency, and rollback/finalization conditions.
+
+**Failure handling:** workflow syntax or contract failure blocks merge. A merged but disabled workflow can be reverted to the WP0 manual freeze without restoring automatic deployment.
+
+**Rollback:** set/keep `RELEASE_PRODUCTION_ENABLED=false` first, then revert to freeze. Do not use a workflow revert as service rollback; use the recorded Cloudflare baseline.
+
+**Exit proof:** repository-side AC-01 through AC-18 and AC-22 through AC-32 pass; external and production proofs remain pending Operator WP7–WP8.
+
+## Work Package 6 — Metadata, Documentation, and Dependency Cleanup
+
+**Objective:** remove semantic-release authority and make operator/public documentation truthful.
+
+**Dependencies:** WP5 workflow contracts.
+
+**Allowed scope:** `.releaserc.json` deletion; `package.json`, lockfile, `knip.json`, `CLAUDE.md`, `CHANGELOG.md`, `docs/releasing.md`, `docs/website/version-pinning.mdx`, and relevant tests.
+
+**Changes:**
+
+1. Remove `semantic-release` and its lockfile graph; delete `.releaserc.json` and knip exceptions.
+2. Set `package.json` to an explicit documented development sentinel that cannot be parsed as a production release. Production build ignores it and requires planned version.
+3. Keep conventional commit linting only as a readability convention; remove statements that commit prefixes choose releases.
+4. Mark changelog historical and link canonical GitHub Releases.
+5. Document exact URL retention as prospective from the recorded cutover tag; disclose unavailable historical files and provenance-only backfill rules.
+6. Complete `docs/releasing.md` with weekly/emergency preparation, dry run, approval, live run, terminal-state matrix, cancellation, rollback, notification-only retry, and evidence capture.
+
+**Verification:**
+
+```sh
+rg -n 'semantic-release|git describe' .github scripts package.json package-lock.json knip.json CLAUDE.md CHANGELOG.md docs test || true
+npm ci
+make check
+npm test
+git diff --check
+```
+
+Expected remaining matches must be historical/migration explanation or negative contract assertions, not executable release authority.
+
+**Failure handling:** dependency/lockfile or documentation inconsistency blocks PR C. Do not re-add semantic-release to work around a manual-workflow defect.
+
+**Rollback:** revert metadata/docs together with WP5 only while production remains disabled. If already cut over, freeze and fix forward; never reinstate automatic releases.
+
+**Exit proof:** AC-20, AC-21, AC-24, and AC-25 repository portions pass.
+
+## External Configuration
+
+External mutations happen only after PR C is merged and repository tests are green. Capture screenshots or API JSON with secret values redacted and attach them to the cutover record.
+
+### Operator Work Package 7 — Protected production and rollback capability
+
+**Objective:** establish audited GitHub authority and prove Cloudflare rollback without enabling production.
+
+**Dependencies:** WP0–WP6 merged and green.
+
+**Rollback:** keep `RELEASE_PRODUCTION_ENABLED=false`, remove or correct incomplete environment/ruleset configuration, and leave the manual workflow disabled. Never compensate by weakening approval or restoring push deployment.
+
+### GitHub configuration
+
+1. Create environment `production` with deployment branch `main`, required reviewer(s), administrative bypass disabled, and self-review prevention when two maintainers are eligible. Document a named exception if only one is eligible.
+2. Move `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, and any production live-test secret into the environment. The token must be least-privilege for this Worker/account.
+3. Put `DISCORD_RELEASE_WEBHOOK_URL` in a notification-appropriate environment/secret scope that supports both direct call and manual notification-only retry without exposing Cloudflare credentials.
+4. Create repository variable `RELEASE_PRODUCTION_ENABLED=false`.
+5. Confirm default `GITHUB_TOKEN` is read-only. Workflow job permissions supply `contents: write` only to `core-release`; no issues/PR write.
+6. Add a tag ruleset for `v*` that prevents update/deletion and restricts creation to the approved release workflow/integration. Prove the workflow can create a test tag in a disposable repository or documented non-production namespace before relying on the rule. Do not create a production SemVer tag for testing.
+7. Confirm merge queue and required checks are unchanged. Record the exact check names used by candidate readiness validation.
+8. Confirm environment deployment history appears for the dry-run-disabled test only after approval; dry runs must create no deployment record.
+
+### Cloudflare capability proof
+
+Using the locked Wrangler version and a preview/disposable Worker:
+
+1. Record `npx wrangler --version` and the exact commands/options that list deployments/versions and return machine-readable IDs.
+2. From two separate immutable checkouts, construct the planned controller-config/candidate-source staging tree. Deploy known candidate source/static hash A with explicit environment/SHA using controller Wrangler, prove live code/assets came from the candidate rather than controller, record its version/deployment ID, then deploy B.
+3. Invoke the candidate rollback mechanism to A. Verify API health identity, latest/static exact hashes, manifest, and aliases all return A's recorded values.
+4. Simulate a deploy command that loses its response if feasible; prove authoritative inspection distinguishes A, B, and unknown state.
+5. Confirm assets participate in version rollback as assumed. If Worker code rolls back but assets do not, design and test an explicit checksum-verified static restoration before cutover.
+6. Put the exact accepted commands, expected JSON fields, timeouts, and manual fallback in `docs/releasing.md` and fixtures. Do not encode a guessed command.
+
+If any capability is absent or unstable, keep the kill switch false and revise the implementation/spec; this is a cutover blocker, not a reason to weaken verification.
+
+## Verification Program
+
+### Repository test layers
+
+1. **Pure unit tests:** canonical identity, SemVer/frontier, completed-plan lookup, static manifests, state transitions, payload formatting.
+2. **Workflow contracts:** triggers, scopes, environments, concurrency, dependencies, explicit inputs, and forbidden strings/commands.
+3. **Adapter integration tests:** sanitized GitHub and Cloudflare fixtures, lost-response behavior, artifact corruption/expiry.
+4. **Dry-run Actions tests:** main and temporary-branch refs, tip and older main ancestors, weekly/emergency inputs, concurrent dispatches.
+5. **Non-production deployment drills:** Worker identity, static package promotion, rollback, retained N/N+1 assets, ambiguous cancellation.
+6. **Production cutover proof:** supervised bootstrap baseline, exact candidate verification, publication, notification, and follow-up monitoring.
+
+### Required scenario matrix
+
+| Scenario | Expected result |
+| --- | --- |
+| Dispatch workflow file from non-main ref | Fails before candidate checkout, artifacts, environment, or secrets |
+| Invalid/branch/abbreviated/unreachable target | Read-only failure |
+| Older releasable main ancestor | Plan lists every excluded newer-main commit and may proceed only after approval |
+| Older main ancestor lacks release helpers/config | Controller checkout supplies all release logic/config; candidate checkout supplies only product source; hashes and live SHA prove the separation |
+| No commits after frontier | No-op-range failure unless exact completed-plan lookup succeeds |
+| Dry run | State 2 artifacts/summary; zero environment/deploy/tag/Release/notification effects |
+| Two plans for same next version | Queue retains both; winner publishes, loser exact-no-ops or fails stale/conflict without increment |
+| Same run rerun | Reuses immutable artifacts and resumes missing state |
+| Partial retry after controller changed | Uses authenticated stored controller SHA/protocol or stops critical; never substitutes current controller into the old identity |
+| Expired artifacts | Deterministic rebuild must match identity or require new approval |
+| Wrong tag/draft/asset | Fails closed; no overwrite/delete/increment |
+| Deploy command error/lost response | Inspect Cloudflare; rollback if candidate/partial is active |
+| Live identity/hash/E2E failure | Verify rollback baseline; no published Release/notification |
+| Publication lost response | Inspect exact tag/draft/published state; resume or recognize success without duplication |
+| Discord failure | Core release remains; explicit notification-only retry succeeds |
+| Cancellation after mutation | Best-effort finalizer; otherwise critical ambiguous state and manual inspection |
+| Candidate script attempts credential access | Contract and instrumented fixture prove no write/Cloudflare/Discord secret is present in the candidate process environment |
+| Exact post-success rerun | Authenticated core no-op before advanced-frontier calculation and no auto-notification |
+| Same target with changed inputs / target contained later | Fail closed; never another version |
+
+## Rollout
+
+### Operator Work Package 8 — Dry run, supervised cutover, and observation
+
+**Objective:** enable the proven system through one bootstrap release and one N+1 retention proof.
+
+**Dependencies:** Operator WP7 evidence accepted.
+
+**Rollback:** immediately set the kill switch false and follow the service/automation recovery sections below; do not move tags or restore semantic-release.
+
+### Pre-cutover checklist
+
+1. PR A, PR B, and PR C are merged through the queue; `main` has no automatic production trigger.
+2. Full repository suite and workflow schema/contracts pass from clean install.
+3. T013-approved specification still matches the implementation; any semantic change returns to spec review.
+4. GitHub production environment, reviewers, branch policy, secret scope, token permissions, tag rules, and false kill switch are evidenced.
+5. Wrangler/Cloudflare version and rollback drill passes, including static assets.
+6. Choose and record the weekly window, reviewer, first target SHA, explicit bump, and retention cutover version.
+7. Capture bootstrap production baseline: Cloudflare ID, live health JSON, current GitHub tag/Release, latest/exact/alias/manifest hashes, and known historical 404 boundary.
+
+### Dry-run sequence
+
+1. Dispatch from `main` with the selected target, bump, `weekly`, `dry_run=true`, and reviewed notes.
+2. Review included/excluded PRs, current-main delta, next version, deterministic timestamp, static/checksum set, Worker input digest, and final release-plan identity.
+3. Confirm the summary shows distinct immutable controller and candidate SHAs/tree/lockfile digests. For an older-ancestor dry-run fixture, prove missing candidate release helpers are never invoked.
+4. Prove the run has no environment deployment, secrets, tag/draft/Release, Cloudflare version, or Discord call.
+5. Repeat the same dry run and prove identical content identity with a distinct audit envelope.
+6. Run negative branch, stale plan, emergency-without-rationale, conflicting artifact, wrong-controller, and credential-canary fixtures.
+
+### Bootstrap production release
+
+1. Set `RELEASE_PRODUCTION_ENABLED=true` only during the staffed window.
+2. Dispatch the exact approved inputs from `main`; a second maintainer reviews the finalized plan and hashes in the environment gate.
+3. Watch baseline capture, provisional deploy, health/static/manifest/retention polling, and live E2E.
+4. Verify annotated tag, complete draft assets, final publication, and direct Discord result.
+5. Download Release assets independently and compare checksums. Query live health and all aliases/exact URL independently.
+6. Record the cutover version as the prospective retention boundary and store the final audit evidence.
+7. Run an exact post-success dispatch and prove it core-no-ops without approval/deploy/notification.
+
+### Observation window
+
+Keep the release system under heightened observation for seven days and through the next weekly release:
+
+- daily scheduled live monitor remains green;
+- no push-triggered Deploy runs exist;
+- production health stays `production` with the released SHA;
+- exact/alias/manifest hashes remain correct;
+- Release/tag/assets and deployment records remain consistent;
+- a second release proves N exact assets survive N+1;
+- notification-only retry is tested with dry run, not a duplicate live post.
+
+After the second successful weekly release, keep the kill switch as an emergency freeze control and close the migration record. Do not add a schedule trigger to the production workflow.
+
+## Rollback and Recovery
+
+### Service rollback
+
+1. Set `RELEASE_PRODUCTION_ENABLED=false` to prevent another live dispatch.
+2. Resolve the exact candidate and recorded prior baseline from the run audit.
+3. Inspect authoritative Cloudflare state; do not infer state from the failed command exit code.
+4. Use the proven rollback mechanism to restore the recorded prior deployment/version and, if required, static asset package.
+5. Verify the full bootstrap or normal baseline, including Cloudflare ID, health, widget/manifest/alias hashes, and later `buildSha`/tag.
+6. Leave matching partial annotated tag/draft objects intact for deterministic resumption. Do not move/delete tags.
+
+### Automation rollback
+
+If the repository workflow itself is defective, keep production disabled and revert PR C to the WP0 freeze or issue a fix-forward PR. A workflow rollback never implies the service rolled back. Never restore semantic-release or a main-push deploy as an emergency shortcut.
+
+### Terminal-state ownership
+
+| State | Operator action |
+| --- | --- |
+| Preflight/candidate failure | Fix source/input and dispatch a new dry run; no external recovery |
+| Approval rejected/stale | Replan; never approve/recalculate in place |
+| Deploy/verify failure with verified rollback | Keep disabled, correct cause, reproduce same plan or create new approved plan |
+| Rollback unverified | Incident/critical state; inspect Cloudflare and live hashes until one baseline is proven |
+| Tag-only or draft partial after rollback | Same version/identity may resume after re-deploy/verify; no tag deletion |
+| Matching published Release after lost response | Treat core as published; do not roll back or republish; continue notification if needed |
+| Discord failure | Use manual notification-only tag path; no core rerun |
+| Cancellation after mutation | Do not trust “cancelled”; run authoritative inspection and recovery checklist |
+
+## Operator Runbook
+
+The final `docs/releasing.md` should use this compact weekly flow:
+
+1. Choose a full SHA from GitHub `main` history only after the intended PR stack is coherent.
+2. Choose explicit bump; use `weekly` normally or `emergency` with mandatory rationale.
+3. Run dry mode and review included/excluded work, version, hashes, Worker inputs, and plan identity.
+4. Re-dispatch live with exactly the reviewed fields during the window.
+5. Approve only the finalized post-build plan in `production`; reject if main/frontier/content differs.
+6. Observe provisional identity and publication. On any critical/ambiguous result, freeze and inspect before retrying.
+7. Confirm GitHub Release, live health/hash/manifest/exact URLs, Discord result, and audit envelope.
+8. For notification failure, run Discord workflow by published tag. For service failure, use rollback—not tag mutation.
+
+Emergency releases differ only in timing and mandatory rationale; they never bypass dry run, environment approval, serialization, verification, identity, retention, publication, or recovery.
+
+## Traceability
+
+| Acceptance criterion | Implementation and proof |
+| --- | --- |
+| AC-01–02 | WP0/WP5 trigger contract and post-merge Actions audit |
+| AC-03–04 | WP1 ref/full-SHA/controller/ancestry tests plus real non-main and older-ancestor dry runs |
+| AC-05 | WP1 summary fixture and environment approval evidence |
+| AC-06 | WP1 published-frontier/SemVer table tests |
+| AC-07 | WP2/WP5 State 2 dry run and zero-effect audit |
+| AC-08 | WP2 package hashes across build, artifact, deploy, live, and Release |
+| AC-09 | WP5 workflow contract plus GitHub environment/concurrency audit |
+| AC-10 | WP1/WP5 concurrent dispatch and stale revalidation drill |
+| AC-11–12 | WP3 explicit health/SHA/hash verifier and live workflow contract |
+| AC-13 | WP4/WP5 order contract and forced live failure |
+| AC-14 | WP4 tag/draft/published transition table and immutable tag rules |
+| AC-15 | WP3, Operator WP7, and Operator WP8 bootstrap/normal rollback drills |
+| AC-16 | WP4 lost-response simulations and cutover failure injection |
+| AC-17–18 | WP3 direct reusable Discord call and notification-only retry |
+| AC-19 | WP2 fixture plus N/N+1 production observation |
+| AC-20 | WP2/WP6 manifest boundary and public documentation |
+| AC-21 | WP2/WP6 strict release build and metadata inspection |
+| AC-22 | Existing CI contract plus trigger/diff audit after every PR |
+| AC-23 | WP5 controller/candidate credential-isolation contract and GitHub settings audit |
+| AC-24 | WP1/WP5 emergency validation and dry-run fixture |
+| AC-25 | WP6 runbook review and Operator WP8 terminal-state exercises |
+| AC-26 | WP1 lifecycle/identity timing tests and approval summary |
+| AC-27 | WP3 controller/candidate source/lock/tool/config/staging digest and live `BUILD_SHA` proof |
+| AC-28 | WP2 available/expired artifact retry tests |
+| AC-29 | WP5 cancellation drill, best-effort finalizer, and manual recovery evidence |
+| AC-30 | WP1 canonical content/audit exclusion and two-dispatch tests |
+| AC-31 | WP1/WP4 tag-only/partial-draft same-version retry tests |
+| AC-32 | WP1/WP5 exact post-success no-op and changed/contained negative tests |
+
+## Definition of Done
+
+Implementation is complete only when all of the following are true:
+
+1. Repository search finds no executable semantic-release authority, production `git describe`, or automatic production trigger.
+2. Clean-install repository checks, unit tests, workflow schema/contracts, builds, and existing preview/live contracts pass, including an older main ancestor with no release helpers and an instrumented candidate credential-isolation fixture.
+3. Every AC-01 through AC-32 has the cited automated or operator evidence; no production-only criterion is marked complete from a mock alone.
+4. GitHub environment, reviewers, token/secret scopes, concurrency, tag rules, and kill switch are independently audited.
+5. The locked Wrangler/Cloudflare rollback mechanism is proven against real non-production state and recorded in the runbook.
+6. A real dry run proves State 2 and zero external mutation.
+7. The supervised bootstrap release proves target SHA, production environment, static hashes, prospective retention, complete publication, direct notification, and post-success no-op.
+8. A verified rollback drill exists for both bootstrap and normal identified baselines, or cutover remains disabled.
+9. The next weekly release proves the previous exact asset survives unchanged.
+10. Only then may the migration record close. Weekly remains a human cadence; no timer publishes production.
+
+The strongest realistic failure mode is a command/API failure after provisional production mutation but before a complete published Release. The implementation is not done until a failure-injection trace proves authoritative state inspection, exact prior-baseline restoration or exact matching publication recognition, no version drift, no duplicate notification, and no tag move/delete at every boundary.

--- a/docs/goals/weekly-manual-release-cadence/state.yaml
+++ b/docs/goals/weekly-manual-release-cadence/state.yaml
@@ -1,0 +1,933 @@
+# GoalBuddy v2 state.yaml
+# Board truth lives here. goal.md is the editable charter; notes/ holds long receipts and planning artifacts.
+
+version: 2
+
+goal:
+  title: "Weekly Manual Release Cadence"
+  slug: "weekly-manual-release-cadence"
+  kind: existing_plan
+  tranche: "Planning only: revalidate evidence, produce and review the specification, then produce and review the detailed implementation plan."
+  status: done
+  oracle:
+    signal: "Every owner concern and verified release risk maps to an explicit specification decision and a bounded implementation-plan step with proof and rollback or deferral."
+    cadence: "after each planning artifact and at final audit"
+    final_proof: "Judge receipt confirms both artifacts are decision-complete, evidence-backed, internally consistent, implementation-ready, and no product or external release state changed."
+  intake:
+    original_request: "On a fresh worktree off GitHub main, start with a spec for weekly manually dispatched releases, then convert it to a detailed implementation plan using GoalBuddyPrep."
+    interpreted_outcome: "Create an approved specification and implementation-ready plan for a safe weekly manual release system without implementing it."
+    input_shape: existing_plan
+    audience: "BugDrop maintainers and release implementers"
+    authority: requested
+    proof_type: artifact
+    completion_proof: "Reviewed specification and implementation plan exist under notes/, cover all known risks and decisions, include observable verification and rollback, and leave implementation untouched."
+    likely_misfire: "Change only the Actions trigger or produce a generic plan while leaving automatic deployment, partial-stack, branch, concurrency, idempotency, notification, asset-retention, and failure-ordering hazards unresolved."
+    blind_spots_considered:
+      - "Manual dispatch still permits an operator to select a non-main branch unless guarded."
+      - "Manual timing does not prove a partially merged stack is release-ready."
+      - "GitHub publication and Cloudflare deployment cannot be made fully atomic."
+      - "A red post-release workflow can already have published and deployed."
+      - "No-release pushes currently still deploy source under the previous tag."
+      - "Exact-version widget assets currently disappear on later deployments."
+      - "GITHUB_TOKEN-created releases usually do not trigger the Discord release workflow."
+      - "Production lacks environment approval, serialized concurrency, deployment records, and BUILD_SHA identity."
+    existing_plan_facts:
+      - "Current deploy.yml triggers on every push to main and couples semantic-release, production deploy, and post-deploy live tests."
+      - "Current semantic-release plugins create tags/notes/GitHub releases but do not publish npm or update package.json/CHANGELOG.md."
+      - "A weekly manual workflow should operate on an immutable reviewed main-history SHA and explicit SemVer decision."
+      - "The release design must be idempotent, serialized, permission-minimal, approval-gated, observable, and rollback-aware."
+      - "Discord notification should be invoked explicitly after successful publication rather than assumed from a GITHUB_TOKEN release event."
+      - "Exact-version asset retention is a current contract defect that must be repaired or explicitly re-specified."
+      - "The planning sequence is evidence validation, specification, specification review, detailed implementation plan, plan review, final audit."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: false
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  exact_human_approval_can_terminal_wait: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/weekly-manual-release-cadence/"
+    command: "node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.4.2/skills/goal-prep/surfaces/local-goal-board/scripts/local-goal-board.mjs --goal docs/goals/weekly-manual-release-cadence"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: low
+    objective: "Revalidate the current release architecture, live behavior, verification surface, and prior audit facts from the fresh main snapshot."
+    inputs:
+      - "Fresh worktree at origin/main commit 12b139c49b157a0decf5570c723fe2935149e5f4"
+      - "Prior evidence-backed release audit summarized in goal intake"
+    constraints:
+      - "Read-only."
+      - "Do not write the specification or implementation plan."
+      - "Do not modify repository, GitHub, or Cloudflare state."
+      - "Distinguish verified facts from proposals and stale observations."
+    expected_output:
+      - "Current release/deploy/notification/versioning architecture map with file-path evidence"
+      - "Revalidated live-history and production-behavior evidence"
+      - "Verification and workflow-contract commands relevant to later implementation"
+      - "Decision inventory and strongest realistic failure modes the specification must resolve"
+    receipt:
+      result: done
+      harness: codex
+      summary: "PM fallback revalidated the fresh main release path after the dedicated Scout exceeded GoalBuddy's one-wait limit. Every push to main runs semantic-release, then deploys HEAD even when no version is created, and only afterward runs live tests. Current v1.55.0 was published and deployed in a workflow that finished red. Production lacks an environment gate, serialization, deployment records, BUILD_SHA, and production environment identity. Exact prior widget URLs return 404, release-event Discord automation is suppressed in practice, and package/changelog metadata is stale. The specification must choose immutable targeting, readiness, versioning, failure ordering, idempotency, rollback, artifact retention, and notification semantics."
+      evidence:
+        - ".github/workflows/deploy.yml:8-75"
+        - ".releaserc.json:1-8"
+        - "package.json:1-80"
+        - "scripts/build-widget.js:22-81"
+        - ".github/workflows/live-tests.yml:3-129"
+        - ".github/workflows/discord-release.yml:3-185"
+        - ".github/workflows/sync-docs.yml:3-42"
+        - "wrangler.toml:12-58"
+        - "src/routes/api.ts:116-129"
+        - "test/ci-workflow-contract.test.sh:93-124"
+        - "https://github.com/mean-weasel/bugdrop/actions/runs/30765978738"
+        - "https://github.com/mean-weasel/bugdrop/actions/runs/30724408445"
+        - "https://bugdrop.neonwatty.workers.dev/api/health"
+        - "https://bugdrop.neonwatty.workers.dev/versions.json"
+      facts:
+        - "Fresh worktree HEAD, origin/main, and GitHub main all resolved to 12b139c49b157a0decf5570c723fe2935149e5f4 during T001."
+        - "deploy.yml triggers only on push to main; release, production deploy, and post-deploy live tests are a single dependency chain with no production concurrency or environment declaration."
+        - "The explicit semantic-release plugin list analyzes commits, generates notes, and publishes to GitHub; it excludes npm/changelog/git prepare plugins, so package.json remains 1.14.0 and CHANGELOG.md stops at 1.11.0 while production is 1.55.0."
+        - "Run 30724408445 logged no relevant release changes, then built HEAD as 1.53.1 and deployed a new Cloudflare version, proving that a no-release push still deploys."
+        - "Run 30765978738 created v1.55.0 and deployed production successfully before live E2E failed; the overall workflow is red after irreversible public effects."
+        - "Current GitHub history contains 121 published releases, 96 since 2026-04-01, 25 multi-release days, and up to 12 releases in one day."
+        - "Repository API reports zero GitHub environments; the default Actions token permission is read and the release job elevates contents/issues/pull-requests explicitly."
+        - "Production health reports environment=development and omits buildSha because wrangler.toml defaults ENVIRONMENT to development and the production deploy does not pass BUILD_SHA."
+        - "The live manifest reports 1.55.0. Current widget.js, widget.v1.js, widget.v1.55.js, and widget.v1.55.0.js return 200; v1.54.1, v1.54.0, v1.53.1, and v1.1.0 exact assets return 404."
+        - "The build emits only current latest/major/minor/exact files into a gitignored public directory, so clean deployments cannot retain older exact assets without an additional durable source."
+        - "Only one recent release-event Discord workflow run exists; the notification workflow already supports workflow_dispatch but is not reusable via workflow_call."
+        - "Preview CI already deploys with BUILD_SHA and polls for exact environment/SHA; production can reuse that proof pattern without changing preview CI behavior."
+        - "docs website synchronization is independently path-filtered on main and need not be coupled to production releases."
+      contradictions:
+        - "CHANGELOG.md says publishing a GitHub Release gives maintainers explicit deployment control, but deploy.yml actually publishes and deploys automatically on every main push."
+        - "CHANGELOG.md promises exact widget URLs for strict control, but every tested prior exact version returns 404 after the newest deployment."
+        - "A failed Deploy workflow visually implies failure, while the latest three failed runs had already published/deployed before post-deploy test failure."
+        - "Production is labeled development and has no SHA identity despite preview having exact deployment identity checks."
+      ambiguity_requiring_judge:
+        - "Choose and justify the least misleading cross-system ordering: validate candidate, reserve immutable tag, deploy and verify, then publish GitHub Release; define recovery for every boundary."
+        - "Choose whether operators select a SemVer bump or enter an explicit version; both must be derived/validated against the latest reachable release tag."
+        - "Define a release-readiness mechanism beyond manual timing, including immutable target SHA, main-history ancestry, and human review of all included PRs."
+        - "Decide whether exact-version retention remains a supported contract; the evidence favors preserving and repairing the documented contract rather than silently weakening it."
+        - "Define whether notification failure fails the release record, retries independently, or records a degraded-success state without redeploying."
+      commands:
+        - cmd: "git status --short --branch; git rev-parse HEAD origin/main; git ls-remote origin refs/heads/main"
+          status: pass
+        - cmd: "inspect deploy, semantic-release, build-widget, live-test, notification, docs-sync, Wrangler, and workflow-contract sources with numbered lines and rg"
+          status: pass
+        - cmd: "gh release list; gh run list/view; gh api rulesets, environments, workflow permissions, refs, and release history"
+          status: pass
+        - cmd: "probe live production health, versions.json, and current/prior versioned widget URLs"
+          status: pass
+        - cmd: "inspect no-release and failed post-deploy workflow logs"
+          status: pass
+      note_needed: false
+  - id: T002
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Write a decision-complete weekly manual release specification from the validated evidence and owner intent."
+    inputs:
+      - "docs/goals/weekly-manual-release-cadence/goal.md"
+      - "T001 receipt and any supporting note"
+    constraints:
+      - "Write only the specification artifact."
+      - "Do not edit release workflows, dependencies, product code, or external settings."
+      - "Separate verified current behavior, chosen policy, alternatives, and deferred work."
+      - "Do not treat workflow_dispatch or a weekly habit as proof that a partially merged stack is release-ready."
+      - "Every normative requirement needs an observable acceptance criterion."
+    expected_output:
+      - "Problem statement, outcomes, audience, scope, non-goals, and terminology"
+      - "Evidence-backed current-state architecture and failure model"
+      - "Decisions for cadence, emergency releases, immutable target SHA, release readiness, SemVer, release notes, permissions, environment approval, concurrency, and operator authority"
+      - "Lifecycle decisions for preflight, tag/release ordering, deployment, verification, notification, retry, partial failure, idempotency, and rollback"
+      - "Decision for exact-version asset retention and stale package/changelog metadata"
+      - "Acceptance criteria, unresolved owner decisions if any, migration boundaries, and explicit non-goals"
+    allowed_files:
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    verify:
+      - "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "rg -n '^## (Problem|Outcomes|Current State|Release Policy|Release Candidate|Release Lifecycle|Failure|Artifact|Notifications|Acceptance|Non-Goals|Open Decisions)' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    stop_if:
+      - "A policy choice materially changes release authority, supported artifacts, or rollback semantics and cannot be safely proposed with a clearly labeled recommendation."
+      - "Validated evidence contradicts the charter in a way that changes the owner outcome."
+      - "Need to write outside allowed_files."
+      - "Verification fails twice."
+    receipt:
+      result: done
+      harness: codex
+      changed_files:
+        - docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md
+      commands:
+        - cmd: "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "rg -n '^## (Problem|Outcomes|Current State|Release Policy|Release Candidate|Release Lifecycle|Failure|Artifact|Notifications|Acceptance|Non-Goals|Open Decisions)' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+      summary: "PM fallback wrote the decision-complete release specification after the dedicated Worker exceeded GoalBuddy's one-wait limit. It defines manual-only weekly/emergency authority, explicit immutable main-history SHA and human bump, readiness attestation, protected approval, serialized/stale-plan-safe execution, build-once artifact promotion, provisional deployment with identity proof and compensating rollback, post-verification publication, idempotent retries, direct recoverable Discord notification, prospective exact-asset retention, and truthful metadata. Twenty-five acceptance criteria bind every normative requirement to observable repository, GitHub, Cloudflare, or live-service proof. It preserves preview CI, daily monitoring, and docs sync, and leaves only named operator configuration values rather than architecture decisions."
+      deviations:
+        - "The installed GoalBuddy Worker was interrupted after the single allowed wait timeout without producing the allowed file; PM fallback completed the same bounded task."
+      remaining_blockers: []
+      verification_attempts: 1
+      stopped_because: null
+  - id: T003
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Skeptically review the release-cadence specification for decision completeness, safety, internal consistency, and fidelity to the owner outcome."
+    inputs:
+      - "docs/goals/weekly-manual-release-cadence/goal.md"
+      - "T001 receipt and supporting evidence"
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    constraints:
+      - "Read-only; do not repair the specification."
+      - "Try to disprove that the design prevents unintended publication and deployment."
+      - "Reject vague future-work language for any safety-critical decision."
+      - "Reject acceptance criteria that cannot be observed in CI, GitHub, Cloudflare, or the deployed service."
+    expected_output:
+      - "approve | revise | blocked"
+      - "Requirement-to-spec traceability"
+      - "Contradictions, ambiguities, unsafe assumptions, and missing acceptance criteria"
+      - "Strongest failure scenario walkthroughs: partial stack, wrong branch, race, duplicate dispatch, no-op release, failure before/after tag, deploy failure, live-test failure, notification failure, and rollback"
+      - "Exact bounded revision task if not approved"
+    receipt:
+      result: done
+      harness: codex
+      decision: rejected
+      full_outcome_complete: false
+      rationale: "PM Judge fallback found the specification direction strong and traceable, but not yet implementation-safe. RC-03 defines one plan identity using artifact hashes before State 2 creates them, while State 1 both precedes and claims completion of candidate verification. The build-once promise clearly covers widget assets but ambiguously claims already verified deployment artifacts although Wrangler builds the Worker during deploy. First-cutover rollback requires a prior build SHA that production does not expose. Retry behavior does not say how expired or rebuilt artifacts preserve identity, and cancellation overstates the guarantee that cleanup will run. These are bounded lifecycle/proof defects, not owner-policy blockers."
+      worker_package:
+        objective: "Revise the release specification to resolve plan-identity timing, Worker-build integrity, bootstrap rollback proof, resumable artifact semantics, and cancellation recovery."
+        allowed_files:
+          - docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md
+        verify:
+          - "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          - "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          - "rg -n 'request identity|release-plan identity|bootstrap baseline|Worker source|artifact retention|cancellation' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+        stop_if:
+          - "A correction requires selecting an unverified Cloudflare/Wrangler capability as fact rather than assigning it to implementation-plan validation."
+          - "Need to write outside allowed_files."
+          - "Verification fails twice."
+      evidence:
+        - "T001 receipt facts and contradictions"
+        - "notes/T002-release-cadence-spec.md:173-236"
+        - "notes/T002-release-cadence-spec.md:244-277"
+        - "notes/T002-release-cadence-spec.md:285-330"
+        - "notes/T002-release-cadence-spec.md:355-357"
+        - "notes/T002-release-cadence-spec.md:385-413"
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks:
+        - T004
+        - T005
+        - T999
+      missing_evidence:
+        - "A consistent identity transition from dispatch inputs to verified artifact hashes."
+        - "An explicit statement of which bytes are promoted unchanged and how immutable Worker source/build identity is proven without assuming unsupported Wrangler behavior."
+        - "A migration bootstrap baseline that can verify rollback before production exposes BUILD_SHA."
+        - "A same-plan retry rule when workflow artifacts are reusable, expired, or rebuilt."
+        - "A cancellation rule that distinguishes best-effort always cleanup from mandatory operator inspection after ambiguous mutation."
+      required_board_updates:
+        - "Activate bounded spec revision T006."
+        - "Require corrected-spec Judge review T007 before T004 implementation planning."
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Convert the Judge-approved specification into a detailed, sequenced, implementation-ready plan without implementing it."
+    inputs:
+      - "docs/goals/weekly-manual-release-cadence/goal.md"
+      - "T001 evidence receipt"
+      - "T013 approved final specification-review receipt"
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    constraints:
+      - "Do not proceed unless T013 approves the specification; if it does not, PM must replace this with the bounded revision task."
+      - "Write only the implementation-plan artifact."
+      - "Do not implement repository or external configuration changes."
+      - "Separate repository PR work from GitHub/Cloudflare operator actions and production cutover."
+      - "Each work package must be independently reviewable, reversible where possible, and verified against the specification."
+    expected_output:
+      - "Architecture delta and target release-state machine"
+      - "Exact anticipated files and external settings affected, validated against current main"
+      - "Ordered migration work packages with dependencies, allowed scope, code/config changes, tests, verification commands, failure handling, and rollback"
+      - "Fast safety cutover, semantic-release removal, explicit version planning, workflow contracts, live-test parameter changes, environment/concurrency setup, notification integration, deployed identity, and exact-asset retention"
+      - "Dry-run, idempotency, concurrent-dispatch, wrong-ref, partial-failure, rollback, and production proof scenarios"
+      - "Release operator runbook, emergency path, rollout sequence, observation window, and definition of done"
+      - "Spec acceptance-criterion traceability matrix"
+    allowed_files:
+      - "docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+    verify:
+      - "test -s docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+      - "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+      - "rg -n '^## (Target Architecture|Migration|Work Package|Repository|External|Verification|Rollout|Rollback|Operator|Traceability|Definition)' docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+    stop_if:
+      - "T013 has not approved the specification."
+      - "A work package cannot name concrete scope and proof without another read-only evidence task."
+      - "The plan requires an unapproved product, versioning, hosting, or compatibility-policy change."
+      - "Need to write outside allowed_files."
+      - "Verification fails twice."
+    receipt:
+      result: done
+      changed_files:
+        - docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md
+      commands:
+        - cmd: "test -s docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+          status: pass
+        - cmd: "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+          status: pass
+        - cmd: "rg -n '^## (Target Architecture|Migration|Work Package|Repository|External|Verification|Rollout|Rollback|Operator|Traceability|Definition)' docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+          status: pass
+        - cmd: "compare unique AC IDs in spec and plan"
+          status: pass
+        - cmd: "validate every planned existing-file target exists at the main snapshot"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "PM fallback produced a 588-line implementation plan after the dedicated Worker timed out without an allowed-file artifact. It defines the target state machine and evidence objects, three repository PRs plus protected operator cutover, exact current/new file inventory, six repository and two operator work packages, a fast production freeze, deterministic identity/static retention, honest Wrangler capability gate, publication/recovery transitions, full workflow contracts, semantic-release cleanup, external settings, dry/failure/cutover drills, weekly/emergency runbook, rollback, observation, and definition of done. AC-01 through AC-32 trace exactly, and every named existing file was validated on main."
+      deviations:
+        - "The dispatched GoalBuddy Worker produced no allowed-file change within the single permitted wait; PM interrupted it and completed the bounded planning artifact as fallback."
+      remaining_blockers: []
+      verification_attempts: 1
+      stopped_because: null
+  - id: T006
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Revise the release specification to resolve plan-identity timing, Worker-build integrity, bootstrap rollback proof, resumable artifact semantics, and cancellation recovery."
+    inputs:
+      - "T003 rejected specification-review receipt"
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    constraints:
+      - "Modify only the specification artifact."
+      - "Preserve approved requirements and acceptance criteria unless the correction requires a traced replacement."
+      - "Do not claim unsupported build promotion or cancellation guarantees."
+      - "Do not implement repository or external configuration changes."
+    expected_output:
+      - "Separate pre-build request identity from post-build immutable release-plan identity"
+      - "Consistent dry-run lifecycle through candidate verification and final artifact hashes"
+      - "Explicit integrity model for prebuilt static assets and the Wrangler-built Worker"
+      - "First-cutover rollback baseline that does not require a pre-existing BUILD_SHA"
+      - "Artifact reuse/rebuild rules for retries and expired workflow artifacts"
+      - "Cancellation semantics that attempt cleanup but require authoritative inspection when cleanup cannot run"
+      - "Updated acceptance proofs for each correction"
+    allowed_files:
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    verify:
+      - "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "rg -n 'request identity|release-plan identity|bootstrap baseline|Worker source|artifact retention|cancellation' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    stop_if:
+      - "A correction requires selecting an unverified Cloudflare/Wrangler capability as fact rather than assigning it to implementation-plan validation."
+      - "Need to write outside allowed_files."
+      - "Verification fails twice."
+    receipt:
+      result: done
+      changed_files:
+        - docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md
+      commands:
+        - cmd: "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "rg -n 'request identity|release-plan identity|bootstrap baseline|Worker source|artifact retention|cancellation' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "git diff --check -- docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+      summary: "The specification now separates a pre-build request identity from the post-verification release-plan identity approved for production. Dry runs complete candidate verification. Static bytes are promoted unchanged, while Worker integrity is honestly bound to immutable source, lockfile, pinned Wrangler, configuration, digest, and live BUILD_SHA unless prebuilt support is proven. The first cutover captures a rollback baseline that does not require a prior build SHA. Retry rules cover reusable, expired, and deterministically rebuilt artifacts. Cancellation after mutation is an ambiguous critical state with best-effort cleanup and mandatory inspection/runbook recovery. Acceptance criteria now prove each correction."
+      deviations:
+        - "The dispatched GoalBuddy Worker returned blocked after looking for state.yaml at the worktree root instead of the task's exact board path; it changed nothing, and PM fallback completed the same bounded allowed-file task."
+      remaining_blockers: []
+      verification_attempts: 1
+      stopped_because: null
+  - id: T007
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Re-review the corrected specification and approve it only if every T003 defect is resolved without weakening the owner outcome."
+    inputs:
+      - "T003 rejected review receipt"
+      - "T006 revision receipt"
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    constraints:
+      - "Read-only; do not repair."
+      - "Trace every T003 defect to corrected normative text and acceptance proof."
+      - "Reject unsupported platform assumptions or lifecycle contradictions."
+    expected_output:
+      - "approved | rejected"
+      - "Defect-by-defect traceability"
+      - "Exact implementation-plan Worker package if approved"
+      - "Exact bounded revision package if rejected"
+    receipt:
+      result: done
+      decision: rejected
+      full_outcome_complete: false
+      rationale: "PM Judge fallback confirmed that T006 resolves the six named T003 defects, but found a remaining contradiction inside the retry correction. RC-03 derives release-plan identity from verification results and a final provenance document, while NM-04 puts GitHub run ID/attempt and other execution observations in provenance. FS-06 then permits a new dispatch to reproduce the same release plan. Run-specific fields make that identity non-reproducible, and an identity-bearing document risks self-reference. The spec must separate a canonical deterministic content payload from an append-only execution/audit envelope before implementation planning."
+      worker_package:
+        objective: "Separate deterministic release content identity from run-specific audit evidence so cross-dispatch resumption is coherent."
+        allowed_files:
+          - docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md
+        verify:
+          - "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          - "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          - "rg -n 'content payload|audit envelope|run ID|deterministic|resume' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+        stop_if:
+          - "The correction requires weakening immutable artifact identity or omitting execution audit records."
+          - "Need to write outside allowed_files."
+          - "Verification fails twice."
+      evidence:
+        - "notes/T002-release-cadence-spec.md:206-210"
+        - "notes/T002-release-cadence-spec.md:241-245"
+        - "notes/T002-release-cadence-spec.md:328-332"
+        - "notes/T002-release-cadence-spec.md:400-404"
+        - "notes/T002-release-cadence-spec.md:435-438"
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks:
+        - T004
+        - T005
+        - T999
+      missing_evidence:
+        - "Normative canonicalization boundary proving release-plan identity excludes run ID, attempt, approval, timing, observed deployment state, notification, and recovery results."
+        - "Acceptance proof that a new dispatch can reproduce content identity while retaining a distinct complete audit trail."
+      required_board_updates:
+        - "Activate bounded identity/provenance revision T008."
+        - "Require final corrected-spec Judge review T009 before T004 implementation planning."
+        - "After T009 approval, update T004 and later review gates to reference the final approved specification receipt rather than T003."
+  - id: T008
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Separate deterministic release content identity from run-specific audit evidence so cross-dispatch resumption is coherent."
+    inputs:
+      - "T007 rejected corrected-spec review receipt"
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    constraints:
+      - "Modify only the specification artifact."
+      - "Preserve all approved T006 corrections and owner outcomes."
+      - "Do not weaken provenance; place run-specific observations in an append-only audit envelope outside the deterministic identity payload."
+      - "Do not implement repository or external configuration changes."
+    expected_output:
+      - "A canonical deterministic release-content payload and hash with no circular or run-specific fields"
+      - "A separate execution/audit envelope containing run ID, attempt, approvals, observations, and recovery results"
+      - "Coherent same-run rerun and new-dispatch resume semantics"
+      - "Acceptance proof for deterministic identity reproduction and preserved auditability"
+    allowed_files:
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    verify:
+      - "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "rg -n 'content payload|audit envelope|run ID|deterministic|resume' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    stop_if:
+      - "The correction requires weakening immutable artifact identity or omitting execution audit records."
+      - "Need to write outside allowed_files."
+      - "Verification fails twice."
+    receipt:
+      result: done
+      changed_files:
+        - docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md
+      commands:
+        - cmd: "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "rg -n 'content payload|audit envelope|run ID|deterministic|resume' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "git diff --check -- docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+      summary: "The spec now hashes a canonically serialized release content payload containing only deterministic source, version, static-artifact, Worker-input, configuration, and verification-contract fields. It excludes its own hash and all run-specific observations. Each execution instead appends a separate audit envelope referencing that identity and recording run/attempt, artifact retention, approval, deployment, publication, notification, cancellation, and recovery evidence. Reruns and new dispatches can therefore reproduce one release identity only when content is byte-equivalent while preserving distinct complete audit trails. Publication attaches both documents, and AC-30 directly tests canonicalization, sensitivity, exclusion, resumption, and auditability."
+      deviations:
+        - "The dispatched GoalBuddy Worker produced no allowed-file change within the single permitted wait; PM interrupted it and completed the bounded revision as fallback."
+      remaining_blockers: []
+      verification_attempts: 1
+      stopped_because: null
+  - id: T009
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Approve the specification only if deterministic release identity, resumption, and run-specific audit provenance are mutually consistent and all prior defects remain resolved."
+    inputs:
+      - "T003 and T007 rejected review receipts"
+      - "T006 and T008 revision receipts"
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    constraints:
+      - "Read-only; do not repair."
+      - "Trace every prior defect and verify content identity contains no run-specific or self-referential field."
+      - "Reject any weakening of artifact, Worker, rollback, cancellation, or audit guarantees."
+    expected_output:
+      - "approved | rejected"
+      - "Defect-by-defect traceability"
+      - "Exact T004 implementation-plan Worker package if approved"
+      - "Exact bounded revision package if rejected"
+    receipt:
+      result: done
+      decision: rejected
+      full_outcome_complete: false
+      rationale: "PM Judge fallback found the deterministic content/audit split correct and all earlier defects preserved, but the publication boundary remains inconsistent. RC-03 chooses the highest stable reachable tag as the previous release. If State 6 creates the tag and Release publication then fails, FS-04 says the same plan/version may retry, yet that orphan tag would become the new frontier and cause recalculation. The spec also does not define durable proof that a tag-only or partial Release belongs to the exact release-plan identity. Frontier, annotated-tag binding, draft assembly, and partial-state recovery must be explicit."
+      worker_package:
+        objective: "Make the SemVer frontier and tag/Release partial-publication recovery mutually consistent and cryptographically attributable to one release plan."
+        allowed_files:
+          - docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md
+        verify:
+          - "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          - "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          - "rg -n 'published release frontier|annotated tag|draft Release|tag-only|silently increment' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+        stop_if:
+          - "The correction would require deleting/moving an immutable tag or treating an unverified tag as a published release."
+          - "Need to write outside allowed_files."
+          - "Verification fails twice."
+      evidence:
+        - "notes/T002-release-cadence-spec.md:194-204"
+        - "notes/T002-release-cadence-spec.md:285-294"
+        - "notes/T002-release-cadence-spec.md:318-322"
+        - "notes/T002-release-cadence-spec.md:423-430"
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks:
+        - T004
+        - T005
+        - T999
+      missing_evidence:
+        - "A version frontier that a tag-only partial publication cannot advance."
+        - "Durable identity proof for tag-only, draft, partial-asset, and lost publish-response states."
+        - "Acceptance proof that retry selects the same version and fails closed on conflicts."
+      required_board_updates:
+        - "Activate bounded publication-frontier revision T010."
+        - "Require final corrected-spec review T011 before T004."
+  - id: T010
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Make the SemVer frontier and tag/Release partial-publication recovery mutually consistent and cryptographically attributable to one release plan."
+    inputs:
+      - "T009 rejected final-spec review receipt"
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    constraints:
+      - "Modify only the specification artifact."
+      - "Preserve every previously approved safety requirement."
+      - "Do not delete or move routine release tags as recovery."
+      - "Do not implement repository or external configuration changes."
+    expected_output:
+      - "A published-GitHub-Release-based SemVer frontier that ignores but detects partial tag/draft states"
+      - "An annotated tag and draft Release binding to the release-plan identity"
+      - "A failure/retry state machine for tag-only, draft, partially uploaded, published, and conflicting states"
+      - "Acceptance proof that a tag-only lost-response failure resumes the same version and never silently increments"
+    allowed_files:
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    verify:
+      - "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "rg -n 'published release frontier|annotated tag|draft Release|tag-only|silently increment' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    stop_if:
+      - "The correction would require deleting/moving an immutable tag or treating an unverified tag as a published release."
+      - "Need to write outside allowed_files."
+      - "Verification fails twice."
+    receipt:
+      result: done
+      changed_files:
+        - docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md
+      commands:
+        - cmd: "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "rg -n 'published release frontier|annotated tag|draft Release|tag-only|silently increment' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "git diff --check -- docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+      summary: "The SemVer frontier now advances only for a consistent published stable GitHub Release, while orphan tags and drafts are detected partial states. Future release tags are annotated with the target and content-addressed release-plan identity. The workflow assembles an identity-bound draft, uploads and read-verifies the complete exact asset set, then publishes in one final action. Tag-only, partial-draft, complete-published, lost-response, and conflict states have explicit fail-closed resume behavior. A partial state keeps the same next version and identity after rollback; it can never silently increment. AC-06, AC-14, AC-16, and new AC-31 prove the boundary."
+      deviations:
+        - "The dispatched GoalBuddy Worker produced no allowed-file change within the single permitted wait; PM interrupted it and completed the bounded revision as fallback."
+      remaining_blockers: []
+      verification_attempts: 1
+      stopped_because: null
+  - id: T011
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Perform the final specification review across all prior defects and approve only if every publication boundary is safely resumable."
+    inputs:
+      - "T003, T007, and T009 rejected review receipts"
+      - "T006, T008, and T010 revision receipts"
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    constraints:
+      - "Read-only; do not repair."
+      - "Trace all prior defects and walk every tag/Release partial state."
+      - "Reject version-frontier drift, unauthenticated resumption, public incomplete Releases, or weakened prior guarantees."
+    expected_output:
+      - "approved | rejected"
+      - "Complete defect and publication-state traceability"
+      - "Exact T004 implementation-plan Worker package if approved"
+      - "Exact bounded revision package if rejected"
+    receipt:
+      result: done
+      decision: rejected
+      full_outcome_complete: false
+      rationale: "PM Judge fallback found the first-run and partial-publication protocol safe, but the post-success rerun path still contradicts idempotency. After vNext is published, it becomes the frontier. Replaying the original target/bump would either calculate the following version or fail the no-op range before reaching State 6's matching-published no-op. The workflow needs an authoritative completed-plan lookup before frontier calculation, using stored release content to prove an exact original request. Exact matches must core-no-op; changed inputs or a target merely contained in a later release must fail closed."
+      worker_package:
+        objective: "Define an early completed-plan lookup so an exact post-success rerun no-ops before the advanced frontier can calculate a later version."
+        allowed_files:
+          - docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md
+        verify:
+          - "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          - "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          - "rg -n 'completed-plan lookup|advanced frontier|already contained|post-success|core no-op' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+        stop_if:
+          - "The correction would weaken the no-op-range rejection or permit multiple versions for one source SHA."
+          - "Need to write outside allowed_files."
+          - "Verification fails twice."
+      evidence:
+        - "notes/T002-release-cadence-spec.md:196-210"
+        - "notes/T002-release-cadence-spec.md:288-304"
+        - "notes/T002-release-cadence-spec.md:332-346"
+        - "notes/T002-release-cadence-spec.md:435-454"
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks:
+        - T004
+        - T005
+        - T999
+      missing_evidence:
+        - "A pre-frontier exact completed-plan recognition rule."
+        - "Proof that an exact post-success rerun performs no core or notification mutation."
+        - "Fail-closed distinction between an exact completed request and same/contained source with different inputs."
+      required_board_updates:
+        - "Activate bounded post-success idempotency revision T012."
+        - "Require final specification review T013 before T004."
+  - id: T012
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Define an early completed-plan lookup so an exact post-success rerun no-ops before the advanced frontier can calculate a later version."
+    inputs:
+      - "T011 rejected specification-review receipt"
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    constraints:
+      - "Modify only the specification artifact."
+      - "Preserve all prior publication-frontier and identity guarantees."
+      - "Do not allow a merely similar request or an already-contained target to publish another version."
+      - "Do not implement repository or external configuration changes."
+    expected_output:
+      - "A pre-frontier lookup against published release content that recognizes an exact completed request"
+      - "A proven core no-op with no deploy, tag, Release, or automatic notification repeat"
+      - "Fail-closed behavior for same target with different inputs and targets already contained by later releases"
+      - "Acceptance proof for post-success rerun idempotency"
+    allowed_files:
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    verify:
+      - "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "rg -n 'completed-plan lookup|advanced frontier|already contained|post-success|core no-op' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    stop_if:
+      - "The correction would weaken the no-op-range rejection or permit multiple versions for one source SHA."
+      - "Need to write outside allowed_files."
+      - "Verification fails twice."
+    receipt:
+      result: done
+      changed_files:
+        - docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md
+      commands:
+        - cmd: "test -s docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "rg -n 'completed-plan lookup|advanced frontier|already contained|post-success|core no-op' docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+        - cmd: "git diff --check -- docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+          status: pass
+      summary: "The specification now authenticates an exact completed request before recalculating from the advanced release frontier. It verifies normalized original inputs against the published Release, annotated tag, canonical payload, final plan, checksums, and required assets. An exact match exits as a post-success core no-op before build, approval, secrets, deployment, publication mutation, or automatic notification. Same-target requests with changed or inconsistent content and targets only contained by later releases fail closed without calculating a new version. The guard is repeated after serialized approval to handle a concurrent winner, and AC-32 exercises exact and negative variants."
+      deviations:
+        - "The GoalBuddy Worker edit became visible just after the single wait timeout and interruption boundary; PM preserved it, directly inspected the result, and ran every required verification rather than replacing the valid allowed-file work."
+      remaining_blockers: []
+      verification_attempts: 1
+      stopped_because: null
+  - id: T013
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Approve the specification only after complete first-run, partial-run, retry, and post-success-rerun state-machine walkthroughs."
+    inputs:
+      - "All prior specification Judge and revision receipts"
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+    constraints:
+      - "Read-only; do not repair."
+      - "Walk first release, every publication partial state, same-run rerun, cross-dispatch retry, and post-success exact/different reruns."
+      - "Reject version drift, duplicate publication/deployment/notification, or weakened prior guarantees."
+    expected_output:
+      - "approved | rejected"
+      - "Complete state-machine and prior-defect traceability"
+      - "Exact T004 implementation-plan Worker package if approved"
+      - "Exact bounded revision package if rejected"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "PM Judge fallback approves the specification after tracing every prior defect and walking first-run, bootstrap rollback, tag-only, draft/partial-asset, complete-publish, lost-response, conflict, same-run rerun, expired-artifact cross-dispatch retry, concurrent-winner, cancellation, and post-success rerun states. Deterministic content identity is separate from audit evidence; static and Worker integrity claims are honest; incomplete Releases remain drafts; only a published consistent Release advances SemVer; exact completed requests no-op before frontier calculation; changed/already-contained requests fail closed. Each guarantee has observable acceptance proof, and no architecture-blocking decision remains."
+      worker_package:
+        objective: "Convert the Judge-approved specification into a detailed, sequenced, implementation-ready plan without implementing it."
+        allowed_files:
+          - docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md
+        verify:
+          - "test -s docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+          - "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+          - "rg -n '^## (Target Architecture|Migration|Work Package|Repository|External|Verification|Rollout|Rollback|Operator|Traceability|Definition)' docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+        stop_if:
+          - "T013 has not approved the specification."
+          - "A work package cannot name concrete scope and proof without another read-only evidence task."
+          - "The plan requires an unapproved product, versioning, hosting, or compatibility-policy change."
+          - "Need to write outside allowed_files."
+          - "Verification fails twice."
+      evidence:
+        - "notes/T002-release-cadence-spec.md:159-270"
+        - "notes/T002-release-cadence-spec.md:272-368"
+        - "notes/T002-release-cadence-spec.md:370-468"
+        - "T003, T007, T009, and T011 rejected Judge receipts"
+        - "T006, T008, T010, and T012 verified revision receipts"
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks: []
+      missing_evidence: []
+      required_board_updates:
+        - "Use T013 as the approved specification gate for T004, T005, and T999."
+        - "Activate T004 implementation planning."
+  - id: T005
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit the detailed implementation plan for executability, safe sequencing, complete proof, rollback realism, and traceability to the approved specification."
+    inputs:
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "T013 approved final specification-review receipt"
+      - "docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+    constraints:
+      - "Read-only; do not repair the plan."
+      - "Try to disprove the plan using current workflow behavior and realistic operator mistakes."
+      - "Reject steps that silently depend on mutable main, local tags, implicit git describe behavior, cross-workflow GITHUB_TOKEN events, or unverified Cloudflare rollback semantics."
+      - "Reject a big-bang cutover when a smaller safe transition can preserve release control."
+    expected_output:
+      - "approve | revise | blocked"
+      - "Spec-to-plan traceability result"
+      - "Dependency and sequencing defects"
+      - "Missing repository tests, operator proofs, failure recovery, or rollback drills"
+      - "Strongest failure mode and the evidence that would disprove it during implementation"
+      - "Exact bounded revision task if not approved"
+    receipt:
+      result: done
+      decision: rejected
+      full_outcome_complete: false
+      rationale: "PM Judge fallback found the sequencing, rollback gates, file inventory, and AC traceability strong, but an older-main-ancestor release is not executable as written. The workflow repeatedly says to checkout target_sha and run new release helpers/hardened Wrangler configuration. A candidate before PR B/C may not contain those files, and using candidate scripts/config would let candidate content control release logic. The plan needs separate immutable controller and candidate checkouts, dual provenance, credential isolation, audited staging/config behavior, and a rule for partial-plan retry after the controller workflow changes."
+      worker_package:
+        objective: "Revise the implementation plan to separate immutable trusted release-controller tooling from the selected candidate source checkout."
+        allowed_files:
+          - docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md
+        verify:
+          - "test -s docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+          - "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+          - "rg -n 'controller SHA|controller checkout|candidate checkout|older main ancestor|credential isolation' docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+        stop_if:
+          - "The correction would require weakening immutable target selection or executing untrusted candidate release tooling with credentials."
+          - "Need to write outside allowed_files."
+          - "Verification fails twice."
+      evidence:
+        - "notes/T002-release-cadence-spec.md RC-01 permits an older main ancestor"
+        - "notes/T004-implementation-plan.md:19-31"
+        - "notes/T004-implementation-plan.md:178-245"
+        - "notes/T004-implementation-plan.md:320-357"
+        - "notes/T004-implementation-plan.md:585-598"
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks:
+        - T999
+      missing_evidence:
+        - "An immutable trusted controller checkout independent of target_sha."
+        - "Proof that candidate source/config cannot replace release tooling or access write/production credentials."
+        - "A deterministic partial-plan retry rule when current workflow/controller code has changed."
+      required_board_updates:
+        - "Activate bounded implementation-plan revision T014."
+        - "Require corrected plan review T015 before final audit."
+  - id: T014
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Revise the implementation plan to separate immutable trusted release-controller tooling from the selected candidate source checkout."
+    inputs:
+      - "T005 rejected implementation-plan review receipt"
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+    constraints:
+      - "Modify only the implementation-plan artifact."
+      - "Preserve all approved specification requirements and existing plan work packages."
+      - "Do not assume an older candidate contains the new release helpers or hardened production config."
+      - "Do not execute candidate code with GitHub write or production credentials."
+    expected_output:
+      - "Two-checkout architecture using immutable workflow/controller SHA and candidate target SHA"
+      - "Explicit controller/candidate lockfile, toolchain, source, and configuration provenance"
+      - "Build/deploy staging that operates on candidate source without mutating it or trusting candidate release scripts"
+      - "Partial-plan retry behavior across later workflow/controller changes"
+      - "Tests and contracts for older-main-ancestor releases and credential isolation"
+    allowed_files:
+      - "docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+    verify:
+      - "test -s docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+      - "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+      - "rg -n 'controller SHA|controller checkout|candidate checkout|older main ancestor|credential isolation' docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+    stop_if:
+      - "The correction would require weakening immutable target selection or executing untrusted candidate release tooling with credentials."
+      - "Need to write outside allowed_files."
+      - "Verification fails twice."
+    receipt:
+      result: done
+      changed_files:
+        - docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md
+      commands:
+        - cmd: "test -s docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+          status: pass
+        - cmd: "npx --yes prettier@3.8.1 --check docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+          status: pass
+        - cmd: "rg -n 'controller SHA|controller checkout|candidate checkout|older main ancestor|credential isolation' docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+          status: pass
+        - cmd: "compare unique AC IDs in spec and plan"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "PM fallback revised the plan after the GoalBuddy Worker timed out without an allowed-file change. Every release now uses an immutable controller checkout at the workflow SHA and a separate candidate checkout at target SHA. The plan records both trees/lockfiles/tool versions, builds and deploys through controller tooling against a content-addressed candidate staging tree, forbids candidate lifecycle/release code in credentialed jobs, and scopes secrets to named controller steps. Partial plans retain their original authenticated controller/protocol across later main changes. Older-ancestor, wrong-controller, staging, partial-retry, and credential-canary tests were added while AC-01 through AC-32 traceability remains exact."
+      deviations:
+        - "The dispatched GoalBuddy Worker produced no allowed-file change within the single permitted wait; PM interrupted it and completed the bounded revision as fallback."
+      remaining_blockers: []
+      verification_attempts: 1
+      stopped_because: null
+  - id: T015
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Re-review the implementation plan and approve only if controller/candidate separation makes older-ancestor release and retry executable without weakening safety."
+    inputs:
+      - "T005 rejected plan-review receipt"
+      - "T014 revision receipt"
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+    constraints:
+      - "Read-only; do not repair."
+      - "Trace controller/candidate provenance, credential boundaries, partial retry, and every AC."
+      - "Reject mutable tooling, candidate-controlled release logic, or unproven deployment configuration behavior."
+    expected_output:
+      - "approved | rejected"
+      - "Complete plan traceability and strongest failure-mode result"
+      - "Activate T999 if approved or exact bounded revision if rejected"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "PM Judge fallback approves the corrected implementation plan. New plans pin documented github.workflow_sha as trusted controller and use a separate target_sha candidate checkout. Both trees, locks, tools, staging, and configuration are content-addressed; older candidates need no release helpers. Candidate code runs only in secretless preflight and never receives write/Cloudflare/Discord credentials. Controller-config/candidate-source Wrangler behavior remains a mandatory non-production capability gate. Partial plans retain their authenticated original controller/protocol rather than substituting current main. Freeze-first sequencing, rollback, publication states, operator cutover, and AC-01 through AC-32 remain complete and executable."
+      worker_package: null
+      evidence:
+        - "notes/T004-implementation-plan.md:8-101"
+        - "notes/T004-implementation-plan.md:178-284"
+        - "notes/T004-implementation-plan.md:320-430"
+        - "notes/T004-implementation-plan.md:459-622"
+        - "Official GitHub contexts documentation for github.workflow_sha"
+        - "T014 verification: Prettier, required-term trace, AC-set equality, and diff check"
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks: []
+      missing_evidence: []
+      required_board_updates:
+        - "Use T015 as the approved implementation-plan review gate."
+        - "Activate T999 final planning audit."
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Perform the final planning audit and decide whether the specification and implementation plan fully satisfy the original owner outcome."
+    inputs:
+      - "All completed task receipts and supporting notes"
+      - "docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md"
+      - "docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md"
+      - "Current worktree status and diff from origin/main"
+    constraints:
+      - "Read-only; do not implement or repair."
+      - "Reject completion unless T013 approved the specification and T015 approved the implementation plan."
+      - "Reject completion if any owner concern, verified risk, spec acceptance criterion, implementation step, verification, or rollback path is untraceable."
+      - "Reject completion if files outside docs/goals/weekly-manual-release-cadence changed."
+      - "This is a plan-only goal; do not demand product implementation as completion proof."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "Oracle traceability result"
+      - "Evidence that only planning artifacts changed"
+      - "Missing evidence and exact next task if not complete"
+      - "Starter scope for the later implementation goal if complete"
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      rationale: "PM Judge fallback completes the plan-only goal. T013 approved the 492-line specification after adversarial lifecycle revisions; T015 approved the 624-line implementation plan after controller/candidate separation. Both artifacts trace the same AC-01 through AC-32 set. The plan starts with a reversible production freeze, gates unverified Wrangler/Cloudflare behavior behind non-production proof, separates repository work from protected operator cutover, and covers every partial, retry, rollback, cancellation, retention, and notification state. HEAD equals origin/main, tracked diff is empty, and every new file is confined to the goal directory; no product or external state changed."
+      worker_package: null
+      evidence:
+        - docs/goals/weekly-manual-release-cadence/notes/T002-release-cadence-spec.md
+        - docs/goals/weekly-manual-release-cadence/notes/T004-implementation-plan.md
+        - "T013 receipt: approved, missing_evidence empty"
+        - "T015 receipt: approved, missing_evidence empty"
+        - "Prettier check passed for the complete goal directory"
+        - "GoalBuddy checker passed with zero errors/warnings before final receipt"
+        - "HEAD and origin/main both 12b139c49b157a0decf5570c723fe2935149e5f4"
+        - "Tracked diff from origin/main empty; all untracked paths confined to docs/goals/weekly-manual-release-cadence"
+        - "Specification/plan unique acceptance-criterion sets match exactly at 32 IDs"
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks: []
+      missing_evidence: []
+      required_board_updates:
+        - "Mark the planning goal done with no active task."
+        - "Use Work Package 0 as the starter scope for a later implementation goal; keep implementation and external mutations out of this goal."
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: unknown
+    task: null
+    commands: []

--- a/docs/goals/weekly-manual-release-cadence/state.yaml
+++ b/docs/goals/weekly-manual-release-cadence/state.yaml
@@ -7,21 +7,21 @@ goal:
   title: "Weekly Manual Release Cadence"
   slug: "weekly-manual-release-cadence"
   kind: existing_plan
-  tranche: "Planning only: revalidate evidence, produce and review the specification, then produce and review the detailed implementation plan."
-  status: done
+  tranche: "Execution tranche 1: land the documentation-only canary, prove the production freeze, then implement and review Work Package 1 from fresh main."
+  status: active
   oracle:
-    signal: "Every owner concern and verified release risk maps to an explicit specification decision and a bounded implementation-plan step with proof and rollback or deferral."
-    cadence: "after each planning artifact and at final audit"
-    final_proof: "Judge receipt confirms both artifacts are decision-complete, evidence-backed, internally consistent, implementation-ready, and no product or external release state changed."
+    signal: "PR #262 merges with zero Production Release runs, the dispatch-only freeze remains intact, and the deterministic WP1 planning/identity engine passes adversarial tests and final review without production side effects."
+    cadence: "after the canary merge, after WP1 implementation, and at final tranche audit"
+    final_proof: "Judge receipt confirms the GitHub canary audit and WP1 test/review evidence satisfy the approved plan while production remains disabled."
   intake:
-    original_request: "On a fresh worktree off GitHub main, start with a spec for weekly manually dispatched releases, then convert it to a detailed implementation plan using GoalBuddyPrep."
-    interpreted_outcome: "Create an approved specification and implementation-ready plan for a safe weekly manual release system without implementing it."
+    original_request: "After approving the weekly manual release specification and plan and merging the safety freeze, prepare the next step."
+    interpreted_outcome: "Use the planning PR as the post-freeze documentation canary, then implement the approved deterministic planning and identity engine from a fresh post-canary main snapshot."
     input_shape: existing_plan
     audience: "BugDrop maintainers and release implementers"
-    authority: requested
-    proof_type: artifact
-    completion_proof: "Reviewed specification and implementation plan exist under notes/, cover all known risks and decisions, include observable verification and rollback, and leave implementation untouched."
-    likely_misfire: "Change only the Actions trigger or produce a generic plan while leaving automatic deployment, partial-stack, branch, concurrency, idempotency, notification, asset-retention, and failure-ordering hazards unresolved."
+    authority: approved
+    proof_type: test
+    completion_proof: "PR #262 has a merge SHA with no production-release workflow run; WP1 focused tests and repository gates pass from a fresh post-canary main worktree; final review finds no production mutation."
+    likely_misfire: "Skip the documentation-only canary, implement only happy-path SemVer logic, trust mutable/candidate-controlled identity, or begin workflow/deployment wiring before WP1 is proven."
     blind_spots_considered:
       - "Manual dispatch still permits an operator to select a non-main branch unless guarded."
       - "Manual timing does not prove a partially merged stack is release-ready."
@@ -39,6 +39,9 @@ goal:
       - "Discord notification should be invoked explicitly after successful publication rather than assumed from a GITHUB_TOKEN release event."
       - "Exact-version asset retention is a current contract defect that must be repaired or explicitly re-specified."
       - "The planning sequence is evidence validation, specification, specification review, detailed implementation plan, plan review, final audit."
+      - "WP0 merged through the queue as PR #263 at 57317afd387f057706ca8e36383957a774218bba; its full merge-group CI passed and no Production Release run was created."
+      - "PR #262 is documentation-only, open, green, and is the exact post-freeze canary required before WP1."
+      - "WP1 is read-only engine work with an approved file scope and no production workflow, credentials, or Cloudflare mutation."
 
 rules:
   pm_owns_state: true
@@ -46,7 +49,7 @@ rules:
   max_write_workers: 1
   no_implementation_without_worker_or_pm_task: true
   no_completion_without_judge_or_pm_audit: true
-  planning_is_not_completion: false
+  planning_is_not_completion: true
   queued_required_worker_blocks_completion: true
   continuous_until_full_outcome: true
   missing_input_or_credentials_do_not_stop_goal: true
@@ -73,7 +76,7 @@ visual_board:
     url: "http://goalbuddy.localhost:41737/weekly-manual-release-cadence/"
     command: "node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.4.2/skills/goal-prep/surfaces/local-goal-board/scripts/local-goal-board.mjs --goal docs/goals/weekly-manual-release-cadence"
 
-active_task: null
+active_task: T016
 
 tasks:
   - id: T001
@@ -925,6 +928,168 @@ tasks:
       required_board_updates:
         - "Mark the planning goal done with no active task."
         - "Use Work Package 0 as the starter scope for a later implementation goal; keep implementation and external mutations out of this goal."
+  - id: T016
+    type: pm
+    assignee: PM
+    status: active
+    reasoning_hint: medium
+    objective: "Land planning PR #262 through the merge queue as the required documentation-only canary, prove no production-release workflow starts, and create the fresh post-canary WP1 worktree."
+    inputs:
+      - "Merged WP0 PR #263 and merge SHA 57317afd387f057706ca8e36383957a774218bba"
+      - "Open documentation-only planning PR #262"
+      - "Approved Work Package 0 exit proof in notes/T004-implementation-plan.md"
+    constraints:
+      - "Before queueing, commit and push only this prep turn's tracked goal.md/state.yaml changes to the existing planning branch; never add .goalbuddy-board/."
+      - "After the push, verify every remote PR #262 path is under docs/goals/weekly-manual-release-cadence/."
+      - "External mutation is limited to updating the goal-only PR #262 branch and enrolling that PR in the merge queue."
+      - "Do not dispatch the Production Release freeze workflow."
+      - "Monitor merge-group CI through merge or a concrete blocker."
+      - "After merge, query the Production Release workflow by merge SHA and require zero runs."
+      - "Verify origin/main still contains the dispatch-only read-only freeze."
+      - "Create /Users/neonwatty/Desktop/bugdrop-weekly-release-engine-wp1 from the exact post-canary origin/main on branch codex/weekly-release-engine-wp1."
+      - "If any production-release run starts, cancel it if possible, preserve evidence, and stop before creating or editing WP1 files."
+    expected_output:
+      - "Goal-only prep commit on PR #262 with generated .goalbuddy-board/ excluded"
+      - "PR #262 merge SHA and successful merge-group run URL"
+      - "GitHub API evidence of zero Production Release runs for the canary merge SHA"
+      - "Direct inspection evidence that main retains workflow_dispatch-only and contents: read"
+      - "Fresh WP1 worktree path, branch, clean status, and exact base SHA"
+      - "Receipt that activates T017 only after every canary gate passes"
+    receipt: null
+  - id: T017
+    type: judge
+    assignee: Judge
+    status: queued
+    reasoning_hint: high
+    objective: "Revalidate the approved Work Package 1 Worker package against the exact post-canary main snapshot and approve the largest safe bounded implementation slice."
+    inputs:
+      - "T016 canary and fresh-worktree receipt"
+      - "T015 approved planning receipt"
+      - "notes/T002-release-cadence-spec.md"
+      - "notes/T004-implementation-plan.md Work Package 1"
+      - "Fresh WP1 worktree repository guidance and verification inventory"
+    constraints:
+      - "Read-only; do not implement or repair."
+      - "Preserve the approved WP1 boundary and production freeze."
+      - "Try to disprove that controller/candidate identity, tag/Release state, retries, and canonical identities can be implemented in one safe slice."
+      - "Reject any need for workflow wiring, credentials, production state, or files outside the approved scope."
+    expected_output:
+      - "approved | revise | blocked"
+      - "Exact Worker objective, allowed_files, verify, and stop_if"
+      - "Required adversarial fixture matrix mapped to AC-03, AC-04, AC-05, AC-06, AC-10, AC-14 planning cases, AC-26, AC-30, AC-31, and AC-32"
+      - "Any pre-existing red checks distinguished from tranche-owned failures"
+    receipt: null
+  - id: T018
+    type: worker
+    assignee: Worker
+    status: queued
+    reasoning_hint: medium
+    objective: "Implement the deterministic planning and identity engine defined by Work Package 1 as one coherent, read-only release-engine slice."
+    inputs:
+      - "T017 approved Worker package"
+      - "notes/T002-release-cadence-spec.md"
+      - "notes/T004-implementation-plan.md Work Package 1"
+      - "Fresh post-canary main worktree from T016"
+    constraints:
+      - "Work only in /Users/neonwatty/Desktop/bugdrop-weekly-release-engine-wp1."
+      - "Keep production disabled and do not edit any workflow except the approved .github/release.yml metadata file."
+      - "Use full immutable main-history SHAs and separate controller/candidate provenance."
+      - "Never run candidate release scripts or expose credentials."
+      - "Identity primitives must not read Date.now(), run IDs, artifact IDs, or ambient environment directly."
+      - "Network/API ambiguity must fail closed as a typed non-mutating result."
+      - "Do not add a dependency or modify package-lock.json without stopping for PM/Judge scope review."
+    expected_output:
+      - "Versioned normalized-input, request-plan, release-content, final-plan, audit-envelope, and publication-marker schemas"
+      - "Canonical JSON and SHA-256 identity primitives"
+      - "Immutable ref/controller validation, published-frontier and GitHub tag/Release/draft modeling"
+      - "Complete/partial/conflicting/no-op plan recognition and stale revalidation"
+      - "Explicit patch/minor/major calculation and complete categorized release provenance"
+      - "Adversarial fixtures and tests for every approved WP1 case"
+    allowed_files:
+      - "scripts/release/canonical-json.mjs"
+      - "scripts/release/plan.mjs"
+      - "test/release/canonical-json.test.ts"
+      - "test/release/plan.test.ts"
+      - "test/fixtures/release/"
+      - ".github/release.yml"
+      - "package.json"
+      - "Makefile"
+      - "knip.json"
+    verify:
+      - "npx vitest run test/release/canonical-json.test.ts test/release/plan.test.ts"
+      - "node scripts/release/plan.mjs --help"
+      - "npm run typecheck"
+      - "npm run lint"
+      - "npm run knip"
+      - "bash test/release-workflow-contract.test.sh"
+      - "git diff --check"
+    stop_if:
+      - "Need any file outside allowed_files."
+      - "Need workflow wiring, GitHub write access, production credentials, or Cloudflare state."
+      - "Need a new dependency or package-lock.json change."
+      - "An approved older-main-ancestor, partial-plan, or controller-separation case cannot be modeled without changing the specification."
+      - "Verification fails twice for the same tranche-owned reason."
+    receipt: null
+  - id: T019
+    type: judge
+    assignee: Judge
+    status: queued
+    reasoning_hint: high
+    objective: "Skeptically review the complete WP1 implementation for deterministic identity, fail-closed state modeling, scope fidelity, and adversarial test completeness."
+    inputs:
+      - "T017 approved package"
+      - "T018 Worker receipt and diff"
+      - "Approved specification and Work Package 1 plan"
+    constraints:
+      - "Read-only; do not repair."
+      - "Try to create identity collisions, mutable-SHA acceptance, tag/Release divergence, partial-plan corruption, nondeterministic output, and stale-winner errors."
+      - "Reject happy-path-only coverage or any hidden dependency on production credentials/state."
+      - "Reject changes outside T018 allowed_files."
+    expected_output:
+      - "approved | rejected"
+      - "Acceptance-criterion and adversarial-case traceability"
+      - "Strongest realistic failure mode and disproof evidence"
+      - "Exact bounded revision package if rejected"
+    receipt: null
+  - id: T020
+    type: pm
+    assignee: PM
+    status: queued
+    reasoning_hint: medium
+    objective: "Run the full tranche verification and prepare a clean, reviewable WP1 handoff without expanding into Work Package 2."
+    inputs:
+      - "T019 approved WP1 review"
+      - "Fresh WP1 worktree and complete diff"
+    constraints:
+      - "Do not implement fixes during this task; any failure returns to a bounded Worker revision."
+      - "Do not begin static assets, retention, deployment, publication, or workflow wiring."
+      - "Do not push or create a partial PR B unless the owner separately requests it; PR B is defined to include Work Packages 1–4."
+    expected_output:
+      - "Focused WP1 verification results"
+      - "Repository-wide gate results with pre-existing findings identified"
+      - "Clean scope/diff inventory and rollback statement"
+      - "Evidence package for T021 final tranche audit"
+    receipt: null
+  - id: T021
+    type: judge
+    assignee: Judge
+    status: queued
+    reasoning_hint: high
+    objective: "Audit whether the documentation canary and deterministic WP1 engine fully satisfy this execution tranche's oracle."
+    inputs:
+      - "T016 through T020 receipts"
+      - "Approved specification and implementation plan"
+      - "GitHub canary evidence and final WP1 diff/tests"
+    constraints:
+      - "Read-only; do not repair or continue into WP2."
+      - "Reject completion if the canary lacks zero-run proof, the freeze changed, WP1 scope expanded, an approved adversarial case is missing, or any production/publication side effect occurred."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false for this tranche"
+      - "Oracle and acceptance-criterion traceability"
+      - "Strongest realistic failure mode and direct disproof evidence"
+      - "Exact next task if incomplete, or WP2 starter boundary if complete"
+    receipt: null
 checks:
   dirty_fingerprint: unknown
   last_verification:


### PR DESCRIPTION
## Summary
- document the evidence-backed weekly/manual release specification
- define failure, retry, rollback, publication, notification, and artifact-retention semantics
- provide an implementation-ready, freeze-first migration plan with AC-01 through AC-32 traceability

## Scope
Planning only. This PR changes no release workflow, product code, GitHub configuration, Cloudflare state, tags, or Releases.

## Verification
- GoalBuddy final audit approved the specification and implementation plan
- Prettier passes for the complete goal directory
- specification and plan trace the same 32 acceptance criteria
- diff is confined to docs/goals/weekly-manual-release-cadence