### PR TITLE
fix: isolate release preflight evidence

### DIFF
--- a/scripts/release/github-adapter.mjs
+++ b/scripts/release/github-adapter.mjs
@@ -326,27 +326,29 @@ async function observePullRequests(transport, repository, commits) {
   return [...pulls.values()];
 }
 
-async function observeChecks(transport, repository, targetSha) {
+export async function observeMergeQueuePreflight(transport, repository, targetSha) {
   const records = [];
   for (let page = 1; page <= 100; page += 1) {
     const result = await transport.request(
-      `/repos/${repository}/commits/${targetSha}/check-runs?per_page=100&page=${page}`
+      `/repos/${repository}/actions/runs?head_sha=${targetSha}&event=merge_group&per_page=100&page=${page}`
     );
-    if (!Array.isArray(result?.data?.check_runs)) {
-      fail('GITHUB_API_INCOMPLETE', 'check-run response is incomplete');
+    if (!Array.isArray(result?.data?.workflow_runs)) {
+      fail('GITHUB_API_INCOMPLETE', 'merge-queue workflow response is incomplete');
     }
-    records.push(...result.data.check_runs);
+    records.push(...result.data.workflow_runs);
     if (result.hasNext === false) break;
     if (result.hasNext !== true || page === 100) {
-      fail('GITHUB_API_INCOMPLETE', 'check-run pagination is incomplete');
+      fail('GITHUB_API_INCOMPLETE', 'merge-queue workflow pagination is incomplete');
     }
   }
   return (
     records.length > 0 &&
     records.every(
-      check =>
-        check?.status === 'completed' &&
-        ['success', 'neutral', 'skipped'].includes(check.conclusion)
+      run =>
+        run?.head_sha === targetSha &&
+        run?.event === 'merge_group' &&
+        run?.status === 'completed' &&
+        run?.conclusion === 'success'
     )
   );
 }
@@ -394,7 +396,7 @@ export async function createRequestPlanFromGithub({
   if (!frontier) fail('FRONTIER_MISSING', 'no stable published Release is available');
   const [remoteMain, preflightSuccessful] = await Promise.all([
     requestRecord(transport, `/repos/${dispatch.repository}/commits/main`, 'remote main'),
-    observeChecks(transport, dispatch.repository, dispatch.targetSha),
+    observeMergeQueuePreflight(transport, dispatch.repository, dispatch.targetSha),
   ]);
   const git = gitObserver({
     repositoryDir: context.repositoryDir,

--- a/test/release/github-adapter.test.ts
+++ b/test/release/github-adapter.test.ts
@@ -7,6 +7,7 @@ import {
   createRequestPlanFromGithub,
   GithubAdapterError,
   loadPublishedReleaseAssets,
+  observeMergeQueuePreflight,
   observeGithubState,
   paginateGithub,
 } from '../../scripts/release/github-adapter.mjs';
@@ -70,6 +71,51 @@ function observationEntries() {
 }
 
 describe('GitHub release-state observation', () => {
+  it('proves preflight from merge-queue runs without observing the active release run', async () => {
+    const path = `/repos/${REPOSITORY}/actions/runs?head_sha=${SHA.target}&event=merge_group&per_page=100&page=1`;
+    const transport = transportFor({
+      [path]: {
+        data: {
+          workflow_runs: [
+            {
+              head_sha: SHA.target,
+              event: 'merge_group',
+              status: 'completed',
+              conclusion: 'success',
+            },
+          ],
+        },
+        hasNext: false,
+      },
+    });
+
+    await expect(observeMergeQueuePreflight(transport, REPOSITORY, SHA.target)).resolves.toBe(true);
+    expect(transport.request).toHaveBeenCalledWith(path);
+  });
+
+  it('fails preflight closed when the exact merge-queue run failed', async () => {
+    const path = `/repos/${REPOSITORY}/actions/runs?head_sha=${SHA.target}&event=merge_group&per_page=100&page=1`;
+    const transport = transportFor({
+      [path]: {
+        data: {
+          workflow_runs: [
+            {
+              head_sha: SHA.target,
+              event: 'merge_group',
+              status: 'completed',
+              conclusion: 'failure',
+            },
+          ],
+        },
+        hasNext: false,
+      },
+    });
+
+    await expect(observeMergeQueuePreflight(transport, REPOSITORY, SHA.target)).resolves.toBe(
+      false
+    );
+  });
+
   it('builds a deterministic request plan from complete authenticated observations', async () => {
     const entries = observationEntries();
     entries[`/repos/${REPOSITORY}/compare/${SHA.release}...${SHA.target}`] = {
@@ -103,10 +149,20 @@ describe('GitHub release-state observation', () => {
         data: { status: 'ahead' },
         hasNext: false,
       },
-      [`/repos/${REPOSITORY}/commits/${SHA.target}/check-runs?per_page=100&page=1`]: {
-        data: { check_runs: [{ status: 'completed', conclusion: 'success' }] },
-        hasNext: false,
-      },
+      [`/repos/${REPOSITORY}/actions/runs?head_sha=${SHA.target}&event=merge_group&per_page=100&page=1`]:
+        {
+          data: {
+            workflow_runs: [
+              {
+                head_sha: SHA.target,
+                event: 'merge_group',
+                status: 'completed',
+                conclusion: 'success',
+              },
+            ],
+          },
+          hasNext: false,
+        },
       [`/repos/${REPOSITORY}/compare/${SHA.target}...main`]: {
         data: { status: 'identical' },
         hasNext: false,


### PR DESCRIPTION
## Summary
- prove release readiness from successful merge-group workflow runs for the exact candidate SHA
- exclude the active workflow-dispatch release run from its own preflight evidence
- fail closed for missing, pending, mismatched, or unsuccessful merge-queue runs

## Proof
- `npm run test:release` (267 tests)
- `npm run typecheck`
- `npm run format:check`
- `git diff --check`
- `codex review --uncommitted` (clean)
- live GitHub API observation matched the successful merge-group run for `b39bc7723ba63b0327750d74054a2ad0d7619832`