### PR TITLE
fix: pass trusted release controller context

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,8 +105,15 @@ jobs:
           RELEASE_REASON: ${{ inputs.release_reason }}
           TARGET_SHA: ${{ inputs.target_sha }}
         run: |
+          candidate_reachable=false
+          if git -C "$GITHUB_WORKSPACE/controller" merge-base --is-ancestor "$TARGET_SHA" origin/main; then
+            candidate_reachable=true
+          fi
           jq -n \
             --arg repositoryDir "$GITHUB_WORKSPACE/controller" \
+            --arg eventName "$GITHUB_EVENT_NAME" \
+            --arg ref "$GITHUB_REF" \
+            --arg workflowSha "$CONTROLLER_SHA" \
             --arg repository "$GITHUB_REPOSITORY" \
             --arg workflowRef '.github/workflows/deploy.yml@refs/heads/main' \
             --arg targetSha "$TARGET_SHA" \
@@ -116,7 +123,8 @@ jobs:
             --arg rationale "$RATIONALE" \
             --arg operatorNotes "$OPERATOR_NOTES" \
             --argjson dryRun "$DRY_RUN" \
-            '{$repositoryDir, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, $dryRun}}' \
+            --argjson candidateReachableFromMain "$candidate_reachable" \
+            '{$repositoryDir, $eventName, $ref, $workflowSha, $candidateReachableFromMain, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, $dryRun}}' \
             > request-context.json
           node controller/scripts/release/workflow.mjs guard request-context.json > guard.json
           node controller/scripts/release/github-adapter.mjs plan request-context.json > request-plan.json

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -11,6 +11,26 @@ fail() {
   exit 1
 }
 
+for controller_context in \
+  '--arg eventName "$GITHUB_EVENT_NAME"' \
+  '--arg ref "$GITHUB_REF"' \
+  '--arg workflowSha "$CONTROLLER_SHA"' \
+  'git -C "$GITHUB_WORKSPACE/controller" merge-base --is-ancestor "$TARGET_SHA" origin/main' \
+  '--argjson candidateReachableFromMain "$candidate_reachable"' \
+  '$candidateReachableFromMain'; do
+  grep -Fq -- "$controller_context" "$workflow" ||
+    fail "guard request context lacks: $controller_context"
+done
+
+guard_plan_block=$(awk '
+  /^  guard-and-plan:$/ { capture = 1 }
+  capture && /^  verify-candidate:$/ { exit }
+  capture { print }
+' "$workflow")
+if grep -Fq -- 'candidateReachableFromMain: true' <<< "$guard_plan_block"; then
+  fail 'guard request context must not assert candidate reachability'
+fi
+
 require_literal() {
   grep -Fq -- "$1" "$workflow" || fail "deploy.yml lacks: $1"
 }


### PR DESCRIPTION
## What changed

- populate the manual release request with the trusted event, ref, and immutable workflow SHA
- derive candidate reachability from the full checked-out `origin/main` history instead of asserting it
- add workflow-contract regression coverage

## Why

The first authorized mutation-free patch-release dry run failed at the guard with `UNTRUSTED_EVENT` because the workflow omitted fields required by its own controller validator. No environment, secret, or deployment was accessed.

## Validation

- `npm run test:release-workflow` (87 tests)
- release workflow contract
- formatting, typecheck, diff check
- Codex review clean after adding real ancestry proof