### PR TITLE
fix: stream release artifacts into plan

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -235,14 +235,14 @@ jobs:
           jq -n \
             --slurpfile requestPlan request/request-plan.json \
             --arg name "$exact_name" \
-            --arg base64 "$(base64 -w 0 "$RUNNER_TEMP/static-package/$exact_name")" \
-            --arg versionsBase64 "$(base64 -w 0 "$RUNNER_TEMP/static-package/versions.json")" \
+            --rawfile widget "$RUNNER_TEMP/static-package/$exact_name" \
+            --rawfile versions "$RUNNER_TEMP/static-package/versions.json" \
             --arg worker "$worker_digest" \
             --arg lockfile "$lock_digest" \
             --arg esbuild "$esbuild_version" \
             --arg wrangler "$wrangler_version" \
             --arg config "$config_digest" \
-            '{$requestPlan: $requestPlan[0], candidateAssets: {($name): {$base64}, "versions.json": {base64: $versionsBase64}}, sourceDigests: {$worker, $lockfile}, toolchain: {$esbuild, $wrangler}, deploymentConfigDigest: $config, verification: {contract: "release-verification/v1", result: "passed"}}' \
+            '{$requestPlan: $requestPlan[0], candidateAssets: {($name): {base64: ($widget | @base64)}, "versions.json": {base64: ($versions | @base64)}}, sourceDigests: {$worker, $lockfile}, toolchain: {$esbuild, $wrangler}, deploymentConfigDigest: $config, verification: {contract: "release-verification/v1", result: "passed"}}' \
             > bundle-input.json
           node controller/scripts/release/workflow.mjs bundle bundle-input.json > state2-bundle.json
           plan_identity=$(jq -er '.finalPlan.planIdentity' state2-bundle.json)

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -159,11 +159,19 @@ for literal in \
   'npm run build' \
   'node controller/scripts/build-widget.js' \
   '--mode release' \
+  '--rawfile widget "$RUNNER_TEMP/static-package/$exact_name"' \
+  '--rawfile versions "$RUNNER_TEMP/static-package/versions.json"' \
+  'base64: ($widget | @base64)' \
+  'base64: ($versions | @base64)' \
   'node controller/scripts/release/workflow.mjs bundle' \
   'static-package/versions.json' \
   'retention-days: 14'; do
   grep -Fq -- "$literal" <<< "$verify_block" || fail "verify-candidate lacks: $literal"
 done
+if grep -Fq -- '--arg base64 "$(base64' <<< "$verify_block" ||
+  grep -Fq -- '--arg versionsBase64 "$(base64' <<< "$verify_block"; then
+  fail 'release artifact bytes must not be passed through the process argument list'
+fi
 if grep -Eq 'secrets\.|environment:' <<< "$verify_block"; then
   fail 'candidate verification must not reference secrets or an environment'
 fi


### PR DESCRIPTION
## Summary
- load built release artifacts from files instead of process arguments
- base64-encode inside jq while preserving the exact widget and manifest bytes
- add a workflow contract preventing large artifacts from returning to argv

## Proof
- `npm run test:release-workflow` (89 tests plus workflow contract)
- `npm run typecheck`
- `bash -n test/release-workflow-contract.test.sh`
- `npx prettier --check .github/workflows/deploy.yml`
- direct round-trip SHA-256 proof for a 182 KB release widget and versions manifest
- `codex review --uncommitted` (clean)