### PR TITLE
chore: freeze automatic production releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,75 +1,21 @@
-name: Deploy
+name: Production Release (Migration Freeze)
 
-# Fires only on actual pushes to main. Merge-queue rulesets gate which commits
-# reach main, so the SHA here has already passed ci.yml in the merge_group context.
-# After the release tag is created and production deploys, run live E2E against
-# production so the post-release widget/version path is covered too.
+# Automatic production releases are intentionally frozen while the guarded
+# weekly manual release workflow is implemented. This workflow is a visible,
+# read-only placeholder: dispatching it cannot publish or deploy anything.
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  # Automated release via semantic-release
-  release:
-    name: Release
+  release-migration-freeze:
+    name: Production release migration is frozen
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
     steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: make install
-
-      - name: Run semantic-release
-        run: npx semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Deploy to Cloudflare Workers (runs after release so the new tag is visible)
-  deploy:
-    name: Deploy to Cloudflare
-    runs-on: ubuntu-latest
-    needs: [release]
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0 # needed for `git describe` to see the release tag
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: make install
-
-      - name: Build all
-        run: VERSION=$(git describe --tags --abbrev=0) make build-all
-
-      - name: Deploy to Cloudflare Workers
-        run: npx wrangler deploy
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-  live-production-tests:
-    name: Live Production Tests
-    needs: [deploy]
-    uses: ./.github/workflows/live-tests.yml
-    with:
-      target: production
-    secrets: inherit
+      - name: Explain the production freeze
+        run: |
+          echo "::notice title=Production release frozen::Automatic production releases are disabled while the guarded weekly manual release workflow is implemented."
+          echo "No tag, GitHub Release, Cloudflare deployment, live production test, or Discord notification was performed."

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build build-widget build-all deploy test test-watch test-e2e test-e2e-ui test-e2e-shard test-radix-e2e test-live-radix test-live-cross-browser lint lint-fix format format-check typecheck knip audit check-actions-node24 check-ci-scope check-ci-workflow check ci clean install install-playwright help
+.PHONY: dev build build-widget build-all deploy test test-watch test-e2e test-e2e-ui test-e2e-shard test-radix-e2e test-live-radix test-live-cross-browser lint lint-fix format format-check typecheck knip audit check-actions-node24 check-ci-scope check-ci-workflow check-release-workflow check ci clean install install-playwright help
 
 # Development
 dev:
@@ -92,8 +92,11 @@ check-ci-scope:
 check-ci-workflow:
 	bash test/ci-workflow-contract.test.sh
 
+check-release-workflow:
+	bash test/release-workflow-contract.test.sh
+
 # Combined Commands
-check: lint format-check typecheck knip audit check-actions-node24 check-ci-scope check-ci-workflow
+check: lint format-check typecheck knip audit check-actions-node24 check-ci-scope check-ci-workflow check-release-workflow
 	@echo "✓ All checks passed"
 
 ci: check test build-all test-e2e
@@ -144,9 +147,10 @@ help:
 	@echo "    make knip             - Check for dead code"
 	@echo "    make audit            - Run npm security audit"
 	@echo "    make check-actions-node24 - Verify GitHub Actions use Node 24-ready entries"
+	@echo "    make check-release-workflow - Verify production release automation is frozen"
 	@echo ""
 	@echo "  Combined:"
