### PR TITLE
fix: preserve canonical release artifact paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -245,6 +245,9 @@ jobs:
             '{requestPlan: $requestPlan[0], candidateAssets: {($name): {base64: ($widget | @base64)}, "versions.json": {base64: ($versions | @base64)}}, sourceDigests: {$worker, $lockfile}, toolchain: {$esbuild, $wrangler}, deploymentConfigDigest: $config, verification: {contract: "release-verification/v1", result: "passed"}}' \
             > bundle-input.json
           node controller/scripts/release/workflow.mjs bundle bundle-input.json > state2-bundle.json
+          install -d "$RUNNER_TEMP/release-plan/static-package"
+          cp state2-bundle.json "$RUNNER_TEMP/release-plan/state2-bundle.json"
+          cp -R "$RUNNER_TEMP/static-package/." "$RUNNER_TEMP/release-plan/static-package/"
           plan_identity=$(jq -er '.finalPlan.planIdentity' state2-bundle.json)
           plan_key=$(jq -er '.finalPlan.planIdentity[7:]' state2-bundle.json)
           tag=$(jq -er '.finalPlan.tag' state2-bundle.json)
@@ -259,9 +262,7 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: release-plan-${{ steps.bundle.outputs.plan_key }}
-          path: |
-            state2-bundle.json
-            ${{ runner.temp }}/static-package/
+          path: ${{ runner.temp }}/release-plan/
           if-no-files-found: error
           retention-days: 14
 

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -165,6 +165,10 @@ for literal in \
   'base64: ($widget | @base64)' \
   'base64: ($versions | @base64)' \
   'node controller/scripts/release/workflow.mjs bundle' \
+  'install -d "$RUNNER_TEMP/release-plan/static-package"' \
+  'cp state2-bundle.json "$RUNNER_TEMP/release-plan/state2-bundle.json"' \
+  'cp -R "$RUNNER_TEMP/static-package/." "$RUNNER_TEMP/release-plan/static-package/"' \
+  'path: ${{ runner.temp }}/release-plan/' \
   'static-package/versions.json' \
   'retention-days: 14'; do
   grep -Fq -- "$literal" <<< "$verify_block" || fail "verify-candidate lacks: $literal"
@@ -175,6 +179,9 @@ fi
 if grep -Fq -- '--arg base64 "$(base64' <<< "$verify_block" ||
   grep -Fq -- '--arg versionsBase64 "$(base64' <<< "$verify_block"; then
   fail 'release artifact bytes must not be passed through the process argument list'
+fi
+if grep -Fq '          path: |' <<< "$verify_block"; then
+  fail 'State 2 evidence must upload from one root so consumers receive canonical flat paths'
 fi
 
 bundle_shape=$(jq -n \


### PR DESCRIPTION
## Summary
- stage State 2 evidence beneath one upload root
- preserve canonical bundle and static-package paths for dry-run and live consumers
- add a contract preventing multi-root release-plan uploads

## Verification
- `npm run validate` (739 tests)
- `npm run test:release-workflow` (89 tests)
- `bash test/release-workflow-contract.test.sh`
- `npx prettier --check .github/workflows/deploy.yml`
- `git diff --check`
- `codex review --uncommitted` (clean after correcting its accepted artifact-layout finding)

## Failure evidence
Run 30932022793 archived `state2-bundle.json` under `bugdrop/bugdrop/` and static assets under `_temp/static-package/`; this patch gives upload-artifact one root so consumers receive `state2-bundle.json` and `static-package/` directly.