### PR TITLE
fix: name release request plan field

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -242,7 +242,7 @@ jobs:
             --arg esbuild "$esbuild_version" \
             --arg wrangler "$wrangler_version" \
             --arg config "$config_digest" \
-            '{$requestPlan: $requestPlan[0], candidateAssets: {($name): {base64: ($widget | @base64)}, "versions.json": {base64: ($versions | @base64)}}, sourceDigests: {$worker, $lockfile}, toolchain: {$esbuild, $wrangler}, deploymentConfigDigest: $config, verification: {contract: "release-verification/v1", result: "passed"}}' \
+            '{requestPlan: $requestPlan[0], candidateAssets: {($name): {base64: ($widget | @base64)}, "versions.json": {base64: ($versions | @base64)}}, sourceDigests: {$worker, $lockfile}, toolchain: {$esbuild, $wrangler}, deploymentConfigDigest: $config, verification: {contract: "release-verification/v1", result: "passed"}}' \
             > bundle-input.json
           node controller/scripts/release/workflow.mjs bundle bundle-input.json > state2-bundle.json
           plan_identity=$(jq -er '.finalPlan.planIdentity' state2-bundle.json)

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -161,6 +161,7 @@ for literal in \
   '--mode release' \
   '--rawfile widget "$RUNNER_TEMP/static-package/$exact_name"' \
   '--rawfile versions "$RUNNER_TEMP/static-package/versions.json"' \
+  'requestPlan: $requestPlan[0]' \
   'base64: ($widget | @base64)' \
   'base64: ($versions | @base64)' \
   'node controller/scripts/release/workflow.mjs bundle' \
@@ -168,10 +169,25 @@ for literal in \
   'retention-days: 14'; do
   grep -Fq -- "$literal" <<< "$verify_block" || fail "verify-candidate lacks: $literal"
 done
+if grep -Fq -- '{$requestPlan:' <<< "$verify_block"; then
+  fail 'slurped request plan must be a literal requestPlan field, not a dynamic object key'
+fi
 if grep -Fq -- '--arg base64 "$(base64' <<< "$verify_block" ||
   grep -Fq -- '--arg versionsBase64 "$(base64' <<< "$verify_block"; then
   fail 'release artifact bytes must not be passed through the process argument list'
 fi
+
+bundle_shape=$(jq -n \
+  --argjson requestPlan '[{"schema":"proof"}]' \
+  --arg name 'widget.v1.2.3.js' \
+  --arg widget 'widget bytes' \
+  --arg versions 'manifest bytes' \
+  '{requestPlan: $requestPlan[0], candidateAssets: {($name): {base64: ($widget | @base64)}, "versions.json": {base64: ($versions | @base64)}}}')
+jq -e '
+  .requestPlan.schema == "proof" and
+  (.candidateAssets["widget.v1.2.3.js"].base64 | @base64d) == "widget bytes" and
+  (.candidateAssets["versions.json"].base64 | @base64d) == "manifest bytes"
+' <<< "$bundle_shape" >/dev/null || fail 'bundle-input jq shape is not executable or byte-safe'
 if grep -Eq 'secrets\.|environment:' <<< "$verify_block"; then
   fail 'candidate verification must not reference secrets or an environment'
 fi


### PR DESCRIPTION
## Summary
- write the slurped request plan under the literal `requestPlan` field
- prevent jq from treating the request-plan array as a dynamic object key
- execute the bundle-input jq shape in the workflow contract and verify artifact round trips

## Proof
- `npm run test:release-workflow` (89 tests plus executable workflow contract)
- `npm run typecheck`
- formatting and diff checks
- `codex review --uncommitted` (clean)