-	@echo "    make check            - Run lint, format check, typecheck, knip, audit, and Actions guard"
+	@echo "    make check            - Run quality, CI scope, and workflow contract checks"
 	@echo "    make ci               - Run full CI pipeline locally"
 	@echo ""
 	@echo "  Utilities:"

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+release_workflow="$repo_root/.github/workflows/deploy.yml"
+workflows_dir="$repo_root/.github/workflows"
+
+fail() {
+  echo "Release workflow contract failed: $*" >&2
+  exit 1
+}
+
+require_literal() {
+  local value=$1
+  grep -Fq -- "$value" "$release_workflow" || fail "deploy.yml lacks: $value"
+}
+
+require_absent() {
+  local value=$1
+  if grep -Fq -- "$value" "$release_workflow"; then
+    fail "deploy.yml must not contain: $value"
+  fi
+}
+
+on_block=$(
+  awk '
+    /^on:$/ { found = 1 }
+    found && /^permissions:$/ { exit }
+    found && $0 !~ /^[[:space:]]*#/ && $0 !~ /^[[:space:]]*$/ { print }
+  ' "$release_workflow"
+)
+
+expected_on_block=$'on:\n  workflow_dispatch:'
+[[ "$on_block" == "$expected_on_block" ]] ||
+  fail "production must be workflow_dispatch-only; found: ${on_block//$'\n'/, }"
+
+require_literal 'name: Production Release (Migration Freeze)'
+require_literal '  contents: read'
+require_literal '  release-migration-freeze:'
+require_literal 'name: Production release migration is frozen'
+require_literal 'Automatic production releases are disabled'
+require_literal 'No tag, GitHub Release, Cloudflare deployment, live production test, or Discord notification was performed.'
+
+for forbidden in \
+  'push:' \
+  'pull_request:' \
+  'merge_group:' \
+  'release:' \
+  'schedule:' \
+  'workflow_call:' \
+  'contents: write' \
+  'issues: write' \
+  'pull-requests: write' \
+  'environment:' \
+  'secrets.' \
+  'actions/checkout' \
+  'actions/setup-node' \
+  'semantic-release' \
+  'wrangler' \
+  'CLOUDFLARE_' \
+  'git tag' \
+  'gh release'; do
+  require_absent "$forbidden"
+done
+
+job_count=$(awk '/^jobs:$/ { found = 1; next } found && /^  [[:alnum:]_-]+:$/ { count += 1 } END { print count + 0 }' "$release_workflow")
+[[ "$job_count" -eq 1 ]] || fail "freeze workflow must have exactly one job; found $job_count"
+
+semantic_release_matches=$(rg -n 'semantic-release' "$workflows_dir" || true)
+[[ -z "$semantic_release_matches" ]] ||
+  fail "semantic-release remains executable in a workflow: $semantic_release_matches"
+
+for production_command in 'npm run deploy' 'make deploy' 'cloudflare/wrangler-action'; do
+  matches=$(rg -n -F -- "$production_command" "$workflows_dir" || true)
+  [[ -z "$matches" ]] || fail "production-capable workflow command remains: $matches"
+done
+
+wrangler_deploy_matches=$(rg -n 'wrangler deploy' "$workflows_dir" || true)
+[[ $(wc -l <<< "$wrangler_deploy_matches" | tr -d ' ') -eq 1 ]] ||
+  fail "expected exactly one preview Wrangler deploy; found: $wrangler_deploy_matches"
+[[ "$wrangler_deploy_matches" == *'.github/workflows/ci.yml:'* ]] ||
+  fail "Wrangler deploy is not owned by preview CI: $wrangler_deploy_matches"
+[[ "$wrangler_deploy_matches" == *'wrangler deploy --env preview'* ]] ||
+  fail "remaining Wrangler deploy is not explicitly preview-only: $wrangler_deploy_matches"
+
+echo 'Release workflow freeze contract checks passed'

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -67,17 +67,18 @@ done
 job_count=$(awk '/^jobs:$/ { found = 1; next } found && /^  [[:alnum:]_-]+:$/ { count += 1 } END { print count + 0 }' "$release_workflow")
 [[ "$job_count" -eq 1 ]] || fail "freeze workflow must have exactly one job; found $job_count"
 
-semantic_release_matches=$(rg -n 'semantic-release' "$workflows_dir" || true)
+semantic_release_matches=$(grep -RInF --include='*.yml' --include='*.yaml' -- 'semantic-release' "$workflows_dir" || true)
 [[ -z "$semantic_release_matches" ]] ||
   fail "semantic-release remains executable in a workflow: $semantic_release_matches"
 
 for production_command in 'npm run deploy' 'make deploy' 'cloudflare/wrangler-action'; do
-  matches=$(rg -n -F -- "$production_command" "$workflows_dir" || true)
+  matches=$(grep -RInF --include='*.yml' --include='*.yaml' -- "$production_command" "$workflows_dir" || true)
   [[ -z "$matches" ]] || fail "production-capable workflow command remains: $matches"
 done
 
-wrangler_deploy_matches=$(rg -n 'wrangler deploy' "$workflows_dir" || true)
-[[ $(wc -l <<< "$wrangler_deploy_matches" | tr -d ' ') -eq 1 ]] ||
+wrangler_deploy_matches=$(grep -RInF --include='*.yml' --include='*.yaml' -- 'wrangler deploy' "$workflows_dir" || true)
+wrangler_deploy_count=$(printf '%s\n' "$wrangler_deploy_matches" | awk 'NF { count += 1 } END { print count + 0 }')
+[[ "$wrangler_deploy_count" -eq 1 ]] ||
   fail "expected exactly one preview Wrangler deploy; found: $wrangler_deploy_matches"
 [[ "$wrangler_deploy_matches" == *'.github/workflows/ci.yml:'* ]] ||
   fail "Wrangler deploy is not owned by preview CI: $wrangler_deploy_matches"


### PR DESCRIPTION
## Summary
- replace the push-triggered semantic-release/deploy workflow with a manual read-only migration freeze
- remove production write permissions, secret access, checkout, build, deploy, live-test, and notification steps
- add a required workflow contract that scans every workflow and proves the only remaining Wrangler deployment is the existing `--env preview` merge-queue path

## Why first
This is Work Package 0 from #262. It immediately prevents ordinary main merges and partially landed PR stacks from publishing or deploying while the guarded weekly manual release workflow is implemented.

## Verification
- `make check`
- red-first proof: the new contract failed against the old push-triggered workflow before the workflow was changed
- `bash -n test/release-workflow-contract.test.sh`
- `bash test/ci-workflow-contract.test.sh`
- `npm run check:actions-node24`
- `git diff --check`

## Safety
The manual workflow is intentionally a no-op. It has `contents: read`, does not checkout code, references no secrets or environment, and performs no external mutation. Preview CI, scheduled live monitoring, and docs synchronization are unchanged.