### PR TITLE
feat: add authenticated release retention

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,11 @@ on:
         required: true
         default: true
         type: boolean
+      retention_bootstrap:
+        description: Establish the prospective exact-version boundary (one time only)
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -100,6 +105,7 @@ jobs:
           BUMP: ${{ inputs.bump }}
           CONTROLLER_SHA: ${{ steps.guard.outputs.controller_sha }}
           DRY_RUN: ${{ inputs.dry_run }}
+          RETENTION_BOOTSTRAP: ${{ inputs.retention_bootstrap }}
           OPERATOR_NOTES: ${{ inputs.operator_notes }}
           RATIONALE: ${{ inputs.rationale }}
           RELEASE_REASON: ${{ inputs.release_reason }}
@@ -124,7 +130,9 @@ jobs:
             --arg operatorNotes "$OPERATOR_NOTES" \
             --argjson dryRun "$DRY_RUN" \
             --argjson candidateReachableFromMain "$candidate_reachable" \
-            '{$repositoryDir, $eventName, $ref, $workflowSha, $candidateReachableFromMain, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, $dryRun}}' \
+            --argjson retentionBootstrap "$RETENTION_BOOTSTRAP" \
+            --arg retentionOutputDir "$GITHUB_WORKSPACE/retention-input" \
+            '{$repositoryDir, $eventName, $ref, $workflowSha, $candidateReachableFromMain, $retentionBootstrap, $retentionOutputDir, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, $dryRun}}' \
             > request-context.json
           node controller/scripts/release/workflow.mjs guard request-context.json > guard.json
           node controller/scripts/release/github-adapter.mjs plan request-context.json > request-plan.json
@@ -160,6 +168,7 @@ jobs:
           path: |
             request-context.json
             request-plan.json
+            retention-input/
           if-no-files-found: error
           retention-days: 14
 
@@ -209,6 +218,12 @@ jobs:
           name: request-plan-${{ needs.guard-and-plan.outputs.request_key }}
           path: request
 
+      - name: Reauthenticate request-keyed local retention input
+        shell: bash
+        run: |
+          test -f request/retention-input/retention-plan.json
+          test "$(jq -er '.requestIdentity' request/retention-input/retention-plan.json)" = '${{ needs.guard-and-plan.outputs.request_identity }}'
+
       - name: Build static release package once with controller tooling
         shell: bash
         run: >-
@@ -220,13 +235,14 @@ jobs:
           --timestamp "$(git -C candidate show -s --format=%cI '${{ inputs.target_sha }}' | sed 's/+00:00/Z/')"
           --target-sha '${{ inputs.target_sha }}'
           --repository "$GITHUB_REPOSITORY"
-          --cutover-version '${{ needs.guard-and-plan.outputs.version }}'
+          --retention-plan request/retention-input/retention-plan.json
+          --request-plan request/request-plan.json
+          --result-path "$RUNNER_TEMP/builder-result.json"
 
       - name: Finalize canonical State 2 bundle
         id: bundle
         shell: bash
         run: |
-          exact_name='widget.v${{ needs.guard-and-plan.outputs.version }}.js'
           worker_digest=$(git -C candidate archive '${{ inputs.target_sha }}' src | sha256sum | awk '{print $1}')
           lock_digest=$(sha256sum candidate/package-lock.json | awk '{print $1}')
           config_digest=$(sha256sum controller/wrangler.toml | awk '{print $1}')
@@ -234,19 +250,19 @@ jobs:
           wrangler_version=$(node -p "require('./controller/node_modules/wrangler/package.json').version")
           jq -n \
             --slurpfile requestPlan request/request-plan.json \
-            --arg name "$exact_name" \
-            --rawfile widget "$RUNNER_TEMP/static-package/$exact_name" \
-            --rawfile versions "$RUNNER_TEMP/static-package/versions.json" \
+            --arg staticPackageDir "$RUNNER_TEMP/static-package" \
+            --arg builderResultPath "$RUNNER_TEMP/builder-result.json" \
             --arg worker "$worker_digest" \
             --arg lockfile "$lock_digest" \
             --arg esbuild "$esbuild_version" \
             --arg wrangler "$wrangler_version" \
             --arg config "$config_digest" \
-            '{requestPlan: $requestPlan[0], candidateAssets: {($name): {base64: ($widget | @base64)}, "versions.json": {base64: ($versions | @base64)}}, sourceDigests: {$worker, $lockfile}, toolchain: {$esbuild, $wrangler}, deploymentConfigDigest: $config, verification: {contract: "release-verification/v1", result: "passed"}}' \
+            '{requestPlan: $requestPlan[0], $staticPackageDir, $builderResultPath, sourceDigests: {$worker, $lockfile}, toolchain: {$esbuild, $wrangler}, deploymentConfigDigest: $config, verification: {contract: "release-verification/v1", result: "passed"}}' \
             > bundle-input.json
-          node controller/scripts/release/workflow.mjs bundle bundle-input.json > state2-bundle.json
+          node controller/scripts/release/workflow.mjs bundle-static bundle-input.json > state2-bundle.json
           install -d "$RUNNER_TEMP/release-plan/static-package"
           cp state2-bundle.json "$RUNNER_TEMP/release-plan/state2-bundle.json"
+          cp "$RUNNER_TEMP/builder-result.json" "$RUNNER_TEMP/release-plan/builder-result.json"
           cp -R "$RUNNER_TEMP/static-package/." "$RUNNER_TEMP/release-plan/static-package/"
           plan_identity=$(jq -er '.finalPlan.planIdentity' state2-bundle.json)
           plan_key=$(jq -er '.finalPlan.planIdentity[7:]' state2-bundle.json)
@@ -295,7 +311,7 @@ jobs:
             --slurpfile bundle approved/state2-bundle.json \
             --arg artifactId "$ARTIFACT_ID" \
             --arg controllerSha "$CONTROLLER_SHA" \
-            '{context: {eventName: "workflow_dispatch", ref: "refs/heads/main", workflowSha: $controllerSha, candidateReachableFromMain: true, dispatch: ($bundle[0].requestPlan.request + {controllerSha: $controllerSha, dryRun: true})}, bundle: $bundle[0], artifact: {artifactId: $artifactId, available: true, planIdentity: $bundle[0].finalPlan.planIdentity, contentIdentity: $bundle[0].releaseContent.contentIdentity, requestIdentity: $bundle[0].requestPlan.requestIdentity, verifiedAssetNames: $bundle[0].finalPlan.requiredAssets}, completed: {kind: "none"}, productionEnabled: false}' \
+            '{context: {eventName: "workflow_dispatch", ref: "refs/heads/main", workflowSha: $controllerSha, candidateReachableFromMain: true, dispatch: ($bundle[0].requestPlan.request + {controllerSha: $controllerSha, dryRun: true})}, bundle: $bundle[0], artifact: {artifactId: $artifactId, available: true, planIdentity: $bundle[0].finalPlan.planIdentity, contentIdentity: $bundle[0].releaseContent.contentIdentity, requestIdentity: $bundle[0].requestPlan.requestIdentity, staticPackageIdentity: $bundle[0].finalPlan.staticPackageIdentity, verifiedAssetNames: $bundle[0].finalPlan.requiredAssets}, completed: {kind: "none"}, productionEnabled: false}' \
             > state2-input.json
           node controller/scripts/release/workflow.mjs state2 state2-input.json > state2-decision.json
           test "$(jq -er '.status' state2-decision.json)" = 'dry-run-complete'
@@ -406,6 +422,7 @@ jobs:
           BUGDROP_GITHUB_TOKEN: ${{ github.token }}
           BUMP: ${{ inputs.bump }}
           CONTROLLER_SHA: ${{ needs.guard-and-plan.outputs.controller_sha }}
+          RETENTION_BOOTSTRAP: ${{ inputs.retention_bootstrap }}
           OPERATOR_NOTES: ${{ inputs.operator_notes }}
           RATIONALE: ${{ inputs.rationale }}
           RELEASE_REASON: ${{ inputs.release_reason }}
@@ -421,7 +438,8 @@ jobs:
             --arg releaseReason "$RELEASE_REASON" \
             --arg rationale "$RATIONALE" \
             --arg operatorNotes "$OPERATOR_NOTES" \
-            '{repositoryDir: $repositoryDir, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, dryRun: false}}' \
+            --argjson retentionBootstrap "$RETENTION_BOOTSTRAP" \
+            '{$repositoryDir, $retentionBootstrap, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, dryRun: false}}' \
             > revalidation-context.json
           node controller/scripts/release/github-adapter.mjs plan revalidation-context.json > revalidated-plan.json
           expected_plan=$(jq -er '.finalPlan.planIdentity' approved/state2-bundle.json)
@@ -438,7 +456,7 @@ jobs:
             --arg artifactId '${{ needs.verify-candidate.outputs.artifact_id }}' \
             --arg controllerSha "$CONTROLLER_SHA" \
             --argjson completed "$completed" \
-            '{context: {eventName: "workflow_dispatch", ref: "refs/heads/main", workflowSha: $controllerSha, candidateReachableFromMain: true, dispatch: ($bundle[0].requestPlan.request + {workflowRef: ".github/workflows/deploy.yml@refs/heads/main", controllerSha: $controllerSha, dryRun: false})}, bundle: $bundle[0], artifact: {artifactId: $artifactId, available: true, planIdentity: $bundle[0].finalPlan.planIdentity, contentIdentity: $bundle[0].releaseContent.contentIdentity, requestIdentity: $bundle[0].requestPlan.requestIdentity, verifiedAssetNames: $bundle[0].finalPlan.requiredAssets}, completed: $completed, productionEnabled: true}' \
+            '{context: {eventName: "workflow_dispatch", ref: "refs/heads/main", workflowSha: $controllerSha, candidateReachableFromMain: true, dispatch: ($bundle[0].requestPlan.request + {workflowRef: ".github/workflows/deploy.yml@refs/heads/main", controllerSha: $controllerSha, dryRun: false})}, bundle: $bundle[0], artifact: {artifactId: $artifactId, available: true, planIdentity: $bundle[0].finalPlan.planIdentity, contentIdentity: $bundle[0].releaseContent.contentIdentity, requestIdentity: $bundle[0].requestPlan.requestIdentity, staticPackageIdentity: $bundle[0].finalPlan.staticPackageIdentity, verifiedAssetNames: $bundle[0].finalPlan.requiredAssets}, completed: $completed, productionEnabled: true}' \
             > state2-live-input.json
           node controller/scripts/release/workflow.mjs state2 state2-live-input.json > state2-live.json
           if [ "$(jq -er '.status' state2-live.json)" = 'core-noop' ]; then

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -26,9 +26,11 @@ identity, so retries must use the same reason and other identity-bearing inputs.
    inventory since the latest published stable Release.
 3. Choose `patch`, `minor`, or `major` from product compatibility, not commit prefixes.
 4. Choose `standard`, or `emergency` with a rationale explaining urgency and approval context.
-5. Keep operator notes bounded and free of secrets. Record the target SHA, bump, reason, rationale,
-   and expected next tag in the release evidence log.
-6. Confirm there is no in-progress release for the same production target. Concurrency queues rather
+5. Choose `retention_bootstrap=false` for normal operation. Set it to `true` only for the separately
+   authorized, one-time retention cutover; use the identical value for dry-run and live dispatch.
+6. Keep operator notes bounded and free of secrets. Record the target SHA, bump, reason, rationale,
+   retention bootstrap decision, and expected next tag in the release evidence log.
+7. Confirm there is no in-progress release for the same production target. Concurrency queues rather
    than cancels runs, but an operator should still avoid creating ambiguous overlapping requests.
 
 The commands below are examples for an authorized future operation. Replace placeholders; do not run
@@ -45,6 +47,7 @@ gh workflow run deploy.yml --ref main \
   -f release_reason=<standard|emergency> \
   -f rationale='<required-for-emergency>' \
   -f operator_notes='<bounded-notes>' \
+  -f retention_bootstrap=<true|false> \
   -f dry_run=true
 ```
 
@@ -67,6 +70,7 @@ gh workflow run deploy.yml --ref main \
   -f release_reason=<same-standard-or-emergency> \
   -f rationale='<same-rationale>' \
   -f operator_notes='<same-notes>' \
+  -f retention_bootstrap=<same-true-or-false> \
   -f dry_run=false
 ```
 
@@ -157,15 +161,24 @@ every command attempted.
 
 GitHub Releases are the canonical durable release record. Workflow artifacts support short-lived
 audit and recovery and currently retain for 14 days; export required evidence according to the
-project's authorized audit process before expiry. The deployed `versions.json` authenticates assets
-in the current deployment only. Exact static URLs are not guaranteed across later releases: the
-installed workflow supplies no prior-release retention plan, so no durable retention boundary has
-been established. Historical bytes absent from both the current deployment and canonical GitHub
-Release assets are unavailable; do not promise or fabricate them.
+project's authorized audit process before expiry. The repository workflow now supports three
+fail-closed retention states. It defaults to `disabled`; an explicitly authorized one-time
+`retention_bootstrap` makes the candidate version the immutable boundary; later releases
+automatically `continue` from the authenticated GitHub Release lineage. Planning authenticates each
+supported Release and exact asset, the credential-free build consumes a request-keyed local handoff,
+and State 2 plus preapproval verification hash the complete static tree. Missing or conflicting
+history stops the release. Historical bytes before the boundary are never reconstructed.
 
-Production cutover remains blocked pending a separately reviewed repository retention wiring package.
-After that wiring exists, a later authorized operator phase must prove N/N+1 retention before any
-durability claim is made. This repository-only package supplies neither that wiring nor that proof.
+No production boundary has been established by landing this code. Production cutover and live N/N+1
+durability remain blocked until a separately authorized operator goal selects a bootstrap candidate
+and later proves the retained exact bytes and digest in production.
+
+Before an authenticated bootstrap Release is published, this repository feature can be rolled back
+as one coherent unit. After bootstrap publication, retention-unaware rollback is forbidden: every
+later implementation must read v2 authority, preserve the original boundary and complete supported
+set, and pass the same installed N/N+1 and complete-tree checks. Production rollback remains the
+existing restoration of the captured exact Cloudflare baseline; it never rebuilds historical bytes.
+Repository tests prove only the offline installed boundaries, not a live deployment or durable URL.
 
 ## WP8 Boundary
 
@@ -173,5 +186,5 @@ This runbook documents repository behavior; it does not authorize production set
 release. Enabling or inspecting environments, variables, secrets, Cloudflare credentials, approval
 rules, notification credentials, or the two production gates—and performing any dry run, live run,
 cutover, rollback, or notification—belongs to a separately authorized operator phase. Cutover is also
-blocked on the retention wiring and N/N+1 proof described above. Until both repository and operator
-evidence exist, production remains disabled and undispatched.
+blocked on the separate operator authorization and live N/N+1 proof described above. Until that
+evidence exists, production remains disabled and undispatched.

--- a/docs/website/version-pinning.mdx
+++ b/docs/website/version-pinning.mdx
@@ -66,11 +66,16 @@ This loads the latest `1.1.x` release. You only get patch updates (bug fixes and
 ```
 
 This requests version `1.1.0` from the current deployment. Confirm that its filename and digest appear
-in the live `versions.json` before using it. That manifest authenticates what is deployed now; it does
-not promise that the file will survive the next release. The installed workflow supplies neither a
-prior-release retention plan nor a durable archive input, so no durable retention boundary exists.
+in the live `versions.json` before using it. The repository supports prospective retention from an
+explicitly bootstrapped boundary, but no production boundary or live N/N+1 durability has yet been
+proved. Until that separate operator proof, the manifest authenticates only what is deployed now.
 Historical bytes that are absent from the current deployment and GitHub Release assets are
 unavailable and must not be reconstructed or promised.
+
+After a future authenticated bootstrap publication, a v2 manifest will declare the immutable
+boundary and supported exact set. Code rollback after that point must remain retention-aware; it may
+not discard the boundary or supported files. The repository's offline N/N+1 tests do not themselves
+prove that any production exact URL is durable.
 
 ## How Versioned URLs Work
 
@@ -114,9 +119,9 @@ Here is a decision guide:
 - You have verified its filename and digest against the live `versions.json`
 - You do not depend on that URL remaining available after another release
 
-Production cutover is blocked until a separately reviewed retention wiring package establishes a
-durable boundary and a later authorized operator phase proves N/N+1 behavior. Until then, use a
-separately controlled archive if your application requires cross-release reproducibility.
+Production cutover is blocked until a separately authorized operator phase establishes the boundary
+and proves live N/N+1 behavior. Until then, use a separately controlled archive if your application
+requires cross-release reproducibility.
 
 ## Upgrading Versions
 

--- a/scripts/build-widget.js
+++ b/scripts/build-widget.js
@@ -2,7 +2,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { readFile, readdir } from 'node:fs/promises';
+import { readFile, readdir, writeFile } from 'node:fs/promises';
 import { basename, dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -12,6 +12,8 @@ import {
   createDevelopmentStaticPackage,
   createReleaseStaticPackage,
 } from './release/static-assets.mjs';
+import { canonicalize } from './release/canonical-json.mjs';
+import { loadRetentionInput } from './release/retention.mjs';
 
 const CONTROLLER_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const VALUE_OPTIONS = new Set([
@@ -24,6 +26,8 @@ const VALUE_OPTIONS = new Set([
   'repository',
   'cutover-version',
   'retention-plan',
+  'request-plan',
+  'result-path',
   'current-archive-url',
   'controller-identity',
   'tool-identity',
@@ -49,6 +53,8 @@ Release options:
   --target-sha SHA            Candidate commit (derived from Git when omitted)
   --repository OWNER/NAME     Release repository (derived from Git when omitted)
   --retention-plan PATH       JSON declaration of retained exact-version assets
+  --request-plan PATH         Approved request plan matching the retention input
+  --result-path PATH          Write the complete builder-result identity outside the output tree
   --cutover-version VERSION   First retained exact version (default: current)
   --current-archive-url URL   Prospective exact-version release URL
   --controller-identity ID    sha256 identity (derived when omitted)
@@ -168,11 +174,21 @@ async function bundleCandidate({ sourceDir, version, enableTestHooks }) {
   return bytes;
 }
 
-async function loadRetentionPlan(path) {
+async function loadRetentionPlan(path, requestPlanPath) {
   if (!path) return {};
-  const plan = JSON.parse(await readFile(resolve(path), 'utf8'));
+  const resolved = resolve(path);
+  const plan = JSON.parse(await readFile(resolved, 'utf8'));
   if (plan === null || Array.isArray(plan) || typeof plan !== 'object') {
     throw new Error('Retention plan must be a JSON object');
+  }
+  if (plan.schema === 'bugdrop.retention-input/v1') {
+    if (!requestPlanPath) throw new Error('Authenticated retention input requires --request-plan');
+    const requestBytes = await readFile(resolve(requestPlanPath));
+    const requestPlan = JSON.parse(requestBytes.toString('utf8'));
+    if (!requestBytes.equals(Buffer.from(`${canonicalize(requestPlan)}\n`))) {
+      throw new Error('Request plan must be canonical JSON');
+    }
+    return loadRetentionInput(resolved, requestPlan.requestIdentity, requestPlan.retention);
   }
   return plan;
 }
@@ -229,8 +245,10 @@ async function main() {
     repositoryFromRemote(git(sourceDir, ['remote', 'get-url', 'origin']))
   );
   const retention = await loadRetentionPlan(
-    option(options, 'retention-plan', 'BUGDROP_RETENTION_PLAN')
+    option(options, 'retention-plan', 'BUGDROP_RETENTION_PLAN'),
+    option(options, 'request-plan', 'BUGDROP_REQUEST_PLAN')
   );
+  const retentionMode = retention.mode ?? (retention.retainedReleases ? undefined : 'disabled');
   const bundleBytes = await bundleCandidate({ sourceDir, version, enableTestHooks: false });
   const exactName = `widget.v${version}.js`;
   const result = await createReleaseStaticPackage({
@@ -244,11 +262,12 @@ async function main() {
     cutoverVersion:
       option(options, 'cutover-version', 'BUGDROP_CUTOVER_VERSION') ??
       retention.cutoverVersion ??
-      version,
+      (retentionMode === 'disabled' ? null : version),
     expectedRetainedVersions: retention.expectedRetainedVersions ?? [],
     outputDir,
     repository,
     retainedReleases: retention.retainedReleases ?? [],
+    retentionMode,
     sourceDigest:
       option(options, 'source-digest', 'BUGDROP_SOURCE_DIGEST') ??
       (await treeDigest(join(sourceDir, 'src/widget'))),
@@ -260,6 +279,15 @@ async function main() {
       `sha256:${sha256(`esbuild:${esbuildVersion}`)}`,
     version,
   });
+  const resultPath = option(options, 'result-path', 'BUGDROP_BUILDER_RESULT');
+  if (resultPath) {
+    const builderResult = {
+      schema: 'bugdrop.builder-result/v1',
+      requestIdentity: retention.requestIdentity ?? null,
+      staticPackage: result.staticPackage,
+    };
+    await writeFile(resolve(resultPath), `${canonicalize(builderResult)}\n`, { flag: 'wx' });
+  }
   process.stdout.write(`Built authoritative widget v${version} (${result.contentIdentity})\n`);
 }
 

--- a/scripts/release/canonical-json.mjs
+++ b/scripts/release/canonical-json.mjs
@@ -29,12 +29,17 @@ export function normalizeCanonicalValue(value, ancestors = new Set()) {
     }
     return Object.fromEntries(
       normalizedEntries
-        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+        .sort(([left], [right]) => compareUtf8(left, right))
         .map(([key, item]) => [key, normalizeCanonicalValue(item, ancestors)])
     );
   } finally {
     ancestors.delete(value);
   }
+}
+
+/** Locale-independent ordering for protocol strings and normalized POSIX paths. */
+export function compareUtf8(left, right) {
+  return Buffer.compare(Buffer.from(left, 'utf8'), Buffer.from(right, 'utf8'));
 }
 
 export function canonicalize(value) {

--- a/scripts/release/github-adapter.mjs
+++ b/scripts/release/github-adapter.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
+import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { canonicalize } from './canonical-json.mjs';
+import { canonicalize, compareUtf8 } from './canonical-json.mjs';
 import { observeGitRange } from './git-observer.mjs';
 import {
   buildReleaseInventory,
@@ -17,11 +18,16 @@ import {
   validateSourceContext,
 } from './plan.mjs';
 import { validatePublicationBundle } from './publication.mjs';
+import { deriveRetentionRequest, writeRetentionInput } from './retention.mjs';
 
 const API_VERSION = '2022-11-28';
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const TAG_PATTERN = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
+const MAX_ASSET_BYTES = 16 * 1024 * 1024;
+const MAX_RETAINED_BYTES = 512 * 1024 * 1024;
+const ASSET_TIMEOUT_MS = 30_000;
+const sha256Bytes = bytes => createHash('sha256').update(bytes).digest('hex');
 
 export class GithubAdapterError extends Error {
   constructor(code, message, details = {}) {
@@ -47,12 +53,54 @@ function assertInput(repository, targetSha) {
   }
 }
 
+function compareReleaseTags(left, right) {
+  const a = left.tag.slice(1).split('.').map(BigInt);
+  const b = right.tag.slice(1).split('.').map(BigInt);
+  for (let index = 0; index < 3; index += 1) {
+    if (a[index] !== b[index]) return a[index] < b[index] ? -1 : 1;
+  }
+  return 0;
+}
+
 export function createGithubTransport({
   token,
   fetchImpl = fetch,
   apiUrl = 'https://api.github.com',
 }) {
   if (typeof token !== 'string' || !token) fail('TOKEN_REQUIRED', 'an explicit token is required');
+  const apiOrigin = new URL(apiUrl).origin;
+  const storageOrigins = new Set([
+    'https://objects.githubusercontent.com',
+    'https://release-assets.githubusercontent.com',
+    'https://github-releases.githubusercontent.com',
+  ]);
+  async function boundedBytes(response, { expectedSize, maxBytes }) {
+    const declared = response.headers.get('content-length');
+    if (declared !== null) {
+      const length = Number(declared);
+      if (!Number.isSafeInteger(length) || length < 0 || length > maxBytes)
+        fail('GITHUB_ASSET_FAILED', 'asset Content-Length exceeds its bound');
+      if (expectedSize !== undefined && length !== expectedSize)
+        fail('GITHUB_ASSET_FAILED', 'asset Content-Length differs from GitHub metadata');
+    }
+    if (!response.body) fail('GITHUB_ASSET_FAILED', 'asset response body is unavailable');
+    const chunks = [];
+    let total = 0;
+    const reader = response.body.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        fail('GITHUB_ASSET_FAILED', 'asset exceeds its streamed byte bound');
+      }
+      chunks.push(Buffer.from(value));
+    }
+    if (expectedSize !== undefined && total !== expectedSize)
+      fail('GITHUB_ASSET_FAILED', 'asset response is truncated or oversized');
+    return Buffer.concat(chunks, total);
+  }
   return {
     async request(path) {
       const response = await fetchImpl(new URL(path, `${apiUrl.replace(/\/$/, '')}/`), {
@@ -77,31 +125,66 @@ export function createGithubTransport({
       }
       return { data, hasNext: /<[^>]+>;\s*rel="next"/.test(response.headers.get('link') ?? '') };
     },
-    async requestBytes(path) {
-      let response = await fetchImpl(new URL(path, `${apiUrl.replace(/\/$/, '')}/`), {
-        headers: {
-          accept: 'application/octet-stream',
-          authorization: `Bearer ${token}`,
-          'x-github-api-version': API_VERSION,
-        },
-        redirect: 'manual',
-      });
-      if ([301, 302, 303, 307, 308].includes(response.status)) {
-        const location = response.headers.get('location');
-        if (!location?.startsWith('https://')) {
-          fail('GITHUB_ASSET_FAILED', 'GitHub asset redirect is not trusted HTTPS');
+    async requestBytes(path, options = {}) {
+      const assetUrl = new URL(path, `${apiUrl.replace(/\/$/, '')}/`);
+      const expectedPath =
+        options.repository && options.assetId
+          ? `/repos/${options.repository}/releases/assets/${options.assetId}`
+          : null;
+      if (
+        assetUrl.origin !== apiOrigin ||
+        !/^\/repos\/[^/]+\/[^/]+\/releases\/assets\/\d+$/.test(assetUrl.pathname) ||
+        (expectedPath && assetUrl.pathname !== expectedPath)
+      ) {
+        fail('GITHUB_ASSET_FAILED', 'asset API identity is outside the selected repository path');
+      }
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), ASSET_TIMEOUT_MS);
+      try {
+        let response = await fetchImpl(assetUrl, {
+          headers: {
+            accept: 'application/octet-stream',
+            authorization: `Bearer ${token}`,
+            'x-github-api-version': API_VERSION,
+          },
+          redirect: 'manual',
+          signal: controller.signal,
+        });
+        if ([301, 302, 303, 307, 308].includes(response.status)) {
+          const location = response.headers.get('location');
+          let redirect;
+          try {
+            redirect = new URL(location);
+          } catch {
+            fail('GITHUB_ASSET_FAILED', 'GitHub asset redirect is malformed');
+          }
+          if (
+            redirect.protocol !== 'https:' ||
+            redirect.username ||
+            redirect.password ||
+            !storageOrigins.has(redirect.origin)
+          ) {
+            fail('GITHUB_ASSET_FAILED', 'GitHub asset redirect is not trusted HTTPS');
+          }
+          response = await fetchImpl(redirect, {
+            headers: { accept: 'application/octet-stream' },
+            redirect: 'error',
+            signal: controller.signal,
+          });
         }
-        response = await fetchImpl(location, {
-          headers: { accept: 'application/octet-stream' },
-          redirect: 'error',
-        });
+        if (!response.ok) {
+          fail('GITHUB_ASSET_FAILED', `GitHub asset returned ${response.status}`, {
+            status: response.status,
+          });
+        }
+        const maxBytes = Math.min(options.maxBytes ?? MAX_ASSET_BYTES, MAX_ASSET_BYTES);
+        return await boundedBytes(response, { expectedSize: options.expectedSize, maxBytes });
+      } catch (error) {
+        if (error instanceof GithubAdapterError) throw error;
+        fail('GITHUB_ASSET_FAILED', 'GitHub asset request failed or timed out');
+      } finally {
+        clearTimeout(timer);
       }
-      if (!response.ok) {
-        fail('GITHUB_ASSET_FAILED', `GitHub asset returned ${response.status}`, {
-          status: response.status,
-        });
-      }
-      return Buffer.from(await response.arrayBuffer());
     },
   };
 }
@@ -151,6 +234,130 @@ function canonicalAsset(assets, name) {
   return value;
 }
 
+function exactObjectKeys(value, keys) {
+  return (
+    value?.constructor === Object &&
+    canonicalize(Object.keys(value).sort(compareUtf8)) === canonicalize([...keys].sort(compareUtf8))
+  );
+}
+
+function validateDisabledManifest({
+  manifest,
+  release,
+  requestPlan,
+  releaseContent,
+  exact,
+  sha256,
+}) {
+  const version = release.tag.slice(1);
+  const [major, minor] = version.split('.');
+  const artifact = manifest?.artifacts?.[`v${version}`];
+  const expectedVersions = {
+    [`v${version}`]: exact.name,
+    [`v${major}`]: `widget.v${major}.js`,
+    [`v${major}.${minor}`]: `widget.v${major}.${minor}.js`,
+  };
+  if (
+    requestPlan.retention?.mode !== 'disabled' ||
+    !exactObjectKeys(manifest, [
+      'artifacts',
+      'authoritative',
+      'current',
+      'cutoverVersion',
+      'generatedAt',
+      'latest',
+      'mode',
+      'repository',
+      'schema',
+      'versions',
+    ]) ||
+    manifest.schema !== 'bugdrop.versions-manifest/v1' ||
+    manifest.authoritative !== true ||
+    manifest.mode !== 'release' ||
+    manifest.current !== version ||
+    manifest.cutoverVersion !== version ||
+    manifest.generatedAt !== requestPlan.attestation.candidateCommitTimestamp ||
+    manifest.latest !== 'widget.js' ||
+    manifest.repository !== requestPlan.request.repository ||
+    !exactObjectKeys(manifest.artifacts, [`v${version}`]) ||
+    !exactObjectKeys(artifact, ['archiveUrl', 'filename', 'publishedAt', 'sha256', 'targetSha']) ||
+    artifact.archiveUrl !== exact.downloadUrl ||
+    artifact.filename !== exact.name ||
+    artifact.publishedAt !== requestPlan.attestation.candidateCommitTimestamp ||
+    artifact.sha256 !== sha256 ||
+    artifact.targetSha !== release.targetSha ||
+    canonicalize(manifest.versions) !== canonicalize(expectedVersions) ||
+    releaseContent.staticPackage?.fileHashes?.[exact.name] !== sha256
+  ) {
+    fail('PUBLISHED_ASSET_INVALID', `${release.tag} disabled manifest is inconsistent`);
+  }
+}
+
+function validateActiveManifest({
+  manifest,
+  manifestBytes,
+  release,
+  requestPlan,
+  releaseContent,
+  exact,
+  exactSha256,
+}) {
+  const version = release.tag.slice(1);
+  const [major, minor] = version.split('.');
+  const retention = requestPlan.retention;
+  const artifacts = Object.fromEntries([
+    ...retention.releases.map(prior => [
+      `v${prior.version}`,
+      {
+        downloadUrl: prior.asset.downloadUrl,
+        filename: prior.asset.name,
+        sha256: prior.asset.sha256,
+        tag: prior.tag,
+        targetSha: prior.targetSha,
+        version: prior.version,
+      },
+    ]),
+    [
+      `v${version}`,
+      {
+        downloadUrl: exact.downloadUrl,
+        filename: exact.name,
+        sha256: exactSha256,
+        tag: release.tag,
+        targetSha: release.targetSha,
+        version,
+      },
+    ],
+  ]);
+  const versions = Object.fromEntries([
+    ...Object.values(artifacts).map(artifact => [`v${artifact.version}`, artifact.filename]),
+    [`v${major}`, `widget.v${major}.js`],
+    [`v${major}.${minor}`, `widget.v${major}.${minor}.js`],
+  ]);
+  const expected = {
+    artifacts,
+    authoritative: true,
+    current: version,
+    cutoverVersion: retention.cutoverVersion,
+    generatedAt: requestPlan.attestation.candidateCommitTimestamp,
+    latest: 'widget.js',
+    mode: 'release',
+    repository: requestPlan.request.repository,
+    schema: 'bugdrop.versions-manifest/v2',
+    versions,
+  };
+  const manifestSha256 = sha256Bytes(manifestBytes);
+  if (
+    !['bootstrap', 'continue'].includes(retention.mode) ||
+    canonicalize(manifest) !== canonicalize(expected) ||
+    releaseContent.publicationAssetHashes?.['versions.json'] !== manifestSha256 ||
+    releaseContent.staticPackage?.fileHashes?.['versions.json'] !== manifestSha256 ||
+    releaseContent.staticPackage?.fileHashes?.[exact.name] !== exactSha256
+  ) {
+    fail('PUBLISHED_ASSET_INVALID', `${release.tag} active manifest is inconsistent`);
+  }
+}
+
 export function authenticatePublishedAssets({ release, assets }) {
   if (release?.published !== true || release.draft !== false || release.prerelease !== false) {
     fail('PUBLISHED_RELEASE_INVALID', 'completed-plan assets must belong to a stable publication');
@@ -188,14 +395,20 @@ export function authenticatePublishedAssets({ release, assets }) {
       contentIdentity: expected.marker.contentIdentity,
       verifiedAssetNames: expected.requiredAssets,
     },
+    publishedAssets: assets,
   };
 }
 
-export async function loadPublishedReleaseAssets({ transport, release }) {
+export async function loadPublishedReleaseAssets({
+  transport,
+  release,
+  repository = release?.repository,
+}) {
   if (!Array.isArray(release?.assets) || release.assets.length === 0) {
     fail('PUBLISHED_ASSET_MISSING', 'published Release has no inspectable assets');
   }
   const assets = {};
+  const budget = { used: 0 };
   for (const asset of release.assets) {
     if (
       !/^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/.test(asset?.name ?? '') ||
@@ -205,7 +418,24 @@ export async function loadPublishedReleaseAssets({ transport, release }) {
     ) {
       fail('PUBLISHED_ASSET_INVALID', 'published Release asset metadata is invalid');
     }
-    assets[asset.name] = await transport.requestBytes(asset.apiUrl);
+    if (
+      !repository ||
+      !/^\d+$/.test(asset.id ?? '') ||
+      !Number.isSafeInteger(asset.size) ||
+      asset.size < 0
+    ) {
+      fail('PUBLISHED_ASSET_INVALID', 'published Release asset authority is incomplete');
+    }
+    if (budget.used + asset.size > MAX_RETAINED_BYTES) {
+      fail('PUBLISHED_ASSET_INVALID', 'published Release assets exceed the cumulative byte limit');
+    }
+    assets[asset.name] = await transport.requestBytes(asset.apiUrl, {
+      repository,
+      assetId: asset.id,
+      expectedSize: asset.size,
+      maxBytes: Math.min(MAX_ASSET_BYTES, MAX_RETAINED_BYTES - budget.used),
+    });
+    budget.used += assets[asset.name].length;
   }
   return authenticatePublishedAssets({ release, assets });
 }
@@ -275,15 +505,20 @@ export async function observeGithubState({ transport, repository, targetSha }) {
     const published = release.draft === false && release.published_at !== null;
     releases.push({
       id: String(release.id ?? ''),
+      repository,
       tag,
       targetSha: ref.sha,
       draft: release.draft,
       prerelease: release.prerelease === true,
       published,
       url: String(release.html_url ?? ''),
+      publishedAt: String(release.published_at ?? ''),
       assets: (release.assets ?? []).map(asset => ({
+        id: String(asset?.id ?? ''),
         name: String(asset?.name ?? ''),
         apiUrl: String(asset?.url ?? ''),
+        downloadUrl: String(asset?.browser_download_url ?? ''),
+        size: Number(asset?.size),
       })),
       marker: decodeMarker(release.body),
       relationToTarget:
@@ -358,7 +593,10 @@ export async function createRequestPlanFromGithub({
   context,
   gitObserver = observeGitRange,
 }) {
-  const dispatch = normalizeDispatch(context?.dispatch);
+  const dispatch = normalizeDispatch({
+    ...context?.dispatch,
+    retentionBootstrap: context?.retentionBootstrap,
+  });
   assertInput(dispatch.repository, dispatch.targetSha);
   const state = await observeGithubState({
     transport,
@@ -421,7 +659,130 @@ export async function createRequestPlanFromGithub({
   });
   const nextTag = calculateNextTag(frontier.tag, dispatch.bump);
   const [major, minor] = nextTag.slice(1).split('.');
-  return buildRequestPlan({
+  const retentionReleases = [];
+  const retainedBytes = {};
+  let retainedBytesUsed = 0;
+  for (const release of [...state.published].sort(compareReleaseTags)) {
+    const version = release.tag.slice(1);
+    if (release.marker?.protocol !== 'release-plan/v2') {
+      retentionReleases.push({
+        version,
+        published: true,
+        draft: false,
+        prerelease: false,
+        retention: null,
+        retentionRecord: null,
+      });
+      continue;
+    }
+    const hydrated = await loadPublishedReleaseAssets({
+      transport,
+      release,
+      repository: dispatch.repository,
+    });
+    if (hydrated.requestPlan.protocol !== 'release-plan/v2') {
+      fail('PUBLISHED_ASSET_INVALID', `${release.tag} v2 marker does not authenticate v2 assets`);
+    }
+    const exact = release.assets.find(asset => asset.name === `widget.v${version}.js`);
+    if (!exact || !/^\d+$/.test(release.id) || !/^\d+$/.test(exact.id)) {
+      fail('PUBLISHED_ASSET_INVALID', `${release.tag} lacks stable Release asset identity`);
+    }
+    const sha256 = hydrated.releaseContent.publicationAssetHashes?.[exact.name];
+    let sourceManifest;
+    try {
+      sourceManifest = JSON.parse(hydrated.publishedAssets['versions.json'].toString('utf8'));
+    } catch {
+      fail('PUBLISHED_ASSET_INVALID', `${release.tag} manifest is invalid`);
+    }
+    if (
+      !hydrated.publishedAssets['versions.json'].equals(
+        Buffer.from(`${canonicalize(sourceManifest)}\n`)
+      ) ||
+      exact.downloadUrl !==
+        `https://github.com/${dispatch.repository}/releases/download/${release.tag}/${exact.name}`
+    ) {
+      fail(
+        'PUBLISHED_ASSET_INVALID',
+        `${release.tag} manifest or download identity is not canonical`
+      );
+    }
+    if (!/^[0-9a-f]{64}$/.test(sha256 ?? '')) {
+      fail('PUBLISHED_ASSET_INVALID', `${release.tag} exact bytes lack four-way authority`);
+    }
+    const sourceRetention = hydrated.requestPlan.retention;
+    if (sourceRetention.mode === 'disabled') {
+      validateDisabledManifest({
+        manifest: sourceManifest,
+        release,
+        requestPlan: hydrated.requestPlan,
+        releaseContent: hydrated.releaseContent,
+        exact,
+        sha256,
+      });
+      retentionReleases.push({
+        version,
+        published: true,
+        draft: false,
+        prerelease: false,
+        retention: null,
+        retentionRecord: null,
+      });
+      continue;
+    }
+    const authenticatedPrefix = retentionReleases
+      .filter(item => ['bootstrap', 'continue'].includes(item.retention?.mode))
+      .map(item => item.retentionRecord);
+    if (canonicalize(sourceRetention.releases) !== canonicalize(authenticatedPrefix)) {
+      fail(
+        'PUBLISHED_ASSET_INVALID',
+        `${release.tag} cumulative retention differs from authenticated preceding Releases`
+      );
+    }
+    validateActiveManifest({
+      manifest: sourceManifest,
+      manifestBytes: hydrated.publishedAssets['versions.json'],
+      release,
+      requestPlan: hydrated.requestPlan,
+      releaseContent: hydrated.releaseContent,
+      exact,
+      exactSha256: sha256,
+    });
+    const exactBytes = hydrated.publishedAssets[exact.name];
+    if (retainedBytesUsed + exactBytes.length > MAX_RETAINED_BYTES) {
+      fail('PUBLISHED_ASSET_INVALID', 'retained exact assets exceed the cumulative byte limit');
+    }
+    retainedBytesUsed += exactBytes.length;
+    retentionReleases.push({
+      version,
+      published: true,
+      draft: false,
+      prerelease: false,
+      retention: hydrated.requestPlan.retention,
+      retentionRecord: {
+        version,
+        tag: release.tag,
+        releaseId: release.id,
+        targetSha: release.targetSha,
+        publishedAt: release.publishedAt,
+        sourcePlanIdentity: hydrated.finalPlan.planIdentity,
+        sourceContentIdentity: hydrated.releaseContent.contentIdentity,
+        asset: {
+          assetId: exact.id,
+          name: exact.name,
+          apiPath: `/repos/${dispatch.repository}/releases/assets/${exact.id}`,
+          downloadUrl: exact.downloadUrl,
+          sha256,
+        },
+      },
+    });
+    retainedBytes[version] = exactBytes;
+  }
+  const retention = deriveRetentionRequest({
+    candidateVersion: nextTag.slice(1),
+    retentionBootstrap: context.retentionBootstrap === true,
+    releases: retentionReleases,
+  });
+  const requestPlan = buildRequestPlan({
     dispatch,
     previousTag: frontier.tag,
     nextTag,
@@ -429,6 +790,8 @@ export async function createRequestPlanFromGithub({
     controllerSha: dispatch.controllerSha,
     remoteMainSha: remoteMain.sha,
     inventory,
+    retentionBootstrap: context.retentionBootstrap === true,
+    retention,
     attestation: {
       previousReleaseSha: frontier.targetSha,
       candidateCommitTimestamp: git.candidateCommitTimestamp,
@@ -438,6 +801,15 @@ export async function createRequestPlanFromGithub({
       verificationCommands: ['npm run validate', 'npm run build'],
     },
   });
+  if (context.retentionOutputDir) {
+    await writeRetentionInput({
+      root: context.retentionOutputDir,
+      requestIdentity: requestPlan.requestIdentity,
+      retention,
+      assets: retainedBytes,
+    });
+  }
+  return requestPlan;
 }
 
 async function runCli() {

--- a/scripts/release/github-publication-adapter.mjs
+++ b/scripts/release/github-publication-adapter.mjs
@@ -5,6 +5,9 @@ const SHA = /^[0-9a-f]{40}$/;
 const ASSET = /^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/;
 const RELEASE_ID = /^[1-9]\d*$/;
 const TOKEN = /^[A-Za-z0-9_.-]{16,4096}$/;
+const MAX_ASSET_BYTES = 16 * 1024 * 1024;
+const MAX_RELEASE_BYTES = 512 * 1024 * 1024;
+const ASSET_TIMEOUT_MS = 30_000;
 
 export class GithubPublicationAdapterError extends Error {
   constructor(code, message, details = {}) {
@@ -63,6 +66,12 @@ export function createGithubPublicationAdapter({
     fail('INVALID_INPUT', 'repository is invalid');
   }
   if (!TOKEN.test(token ?? '')) fail('TOKEN_REQUIRED', 'token is required');
+  const apiOrigin = new URL(apiUrl).origin;
+  const storageOrigins = new Set([
+    'https://objects.githubusercontent.com',
+    'https://release-assets.githubusercontent.com',
+    'https://github-releases.githubusercontent.com',
+  ]);
   const headers = accept => ({
     accept,
     authorization: `Bearer ${token}`,
@@ -113,34 +122,69 @@ export function createGithubPublicationAdapter({
       fail('INVALID_RESPONSE', `${url.pathname} did not return JSON`);
     }
   };
-  const requestBytes = async assetUrl => {
+  const requestBytes = async (assetUrl, expectedSize, assetId) => {
     const url = new URL(assetUrl);
-    if (url.origin !== new URL(apiUrl).origin)
+    if (
+      url.origin !== apiOrigin ||
+      url.pathname !== `/repos/${repository}/releases/assets/${assetId}`
+    )
       fail('UNSAFE_ENDPOINT', 'asset API URL is untrusted');
     let response;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ASSET_TIMEOUT_MS);
     try {
       response = await fetchImpl(url, {
         headers: headers('application/octet-stream'),
         redirect: 'manual',
+        signal: controller.signal,
       });
-    } catch {
-      fail('GITHUB_REQUEST_FAILED', 'GitHub asset request failed', { status: null });
-    }
-    if ([301, 302, 303, 307, 308].includes(response.status)) {
-      const location = response.headers.get('location');
-      if (!location?.startsWith('https://')) fail('UNSAFE_ENDPOINT', 'asset redirect is untrusted');
-      try {
+      if ([301, 302, 303, 307, 308].includes(response.status)) {
+        let location;
+        try {
+          location = new URL(response.headers.get('location'));
+        } catch {
+          fail('UNSAFE_ENDPOINT', 'asset redirect is malformed');
+        }
+        if (
+          location.protocol !== 'https:' ||
+          location.username ||
+          location.password ||
+          !storageOrigins.has(location.origin)
+        )
+          fail('UNSAFE_ENDPOINT', 'asset redirect is untrusted');
         response = await fetchImpl(location, {
           headers: { accept: 'application/octet-stream' },
           redirect: 'error',
+          signal: controller.signal,
         });
-      } catch {
-        fail('GITHUB_REQUEST_FAILED', 'GitHub asset request failed', { status: null });
       }
+      if (!response.ok)
+        fail('GITHUB_REQUEST_FAILED', 'GitHub asset request failed', { status: response.status });
+      const declared = response.headers.get('content-length');
+      if (declared !== null && Number(declared) !== expectedSize)
+        fail('INVALID_RESPONSE', 'asset Content-Length differs from GitHub metadata');
+      if (!response.body) fail('INVALID_RESPONSE', 'asset body is unavailable');
+      const chunks = [];
+      let total = 0;
+      const reader = response.body.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.byteLength;
+        if (total > MAX_ASSET_BYTES || total > expectedSize) {
+          await reader.cancel();
+          fail('INVALID_RESPONSE', 'asset exceeds its authenticated byte bound');
+        }
+        chunks.push(Buffer.from(value));
+      }
+      if (total !== expectedSize) fail('INVALID_RESPONSE', 'asset response is truncated');
+      return Buffer.concat(chunks, total);
+    } catch (error) {
+      if (error instanceof GithubPublicationAdapterError) throw error;
+      fail('GITHUB_REQUEST_FAILED', 'GitHub asset request failed or timed out', { status: null });
+    } finally {
+      clearTimeout(timer);
     }
-    if (!response.ok)
-      fail('GITHUB_REQUEST_FAILED', 'GitHub asset request failed', { status: response.status });
-    return Buffer.from(await response.arrayBuffer());
   };
   const inspectTag = async tag => {
     const ref = await request(
@@ -186,11 +230,24 @@ export function createGithubPublicationAdapter({
       }
       if (!Array.isArray(release.assets)) fail('INVALID_RESPONSE', 'release assets are incomplete');
       const assets = [];
+      let totalBytes = 0;
       for (const asset of release.assets) {
-        if (!ASSET.test(asset?.name ?? '') || typeof asset?.url !== 'string') {
+        if (
+          !ASSET.test(asset?.name ?? '') ||
+          !RELEASE_ID.test(String(asset?.id ?? '')) ||
+          typeof asset?.url !== 'string' ||
+          !Number.isSafeInteger(asset?.size) ||
+          asset.size < 0 ||
+          asset.size > MAX_ASSET_BYTES ||
+          totalBytes + asset.size > MAX_RELEASE_BYTES
+        ) {
           fail('INVALID_RESPONSE', 'release asset identity is invalid');
         }
-        assets.push({ name: asset.name, bytes: await requestBytes(asset.url) });
+        assets.push({
+          name: asset.name,
+          bytes: await requestBytes(asset.url, asset.size, String(asset.id)),
+        });
+        totalBytes += asset.size;
       }
       releases.push({
         ...marker(release.body),

--- a/scripts/release/live-release.mjs
+++ b/scripts/release/live-release.mjs
@@ -15,6 +15,7 @@ import {
 } from './publication.mjs';
 import { canonicalize } from './canonical-json.mjs';
 import { collectRecoveryIdentity, pollLiveVerification } from './verify-live.mjs';
+import { assertStaticTree } from './static-tree.mjs';
 
 const PROTOCOL = 'bugdrop.live-release/v1';
 const SHA = /^[0-9a-f]{40}$/;
@@ -57,6 +58,9 @@ export async function buildExpectedLive({ bundle: rawBundle, origin, staticPacka
   const expectedPublication = validatePublicationBundle(bundle);
   const tag = match(expectedPublication.tag, TAG, 'tag');
   const version = tag.slice(1);
+  if (bundle.requestPlan.protocol === 'release-plan/v2') {
+    await assertStaticTree(staticPackageDir, bundle.releaseContent.staticPackage);
+  }
   const exactFilename = `widget.${tag}.js`;
   const aliases = bundle.requestPlan.attestation.expectedAliases;
   const exactBytes = await readFile(resolve(staticPackageDir, exactFilename));
@@ -78,8 +82,12 @@ export async function buildExpectedLive({ bundle: rawBundle, origin, staticPacka
   const widgetSha256 = sha256(exactBytes);
   const manifestSha256 = sha256(manifestBytes);
   if (
-    bundle.releaseContent.artifactHashes[exactFilename] !== widgetSha256 ||
-    bundle.releaseContent.artifactHashes['versions.json'] !== manifestSha256
+    (bundle.releaseContent.publicationAssetHashes ?? bundle.releaseContent.artifactHashes)[
+      exactFilename
+    ] !== widgetSha256 ||
+    (bundle.releaseContent.publicationAssetHashes ?? bundle.releaseContent.artifactHashes)[
+      'versions.json'
+    ] !== manifestSha256
   ) {
     fail('INVALID_STATIC_PACKAGE', 'static package bytes differ from authenticated State 2');
   }
@@ -89,11 +97,20 @@ export async function buildExpectedLive({ bundle: rawBundle, origin, staticPacka
     if (
       typeof artifact?.filename !== 'string' ||
       !/^widget\.v\d+\.\d+\.\d+\.js$/.test(artifact.filename) ||
-      !/^[0-9a-f]{64}$/.test(artifact.sha256 ?? '')
+      !/^[0-9a-f]{64}$/.test(artifact.sha256 ?? '') ||
+      (manifest.schema === 'bugdrop.versions-manifest/v2' &&
+        artifact.version !== artifactVersion.slice(1))
     ) {
       fail('INVALID_STATIC_PACKAGE', 'retained artifact identity is invalid');
     }
     retainedAssets[artifact.filename] = artifact.sha256;
+    const retainedBytes = await readFile(resolve(staticPackageDir, artifact.filename));
+    if (sha256(retainedBytes) !== artifact.sha256) {
+      fail(
+        'INVALID_STATIC_PACKAGE',
+        `retained ${artifact.filename} bytes differ from the manifest`
+      );
+    }
   }
   return {
     protocol: PROTOCOL,

--- a/scripts/release/plan.mjs
+++ b/scripts/release/plan.mjs
@@ -3,11 +3,21 @@
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { canonicalHash, canonicalize, normalizeCanonicalValue } from './canonical-json.mjs';
+import {
+  canonicalHash,
+  canonicalize,
+  compareUtf8,
+  normalizeCanonicalValue,
+} from './canonical-json.mjs';
+import { validateRetentionRequest } from './retention.mjs';
+import { validateStaticTreeRecord } from './static-tree.mjs';
 
 export const RELEASE_PROTOCOL = 'release-plan/v1';
 export const REQUEST_SCHEMA = 'bugdrop.release-request/v1';
 export const CONTENT_SCHEMA = 'bugdrop.release-content/v1';
+export const RELEASE_PROTOCOL_V2 = 'release-plan/v2';
+export const REQUEST_SCHEMA_V2 = 'bugdrop.release-request/v2';
+export const CONTENT_SCHEMA_V2 = 'bugdrop.release-content/v2';
 export const AUDIT_SCHEMA = 'bugdrop.release-audit/v1';
 export const MARKER_SCHEMA = 'bugdrop.publication-marker/v1';
 export const INVENTORY_SCHEMA = 'bugdrop.release-inventory/v1';
@@ -41,8 +51,8 @@ function exactKeys(value, keys, field) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     fail('INVALID_SCHEMA', `${field} must be an object`);
   }
-  const actual = Object.keys(value).sort();
-  const expected = [...keys].sort();
+  const actual = Object.keys(value).sort(compareUtf8);
+  const expected = [...keys].sort(compareUtf8);
   if (canonicalize(actual) !== canonicalize(expected)) {
     fail('INVALID_SCHEMA', `${field} must contain exactly ${expected.join(', ')}`);
   }
@@ -88,6 +98,9 @@ export function normalizeDispatch(input) {
     rationale,
     operatorNotes: text(input.operatorNotes ?? '', 'operatorNotes', { max: 5000 }),
     dryRun: input.dryRun ?? true,
+    ...(input.retentionBootstrap !== undefined
+      ? { retentionBootstrap: input.retentionBootstrap === true }
+      : {}),
   };
 }
 
@@ -223,9 +236,9 @@ export function publishedFrontier(state) {
 
 function normalizedLabels(labels = []) {
   if (!Array.isArray(labels)) fail('INVALID_INVENTORY', 'labels must be an array');
-  return [
-    ...new Set(labels.map(label => text(label, 'label', { required: true, max: 100 }))),
-  ].sort();
+  return [...new Set(labels.map(label => text(label, 'label', { required: true, max: 100 })))].sort(
+    compareUtf8
+  );
 }
 
 export function buildReleaseInventory(input) {
@@ -253,7 +266,7 @@ export function buildReleaseInventory(input) {
   if (commits.length === 0) fail('EMPTY_RELEASE_RANGE', 'compare inventory has no commits');
   const changedPaths = [
     ...new Set((input.changedPaths ?? []).map(path => text(path, 'path', { required: true }))),
-  ].sort();
+  ].sort(compareUtf8);
   const excludedNewerMainCommits = (input.excludedNewerMainCommits ?? [])
     .map(commit => ({
       sha: fullSha(commit.sha, 'excluded main commit SHA'),
@@ -288,15 +301,17 @@ export function buildReleaseInventory(input) {
     pullRequests,
     commits,
     changedPaths,
-    changedTopLevelPaths: [...new Set(changedPaths.map(path => path.split('/')[0]))].sort(),
+    changedTopLevelPaths: [...new Set(changedPaths.map(path => path.split('/')[0]))].sort(
+      compareUtf8
+    ),
     excludedNewerMainCommits,
     categorized,
     generatedNotes,
   });
 }
 
-function requestIdentity(request) {
-  return canonicalHash({ schema: REQUEST_SCHEMA, request });
+function requestIdentity(request, schema = REQUEST_SCHEMA, authority) {
+  return canonicalHash(authority ?? { schema, request });
 }
 
 function composeReleaseNotes(request) {
@@ -310,6 +325,7 @@ function composeReleaseNotes(request) {
 }
 
 function validateRequestPlanRecord(plan) {
+  const v2 = plan?.protocol === RELEASE_PROTOCOL_V2;
   exactKeys(
     plan,
     [
@@ -321,10 +337,14 @@ function validateRequestPlanRecord(plan) {
       'source',
       'attestation',
       'inventory',
+      ...(v2 ? ['retention'] : []),
     ],
     'requestPlan'
   );
-  if (plan.schema !== REQUEST_SCHEMA || plan.protocol !== RELEASE_PROTOCOL) {
+  if (
+    (v2 && plan.schema !== REQUEST_SCHEMA_V2) ||
+    (!v2 && (plan.schema !== REQUEST_SCHEMA || plan.protocol !== RELEASE_PROTOCOL))
+  ) {
     fail('INVALID_SCHEMA', 'unsupported request-plan schema or protocol');
   }
   exactKeys(
@@ -340,6 +360,7 @@ function validateRequestPlanRecord(plan) {
       'rationale',
       'generatedNotes',
       'operatorNotes',
+      ...(v2 ? ['retentionBootstrap'] : []),
     ],
     'requestPlan.request'
   );
@@ -357,6 +378,8 @@ function validateRequestPlanRecord(plan) {
     'requestPlan.attestation'
   );
   normalizeDispatch({ ...plan.request, controllerSha: plan.source.controllerSha });
+  if (v2)
+    validateRetentionRequest(plan.retention, { candidateVersion: plan.request.nextTag.slice(1) });
   text(plan.request.generatedNotes, 'generatedNotes');
   fullSha(plan.source.candidateSha, 'candidateSha');
   fullSha(plan.source.remoteMainSha, 'remoteMainSha');
@@ -388,7 +411,22 @@ function validateRequestPlanRecord(plan) {
   }
   const rebuiltInventory = buildReleaseInventory(plan.inventory);
   if (
-    plan.requestIdentity !== requestIdentity(plan.request) ||
+    plan.requestIdentity !==
+      requestIdentity(
+        plan.request,
+        plan.schema,
+        v2
+          ? {
+              schema: plan.schema,
+              protocol: plan.protocol,
+              request: plan.request,
+              source: plan.source,
+              attestation: plan.attestation,
+              inventory: plan.inventory,
+              retention: plan.retention,
+            }
+          : undefined
+      ) ||
     plan.releaseNotes !== composeReleaseNotes(plan.request) ||
     plan.inventory.schema !== INVENTORY_SCHEMA ||
     plan.inventory.generatedNotes !== plan.request.generatedNotes ||
@@ -400,6 +438,7 @@ function validateRequestPlanRecord(plan) {
 }
 
 function validateReleaseContentRecord(content, requestPlan) {
+  const v2 = requestPlan.protocol === RELEASE_PROTOCOL_V2;
   exactKeys(
     content,
     [
@@ -411,11 +450,12 @@ function validateReleaseContentRecord(content, requestPlan) {
       'deploymentConfigDigest',
       'verification',
       'contentIdentity',
+      ...(v2 ? ['publicationAssetHashes', 'staticPackage'] : []),
     ],
     'releaseContent'
   );
   if (
-    content.schema !== CONTENT_SCHEMA ||
+    content.schema !== (v2 ? CONTENT_SCHEMA_V2 : CONTENT_SCHEMA) ||
     content.requestIdentity !== requestPlan.requestIdentity
   ) {
     fail('INVALID_SCHEMA', 'release content schema or request identity is invalid');
@@ -435,6 +475,14 @@ function validateReleaseContentRecord(content, requestPlan) {
   digest(content.sourceDigests.worker, 'worker source');
   digest(content.sourceDigests.lockfile, 'lockfile');
   digest(content.deploymentConfigDigest, 'deploymentConfigDigest');
+  if (v2) {
+    validateStaticTreeRecord(content.staticPackage);
+    for (const [name, hash] of Object.entries(content.publicationAssetHashes ?? {})) {
+      if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name))
+        fail('INVALID_SCHEMA', 'invalid publication asset name');
+      digest(hash, `publication asset ${name}`);
+    }
+  }
   if (!['passed', 'failed'].includes(content.verification.result)) {
     fail('INVALID_SCHEMA', 'verification result must be passed or failed');
   }
@@ -447,6 +495,7 @@ function validateReleaseContentRecord(content, requestPlan) {
 }
 
 function validateFinalPlanRecord(finalPlan, requestPlan, releaseContent) {
+  const v2 = requestPlan.protocol === RELEASE_PROTOCOL_V2;
   exactKeys(
     finalPlan,
     [
@@ -462,14 +511,15 @@ function validateFinalPlanRecord(finalPlan, requestPlan, releaseContent) {
       'tag',
       'requiredAssets',
       'planIdentity',
+      ...(v2 ? ['staticPackageIdentity'] : []),
     ],
     'finalPlan'
   );
   const payload = { ...finalPlan };
   delete payload.planIdentity;
   const valid =
-    finalPlan.schema === RELEASE_PROTOCOL &&
-    finalPlan.protocol === RELEASE_PROTOCOL &&
+    finalPlan.schema === requestPlan.protocol &&
+    finalPlan.protocol === requestPlan.protocol &&
     finalPlan.requestIdentity === requestPlan.requestIdentity &&
     finalPlan.requestPlanHash === canonicalHash(requestPlan) &&
     finalPlan.repository === requestPlan.request.repository &&
@@ -480,7 +530,10 @@ function validateFinalPlanRecord(finalPlan, requestPlan, releaseContent) {
     /^sha256:[0-9a-f]{64}$/.test(finalPlan.contentIdentity) &&
     canonicalize(finalPlan.requiredAssets) === canonicalize(requiredAssetsFor(requestPlan)) &&
     finalPlan.planIdentity === canonicalHash(payload) &&
-    (!releaseContent || finalPlan.contentIdentity === releaseContent.contentIdentity);
+    (!v2 || /^sha256:[0-9a-f]{64}$/.test(finalPlan.staticPackageIdentity)) &&
+    (!releaseContent ||
+      (finalPlan.contentIdentity === releaseContent.contentIdentity &&
+        (!v2 || finalPlan.staticPackageIdentity === releaseContent.staticPackage.contentIdentity)));
   if (!valid) fail('INVALID_SCHEMA', 'final release plan is not internally consistent');
   return finalPlan;
 }
@@ -494,7 +547,7 @@ function requiredAssetsFor(requestPlan) {
       'final-release-plan.json',
       'checksums.sha256',
     ]),
-  ].sort();
+  ].sort(compareUtf8);
 }
 
 export function buildRequestPlan(input) {
@@ -552,6 +605,8 @@ export function buildRequestPlan(input) {
   ) {
     fail('INVALID_ATTESTATION', 'behind count, assets, and verification contract are invalid');
   }
+  const v2 = input.retention !== undefined;
+  if (v2) validateRetentionRequest(input.retention, { candidateVersion: input.nextTag.slice(1) });
   const request = normalizeCanonicalValue({
     repository: dispatch.repository,
     workflowRef: dispatch.workflowRef,
@@ -563,15 +618,31 @@ export function buildRequestPlan(input) {
     rationale: dispatch.rationale,
     generatedNotes: input.generatedNotes,
     operatorNotes: dispatch.operatorNotes,
+    ...(v2 ? { retentionBootstrap: input.retentionBootstrap === true } : {}),
   });
   if (calculateNextTag(request.previousTag, request.bump) !== request.nextTag) {
     fail('VERSION_MISMATCH', 'nextTag does not match the explicit bump');
   }
   const releaseNotes = composeReleaseNotes(request);
+  const schema = v2 ? REQUEST_SCHEMA_V2 : REQUEST_SCHEMA;
+  const protocol = v2 ? RELEASE_PROTOCOL_V2 : RELEASE_PROTOCOL;
+  const authority = {
+    schema,
+    protocol,
+    request,
+    source: {
+      controllerSha: fullSha(input.controllerSha, 'controllerSha'),
+      candidateSha: dispatch.targetSha,
+      remoteMainSha: fullSha(input.remoteMainSha, 'remoteMainSha'),
+    },
+    attestation: normalizedAttestation,
+    inventory: input.inventory,
+    ...(v2 ? { retention: input.retention } : {}),
+  };
   const plan = normalizeCanonicalValue({
-    schema: REQUEST_SCHEMA,
-    protocol: RELEASE_PROTOCOL,
-    requestIdentity: requestIdentity(request),
+    schema,
+    protocol,
+    requestIdentity: requestIdentity(request, schema, v2 ? authority : undefined),
     request,
     releaseNotes,
     source: {
@@ -581,6 +652,7 @@ export function buildRequestPlan(input) {
     },
     attestation: normalizedAttestation,
     inventory: input.inventory,
+    ...(v2 ? { retention: input.retention } : {}),
   });
   return validateRequestPlanRecord(plan);
 }
@@ -602,14 +674,22 @@ export function buildReleaseContent(input) {
     fail('INVALID_SCHEMA', 'verification result must be passed or failed');
   }
   digest(input.deploymentConfigDigest, 'deploymentConfigDigest');
+  const v2 = input.requestPlan.protocol === RELEASE_PROTOCOL_V2;
+  if (v2) validateStaticTreeRecord(input.staticPackage);
   const payload = normalizeCanonicalValue({
-    schema: CONTENT_SCHEMA,
+    schema: v2 ? CONTENT_SCHEMA_V2 : CONTENT_SCHEMA,
     requestIdentity: input.requestPlan.requestIdentity,
     artifactHashes: input.artifactHashes,
     sourceDigests: input.sourceDigests,
     toolchain: input.toolchain,
     deploymentConfigDigest: input.deploymentConfigDigest,
     verification: input.verification,
+    ...(v2
+      ? {
+          publicationAssetHashes: input.publicationAssetHashes ?? input.artifactHashes,
+          staticPackage: input.staticPackage,
+        }
+      : {}),
   });
   return validateReleaseContentRecord(
     { ...payload, contentIdentity: canonicalHash(payload) },
@@ -627,8 +707,8 @@ export function buildFinalPlan({ requestPlan, releaseContent }) {
   }
   const requiredAssets = requiredAssetsFor(requestPlan);
   const payload = normalizeCanonicalValue({
-    schema: RELEASE_PROTOCOL,
-    protocol: RELEASE_PROTOCOL,
+    schema: requestPlan.protocol,
+    protocol: requestPlan.protocol,
     requestIdentity: requestPlan.requestIdentity,
     contentIdentity: releaseContent.contentIdentity,
     requestPlanHash: canonicalHash(requestPlan),
@@ -638,6 +718,9 @@ export function buildFinalPlan({ requestPlan, releaseContent }) {
     remoteMainSha: requestPlan.source.remoteMainSha,
     tag: requestPlan.request.nextTag,
     requiredAssets,
+    ...(requestPlan.protocol === RELEASE_PROTOCOL_V2
+      ? { staticPackageIdentity: releaseContent.staticPackage.contentIdentity }
+      : {}),
   });
   return validateFinalPlanRecord(
     { ...payload, planIdentity: canonicalHash(payload) },
@@ -648,8 +731,9 @@ export function buildFinalPlan({ requestPlan, releaseContent }) {
 
 export function buildPublicationMarker(finalPlan) {
   return normalizeCanonicalValue({
-    schema: MARKER_SCHEMA,
-    protocol: RELEASE_PROTOCOL,
+    schema:
+      finalPlan.protocol === RELEASE_PROTOCOL_V2 ? 'bugdrop.publication-marker/v2' : MARKER_SCHEMA,
+    protocol: finalPlan.protocol,
     planIdentity: finalPlan.planIdentity,
     requestIdentity: finalPlan.requestIdentity,
     contentIdentity: finalPlan.contentIdentity,
@@ -682,6 +766,7 @@ function authenticateCompleted(release, dispatch) {
     'releaseReason',
     'rationale',
     'operatorNotes',
+    ...(requestPlan.protocol === RELEASE_PROTOCOL_V2 ? ['retentionBootstrap'] : []),
   ];
   for (const field of compared) {
     if (requestPlan.request?.[field] !== dispatch[field]) {
@@ -705,14 +790,31 @@ function authenticateCompleted(release, dispatch) {
     ],
     'assetVerification'
   );
-  const verifiedAssetNames = [...(assetVerification?.verifiedAssetNames ?? [])].sort();
+  const verifiedAssetNames = [...(assetVerification?.verifiedAssetNames ?? [])].sort(compareUtf8);
   const valid =
-    requestPlan.schema === REQUEST_SCHEMA &&
-    requestPlan.protocol === RELEASE_PROTOCOL &&
-    releaseContent.schema === CONTENT_SCHEMA &&
-    finalPlan.schema === RELEASE_PROTOCOL &&
-    finalPlan.protocol === RELEASE_PROTOCOL &&
-    requestPlan.requestIdentity === requestIdentity(requestPlan.request) &&
+    [RELEASE_PROTOCOL, RELEASE_PROTOCOL_V2].includes(requestPlan.protocol) &&
+    requestPlan.schema ===
+      (requestPlan.protocol === RELEASE_PROTOCOL_V2 ? REQUEST_SCHEMA_V2 : REQUEST_SCHEMA) &&
+    releaseContent.schema ===
+      (requestPlan.protocol === RELEASE_PROTOCOL_V2 ? CONTENT_SCHEMA_V2 : CONTENT_SCHEMA) &&
+    finalPlan.schema === requestPlan.protocol &&
+    finalPlan.protocol === requestPlan.protocol &&
+    requestPlan.requestIdentity ===
+      requestIdentity(
+        requestPlan.request,
+        requestPlan.schema,
+        requestPlan.protocol === RELEASE_PROTOCOL_V2
+          ? {
+              schema: requestPlan.schema,
+              protocol: requestPlan.protocol,
+              request: requestPlan.request,
+              source: requestPlan.source,
+              attestation: requestPlan.attestation,
+              inventory: requestPlan.inventory,
+              retention: requestPlan.retention,
+            }
+          : undefined
+      ) &&
     releaseContent.requestIdentity === requestPlan.requestIdentity &&
     releaseContent.contentIdentity === canonicalHash(contentPayload) &&
     finalPlan.requestIdentity === requestPlan.requestIdentity &&

--- a/scripts/release/publication.mjs
+++ b/scripts/release/publication.mjs
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { canonicalHash, canonicalize } from './canonical-json.mjs';
+import { canonicalHash, canonicalize, compareUtf8 } from './canonical-json.mjs';
 import { buildPublicationMarker } from './plan.mjs';
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const TAG_PATTERN = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
@@ -39,7 +39,7 @@ const same = (left, right) => canonicalize(left) === canonicalize(right);
 function expectedChecksumBytes(hashes) {
   return Buffer.from(
     `${Object.entries(hashes)
-      .sort(([left], [right]) => left.localeCompare(right))
+      .sort(([left], [right]) => compareUtf8(left, right))
       .map(([name, digest]) => `${digest}  ${name}`)
       .join('\n')}\n`
   );
@@ -51,7 +51,17 @@ export function validatePublicationBundle(input) {
   }
   const validIdentity =
     requestPlan.requestIdentity ===
-      canonicalHash({ schema: requestPlan.schema, request: requestPlan.request }) &&
+      (requestPlan.protocol === 'release-plan/v2'
+        ? canonicalHash({
+            schema: requestPlan.schema,
+            protocol: requestPlan.protocol,
+            request: requestPlan.request,
+            source: requestPlan.source,
+            attestation: requestPlan.attestation,
+            inventory: requestPlan.inventory,
+            retention: requestPlan.retention,
+          })
+        : canonicalHash({ schema: requestPlan.schema, request: requestPlan.request })) &&
     releaseContent.contentIdentity === canonicalHash(without(releaseContent, 'contentIdentity')) &&
     finalPlan.planIdentity === canonicalHash(without(finalPlan, 'planIdentity')) &&
     finalPlan.requestPlanHash === canonicalHash(requestPlan) &&
@@ -60,8 +70,8 @@ export function validatePublicationBundle(input) {
     finalPlan.contentIdentity === releaseContent.contentIdentity;
   if (!validIdentity) fail('INVALID_BUNDLE', 'release identity records do not authenticate');
   if (
-    requestPlan.protocol !== 'release-plan/v1' ||
-    finalPlan.protocol !== 'release-plan/v1' ||
+    !['release-plan/v1', 'release-plan/v2'].includes(requestPlan.protocol) ||
+    finalPlan.protocol !== requestPlan.protocol ||
     !TAG_PATTERN.test(finalPlan.tag ?? '') ||
     !SHA_PATTERN.test(finalPlan.targetSha ?? '') ||
     finalPlan.tag !== requestPlan.request?.nextTag ||
@@ -80,12 +90,16 @@ export function validatePublicationBundle(input) {
   });
   const plannedRequired = [
     ...new Set([...(requestPlan.attestation?.expectedAssetNames ?? []), ...CORE_ASSETS]),
-  ].sort();
+  ].sort(compareUtf8);
   if (!same(required, plannedRequired)) {
     fail('INVALID_BUNDLE', 'requiredAssets must exactly match the request attestation');
   }
   const assets = input.assets;
-  if (!assets || assets.constructor !== Object || !same(Object.keys(assets).sort(), required)) {
+  if (
+    !assets ||
+    assets.constructor !== Object ||
+    !same(Object.keys(assets).sort(compareUtf8), required)
+  ) {
     fail('INVALID_BUNDLE', 'asset names do not exactly match the final plan');
   }
   const expectedBytes = {
@@ -100,7 +114,9 @@ export function validatePublicationBundle(input) {
       fail('INVALID_BUNDLE', `${name} bytes are not canonical`);
     }
     const digest = sha256(bytes);
-    const declared = releaseContent.artifactHashes?.[name];
+    const declared = (releaseContent.publicationAssetHashes ?? releaseContent.artifactHashes)?.[
+      name
+    ];
     if (!expectedBytes[name] && declared !== digest) {
       fail('INVALID_BUNDLE', `${name} does not match release content`);
     }
@@ -122,7 +138,11 @@ export function validatePublicationBundle(input) {
     marker,
     name: `BugDrop ${finalPlan.tag.slice(1)}`,
     planIdentity: finalPlan.planIdentity,
+    protocol: finalPlan.protocol,
     requiredAssets: required,
+    ...(finalPlan.staticPackageIdentity
+      ? { staticPackageIdentity: finalPlan.staticPackageIdentity }
+      : {}),
     tag: finalPlan.tag,
     tagAnnotation: `BugDrop ${finalPlan.tag}\n\n${canonicalize(marker)}`,
     targetSha: finalPlan.targetSha,

--- a/scripts/release/retention.mjs
+++ b/scripts/release/retention.mjs
@@ -1,0 +1,319 @@
+import { createHash } from 'node:crypto';
+import { lstat, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { basename, join, resolve } from 'node:path';
+
+import { canonicalize, compareUtf8 } from './canonical-json.mjs';
+
+const RETENTION_REQUEST_SCHEMA = 'bugdrop.retention-request/v1';
+const RETENTION_INPUT_SCHEMA = 'bugdrop.retention-input/v1';
+const VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const SHA = /^[0-9a-f]{40}$/;
+const DIGEST = /^[0-9a-f]{64}$/;
+const IDENTITY = /^sha256:[0-9a-f]{64}$/;
+const DECIMAL = /^(0|[1-9]\d*)$/;
+const MAX_ASSET = 16 * 1024 * 1024;
+const MAX_TOTAL = 512 * 1024 * 1024;
+
+class RetentionError extends Error {
+  constructor(code, message) {
+    super(`${code}: ${message}`);
+    this.name = 'RetentionError';
+    this.code = code;
+  }
+}
+const fail = (code, message) => {
+  throw new RetentionError(code, message);
+};
+const hash = bytes => createHash('sha256').update(bytes).digest('hex');
+
+function compareVersions(left, right) {
+  const a = VERSION.exec(left ?? '');
+  const b = VERSION.exec(right ?? '');
+  if (!a || !b) fail('INVALID_VERSION', 'versions must be stable MAJOR.MINOR.PATCH');
+  for (let i = 1; i < 4; i += 1) {
+    const x = Number(a[i]);
+    const y = Number(b[i]);
+    if (!Number.isSafeInteger(x) || !Number.isSafeInteger(y))
+      fail('INVALID_VERSION', 'version is too large');
+    if (x !== y) return x - y;
+  }
+  return 0;
+}
+
+function validateRecord(record) {
+  const keys = [
+    'version',
+    'tag',
+    'releaseId',
+    'targetSha',
+    'publishedAt',
+    'sourcePlanIdentity',
+    'sourceContentIdentity',
+    'asset',
+  ];
+  if (
+    record?.constructor !== Object ||
+    Object.keys(record).sort(compareUtf8).join() !== keys.sort(compareUtf8).join()
+  )
+    fail('INVALID_RETENTION_RECORD', 'record fields are not exact');
+  if (
+    !VERSION.test(record.version) ||
+    record.tag !== `v${record.version}` ||
+    !DECIMAL.test(record.releaseId) ||
+    !SHA.test(record.targetSha)
+  )
+    fail('INVALID_RETENTION_RECORD', `invalid authority for v${record.version}`);
+  if (
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(record.publishedAt) ||
+    !IDENTITY.test(record.sourcePlanIdentity) ||
+    !IDENTITY.test(record.sourceContentIdentity)
+  )
+    fail('INVALID_RETENTION_RECORD', `invalid identities for v${record.version}`);
+  const asset = record.asset;
+  const assetKeys = ['assetId', 'name', 'apiPath', 'downloadUrl', 'sha256'];
+  if (
+    asset?.constructor !== Object ||
+    Object.keys(asset).sort(compareUtf8).join() !== assetKeys.sort(compareUtf8).join()
+  )
+    fail('INVALID_RETENTION_RECORD', 'asset fields are not exact');
+  if (
+    !DECIMAL.test(asset.assetId) ||
+    asset.name !== `widget.v${record.version}.js` ||
+    !asset.apiPath.startsWith('/repos/') ||
+    !asset.apiPath.endsWith(`/releases/assets/${asset.assetId}`) ||
+    !asset.downloadUrl.startsWith('https://github.com/') ||
+    !DIGEST.test(asset.sha256)
+  )
+    fail('INVALID_RETENTION_RECORD', `invalid asset for v${record.version}`);
+  return record;
+}
+
+export function validateRetentionRequest(value, { candidateVersion } = {}) {
+  const requestKeys = ['schema', 'mode', 'cutoverVersion', 'expectedRetainedVersions', 'releases'];
+  if (
+    value?.constructor !== Object ||
+    Object.keys(value).sort(compareUtf8).join() !== requestKeys.sort(compareUtf8).join()
+  )
+    fail('INVALID_RETENTION_REQUEST', 'retention request fields are not exact');
+  if (
+    value?.schema !== RETENTION_REQUEST_SCHEMA ||
+    !['disabled', 'bootstrap', 'continue'].includes(value.mode)
+  )
+    fail('INVALID_RETENTION_REQUEST', 'schema or mode is invalid');
+  const versions = value.expectedRetainedVersions;
+  if (!Array.isArray(versions) || !Array.isArray(value.releases))
+    fail('INVALID_RETENTION_REQUEST', 'retained collections are required');
+  if (value.mode === 'disabled') {
+    if (value.cutoverVersion !== null || versions.length || value.releases.length)
+      fail('INVALID_RETENTION_REQUEST', 'disabled retention must be empty');
+    return value;
+  }
+  if (!VERSION.test(value.cutoverVersion ?? ''))
+    fail('INVALID_RETENTION_REQUEST', 'active cutover is invalid');
+  if (
+    value.mode === 'bootstrap' &&
+    ((candidateVersion !== undefined && value.cutoverVersion !== candidateVersion) ||
+      versions.length)
+  )
+    fail('INVALID_RETENTION_REQUEST', 'bootstrap must begin at the candidate with no history');
+  if (
+    new Set(versions).size !== versions.length ||
+    versions.some((v, i) => i && compareVersions(versions[i - 1], v) >= 0)
+  )
+    fail('INVALID_RETENTION_REQUEST', 'versions must be unique numeric SemVer order');
+  if (candidateVersion && versions.some(v => compareVersions(v, candidateVersion) >= 0))
+    fail('INVALID_RETENTION_REQUEST', 'retained version is not prior');
+  value.releases.forEach(validateRecord);
+  if (value.releases.map(r => r.version).join() !== versions.join())
+    fail('INVALID_RETENTION_REQUEST', 'release chain does not equal expected set');
+  return value;
+}
+
+export function deriveRetentionRequest({
+  candidateVersion,
+  retentionBootstrap = false,
+  releases = [],
+}) {
+  const stable = releases
+    .filter(r => r.published && !r.draft && !r.prerelease)
+    .sort((a, b) => compareVersions(a.version, b.version));
+  const active = stable.filter(
+    r => r.retention?.mode === 'bootstrap' || r.retention?.mode === 'continue'
+  );
+  if (!active.length)
+    return validateRetentionRequest(
+      {
+        schema: RETENTION_REQUEST_SCHEMA,
+        mode: retentionBootstrap ? 'bootstrap' : 'disabled',
+        cutoverVersion: retentionBootstrap ? candidateVersion : null,
+        expectedRetainedVersions: [],
+        releases: [],
+      },
+      { candidateVersion }
+    );
+  if (retentionBootstrap) fail('RETENTION_ALREADY_ACTIVE', 'bootstrap cannot be selected twice');
+  const boundaries = new Set(active.map(r => r.retention.cutoverVersion));
+  if (boundaries.size !== 1)
+    fail('RETENTION_BOUNDARY_CONFLICT', 'published Releases disagree on cutover');
+  const cutoverVersion = [...boundaries][0];
+  const supported = stable.filter(
+    r =>
+      compareVersions(r.version, cutoverVersion) >= 0 &&
+      compareVersions(r.version, candidateVersion) < 0
+  );
+  if (supported.some(r => !active.includes(r)))
+    fail('RETENTION_HISTORY_INCOMPLETE', 'post-boundary Release is not retention-capable');
+  supported.forEach((release, index) => {
+    const expectedPrior = supported.slice(0, index).map(item => item.version);
+    const authenticatedPrefix = supported
+      .slice(0, index)
+      .map(item => validateRecord(item.retentionRecord));
+    if (
+      release.retention.cutoverVersion !== cutoverVersion ||
+      release.retention.mode !== (index === 0 ? 'bootstrap' : 'continue') ||
+      release.retention.expectedRetainedVersions.join() !== expectedPrior.join() ||
+      !Array.isArray(release.retention.releases) ||
+      canonicalize(release.retention.releases) !== canonicalize(authenticatedPrefix)
+    ) {
+      fail(
+        'RETENTION_CHAIN_MISMATCH',
+        `${release.version} does not declare the exact preceding set`
+      );
+    }
+  });
+  const records = supported.map(r => validateRecord(r.retentionRecord));
+  return validateRetentionRequest(
+    {
+      schema: RETENTION_REQUEST_SCHEMA,
+      mode: 'continue',
+      cutoverVersion,
+      expectedRetainedVersions: records.map(r => r.version),
+      releases: records,
+    },
+    { candidateVersion }
+  );
+}
+
+function confined(root, relativePath) {
+  if (relativePath !== basename(relativePath)) fail('UNSAFE_RETENTION_PATH', relativePath);
+  const target = resolve(root, relativePath);
+  if (!target.startsWith(`${resolve(root)}/`)) fail('UNSAFE_RETENTION_PATH', relativePath);
+  return target;
+}
+
+export async function writeRetentionInput({ root, requestIdentity, retention, assets }) {
+  validateRetentionRequest(retention);
+  await mkdir(root, { recursive: true });
+  let total = 0;
+  const retainedReleases = [];
+  for (const record of retention.releases) {
+    const bytes = assets[record.version];
+    if (!Buffer.isBuffer(bytes) || !bytes.length || bytes.length > MAX_ASSET)
+      fail('RETENTION_SIZE_LIMIT', `invalid size for v${record.version}`);
+    total += bytes.length;
+    if (total > MAX_TOTAL) fail('RETENTION_SIZE_LIMIT', 'cumulative retained bytes exceed limit');
+    if (hash(bytes) !== record.asset.sha256) fail('RETAINED_HASH_MISMATCH', `v${record.version}`);
+    const assetPath = record.asset.name;
+    await writeFile(confined(root, assetPath), bytes, { flag: 'wx' });
+    retainedReleases.push({
+      version: record.version,
+      targetSha: record.targetSha,
+      publishedAt: record.publishedAt,
+      archiveUrl: record.asset.downloadUrl,
+      sha256: record.asset.sha256,
+      assetPath,
+    });
+  }
+  const plan = { schema: RETENTION_INPUT_SCHEMA, requestIdentity, retention, retainedReleases };
+  await writeFile(join(root, 'retention-plan.json'), `${canonicalize(plan)}\n`, { flag: 'wx' });
+  return plan;
+}
+
+export async function loadRetentionInput(path, requestIdentity, expectedRetention) {
+  const root = resolve(path, '..');
+  const planDetails = await lstat(path);
+  if (!planDetails.isFile() || planDetails.isSymbolicLink() || planDetails.size > 1024 * 1024) {
+    fail('RETENTION_INPUT_MISMATCH', 'retention-plan.json is not a bounded regular file');
+  }
+  const inputBytes = await readFile(path);
+  let input;
+  try {
+    input = JSON.parse(inputBytes.toString('utf8'));
+  } catch {
+    fail('RETENTION_INPUT_MISMATCH', 'transport plan is not JSON');
+  }
+  if (!inputBytes.equals(Buffer.from(`${canonicalize(input)}\n`))) {
+    fail('RETENTION_INPUT_MISMATCH', 'transport plan is not canonical JSON');
+  }
+  const inputKeys = ['schema', 'requestIdentity', 'retention', 'retainedReleases'];
+  if (
+    input?.constructor !== Object ||
+    Object.keys(input).sort(compareUtf8).join() !== inputKeys.sort(compareUtf8).join()
+  ) {
+    fail('RETENTION_INPUT_MISMATCH', 'transport plan fields are not exact');
+  }
+  if (input.schema !== RETENTION_INPUT_SCHEMA || input.requestIdentity !== requestIdentity)
+    fail('RETENTION_INPUT_MISMATCH', 'transport identity differs from request');
+  validateRetentionRequest(input.retention);
+  if (expectedRetention && canonicalize(input.retention) !== canonicalize(expectedRetention)) {
+    fail('RETENTION_INPUT_MISMATCH', 'transport retention differs from the approved request');
+  }
+  if (
+    !Array.isArray(input.retainedReleases) ||
+    input.retainedReleases.length !== input.retention.releases.length
+  ) {
+    fail('RETENTION_INPUT_MISMATCH', 'transport records differ from the approved request');
+  }
+  const retainedReleases = [];
+  let totalBytes = 0;
+  for (let index = 0; index < input.retainedReleases.length; index += 1) {
+    const item = input.retainedReleases[index];
+    const authority = input.retention.releases[index];
+    const keys = ['version', 'targetSha', 'publishedAt', 'archiveUrl', 'sha256', 'assetPath'];
+    if (
+      item?.constructor !== Object ||
+      Object.keys(item).sort(compareUtf8).join() !== keys.sort(compareUtf8).join() ||
+      !authority ||
+      item.version !== authority.version ||
+      item.targetSha !== authority.targetSha ||
+      item.publishedAt !== authority.publishedAt ||
+      item.archiveUrl !== authority.asset.downloadUrl ||
+      item.sha256 !== authority.asset.sha256 ||
+      item.assetPath !== authority.asset.name
+    ) {
+      fail('RETENTION_INPUT_MISMATCH', 'transport metadata is not an exact request projection');
+    }
+    const assetPath = confined(root, item.assetPath);
+    const details = await lstat(assetPath);
+    if (
+      !details.isFile() ||
+      details.isSymbolicLink() ||
+      details.size < 1 ||
+      details.size > MAX_ASSET
+    ) {
+      fail('RETENTION_SIZE_LIMIT', `invalid retained file for v${item.version}`);
+    }
+    totalBytes += details.size;
+    if (totalBytes > MAX_TOTAL)
+      fail('RETENTION_SIZE_LIMIT', 'cumulative retained bytes exceed limit');
+    const bytes = await readFile(assetPath);
+    if (hash(bytes) !== item.sha256) fail('RETAINED_HASH_MISMATCH', `v${item.version}`);
+    retainedReleases.push({ ...item, assetPath });
+  }
+  const expectedFiles = [
+    'retention-plan.json',
+    ...input.retention.releases.map(record => record.asset.name),
+  ].sort(compareUtf8);
+  const actualFiles = [];
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const details = await lstat(join(root, entry.name));
+    if (!details.isFile() || details.isSymbolicLink()) {
+      fail('RETENTION_INPUT_MISMATCH', `unexpected retention input entry ${entry.name}`);
+    }
+    actualFiles.push(entry.name);
+  }
+  if (canonicalize(actualFiles.sort(compareUtf8)) !== canonicalize(expectedFiles)) {
+    fail('RETENTION_INPUT_MISMATCH', 'retention input file set is not exact');
+  }
+  return { ...input.retention, requestIdentity: input.requestIdentity, retainedReleases };
+}

--- a/scripts/release/static-assets.mjs
+++ b/scripts/release/static-assets.mjs
@@ -2,10 +2,12 @@ import { createHash } from 'node:crypto';
 import { copyFile, lstat, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { basename, dirname, join, relative, resolve, sep } from 'node:path';
 
-import { canonicalHash, canonicalize } from './canonical-json.mjs';
+import { canonicalize, compareUtf8 } from './canonical-json.mjs';
+import { hashStaticTree } from './static-tree.mjs';
 
 const STATIC_PACKAGE_SCHEMA = 'bugdrop.static-package/v1';
 const VERSIONS_SCHEMA = 'bugdrop.versions-manifest/v1';
+const VERSIONS_SCHEMA_V2 = 'bugdrop.versions-manifest/v2';
 const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
@@ -13,9 +15,7 @@ const IDENTITY_PATTERN = /^sha256:[0-9a-f]{64}$/;
 const GENERATED_PATTERN =
   /^(?:widget\.js|widget\.v[^/]+\.js|versions\.json|checksums\.sha256|static-package\.json)$/;
 
-function compareText(left, right) {
-  return left < right ? -1 : left > right ? 1 : 0;
-}
+const compareText = compareUtf8;
 
 export class ReleaseStaticError extends Error {
   constructor(code, message, details = {}) {
@@ -179,7 +179,10 @@ async function stageRetainedAssets(input, outputDir) {
     if (seen.has(record.version)) fail('DUPLICATE_RETAINED_ASSET', `duplicate v${record.version}`);
     seen.add(record.version);
   }
-  if (canonicalize([...seen].sort()) !== canonicalize([...expected].sort())) {
+  if (
+    canonicalize([...seen].sort(compareVersions)) !==
+    canonicalize([...expected].sort(compareVersions))
+  ) {
     fail('RETAINED_SET_MISMATCH', 'retained archives do not match the declared complete set');
   }
   const artifacts = {};
@@ -200,9 +203,10 @@ async function stageRetainedAssets(input, outputDir) {
     const filename = `widget.v${record.version}.js`;
     await writeFile(join(outputDir, filename), bytes, { flag: 'wx' });
     artifacts[`v${record.version}`] = {
-      archiveUrl: record.archiveUrl,
+      ...(input.retentionMode
+        ? { downloadUrl: record.archiveUrl, tag: `v${record.version}`, version: record.version }
+        : { archiveUrl: record.archiveUrl, publishedAt: record.publishedAt }),
       filename,
-      publishedAt: record.publishedAt,
       sha256: actual,
       targetSha: record.targetSha,
     };
@@ -212,8 +216,11 @@ async function stageRetainedAssets(input, outputDir) {
 
 function validatePackageInput(input) {
   parseVersion(input.version);
-  parseVersion(input.cutoverVersion, 'cutoverVersion');
-  if (compareVersions(input.cutoverVersion, input.version) > 0) {
+  if (input.retentionMode !== 'disabled') parseVersion(input.cutoverVersion, 'cutoverVersion');
+  if (
+    input.retentionMode !== 'disabled' &&
+    compareVersions(input.cutoverVersion, input.version) > 0
+  ) {
     fail('INVALID_RETENTION_CUTOVER', 'cutover cannot be newer than the current version');
   }
   timestamp(input.timestamp);
@@ -245,12 +252,14 @@ export async function createReleaseStaticPackage(input) {
   ];
   for (const filename of aliases)
     await writeFile(join(input.outputDir, filename), input.bundleBytes, { flag: 'wx' });
-  const artifacts = await stageRetainedAssets(input, input.outputDir);
+  const artifacts =
+    input.retentionMode === 'disabled' ? {} : await stageRetainedAssets(input, input.outputDir);
   const bundleHash = sha256(input.bundleBytes);
   artifacts[`v${input.version}`] = {
-    archiveUrl: input.currentArchiveUrl,
+    ...(input.retentionMode && input.retentionMode !== 'disabled'
+      ? { downloadUrl: input.currentArchiveUrl, tag: `v${input.version}`, version: input.version }
+      : { archiveUrl: input.currentArchiveUrl, publishedAt: input.timestamp }),
     filename: exactFilename,
-    publishedAt: input.timestamp,
     sha256: bundleHash,
     targetSha: input.targetSha,
   };
@@ -268,12 +277,15 @@ export async function createReleaseStaticPackage(input) {
     artifacts,
     authoritative: true,
     current: input.version,
-    cutoverVersion: input.cutoverVersion,
+    cutoverVersion: input.retentionMode === 'disabled' ? input.version : input.cutoverVersion,
     generatedAt: input.timestamp,
     latest: 'widget.js',
     mode: 'release',
     repository: input.repository,
-    schema: VERSIONS_SCHEMA,
+    schema:
+      input.retentionMode && input.retentionMode !== 'disabled'
+        ? VERSIONS_SCHEMA_V2
+        : VERSIONS_SCHEMA,
     versions,
   };
   await writeFile(join(input.outputDir, 'versions.json'), `${canonicalize(manifest)}\n`, {
@@ -297,10 +309,11 @@ export async function createReleaseStaticPackage(input) {
     .map(([path, hash]) => `${hash}  ${path}`)
     .join('\n');
   await writeFile(join(input.outputDir, 'checksums.sha256'), `${checksums}\n`, { flag: 'wx' });
-  const fileHashes = await hashTree(input.outputDir);
+  const staticTree = await hashStaticTree(input.outputDir);
   return {
-    contentIdentity: canonicalHash({ schema: STATIC_PACKAGE_SCHEMA, fileHashes }),
-    fileHashes,
+    contentIdentity: staticTree.contentIdentity,
+    fileHashes: staticTree.fileHashes,
+    staticPackage: staticTree,
     outputDir: input.outputDir,
   };
 }
@@ -331,8 +344,19 @@ export async function createDevelopmentStaticPackage(input) {
 
 export function resolveStaticArtifactRetry(input) {
   assertMatch(input.expectedContentIdentity, IDENTITY_PATTERN, 'expectedContentIdentity');
+  const identityFields = ['RequestIdentity', 'StaticPackageIdentity', 'PlanIdentity'];
+  for (const suffix of identityFields) {
+    const expected = input[`expected${suffix}`];
+    if (expected !== undefined) assertMatch(expected, IDENTITY_PATTERN, `expected${suffix}`);
+  }
+  const identitiesMatch = prefix =>
+    input[`${prefix}ContentIdentity`] === input.expectedContentIdentity &&
+    identityFields.every(suffix => {
+      const expected = input[`expected${suffix}`];
+      return expected === undefined || input[`${prefix}${suffix}`] === expected;
+    });
   if (input.artifactStatus === 'available') {
-    if (!input.artifactId || input.storedContentIdentity !== input.expectedContentIdentity) {
+    if (!input.artifactId || !identitiesMatch('stored')) {
       fail(
         'ARTIFACT_IDENTITY_MISMATCH',
         'available artifact is not the planned immutable artifact'
@@ -341,10 +365,26 @@ export function resolveStaticArtifactRetry(input) {
     return { kind: 'reuse-artifact', artifactId: input.artifactId };
   }
   if (input.artifactStatus === 'expired') {
-    if (input.rebuiltContentIdentity === input.expectedContentIdentity) {
-      return { kind: 'rebuilt-exact', contentIdentity: input.rebuiltContentIdentity };
+    if (identitiesMatch('rebuilt')) {
+      return {
+        kind: 'rebuilt-exact',
+        contentIdentity: input.rebuiltContentIdentity,
+        ...Object.fromEntries(
+          identityFields
+            .filter(suffix => input[`expected${suffix}`] !== undefined)
+            .map(suffix => [
+              `${suffix[0].toLowerCase()}${suffix.slice(1)}`,
+              input[`rebuilt${suffix}`],
+            ])
+        ),
+      };
     }
-    return { kind: 'new-plan-required', reason: 'content-identity-mismatch' };
+    return {
+      kind: 'new-plan-required',
+      reason: identityFields.some(suffix => input[`expected${suffix}`] !== undefined)
+        ? 'total-identity-mismatch'
+        : 'content-identity-mismatch',
+    };
   }
   fail('ARTIFACT_STATE_UNCERTAIN', `unsupported artifact status ${input.artifactStatus}`);
 }

--- a/scripts/release/static-tree.mjs
+++ b/scripts/release/static-tree.mjs
@@ -1,0 +1,80 @@
+import { createHash } from 'node:crypto';
+import { lstat, readFile, readdir } from 'node:fs/promises';
+import { join, relative, resolve, sep } from 'node:path';
+
+import { canonicalHash, compareUtf8 } from './canonical-json.mjs';
+
+const STATIC_TREE_SCHEMA = 'bugdrop.static-tree/v1';
+const DIGEST = /^[0-9a-f]{64}$/;
+
+class StaticTreeError extends Error {
+  constructor(code, message) {
+    super(`${code}: ${message}`);
+    this.name = 'StaticTreeError';
+    this.code = code;
+  }
+}
+
+const fail = (code, message) => {
+  throw new StaticTreeError(code, message);
+};
+const posix = path => path.split(sep).join('/');
+const digest = bytes => createHash('sha256').update(bytes).digest('hex');
+
+async function enumerateStaticFiles(root, current = resolve(root)) {
+  const base = resolve(root);
+  const entries = await readdir(current, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries.sort((a, b) => compareUtf8(a.name, b.name))) {
+    const path = join(current, entry.name);
+    const details = await lstat(path);
+    if (details.isSymbolicLink()) fail('UNSAFE_STATIC_TREE', `symlink ${path}`);
+    if (details.isDirectory()) files.push(...(await enumerateStaticFiles(base, path)));
+    else if (details.isFile()) files.push(posix(relative(base, path)));
+    else fail('UNSAFE_STATIC_TREE', `special file ${path}`);
+  }
+  return files.sort(compareUtf8);
+}
+
+export async function hashStaticTree(root) {
+  const fileHashes = {};
+  for (const path of await enumerateStaticFiles(root)) {
+    fileHashes[path] = digest(await readFile(join(resolve(root), path)));
+  }
+  const staticPackage = { schema: STATIC_TREE_SCHEMA, fileHashes };
+  return { ...staticPackage, contentIdentity: canonicalHash(staticPackage) };
+}
+
+export function validateStaticTreeRecord(record) {
+  if (record?.schema !== STATIC_TREE_SCHEMA || record.fileHashes?.constructor !== Object) {
+    fail('INVALID_STATIC_TREE', 'unsupported static tree record');
+  }
+  const entries = Object.entries(record.fileHashes);
+  if (entries.length === 0) fail('INVALID_STATIC_TREE', 'file map is empty');
+  for (const [path, hash] of entries) {
+    if (
+      !path ||
+      path.startsWith('/') ||
+      path.includes('..') ||
+      path.includes('\\') ||
+      !DIGEST.test(hash)
+    ) {
+      fail('INVALID_STATIC_TREE', `invalid file record ${path}`);
+    }
+  }
+  const ordered = Object.fromEntries(entries.sort(([a], [b]) => compareUtf8(a, b)));
+  const payload = { schema: STATIC_TREE_SCHEMA, fileHashes: ordered };
+  if (record.contentIdentity !== canonicalHash(payload)) {
+    fail('STATIC_TREE_IDENTITY_MISMATCH', 'static tree identity does not match its file map');
+  }
+  return { ...payload, contentIdentity: record.contentIdentity };
+}
+
+export async function assertStaticTree(root, expected) {
+  const actual = await hashStaticTree(root);
+  const normalized = validateStaticTreeRecord(expected);
+  if (actual.contentIdentity !== normalized.contentIdentity) {
+    fail('STATIC_TREE_MISMATCH', 'on-disk static tree differs from State 2');
+  }
+  return actual;
+}

--- a/scripts/release/verify-live.mjs
+++ b/scripts/release/verify-live.mjs
@@ -9,6 +9,10 @@ const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
 const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const ASSET_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/;
+const MAX_HEALTH_BYTES = 64 * 1024;
+const MAX_MANIFEST_BYTES = 1024 * 1024;
+const MAX_WIDGET_BYTES = 16 * 1024 * 1024;
+const MAX_SNAPSHOT_BYTES = 512 * 1024 * 1024;
 
 export class LiveVerificationError extends Error {
   constructor(code, message, details = {}) {
@@ -117,7 +121,11 @@ export function verifyLiveSnapshot(input, snapshot) {
     fail('LIVE_MANIFEST_MISMATCH', 'manifest does not identify the planned release');
   }
   const current = manifest.artifacts?.[`v${expected.version}`];
-  if (current?.filename !== expected.exactFilename || current?.sha256 !== expected.widgetSha256) {
+  if (
+    current?.filename !== expected.exactFilename ||
+    current?.sha256 !== expected.widgetSha256 ||
+    (manifest.schema === 'bugdrop.versions-manifest/v2' && current.version !== expected.version)
+  ) {
     fail('LIVE_MANIFEST_MISMATCH', 'manifest current artifact is inconsistent');
   }
   const [major, minor] = expected.version.split('.');
@@ -134,7 +142,11 @@ export function verifyLiveSnapshot(input, snapshot) {
   for (const [filename, digest] of Object.entries(expected.retainedAssets)) {
     const version = filename.slice('widget.v'.length, -'.js'.length);
     const retained = manifest.artifacts?.[`v${version}`];
-    if (retained?.filename !== filename || retained?.sha256 !== digest) {
+    if (
+      retained?.filename !== filename ||
+      retained?.sha256 !== digest ||
+      (manifest.schema === 'bugdrop.versions-manifest/v2' && retained.version !== version)
+    ) {
       fail('LIVE_MANIFEST_MISMATCH', `manifest retained artifact ${filename} is inconsistent`);
     }
     if (manifest.versions?.[`v${version}`] !== filename) {
@@ -162,13 +174,61 @@ async function fetchOk(url, fetchImpl, timeoutMs) {
   if (!response.ok) fail('LIVE_FETCH_FAILED', `${url} returned ${response.status}`);
   return response;
 }
+async function readBoundedBytes(response, url, maxBytes, budget) {
+  const remaining = MAX_SNAPSHOT_BYTES - budget.used;
+  const allowed = Math.min(maxBytes, remaining);
+  const declared = response.headers.get('content-length');
+  if (declared !== null) {
+    if (!/^(0|[1-9]\d*)$/.test(declared) || !Number.isSafeInteger(Number(declared))) {
+      fail('LIVE_FETCH_FAILED', `${url} returned an invalid Content-Length`);
+    }
+    if (Number(declared) > allowed) {
+      fail('LIVE_FETCH_TOO_LARGE', `${url} exceeds its live verification byte bound`);
+    }
+  }
+  if (!response.body) fail('LIVE_FETCH_FAILED', `${url} returned no response body`);
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > allowed) {
+      await reader.cancel();
+      fail('LIVE_FETCH_TOO_LARGE', `${url} exceeds its live verification byte bound`);
+    }
+    chunks.push(Buffer.from(value));
+  }
+  budget.used += total;
+  return Buffer.concat(chunks, total);
+}
 async function collectSnapshot(origin, filenames, fetchImpl, timeoutMs, manifestErrorCode) {
-  const health = await (await fetchOk(`${origin}/api/health`, fetchImpl, timeoutMs)).json();
+  const budget = { used: 0 };
+  const healthUrl = `${origin}/api/health`;
+  const healthBytes = await readBoundedBytes(
+    await fetchOk(healthUrl, fetchImpl, timeoutMs),
+    healthUrl,
+    MAX_HEALTH_BYTES,
+    budget
+  );
+  let health;
+  try {
+    health = JSON.parse(healthBytes.toString('utf8'));
+  } catch {
+    fail('LIVE_OBSERVATION_FAILED', 'health response is not valid JSON');
+  }
   const assetHashes = {};
   let manifest;
   for (const filename of [...new Set(filenames)]) {
-    const response = await fetchOk(`${origin}/${filename}`, fetchImpl, timeoutMs);
-    const payload = Buffer.from(await response.arrayBuffer());
+    const url = `${origin}/${filename}`;
+    const response = await fetchOk(url, fetchImpl, timeoutMs);
+    const payload = await readBoundedBytes(
+      response,
+      url,
+      filename === 'versions.json' ? MAX_MANIFEST_BYTES : MAX_WIDGET_BYTES,
+      budget
+    );
     assetHashes[filename] = sha256(payload);
     if (filename === 'versions.json') {
       try {

--- a/scripts/release/workflow.mjs
+++ b/scripts/release/workflow.mjs
@@ -2,13 +2,15 @@
 
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { canonicalize } from './canonical-json.mjs';
+import { canonicalize, compareUtf8 } from './canonical-json.mjs';
 import { buildFinalPlan, buildReleaseContent, normalizeDispatch } from './plan.mjs';
 import { createRecoveryEvidence } from './production-state.mjs';
 import { validatePublicationBundle } from './publication.mjs';
+import { hashStaticTree, validateStaticTreeRecord } from './static-tree.mjs';
 
 const WORKFLOW_PROTOCOL = 'bugdrop.release-workflow/v1';
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
@@ -58,6 +60,9 @@ export function createState2Bundle(input) {
     toolchain: input.toolchain,
     deploymentConfigDigest: input.deploymentConfigDigest,
     verification: input.verification,
+    ...(input.staticPackage
+      ? { publicationAssetHashes: artifactHashes, staticPackage: input.staticPackage }
+      : {}),
   });
   const finalPlan = buildFinalPlan({ requestPlan: input.requestPlan, releaseContent });
   const assets = {
@@ -67,7 +72,7 @@ export function createState2Bundle(input) {
     'final-release-plan.json': Buffer.from(`${canonicalize(finalPlan)}\n`),
   };
   const checksums = Object.entries(assets)
-    .sort(([left], [right]) => left.localeCompare(right))
+    .sort(([left], [right]) => compareUtf8(left, right))
     .map(([name, bytes]) => `${sha256(bytes)}  ${name}`)
     .join('\n');
   assets['checksums.sha256'] = Buffer.from(`${checksums}\n`);
@@ -78,6 +83,191 @@ export function createState2Bundle(input) {
     assets,
   });
   return { requestPlan: input.requestPlan, releaseContent, finalPlan, assets };
+}
+
+async function readCanonicalJson(path, field) {
+  const bytes = await readFile(path);
+  let value;
+  try {
+    value = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    fail('INVALID_STATIC_PACKAGE', `${field} is not JSON`);
+  }
+  if (!bytes.equals(Buffer.from(`${canonicalize(value)}\n`))) {
+    fail('INVALID_STATIC_PACKAGE', `${field} is not canonical`);
+  }
+  return value;
+}
+
+function expectedChecksums(fileHashes) {
+  return `${Object.entries(fileHashes)
+    .filter(([path]) => path !== 'checksums.sha256')
+    .sort(([left], [right]) => compareUtf8(left, right))
+    .map(([path, digest]) => `${digest}  ${path}`)
+    .join('\n')}\n`;
+}
+
+async function validateStaticPackageSemantics(input, staticPackage) {
+  const root = input.staticPackageDir;
+  const requestPlan = input.requestPlan;
+  const retention = requestPlan.retention;
+  const version = requestPlan.request.nextTag.slice(1);
+  const exactFilename = `widget.v${version}.js`;
+  const hashes = staticPackage.fileHashes;
+  const manifest = await readCanonicalJson(join(root, 'versions.json'), 'versions.json');
+  const metadata = await readCanonicalJson(
+    join(root, 'static-package.json'),
+    'static-package.json'
+  );
+  const checksumBytes = await readFile(join(root, 'checksums.sha256'), 'utf8');
+  if (checksumBytes !== expectedChecksums(hashes)) {
+    fail('STATIC_CHECKSUM_MISMATCH', 'checksums.sha256 does not bind the exact static tree');
+  }
+  const publicationNames = [...requestPlan.attestation.expectedAssetNames].sort(compareUtf8);
+  if (!same(publicationNames, [exactFilename, 'versions.json'].sort(compareUtf8))) {
+    fail('INVALID_STATIC_PACKAGE', 'publication asset names do not match the candidate version');
+  }
+  const currentHash = hashes[exactFilename];
+  if (
+    !currentHash ||
+    manifest.current !== version ||
+    manifest.repository !== requestPlan.request.repository ||
+    manifest.authoritative !== true ||
+    manifest.mode !== 'release' ||
+    manifest.latest !== 'widget.js' ||
+    manifest.generatedAt !== requestPlan.attestation.candidateCommitTimestamp ||
+    metadata.schema !== 'bugdrop.static-package/v1' ||
+    metadata.mode !== 'release' ||
+    metadata.version !== version ||
+    metadata.targetSha !== requestPlan.request.targetSha ||
+    metadata.timestamp !== requestPlan.attestation.candidateCommitTimestamp
+  ) {
+    fail('INVALID_STATIC_PACKAGE', 'manifest current identity differs from the request');
+  }
+  const aliases = requestPlan.attestation.expectedAliases;
+  if (!Array.isArray(aliases) || aliases.some(alias => hashes[alias] !== currentHash)) {
+    fail('STATIC_ALIAS_MISMATCH', 'every approved alias must contain exact current bytes');
+  }
+  const exactPaths = Object.keys(hashes)
+    .filter(path => /^widget\.v\d+\.\d+\.\d+\.js$/.test(path))
+    .sort(compareUtf8);
+  const expectedRetained = retention?.expectedRetainedVersions ?? [];
+  const expectedExactPaths = [
+    ...expectedRetained.map(item => `widget.v${item}.js`),
+    exactFilename,
+  ].sort(compareUtf8);
+  if (!same(exactPaths, expectedExactPaths)) {
+    fail('RETAINED_SET_MISMATCH', 'static exact-version paths differ from the approved set');
+  }
+  const [major, minor] = version.split('.');
+  const expectedVersions = Object.fromEntries(
+    [
+      ...expectedExactPaths.map(path => [`v${path.slice(8, -3)}`, path]),
+      [`v${major}`, `widget.v${major}.js`],
+      [`v${major}.${minor}`, `widget.v${major}.${minor}.js`],
+    ].sort(([left], [right]) => compareUtf8(left, right))
+  );
+  if (!same(manifest.versions, expectedVersions)) {
+    fail('RETENTION_MANIFEST_MISMATCH', 'manifest version map differs from approved paths');
+  }
+  if (retention?.mode === 'bootstrap' || retention?.mode === 'continue') {
+    if (
+      manifest.schema !== 'bugdrop.versions-manifest/v2' ||
+      manifest.cutoverVersion !== retention.cutoverVersion ||
+      !same(
+        Object.keys(manifest.artifacts ?? {}).sort(compareUtf8),
+        [...expectedRetained.map(item => `v${item}`), `v${version}`].sort(compareUtf8)
+      )
+    ) {
+      fail(
+        'RETENTION_MANIFEST_MISMATCH',
+        'v2 manifest does not project the approved retention set'
+      );
+    }
+    for (const record of retention.releases) {
+      const expected = {
+        downloadUrl: record.asset.downloadUrl,
+        filename: record.asset.name,
+        sha256: record.asset.sha256,
+        tag: record.tag,
+        targetSha: record.targetSha,
+        version: record.version,
+      };
+      if (
+        !same(manifest.artifacts[`v${record.version}`], expected) ||
+        hashes[record.asset.name] !== record.asset.sha256
+      ) {
+        fail('RETAINED_BYTE_MISMATCH', `retained v${record.version} differs from its authority`);
+      }
+    }
+    const current = manifest.artifacts[`v${version}`];
+    const expectedCurrent = {
+      downloadUrl: `https://github.com/${requestPlan.request.repository}/releases/download/${requestPlan.request.nextTag}/${exactFilename}`,
+      filename: exactFilename,
+      sha256: currentHash,
+      tag: requestPlan.request.nextTag,
+      targetSha: requestPlan.request.targetSha,
+      version,
+    };
+    if (!same(current, expectedCurrent)) {
+      fail('INVALID_STATIC_PACKAGE', 'current manifest record differs from current bytes');
+    }
+  } else {
+    const expectedCurrent = {
+      archiveUrl: `https://github.com/${requestPlan.request.repository}/releases/download/${requestPlan.request.nextTag}/${exactFilename}`,
+      filename: exactFilename,
+      publishedAt: requestPlan.attestation.candidateCommitTimestamp,
+      sha256: currentHash,
+      targetSha: requestPlan.request.targetSha,
+    };
+    if (
+      retention?.mode !== 'disabled' ||
+      manifest.schema !== 'bugdrop.versions-manifest/v1' ||
+      manifest.cutoverVersion !== version ||
+      expectedRetained.length !== 0 ||
+      exactPaths.length !== 1 ||
+      !same(Object.keys(manifest.artifacts ?? {}), [`v${version}`]) ||
+      !same(manifest.artifacts[`v${version}`], expectedCurrent)
+    ) {
+      fail(
+        'RETENTION_MANIFEST_MISMATCH',
+        'disabled retention must preserve v1 current-only output'
+      );
+    }
+  }
+  return manifest;
+}
+
+/** Installed State-2 boundary: enumerate the deployment tree independently of the builder. */
+export async function createState2BundleFromStaticPackage(input) {
+  if (!input.builderResultPath) {
+    fail('INVALID_STATE2_INPUT', 'installed State 2 requires the controller builder result');
+  }
+  const builderResult = await readCanonicalJson(input.builderResultPath, 'builder result');
+  if (
+    builderResult?.schema !== 'bugdrop.builder-result/v1' ||
+    builderResult.requestIdentity !== input.requestPlan.requestIdentity ||
+    !same(Object.keys(builderResult).sort(compareUtf8), [
+      'requestIdentity',
+      'schema',
+      'staticPackage',
+    ])
+  ) {
+    fail('BUILDER_RESULT_MISMATCH', 'builder result does not bind the approved request');
+  }
+  const builtStaticPackage = validateStaticTreeRecord(builderResult.staticPackage);
+  const staticPackage = await hashStaticTree(input.staticPackageDir);
+  if (staticPackage.contentIdentity !== builtStaticPackage.contentIdentity) {
+    fail('BUILDER_RESULT_MISMATCH', 'static tree changed after controller package generation');
+  }
+  await validateStaticPackageSemantics(input, staticPackage);
+  const names = input.requestPlan.attestation.expectedAssetNames;
+  const candidateAssets = Object.fromEntries(
+    await Promise.all(
+      names.map(async name => [name, await readFile(join(input.staticPackageDir, name))])
+    )
+  );
+  return createState2Bundle({ ...input, candidateAssets, staticPackage });
 }
 
 export function validateControllerContext(input) {
@@ -111,8 +301,10 @@ function verifyArtifact(expected, artifact) {
     artifact.planIdentity !== expected.planIdentity ||
     artifact.contentIdentity !== expected.marker.contentIdentity ||
     artifact.requestIdentity !== expected.marker.requestIdentity ||
+    (expected.protocol === 'release-plan/v2' &&
+      artifact.staticPackageIdentity !== expected.staticPackageIdentity) ||
     !Array.isArray(artifact.verifiedAssetNames) ||
-    !same([...artifact.verifiedAssetNames].sort(), expected.requiredAssets)
+    !same([...artifact.verifiedAssetNames].sort(compareUtf8), expected.requiredAssets)
   ) {
     fail('ARTIFACT_IDENTITY_MISMATCH', 'immutable State 2 artifact does not match the plan');
   }
@@ -299,11 +491,13 @@ async function runCli() {
           ),
         })
       ),
+    'bundle-static': async value =>
+      dehydrateBundle(await createState2BundleFromStaticPackage(value)),
     core: classifyCoreOutcome,
     finalize: createFinalizationDecision,
   };
   if (!operations[mode]) fail('INVALID_CLI', `unsupported mode ${mode ?? '<missing>'}`);
-  process.stdout.write(`${canonicalize(operations[mode](input))}\n`);
+  process.stdout.write(`${canonicalize(await operations[mode](input))}\n`);
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {

--- a/test/fixtures/release/workflow/bundle.ts
+++ b/test/fixtures/release/workflow/bundle.ts
@@ -1,6 +1,10 @@
 import { createHash } from 'node:crypto';
 
-import { canonicalize } from '../../../../scripts/release/canonical-json.mjs';
+import {
+  canonicalHash,
+  canonicalize,
+  compareUtf8,
+} from '../../../../scripts/release/canonical-json.mjs';
 import {
   buildFinalPlan,
   buildReleaseContent,
@@ -97,6 +101,155 @@ export function workflowBundle() {
     .join('\n');
   assets['checksums.sha256'] = Buffer.from(`${checksums}\n`);
   return { requestPlan, releaseContent, finalPlan, assets };
+}
+
+export function disabledV2WorkflowBundle({
+  previousTag = 'v1.55.0',
+  nextTag = 'v1.55.1',
+  bump = 'patch',
+  targetSha = SHA.target,
+  timestamp = '2026-08-03T00:00:00Z',
+  retentionMode = 'disabled',
+  retentionOverride = null,
+  manifestChanges = {},
+  manifestTransform = (value: Record<string, unknown>) => value,
+  staticManifestHashOverride = null,
+} = {}) {
+  const version = nextTag.slice(1);
+  const [major, minor] = version.split('.');
+  const inventory = buildReleaseInventory({
+    compareUrl: `https://github.test/compare/${previousTag}...${targetSha}`,
+    pullRequests: [],
+    commits: [{ sha: targetSha, subject: `Ship ${nextTag}` }],
+    changedPaths: ['src/index.ts'],
+  });
+  const retention =
+    retentionOverride ??
+    ({
+      schema: 'bugdrop.retention-request/v1',
+      mode: retentionMode,
+      cutoverVersion: retentionMode === 'bootstrap' ? version : null,
+      expectedRetainedVersions: [],
+      releases: [],
+    } as const);
+  const requestPlan = buildRequestPlan({
+    dispatch: normalizeDispatch({
+      ...workflowContext(false).dispatch,
+      targetSha,
+      bump,
+    }),
+    previousTag,
+    nextTag,
+    generatedNotes: inventory.generatedNotes,
+    controllerSha: SHA.controller,
+    remoteMainSha: SHA.main,
+    inventory,
+    retentionBootstrap: retention.mode === 'bootstrap',
+    retention,
+    attestation: {
+      previousReleaseSha: 'd'.repeat(40),
+      candidateCommitTimestamp: timestamp,
+      candidateBehindMainBy: 0,
+      expectedAliases: ['widget.js', `widget.v${major}.js`, `widget.v${major}.${minor}.js`],
+      expectedAssetNames: [`widget.v${version}.js`, 'versions.json'],
+      verificationCommands: ['npm test'],
+    },
+  });
+  const widget = Buffer.from(`disabled v2 widget ${version}`);
+  const exactName = `widget.v${version}.js`;
+  const priorArtifacts = Object.fromEntries(
+    retention.releases.map(prior => [
+      `v${prior.version}`,
+      {
+        downloadUrl: prior.asset.downloadUrl,
+        filename: prior.asset.name,
+        sha256: prior.asset.sha256,
+        tag: prior.tag,
+        targetSha: prior.targetSha,
+        version: prior.version,
+      },
+    ])
+  );
+  const manifestRecord = manifestTransform({
+    artifacts: {
+      ...priorArtifacts,
+      [`v${version}`]: {
+        ...(retention.mode !== 'disabled'
+          ? {
+              downloadUrl: `https://github.com/mean-weasel/bugdrop/releases/download/${nextTag}/${exactName}`,
+              tag: nextTag,
+              version,
+            }
+          : {
+              archiveUrl: `https://github.com/mean-weasel/bugdrop/releases/download/${nextTag}/${exactName}`,
+              publishedAt: timestamp,
+            }),
+        filename: exactName,
+        sha256: sha256(widget),
+        targetSha,
+      },
+    },
+    authoritative: true,
+    current: version,
+    cutoverVersion: retention.cutoverVersion ?? version,
+    generatedAt: timestamp,
+    latest: 'widget.js',
+    mode: 'release',
+    repository: 'mean-weasel/bugdrop',
+    schema:
+      retention.mode !== 'disabled'
+        ? 'bugdrop.versions-manifest/v2'
+        : 'bugdrop.versions-manifest/v1',
+    versions: {
+      ...Object.fromEntries(
+        retention.releases.map(prior => [`v${prior.version}`, prior.asset.name])
+      ),
+      [`v${version}`]: exactName,
+      [`v${major}`]: `widget.v${major}.js`,
+      [`v${major}.${minor}`]: `widget.v${major}.${minor}.js`,
+    },
+    ...manifestChanges,
+  });
+  const manifest = Buffer.from(`${canonicalize(manifestRecord)}\n`);
+  const fileHashes = {
+    ...Object.fromEntries(retention.releases.map(prior => [prior.asset.name, prior.asset.sha256])),
+    [exactName]: sha256(widget),
+    'versions.json': staticManifestHashOverride ?? sha256(manifest),
+  };
+  const staticPayload = { schema: 'bugdrop.static-tree/v1', fileHashes };
+  const staticPackage = { ...staticPayload, contentIdentity: canonicalHash(staticPayload) };
+  const publicationAssetHashes = {
+    [exactName]: fileHashes[exactName],
+    'versions.json': sha256(manifest),
+  };
+  const releaseContent = buildReleaseContent({
+    requestPlan,
+    artifactHashes: publicationAssetHashes,
+    publicationAssetHashes,
+    staticPackage,
+    sourceDigests: { worker: 'e'.repeat(64), lockfile: 'f'.repeat(64) },
+    toolchain: { esbuild: '0.28.0', wrangler: '4.98.0' },
+    deploymentConfigDigest: '1'.repeat(64),
+    verification: { contract: 'release-verification/v1', result: 'passed' },
+  });
+  const finalPlan = buildFinalPlan({ requestPlan, releaseContent });
+  const assets: Record<string, Buffer> = {
+    [exactName]: widget,
+    'versions.json': manifest,
+    'request-plan.json': Buffer.from(`${canonicalize(requestPlan)}\n`),
+    'release-content.json': Buffer.from(`${canonicalize(releaseContent)}\n`),
+    'final-release-plan.json': Buffer.from(`${canonicalize(finalPlan)}\n`),
+  };
+  const checksums = Object.entries(assets)
+    .sort(([left], [right]) => compareUtf8(left, right))
+    .map(([name, bytes]) => `${sha256(bytes)}  ${name}`)
+    .join('\n');
+  assets['checksums.sha256'] = Buffer.from(`${checksums}\n`);
+  return { requestPlan, releaseContent, finalPlan, assets };
+}
+
+export function bootstrapV2WorkflowBundle(options = {}) {
+  return disabledV2WorkflowBundle({ ...options, retentionMode: 'bootstrap' });
 }
 
 export function artifactFor(bundle = workflowBundle()) {

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -65,7 +65,7 @@ top_level_events=$(awk '
 [[ "$top_level_events" == 'workflow_dispatch:' ]] ||
   fail "workflow_dispatch must be the only trigger; found: $top_level_events"
 
-for input in target_sha bump release_reason rationale operator_notes dry_run; do
+for input in target_sha bump release_reason rationale operator_notes dry_run retention_bootstrap; do
   require_literal "      $input:"
 done
 for literal in \
@@ -159,17 +159,19 @@ for literal in \
   'npm run build' \
   'node controller/scripts/build-widget.js' \
   '--mode release' \
-  '--rawfile widget "$RUNNER_TEMP/static-package/$exact_name"' \
-  '--rawfile versions "$RUNNER_TEMP/static-package/versions.json"' \
+  '--retention-plan request/retention-input/retention-plan.json' \
+  '--request-plan request/request-plan.json' \
+  '--result-path "$RUNNER_TEMP/builder-result.json"' \
+  'node controller/scripts/release/workflow.mjs bundle-static' \
   'requestPlan: $requestPlan[0]' \
-  'base64: ($widget | @base64)' \
-  'base64: ($versions | @base64)' \
-  'node controller/scripts/release/workflow.mjs bundle' \
+  'builderResultPath' \
+  'request/retention-input/retention-plan.json' \
+  'staticPackageDir' \
   'install -d "$RUNNER_TEMP/release-plan/static-package"' \
   'cp state2-bundle.json "$RUNNER_TEMP/release-plan/state2-bundle.json"' \
+  'cp "$RUNNER_TEMP/builder-result.json" "$RUNNER_TEMP/release-plan/builder-result.json"' \
   'cp -R "$RUNNER_TEMP/static-package/." "$RUNNER_TEMP/release-plan/static-package/"' \
   'path: ${{ runner.temp }}/release-plan/' \
-  'static-package/versions.json' \
   'retention-days: 14'; do
   grep -Fq -- "$literal" <<< "$verify_block" || fail "verify-candidate lacks: $literal"
 done
@@ -186,15 +188,14 @@ fi
 
 bundle_shape=$(jq -n \
   --argjson requestPlan '[{"schema":"proof"}]' \
-  --arg name 'widget.v1.2.3.js' \
-  --arg widget 'widget bytes' \
-  --arg versions 'manifest bytes' \
-  '{requestPlan: $requestPlan[0], candidateAssets: {($name): {base64: ($widget | @base64)}, "versions.json": {base64: ($versions | @base64)}}}')
+  --arg staticPackageDir '/tmp/static-package' \
+  --arg builderResultPath '/tmp/builder-result.json' \
+  '{requestPlan: $requestPlan[0], $staticPackageDir, $builderResultPath}')
 jq -e '
   .requestPlan.schema == "proof" and
-  (.candidateAssets["widget.v1.2.3.js"].base64 | @base64d) == "widget bytes" and
-  (.candidateAssets["versions.json"].base64 | @base64d) == "manifest bytes"
-' <<< "$bundle_shape" >/dev/null || fail 'bundle-input jq shape is not executable or byte-safe'
+  .staticPackageDir == "/tmp/static-package" and
+  .builderResultPath == "/tmp/builder-result.json"
+' <<< "$bundle_shape" >/dev/null || fail 'bundle-input jq shape is not executable or path-safe'
 if grep -Eq 'secrets\.|environment:' <<< "$verify_block"; then
   fail 'candidate verification must not reference secrets or an environment'
 fi
@@ -241,6 +242,10 @@ for literal in \
   'node controller/scripts/release/live-release.mjs baseline'; do
   grep -Fq -- "$literal" <<< "$approval_block" || fail "approval-baseline lacks: $literal"
 done
+[[ $(grep -Fc 'RETENTION_BOOTSTRAP: ${{ inputs.retention_bootstrap }}' "$workflow") -eq 2 ]] ||
+  fail 'bootstrap authority must be identical during planning and protected revalidation'
+grep -Fq 'RETENTION_BOOTSTRAP: ${{ inputs.retention_bootstrap }}' <<< "$approval_block" ||
+  fail 'protected revalidation omits bootstrap authority'
 for secret in CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN; do
   grep -Fq "secrets.$secret" <<< "$approval_block" || fail "baseline lacks named $secret"
 done
@@ -317,5 +322,19 @@ wrangler_deploy_matches=$(grep -RInF --include='*.yml' --include='*.yaml' -- 'wr
   fail "only preview CI may deploy before WP7: $wrangler_deploy_matches"
 [[ "$wrangler_deploy_matches" == *'.github/workflows/ci.yml:'*'wrangler deploy --env preview'* ]] ||
   fail "remaining Wrangler deploy is not preview-only: $wrangler_deploy_matches"
+
+(
+  cd "$repo_root"
+  npx vitest run test/release/retention-integration.test.ts \
+    -t 'authenticates published v2 N through createGithubTransport, handoff, CLI, and real State 2' \
+    >/dev/null
+) || fail 'installed builder-result to bundle-static boundary did not execute successfully'
+
+(
+  cd "$repo_root"
+  npx vitest run test/release/github-adapter.test.ts \
+    -t 'reproduces protected bootstrap history revalidation exactly' \
+    >/dev/null
+) || fail 'protected bootstrap/history revalidation did not execute successfully'
 
 echo 'Guarded manual release workflow contract checks passed'

--- a/test/release/github-adapter.test.ts
+++ b/test/release/github-adapter.test.ts
@@ -1,6 +1,8 @@
+import { createHash } from 'node:crypto';
+
 import { describe, expect, it, vi } from 'vitest';
 
-import { canonicalize } from '../../scripts/release/canonical-json.mjs';
+import { canonicalHash, canonicalize, compareUtf8 } from '../../scripts/release/canonical-json.mjs';
 import {
   authenticatePublishedAssets,
   createGithubTransport,
@@ -16,7 +18,12 @@ import {
   findCompletedPlan,
   normalizeDispatch,
 } from '../../scripts/release/plan.mjs';
-import { workflowBundle, workflowContext } from '../fixtures/release/workflow/bundle';
+import {
+  bootstrapV2WorkflowBundle,
+  disabledV2WorkflowBundle,
+  workflowBundle,
+  workflowContext,
+} from '../fixtures/release/workflow/bundle';
 
 const SHA = {
   target: 'a'.repeat(40),
@@ -68,6 +75,237 @@ function observationEntries() {
       hasNext: false,
     },
   };
+}
+
+function publishedBundleRecord(bundle: ReturnType<typeof disabledV2WorkflowBundle>, index: number) {
+  const marker = buildPublicationMarker(bundle.finalPlan);
+  const authorityIndex = Number.parseInt(bundle.finalPlan.targetSha[0], 16) || index;
+  return {
+    release: {
+      id: 100 + authorityIndex,
+      tag_name: bundle.finalPlan.tag,
+      draft: false,
+      prerelease: false,
+      published_at: bundle.requestPlan.attestation.candidateCommitTimestamp,
+      html_url: `https://github.test/releases/${bundle.finalPlan.tag}`,
+      body: `<!-- bugdrop-publication ${Buffer.from(canonicalize(marker)).toString('base64url')} -->`,
+      assets: Object.keys(bundle.assets).map((name, assetIndex) => ({
+        id: authorityIndex * 100 + assetIndex + 1,
+        name,
+        url: `https://api.github.test/repos/${REPOSITORY}/releases/assets/${authorityIndex * 100 + assetIndex + 1}`,
+        browser_download_url: `https://github.com/${REPOSITORY}/releases/download/${bundle.finalPlan.tag}/${name}`,
+        size: bundle.assets[name].length,
+      })),
+    },
+    ref: {
+      ref: `refs/tags/${bundle.finalPlan.tag}`,
+      object: { type: 'commit', sha: bundle.finalPlan.targetSha },
+    },
+    bundle,
+  };
+}
+
+async function planFromPublishedBundles({
+  bundles,
+  candidateSha = '9'.repeat(40),
+  retentionBootstrap = false,
+  legacy = [],
+  reverseAssets = false,
+  downloadDelay = 0,
+}: {
+  bundles: ReturnType<typeof disabledV2WorkflowBundle>[];
+  candidateSha?: string;
+  retentionBootstrap?: boolean;
+  legacy?: Array<{ tag: string; targetSha: string }>;
+  reverseAssets?: boolean;
+  downloadDelay?: number;
+}) {
+  const records = bundles.map((bundle, index) => publishedBundleRecord(bundle, index + 1));
+  if (reverseAssets) records.forEach(record => record.release.assets.reverse());
+  const assetBytes = new Map<string, Buffer>();
+  for (const record of records) {
+    for (const asset of record.release.assets) {
+      assetBytes.set(String(asset.id), record.bundle.assets[asset.name]);
+    }
+  }
+  const releases = [
+    ...records.map(record => record.release),
+    ...legacy.map((item, index) => ({
+      id: 900 + index,
+      tag_name: item.tag,
+      draft: false,
+      prerelease: false,
+      published_at: `2026-08-${String(20 + index).padStart(2, '0')}T00:00:00Z`,
+      html_url: `https://github.test/releases/${item.tag}`,
+      body: '',
+      assets: [],
+    })),
+  ];
+  const refs = [
+    ...records.map(record => record.ref),
+    ...legacy.map(item => ({
+      ref: `refs/tags/${item.tag}`,
+      object: { type: 'commit', sha: item.targetSha },
+    })),
+  ];
+  const transport = transportFor({
+    [`/repos/${REPOSITORY}/releases?per_page=100&page=1`]: { data: releases, hasNext: false },
+    [`/repos/${REPOSITORY}/git/matching-refs/tags/v?per_page=100&page=1`]: {
+      data: refs,
+      hasNext: false,
+    },
+    ...Object.fromEntries(
+      [
+        ...records.map(record => record.bundle.finalPlan.targetSha),
+        ...legacy.map(x => x.targetSha),
+      ].map(sha => [
+        `/repos/${REPOSITORY}/compare/${sha}...${candidateSha}`,
+        { data: { status: 'ahead' }, hasNext: false },
+      ])
+    ),
+    [`/repos/${REPOSITORY}/commits/main`]: { data: { sha: candidateSha }, hasNext: false },
+    [`/repos/${REPOSITORY}/actions/runs?head_sha=${candidateSha}&event=merge_group&per_page=100&page=1`]:
+      {
+        data: {
+          workflow_runs: [
+            {
+              head_sha: candidateSha,
+              event: 'merge_group',
+              status: 'completed',
+              conclusion: 'success',
+            },
+          ],
+        },
+        hasNext: false,
+      },
+    [`/repos/${REPOSITORY}/commits/${candidateSha}/pulls?per_page=100&page=1`]: {
+      data: [],
+      hasNext: false,
+    },
+  });
+  Object.assign(transport, {
+    requestBytes: vi.fn(async (_url: string, options: { assetId: string }) => {
+      if (downloadDelay) await new Promise(resolve => setTimeout(resolve, downloadDelay));
+      const bytes = assetBytes.get(options.assetId);
+      if (!bytes) throw new Error(`missing asset ${options.assetId}`);
+      return bytes;
+    }),
+  });
+  return createRequestPlanFromGithub({
+    transport,
+    context: {
+      repositoryDir: '/controller',
+      retentionBootstrap,
+      dispatch: {
+        ...workflowContext(false).dispatch,
+        targetSha: candidateSha,
+        bump: 'patch',
+      },
+    },
+    gitObserver: () => ({
+      commits: [{ sha: candidateSha, subject: 'candidate' }],
+      changedPaths: ['src/index.ts'],
+      excludedNewerMainCommits: [],
+      candidateCommitTimestamp: '2026-08-30T00:00:00Z',
+      candidateBehindMainBy: 0,
+      facts: {
+        candidateRef: 'refs/heads/main',
+        targetExists: true,
+        targetReachableFromMain: true,
+        controllerReachableFromMain: true,
+        previousReleaseAncestor: true,
+        targetStrictlyLater: true,
+      },
+    }),
+  });
+}
+
+function activeHistoryBundles({
+  continuationManifestTransform = (value: Record<string, unknown>) => value,
+  continuationStaticManifestHash = null,
+  continuationRetentionTransform = (value: Record<string, unknown>) => value,
+} = {}) {
+  const bootstrap = bootstrapV2WorkflowBundle({
+    previousTag: 'v1.54.0',
+    nextTag: 'v1.55.0',
+    bump: 'minor',
+    targetSha: '1'.repeat(40),
+    timestamp: '2026-08-10T00:00:00Z',
+  });
+  const bootstrapAsset = bootstrap.assets['widget.v1.55.0.js'];
+  const retention = continuationRetentionTransform({
+    schema: 'bugdrop.retention-request/v1',
+    mode: 'continue',
+    cutoverVersion: '1.55.0',
+    expectedRetainedVersions: ['1.55.0'],
+    releases: [
+      {
+        version: '1.55.0',
+        tag: 'v1.55.0',
+        releaseId: '101',
+        targetSha: '1'.repeat(40),
+        publishedAt: '2026-08-10T00:00:00Z',
+        sourcePlanIdentity: bootstrap.finalPlan.planIdentity,
+        sourceContentIdentity: bootstrap.releaseContent.contentIdentity,
+        asset: {
+          assetId: '101',
+          name: 'widget.v1.55.0.js',
+          apiPath: `/repos/${REPOSITORY}/releases/assets/101`,
+          downloadUrl:
+            'https://github.com/mean-weasel/bugdrop/releases/download/v1.55.0/widget.v1.55.0.js',
+          sha256: createHash('sha256').update(bootstrapAsset).digest('hex'),
+        },
+      },
+    ],
+  });
+  const continuation = disabledV2WorkflowBundle({
+    previousTag: 'v1.55.0',
+    nextTag: 'v1.56.0',
+    bump: 'minor',
+    targetSha: '2'.repeat(40),
+    timestamp: '2026-08-11T00:00:00Z',
+    retentionMode: 'continue',
+    retentionOverride: retention,
+    manifestTransform: continuationManifestTransform,
+    staticManifestHashOverride: continuationStaticManifestHash,
+  });
+  return [bootstrap, continuation];
+}
+
+function rebindPublishedBundle(bundle: ReturnType<typeof disabledV2WorkflowBundle>) {
+  bundle.requestPlan.requestIdentity = canonicalHash({
+    schema: bundle.requestPlan.schema,
+    protocol: bundle.requestPlan.protocol,
+    request: bundle.requestPlan.request,
+    source: bundle.requestPlan.source,
+    attestation: bundle.requestPlan.attestation,
+    inventory: bundle.requestPlan.inventory,
+    retention: bundle.requestPlan.retention,
+  });
+  bundle.releaseContent.requestIdentity = bundle.requestPlan.requestIdentity;
+  const contentPayload = { ...bundle.releaseContent };
+  delete contentPayload.contentIdentity;
+  bundle.releaseContent.contentIdentity = canonicalHash(contentPayload);
+  Object.assign(bundle.finalPlan, {
+    requestIdentity: bundle.requestPlan.requestIdentity,
+    contentIdentity: bundle.releaseContent.contentIdentity,
+    requestPlanHash: canonicalHash(bundle.requestPlan),
+  });
+  const finalPayload = { ...bundle.finalPlan };
+  delete finalPayload.planIdentity;
+  bundle.finalPlan.planIdentity = canonicalHash(finalPayload);
+  Object.assign(bundle.assets, {
+    'request-plan.json': Buffer.from(`${canonicalize(bundle.requestPlan)}\n`),
+    'release-content.json': Buffer.from(`${canonicalize(bundle.releaseContent)}\n`),
+    'final-release-plan.json': Buffer.from(`${canonicalize(bundle.finalPlan)}\n`),
+  });
+  const checksums = Object.entries(bundle.assets)
+    .filter(([name]) => name !== 'checksums.sha256')
+    .sort(([left], [right]) => compareUtf8(left, right))
+    .map(([name, bytes]) => `${createHash('sha256').update(bytes).digest('hex')}  ${name}`)
+    .join('\n');
+  bundle.assets['checksums.sha256'] = Buffer.from(`${checksums}\n`);
+  return bundle;
 }
 
 describe('GitHub release-state observation', () => {
@@ -270,13 +508,16 @@ describe('GitHub release-state observation', () => {
       draft: false,
       prerelease: false,
       marker: buildPublicationMarker(bundle.finalPlan),
-      assets: Object.keys(bundle.assets).map(name => ({
+      repository: REPOSITORY,
+      assets: Object.keys(bundle.assets).map((name, index) => ({
+        id: String(index + 1),
         name,
-        apiUrl: `https://api.github.test/assets/${name}`,
+        apiUrl: `https://api.github.test/repos/${REPOSITORY}/releases/assets/${index + 1}`,
+        size: bundle.assets[name].length,
       })),
     };
-    const requestBytes = vi.fn(async (url: string) => {
-      const name = url.split('/').at(-1) as keyof typeof bundle.assets;
+    const requestBytes = vi.fn(async (_url: string, options: { assetId: string }) => {
+      const name = Object.keys(bundle.assets)[Number(options.assetId) - 1];
       return bundle.assets[name];
     });
     await expect(
@@ -288,14 +529,51 @@ describe('GitHub release-state observation', () => {
     expect(requestBytes).toHaveBeenCalledTimes(bundle.finalPlan.requiredAssets.length);
   });
 
+  it('authenticates retention mode before charging an exact asset to cumulative history', async () => {
+    const bundle = disabledV2WorkflowBundle();
+    const exactName = `widget.${bundle.finalPlan.tag}.js`;
+    const names = Object.keys(bundle.assets);
+    const release = {
+      tag: bundle.finalPlan.tag,
+      targetSha: bundle.finalPlan.targetSha,
+      resolvedTagSha: bundle.finalPlan.targetSha,
+      published: true,
+      draft: false,
+      prerelease: false,
+      marker: buildPublicationMarker(bundle.finalPlan),
+      repository: REPOSITORY,
+      assets: names.map((name, index) => ({
+        id: String(index + 1),
+        name,
+        apiUrl: `https://api.github.test/repos/${REPOSITORY}/releases/assets/${index + 1}`,
+        downloadUrl: `https://github.com/${REPOSITORY}/releases/download/${bundle.finalPlan.tag}/${name}`,
+        size: bundle.assets[name].length,
+      })),
+    };
+    const requestBytes = vi.fn(async (_url: string, options: { assetId: string }) => {
+      return bundle.assets[names[Number(options.assetId) - 1]];
+    });
+
+    await expect(
+      loadPublishedReleaseAssets({
+        transport: { requestBytes },
+        release,
+        retainedBudget: { used: 512 * 1024 * 1024 - 1, assetName: exactName },
+      })
+    ).resolves.toMatchObject({ requestPlan: { retention: { mode: 'disabled' } } });
+  });
+
   it('returns an authenticated completed no-op before local Git planning', async () => {
     const bundle = workflowBundle();
     const marker = buildPublicationMarker(bundle.finalPlan);
     const encodedMarker = Buffer.from(canonicalize(marker)).toString('base64url');
     const tagObjectSha = '9'.repeat(40);
-    const releaseAssets = Object.keys(bundle.assets).map(name => ({
+    const releaseAssets = Object.keys(bundle.assets).map((name, index) => ({
+      id: index + 1,
       name,
-      url: `https://api.github.test/assets/${name}`,
+      url: `https://api.github.test/repos/${REPOSITORY}/releases/assets/${index + 1}`,
+      size: bundle.assets[name].length,
+      browser_download_url: `https://github.com/${REPOSITORY}/releases/download/${bundle.finalPlan.tag}/${name}`,
     }));
     const transport = transportFor({
       [`/repos/${REPOSITORY}/releases?per_page=100&page=1`]: {
@@ -336,8 +614,8 @@ describe('GitHub release-state observation', () => {
         },
     });
     Object.assign(transport, {
-      requestBytes: vi.fn(async (url: string) => {
-        const name = url.split('/').at(-1) as keyof typeof bundle.assets;
+      requestBytes: vi.fn(async (_url: string, options: { assetId: string }) => {
+        const name = Object.keys(bundle.assets)[Number(options.assetId) - 1];
         return bundle.assets[name];
       }),
     });
@@ -450,6 +728,397 @@ describe('GitHub release-state observation', () => {
   });
 });
 
+describe('authenticated disabled v2 frontier history', () => {
+  const first = () =>
+    disabledV2WorkflowBundle({
+      previousTag: 'v1.54.0',
+      nextTag: 'v1.55.0',
+      bump: 'minor',
+      targetSha: '1'.repeat(40),
+      timestamp: '2026-08-10T00:00:00Z',
+    });
+  const second = () =>
+    disabledV2WorkflowBundle({
+      previousTag: 'v1.55.0',
+      nextTag: 'v1.55.1',
+      targetSha: '2'.repeat(40),
+      timestamp: '2026-08-11T00:00:00Z',
+    });
+
+  it('authenticates consecutive disabled publications without activating retention', async () => {
+    await expect(planFromPublishedBundles({ bundles: [first(), second()] })).resolves.toMatchObject(
+      {
+        request: { previousTag: 'v1.55.1', nextTag: 'v1.55.2', retentionBootstrap: false },
+        retention: {
+          mode: 'disabled',
+          cutoverVersion: null,
+          expectedRetainedVersions: [],
+          releases: [],
+        },
+      }
+    );
+  });
+
+  it('allows an explicit bootstrap after authenticated disabled history', async () => {
+    await expect(
+      planFromPublishedBundles({ bundles: [first(), second()], retentionBootstrap: true })
+    ).resolves.toMatchObject({
+      retention: {
+        mode: 'bootstrap',
+        cutoverVersion: '1.55.2',
+        expectedRetainedVersions: [],
+      },
+    });
+  });
+
+  it('reproduces protected bootstrap history revalidation exactly', async () => {
+    const bundles = [first(), second()];
+    const planned = await planFromPublishedBundles({ bundles, retentionBootstrap: true });
+    const revalidated = await planFromPublishedBundles({
+      bundles: [...bundles].reverse(),
+      retentionBootstrap: true,
+    });
+    expect(revalidated).toEqual(planned);
+    expect(revalidated.request.retentionBootstrap).toBe(true);
+    expect(revalidated.retention).toMatchObject({
+      mode: 'bootstrap',
+      cutoverVersion: '1.55.2',
+    });
+  });
+
+  it.each([
+    ['disabled', () => second(), []],
+    ['legacy', () => null, [{ tag: 'v1.55.1', targetSha: '2'.repeat(40) }]],
+  ])(
+    'rejects %s history at or above an authenticated active boundary',
+    async (_kind, later, legacy) => {
+      const active = bootstrapV2WorkflowBundle({
+        previousTag: 'v1.54.0',
+        nextTag: 'v1.55.0',
+        bump: 'minor',
+        targetSha: '1'.repeat(40),
+        timestamp: '2026-08-10T00:00:00Z',
+      });
+      const laterBundle = later();
+      await expect(
+        planFromPublishedBundles({
+          bundles: laterBundle ? [active, laterBundle] : [active],
+          legacy,
+        })
+      ).rejects.toThrow(/RETENTION_HISTORY_INCOMPLETE/);
+    }
+  );
+
+  it('is invariant to GitHub order and locale collation', async () => {
+    const bundles = [first(), second()];
+    const baseline = await planFromPublishedBundles({ bundles });
+    const locale = vi.spyOn(String.prototype, 'localeCompare').mockImplementation(function (
+      other: string
+    ) {
+      return String(other) < String(this) ? -1 : String(other) > String(this) ? 1 : 0;
+    });
+    try {
+      const permuted = await planFromPublishedBundles({ bundles: [...bundles].reverse() });
+      expect(permuted.requestIdentity).toBe(baseline.requestIdentity);
+      expect(permuted.retention).toEqual(baseline.retention);
+    } finally {
+      locale.mockRestore();
+    }
+  });
+
+  it('rejects missing, duplicate, and inconsistent disabled publication history', async () => {
+    const missing = first();
+    delete missing.assets['versions.json'];
+    await expect(planFromPublishedBundles({ bundles: [missing] })).rejects.toThrow(
+      /PUBLISHED_ASSET/
+    );
+
+    const duplicate = first();
+    await expect(planFromPublishedBundles({ bundles: [duplicate, duplicate] })).rejects.toThrow(
+      /AMBIGUOUS_RELEASE/
+    );
+
+    const inconsistent = disabledV2WorkflowBundle({
+      previousTag: 'v1.54.0',
+      nextTag: 'v1.55.0',
+      bump: 'minor',
+      targetSha: '1'.repeat(40),
+      timestamp: '2026-08-10T00:00:00Z',
+      manifestChanges: { cutoverVersion: '1.54.0' },
+    });
+    await expect(planFromPublishedBundles({ bundles: [inconsistent] })).rejects.toThrow(
+      /disabled manifest is inconsistent/
+    );
+  });
+});
+
+describe('complete active v2 manifest authority', () => {
+  function transformed(
+    mutate: (manifest: Record<string, unknown>) => void
+  ): ReturnType<typeof disabledV2WorkflowBundle>[] {
+    return activeHistoryBundles({
+      continuationManifestTransform: value => {
+        const changed = structuredClone(value);
+        mutate(changed);
+        return changed;
+      },
+    });
+  }
+
+  it.each([
+    [
+      'tag',
+      (artifact: Record<string, unknown>) => {
+        artifact.tag = 'v9.9.9';
+      },
+    ],
+    [
+      'target',
+      (artifact: Record<string, unknown>) => {
+        artifact.targetSha = '8'.repeat(40);
+      },
+    ],
+  ])(
+    'rejects an identity-consistent bootstrap manifest with false current %s',
+    async (_field, mutate) => {
+      const bootstrap = bootstrapV2WorkflowBundle({
+        previousTag: 'v1.54.0',
+        nextTag: 'v1.55.0',
+        bump: 'minor',
+        targetSha: '1'.repeat(40),
+        timestamp: '2026-08-10T00:00:00Z',
+        manifestTransform: (value: Record<string, unknown>) => {
+          const changed = structuredClone(value);
+          const artifacts = changed.artifacts as Record<string, Record<string, unknown>>;
+          mutate(artifacts['v1.55.0']);
+          return changed;
+        },
+      });
+      await expect(planFromPublishedBundles({ bundles: [bootstrap] })).rejects.toThrow(
+        /active manifest is inconsistent/
+      );
+    }
+  );
+
+  it('authenticates a compact bootstrap and continuation projection', async () => {
+    await expect(
+      planFromPublishedBundles({ bundles: activeHistoryBundles() })
+    ).resolves.toMatchObject({
+      request: { previousTag: 'v1.56.0', nextTag: 'v1.56.1' },
+      retention: {
+        mode: 'continue',
+        cutoverVersion: '1.55.0',
+        expectedRetainedVersions: ['1.55.0', '1.56.0'],
+      },
+    });
+  });
+
+  it.each([
+    [
+      'current tag',
+      (manifest: Record<string, unknown>) => {
+        const artifacts = manifest.artifacts as Record<string, Record<string, unknown>>;
+        artifacts['v1.56.0'].tag = 'v9.9.9';
+      },
+    ],
+    [
+      'current target',
+      (manifest: Record<string, unknown>) => {
+        const artifacts = manifest.artifacts as Record<string, Record<string, unknown>>;
+        artifacts['v1.56.0'].targetSha = '8'.repeat(40);
+      },
+    ],
+    [
+      'current download URL',
+      (manifest: Record<string, unknown>) => {
+        const artifacts = manifest.artifacts as Record<string, Record<string, unknown>>;
+        artifacts['v1.56.0'].downloadUrl =
+          'https://github.com/mean-weasel/bugdrop/releases/download/v9.9.9/widget.v1.56.0.js';
+      },
+    ],
+    [
+      'repository root',
+      (manifest: Record<string, unknown>) => (manifest.repository = 'other/repo'),
+    ],
+    [
+      'generated timestamp',
+      (manifest: Record<string, unknown>) => (manifest.generatedAt = '2026-08-12T00:00:00Z'),
+    ],
+    ['latest root', (manifest: Record<string, unknown>) => (manifest.latest = 'widget.v1.js')],
+    [
+      'versions map',
+      (manifest: Record<string, unknown>) => (manifest.versions = { v1: 'wrong.js' }),
+    ],
+    ['extra root', (manifest: Record<string, unknown>) => (manifest.unapproved = true)],
+    [
+      'missing root',
+      (manifest: Record<string, unknown>) => {
+        delete manifest.latest;
+      },
+    ],
+    [
+      'extra current field',
+      (manifest: Record<string, unknown>) => {
+        const artifacts = manifest.artifacts as Record<string, Record<string, unknown>>;
+        artifacts['v1.56.0'].unapproved = true;
+      },
+    ],
+    [
+      'missing retained field',
+      (manifest: Record<string, unknown>) => {
+        const artifacts = manifest.artifacts as Record<string, Record<string, unknown>>;
+        delete artifacts['v1.55.0'].tag;
+      },
+    ],
+  ])('rejects an identity-consistent active manifest with wrong %s', async (_field, mutate) => {
+    await expect(planFromPublishedBundles({ bundles: transformed(mutate) })).rejects.toThrow(
+      /active manifest is inconsistent/
+    );
+  });
+
+  it('rejects identity-consistent disagreement between attached and static-tree manifest hashes', async () => {
+    await expect(
+      planFromPublishedBundles({
+        bundles: activeHistoryBundles({ continuationStaticManifestHash: '7'.repeat(64) }),
+      })
+    ).rejects.toThrow(/active manifest is inconsistent/);
+  });
+
+  it('is invariant to Release, asset, and download timing permutations', async () => {
+    const bundles = activeHistoryBundles();
+    const baseline = await planFromPublishedBundles({ bundles });
+    const permuted = await planFromPublishedBundles({
+      bundles: [...bundles].reverse(),
+      reverseAssets: true,
+      downloadDelay: 1,
+    });
+    expect(permuted.requestIdentity).toBe(baseline.requestIdentity);
+    expect(permuted.retention).toEqual(baseline.retention);
+  });
+});
+
+describe('independent cumulative retention authority', () => {
+  type RetentionRecord = Record<string, unknown> & { asset: Record<string, unknown> };
+
+  function selfConsistentLie(
+    mutate: (record: RetentionRecord, retention: Record<string, unknown>) => void
+  ) {
+    return activeHistoryBundles({
+      continuationRetentionTransform: value => {
+        const changed = structuredClone(value);
+        const records = changed.releases as RetentionRecord[];
+        mutate(records[0], changed);
+        return changed;
+      },
+    });
+  }
+
+  it.each([
+    ['targetSha', (record: RetentionRecord) => (record.targetSha = '8'.repeat(40))],
+    [
+      'downloadUrl',
+      (record: RetentionRecord) =>
+        (record.asset.downloadUrl =
+          'https://github.com/mean-weasel/bugdrop/releases/download/v9.9.9/widget.v1.55.0.js'),
+    ],
+    ['releaseId', (record: RetentionRecord) => (record.releaseId = '999')],
+    [
+      'assetId',
+      (record: RetentionRecord) => {
+        record.asset.assetId = '999';
+        record.asset.apiPath = `/repos/${REPOSITORY}/releases/assets/999`;
+      },
+    ],
+    [
+      'apiPath',
+      (record: RetentionRecord) =>
+        (record.asset.apiPath = '/repos/other/repository/releases/assets/101'),
+    ],
+    ['publishedAt', (record: RetentionRecord) => (record.publishedAt = '2026-08-09T00:00:00Z')],
+    [
+      'sourcePlanIdentity',
+      (record: RetentionRecord) => (record.sourcePlanIdentity = `sha256:${'8'.repeat(64)}`),
+    ],
+    [
+      'sourceContentIdentity',
+      (record: RetentionRecord) => (record.sourceContentIdentity = `sha256:${'8'.repeat(64)}`),
+    ],
+    ['digest', (record: RetentionRecord) => (record.asset.sha256 = '8'.repeat(64))],
+    [
+      'version/tag/filename',
+      (record: RetentionRecord, retention: Record<string, unknown>) => {
+        record.version = '1.55.1';
+        record.tag = 'v1.55.1';
+        record.asset.name = 'widget.v1.55.1.js';
+        retention.expectedRetainedVersions = ['1.55.1'];
+      },
+    ],
+  ])('rejects a self-consistent later declaration with false prior %s', async (_field, mutate) => {
+    await expect(planFromPublishedBundles({ bundles: selfConsistentLie(mutate) })).rejects.toThrow(
+      /cumulative retention differs from authenticated preceding Releases/
+    );
+  });
+
+  it.each([
+    [
+      'tag',
+      (record: RetentionRecord) => {
+        record.tag = 'v9.9.9';
+      },
+    ],
+    [
+      'filename',
+      (record: RetentionRecord) => {
+        record.asset.name = 'widget.v9.9.9.js';
+      },
+    ],
+    [
+      'extra field',
+      (record: RetentionRecord) => {
+        record.unapproved = true;
+      },
+    ],
+    [
+      'missing field',
+      (record: RetentionRecord) => {
+        delete record.sourcePlanIdentity;
+      },
+    ],
+    [
+      'extra record/order',
+      (_record: RetentionRecord, records: RetentionRecord[]) => {
+        records.unshift(structuredClone(records[0]));
+      },
+    ],
+  ])('rejects identity-bound malformed cumulative %s before authority', async (_field, mutate) => {
+    const bundles = activeHistoryBundles();
+    const continuation = bundles[1];
+    const records = continuation.requestPlan.retention.releases as RetentionRecord[];
+    mutate(records[0], records);
+    rebindPublishedBundle(continuation);
+    await expect(planFromPublishedBundles({ bundles })).rejects.toThrow(
+      /cumulative retention differs from authenticated preceding Releases/
+    );
+  });
+
+  it('preserves the exact independently authenticated prefix on correct history', async () => {
+    const plan = await planFromPublishedBundles({ bundles: activeHistoryBundles() });
+    expect(plan.retention.releases).toHaveLength(2);
+    expect(plan.retention.releases[0]).toMatchObject({
+      version: '1.55.0',
+      releaseId: '101',
+      targetSha: '1'.repeat(40),
+      asset: { assetId: '101', name: 'widget.v1.55.0.js' },
+    });
+    expect(plan.retention.releases[1]).toMatchObject({
+      version: '1.56.0',
+      releaseId: '102',
+      targetSha: '2'.repeat(40),
+      asset: { assetId: '201', name: 'widget.v1.56.0.js' },
+    });
+  });
+});
+
 describe('authenticated transport', () => {
   it('keeps tokens out of errors while requiring complete JSON responses', async () => {
     const token = 'top-secret-token';
@@ -474,7 +1143,7 @@ describe('authenticated transport', () => {
       if (calls.length === 1) {
         return new Response(null, {
           status: 302,
-          headers: { location: 'https://objects.example.test/release-asset' },
+          headers: { location: 'https://objects.githubusercontent.com/release-asset' },
         });
       }
       return new Response('asset bytes', { status: 200 });
@@ -485,5 +1154,62 @@ describe('authenticated transport', () => {
     );
     expect(calls[0][1]?.headers).toMatchObject({ authorization: 'Bearer repository-token' });
     expect(calls[1][1]?.headers).not.toHaveProperty('authorization');
+  });
+
+  it('rejects repository substitution and truncated streamed assets', async () => {
+    const transport = createGithubTransport({
+      token: 'repository-token',
+      fetchImpl: async () => new Response('short', { status: 200 }),
+    });
+    await expect(
+      transport.requestBytes('/repos/owner/other/releases/assets/1', {
+        repository: 'owner/repo',
+        assetId: '1',
+        expectedSize: 5,
+      })
+    ).rejects.toThrow(/outside the selected repository/);
+    await expect(
+      transport.requestBytes('/repos/owner/repo/releases/assets/1', {
+        repository: 'owner/repo',
+        assetId: '1',
+        expectedSize: 6,
+      })
+    ).rejects.toThrow(/truncated|Content-Length/);
+  });
+
+  it('keeps the abort timeout active until the redirected response stream completes', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn(async (_url: URL | RequestInfo, options?: RequestInit) => {
+        if (fetchImpl.mock.calls.length === 1) {
+          return new Response(null, {
+            status: 302,
+            headers: { location: 'https://objects.githubusercontent.com/slow-asset' },
+          });
+        }
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              options?.signal?.addEventListener('abort', () =>
+                controller.error(new Error('aborted'))
+              );
+            },
+          }),
+          { status: 200 }
+        );
+      });
+      const transport = createGithubTransport({ token: 'repository-token', fetchImpl });
+      const pending = transport.requestBytes('/repos/owner/repo/releases/assets/1', {
+        repository: 'owner/repo',
+        assetId: '1',
+        expectedSize: 1,
+      });
+      const assertion = expect(pending).rejects.toThrow(/timed out/);
+      await vi.advanceTimersByTimeAsync(30_001);
+      await assertion;
+      expect(fetchImpl.mock.calls[1][1]?.headers).not.toHaveProperty('authorization');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/test/release/github-publication-adapter.test.ts
+++ b/test/release/github-publication-adapter.test.ts
@@ -45,16 +45,23 @@ describe('GitHub publication inspection', () => {
           draft: false,
           prerelease: false,
           published_at: '2026-08-03T12:00:00Z',
-          assets: [{ name: 'widget.v1.2.3.js', url: `${API}/assets/7` }],
+          assets: [
+            {
+              id: 7,
+              name: 'widget.v1.2.3.js',
+              url: `${API}/repos/mean-weasel/bugdrop/releases/assets/7`,
+              size: Buffer.byteLength('widget-bytes'),
+            },
+          ],
         });
       }
-      if (url.pathname === '/assets/7') {
+      if (url.pathname === '/repos/mean-weasel/bugdrop/releases/assets/7') {
         return new Response(null, {
           status: 302,
-          headers: { location: 'https://objects.example.test/widget' },
+          headers: { location: 'https://objects.githubusercontent.com/widget' },
         });
       }
-      if (url.origin === 'https://objects.example.test') {
+      if (url.origin === 'https://objects.githubusercontent.com') {
         return new Response(Buffer.from('widget-bytes'));
       }
       throw new Error(`unexpected ${url.pathname}`);

--- a/test/release/plan.test.ts
+++ b/test/release/plan.test.ts
@@ -23,6 +23,7 @@ import {
   selectStoredController,
   validateSourceContext,
 } from '../../scripts/release/plan.mjs';
+import { disabledV2WorkflowBundle } from '../fixtures/release/workflow/bundle';
 
 const SHA = {
   target: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -352,6 +353,65 @@ describe('deterministic identities and completed-plan lookup', () => {
     );
   });
 
+  it('binds every v2 retention authority field while still excluding dryRun', () => {
+    const make = (assetId: string, sha256: string, dryRun: boolean) => {
+      const inventory = buildReleaseInventory({
+        compareUrl: 'https://github.test/compare/v1.2.0...target',
+        pullRequests: [],
+        commits: [{ sha: SHA.target, subject: 'retain' }],
+        changedPaths: ['src/widget.ts'],
+      });
+      const retention = {
+        schema: 'bugdrop.retention-request/v1',
+        mode: 'continue',
+        cutoverVersion: '1.2.0',
+        expectedRetainedVersions: ['1.2.0'],
+        releases: [
+          {
+            version: '1.2.0',
+            tag: 'v1.2.0',
+            releaseId: '12',
+            targetSha: '1'.repeat(40),
+            publishedAt: '2026-07-01T00:00:00Z',
+            sourcePlanIdentity: `sha256:${'2'.repeat(64)}`,
+            sourceContentIdentity: `sha256:${'3'.repeat(64)}`,
+            asset: {
+              assetId,
+              name: 'widget.v1.2.0.js',
+              apiPath: `/repos/mean-weasel/bugdrop/releases/assets/${assetId}`,
+              downloadUrl:
+                'https://github.com/mean-weasel/bugdrop/releases/download/v1.2.0/widget.v1.2.0.js',
+              sha256,
+            },
+          },
+        ],
+      };
+      return buildRequestPlan({
+        dispatch: normalizeDispatch({ ...rawDispatch, dryRun }),
+        previousTag: 'v1.2.0',
+        nextTag: 'v1.2.1',
+        generatedNotes: inventory.generatedNotes,
+        controllerSha: SHA.controller,
+        remoteMainSha: SHA.main,
+        inventory,
+        retentionBootstrap: false,
+        retention,
+        attestation: {
+          previousReleaseSha: '1'.repeat(40),
+          candidateCommitTimestamp: '2026-08-01T12:00:00Z',
+          candidateBehindMainBy: 0,
+          expectedAliases: ['widget.js'],
+          expectedAssetNames: ['widget.v1.2.1.js', 'versions.json'],
+          verificationCommands: ['npm test'],
+        },
+      });
+    };
+    const baseline = make('120', '4'.repeat(64), true);
+    expect(make('120', '4'.repeat(64), false).requestIdentity).toBe(baseline.requestIdentity);
+    expect(make('121', '4'.repeat(64), true).requestIdentity).not.toBe(baseline.requestIdentity);
+    expect(make('120', '5'.repeat(64), true).requestIdentity).not.toBe(baseline.requestIdentity);
+  });
+
   it('keeps run, artifact storage, timing, and approval observations out of identity', () => {
     const release = completedRelease();
     const first = buildAuditEnvelope({
@@ -535,6 +595,34 @@ describe('partial retry and stale revalidation', () => {
       kind: 'resume',
       tag: 'v1.2.1',
       planIdentity: release.finalPlan.planIdentity,
+    });
+  });
+
+  it('resumes an authenticated v2 partial tag without requiring rebuilt release content', () => {
+    const bundle = disabledV2WorkflowBundle();
+    const marker = buildPublicationMarker(bundle.finalPlan);
+    const state = normalizeGithubState({
+      refs: [
+        {
+          tag: bundle.finalPlan.tag,
+          sha: bundle.finalPlan.targetSha,
+          kind: 'annotated',
+          marker,
+        },
+      ],
+      releases: [],
+    });
+
+    expect(
+      resolvePartialPublication({
+        state,
+        requestPlan: bundle.requestPlan,
+        storedFinalPlan: bundle.finalPlan,
+      })
+    ).toMatchObject({
+      kind: 'resume',
+      tag: bundle.finalPlan.tag,
+      planIdentity: bundle.finalPlan.planIdentity,
     });
   });
 

--- a/test/release/retention-integration.test.ts
+++ b/test/release/retention-integration.test.ts
@@ -1,0 +1,476 @@
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { canonicalize } from '../../scripts/release/canonical-json.mjs';
+import {
+  authenticatePublishedAssets,
+  createGithubTransport,
+  createRequestPlanFromGithub,
+} from '../../scripts/release/github-adapter.mjs';
+import {
+  buildPublicationMarker,
+  buildReleaseInventory,
+  buildRequestPlan,
+} from '../../scripts/release/plan.mjs';
+import { writeRetentionInput } from '../../scripts/release/retention.mjs';
+import { resolveStaticArtifactRetry } from '../../scripts/release/static-assets.mjs';
+import { hashStaticTree } from '../../scripts/release/static-tree.mjs';
+import { createState2BundleFromStaticPackage } from '../../scripts/release/workflow.mjs';
+import { buildExpectedLive } from '../../scripts/release/live-release.mjs';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const CANDIDATE = join(ROOT, 'test/fixtures/release/static-assets/older-candidate');
+const roots: string[] = [];
+const digest = (bytes: Buffer) => createHash('sha256').update(bytes).digest('hex');
+const REPOSITORY = 'mean-weasel/bugdrop';
+const CONTROLLER = 'b'.repeat(40);
+const N_SHA = 'c'.repeat(40);
+const N1_SHA = 'a'.repeat(40);
+
+afterEach(async () =>
+  Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })))
+);
+
+async function vertical({ postBoundaryLegacy = false } = {}) {
+  const root = await mkdtemp(join(tmpdir(), 'bugdrop-n-n1-'));
+  roots.push(root);
+  const candidateN = join(root, 'candidate-n');
+  const candidate = join(root, 'candidate-n1');
+  const outputN = join(root, 'public-n');
+  const output = join(root, 'public-n1');
+  const bootstrapHandoff = join(root, 'bootstrap-input');
+  const handoff = join(root, 'retention');
+  const requestNPath = join(root, 'request-n.json');
+  const builderResultN = join(root, 'builder-result-n.json');
+  const requestN1Path = join(root, 'request-n1.json');
+  const builderResultN1 = join(root, 'builder-result-n1.json');
+  await cp(CANDIDATE, candidateN, { recursive: true });
+  await cp(CANDIDATE, candidate, { recursive: true });
+  const bootstrapRetention = {
+    schema: 'bugdrop.retention-request/v1',
+    mode: 'bootstrap',
+    cutoverVersion: '1.55.0',
+    expectedRetainedVersions: [],
+    releases: [],
+  };
+  const inventoryN = buildReleaseInventory({
+    compareUrl: 'https://github.test/compare/v1.54.0...n',
+    pullRequests: [],
+    commits: [{ sha: N_SHA, subject: 'N' }],
+    changedPaths: ['src/widget/index.ts'],
+  });
+  const requestN = buildRequestPlan({
+    dispatch: {
+      repository: REPOSITORY,
+      workflowRef: '.github/workflows/deploy.yml@refs/heads/main',
+      targetSha: N_SHA,
+      controllerSha: CONTROLLER,
+      bump: 'minor',
+      releaseReason: 'standard',
+      rationale: '',
+      operatorNotes: '',
+      dryRun: true,
+    },
+    previousTag: 'v1.54.0',
+    nextTag: 'v1.55.0',
+    generatedNotes: inventoryN.generatedNotes,
+    controllerSha: CONTROLLER,
+    remoteMainSha: 'f'.repeat(40),
+    inventory: inventoryN,
+    retentionBootstrap: true,
+    retention: bootstrapRetention,
+    attestation: {
+      previousReleaseSha: 'd'.repeat(40),
+      candidateCommitTimestamp: '2026-08-01T00:00:00Z',
+      candidateBehindMainBy: 0,
+      expectedAliases: ['widget.js', 'widget.v1.js', 'widget.v1.55.js'],
+      expectedAssetNames: ['widget.v1.55.0.js', 'versions.json'],
+      verificationCommands: ['npm test'],
+    },
+  });
+  await writeRetentionInput({
+    root: bootstrapHandoff,
+    requestIdentity: requestN.requestIdentity,
+    retention: bootstrapRetention,
+    assets: {},
+  });
+  await writeFile(requestNPath, `${canonicalize(requestN)}\n`);
+  const runN = spawnSync(
+    process.execPath,
+    [
+      join(ROOT, 'scripts/build-widget.js'),
+      '--mode',
+      'release',
+      '--source-dir',
+      candidateN,
+      '--output-dir',
+      outputN,
+      '--version',
+      '1.55.0',
+      '--timestamp',
+      '2026-08-01T00:00:00Z',
+      '--target-sha',
+      N_SHA,
+      '--repository',
+      REPOSITORY,
+      '--controller-identity',
+      `sha256:${'1'.repeat(64)}`,
+      '--tool-identity',
+      `sha256:${'2'.repeat(64)}`,
+      '--source-digest',
+      '3'.repeat(64),
+      '--retention-plan',
+      join(bootstrapHandoff, 'retention-plan.json'),
+      '--request-plan',
+      requestNPath,
+      '--result-path',
+      builderResultN,
+    ],
+    { cwd: ROOT, encoding: 'utf8' }
+  );
+  expect(runN.stderr).toBe('');
+  expect(runN.status).toBe(0);
+  const bundleN = await createState2BundleFromStaticPackage({
+    requestPlan: requestN,
+    staticPackageDir: outputN,
+    builderResultPath: builderResultN,
+    sourceDigests: { worker: '4'.repeat(64), lockfile: '5'.repeat(64) },
+    toolchain: { esbuild: '0.28.0', wrangler: '4.98.0' },
+    deploymentConfigDigest: '6'.repeat(64),
+    verification: { contract: 'release-verification/v1', result: 'passed' },
+  });
+  const marker = buildPublicationMarker(bundleN.finalPlan);
+  const legacySha = '7'.repeat(40);
+  const assetEntries = Object.entries(bundleN.assets).map(([name, bytes], index) => ({
+    id: 1000 + index,
+    name,
+    url: `https://api.github.test/repos/${REPOSITORY}/releases/assets/${1000 + index}`,
+    browser_download_url: `https://github.com/${REPOSITORY}/releases/download/v1.55.0/${name}`,
+    size: bytes.length,
+  }));
+  const bytesById = Object.fromEntries(
+    assetEntries.map(asset => [String(asset.id), bundleN.assets[asset.name]])
+  );
+  const request = async (path: string) => {
+    if (path === `/repos/${REPOSITORY}/releases?per_page=100&page=1`)
+      return {
+        data: [
+          {
+            id: 55,
+            tag_name: 'v1.55.0',
+            draft: false,
+            prerelease: false,
+            published_at: '2026-08-01T00:00:00Z',
+            html_url: 'https://github.test/releases/55',
+            body: `<!-- bugdrop-publication ${Buffer.from(canonicalize(marker)).toString('base64url')} -->`,
+            assets: assetEntries,
+          },
+          ...(postBoundaryLegacy
+            ? [
+                {
+                  id: 56,
+                  tag_name: 'v1.55.1',
+                  draft: false,
+                  prerelease: false,
+                  published_at: '2026-08-01T12:00:00Z',
+                  html_url: 'https://github.test/releases/56',
+                  body: '',
+                  assets: [],
+                },
+              ]
+            : []),
+        ],
+        hasNext: false,
+      };
+    if (path === `/repos/${REPOSITORY}/git/matching-refs/tags/v?per_page=100&page=1`)
+      return {
+        data: [
+          { ref: 'refs/tags/v1.55.0', object: { type: 'commit', sha: N_SHA } },
+          ...(postBoundaryLegacy
+            ? [{ ref: 'refs/tags/v1.55.1', object: { type: 'commit', sha: legacySha } }]
+            : []),
+        ],
+        hasNext: false,
+      };
+    if (path === `/repos/${REPOSITORY}/compare/${N_SHA}...${N1_SHA}`)
+      return { data: { status: 'ahead' }, hasNext: false };
+    if (path === `/repos/${REPOSITORY}/compare/${legacySha}...${N1_SHA}`)
+      return { data: { status: 'ahead' }, hasNext: false };
+    if (path === `/repos/${REPOSITORY}/commits/main`)
+      return { data: { sha: N1_SHA }, hasNext: false };
+    if (
+      path ===
+      `/repos/${REPOSITORY}/actions/runs?head_sha=${N1_SHA}&event=merge_group&per_page=100&page=1`
+    )
+      return {
+        data: {
+          workflow_runs: [
+            {
+              head_sha: N1_SHA,
+              event: 'merge_group',
+              status: 'completed',
+              conclusion: 'success',
+            },
+          ],
+        },
+        hasNext: false,
+      };
+    if (path === `/repos/${REPOSITORY}/commits/${N1_SHA}/pulls?per_page=100&page=1`)
+      return { data: [], hasNext: false };
+    throw new Error(`unexpected adapter request ${path}`);
+  };
+  const requestPlan = await createRequestPlanFromGithub({
+    transport: createGithubTransport({
+      token: 'offline-read-token',
+      apiUrl: 'https://api.github.test',
+      fetchImpl: async input => {
+        const url = new URL(String(input));
+        const assetMatch = /^\/repos\/mean-weasel\/bugdrop\/releases\/assets\/(\d+)$/.exec(
+          url.pathname
+        );
+        if (url.origin === 'https://api.github.test' && assetMatch) {
+          return new Response(null, {
+            status: 302,
+            headers: { location: `https://objects.githubusercontent.com/${assetMatch[1]}` },
+          });
+        }
+        if (url.origin === 'https://objects.githubusercontent.com') {
+          const bytes = bytesById[url.pathname.slice(1)];
+          return new Response(bytes, {
+            status: 200,
+            headers: { 'content-length': String(bytes.length) },
+          });
+        }
+        const result = await request(`${url.pathname}${url.search}`);
+        return new Response(JSON.stringify(result.data), {
+          status: 200,
+          headers: result.hasNext ? { link: `<${url.href}&page=2>; rel="next"` } : undefined,
+        });
+      },
+    }),
+    context: {
+      repositoryDir: candidate,
+      retentionOutputDir: handoff,
+      retentionBootstrap: false,
+      dispatch: {
+        repository: REPOSITORY,
+        workflowRef: '.github/workflows/deploy.yml@refs/heads/main',
+        targetSha: N1_SHA,
+        controllerSha: CONTROLLER,
+        bump: 'minor',
+        releaseReason: 'standard',
+        rationale: '',
+        operatorNotes: '',
+        dryRun: true,
+      },
+    },
+    gitObserver: () => ({
+      commits: [{ sha: N1_SHA, subject: 'N+1' }],
+      changedPaths: ['src/widget/index.ts'],
+      excludedNewerMainCommits: [],
+      candidateCommitTimestamp: '2026-08-02T00:00:00Z',
+      candidateBehindMainBy: 0,
+      facts: {
+        candidateRef: 'refs/heads/main',
+        targetExists: true,
+        targetReachableFromMain: true,
+        controllerReachableFromMain: true,
+        previousReleaseAncestor: true,
+        targetStrictlyLater: true,
+      },
+    }),
+  });
+  const retainedN = await readFile(join(handoff, 'widget.v1.55.0.js'));
+  await writeFile(requestN1Path, `${canonicalize(requestPlan)}\n`);
+  const run = spawnSync(
+    process.execPath,
+    [
+      join(ROOT, 'scripts/build-widget.js'),
+      '--mode',
+      'release',
+      '--source-dir',
+      candidate,
+      '--output-dir',
+      output,
+      '--version',
+      '1.56.0',
+      '--timestamp',
+      '2026-08-02T00:00:00Z',
+      '--target-sha',
+      N1_SHA,
+      '--repository',
+      REPOSITORY,
+      '--controller-identity',
+      `sha256:${'1'.repeat(64)}`,
+      '--tool-identity',
+      `sha256:${'2'.repeat(64)}`,
+      '--source-digest',
+      '3'.repeat(64),
+      '--retention-plan',
+      join(handoff, 'retention-plan.json'),
+      '--request-plan',
+      requestN1Path,
+      '--result-path',
+      builderResultN1,
+    ],
+    { cwd: ROOT, encoding: 'utf8' }
+  );
+  expect(run.stderr).toBe('');
+  expect(run.status).toBe(0);
+  const common = {
+    requestPlan,
+    staticPackageDir: output,
+    builderResultPath: builderResultN1,
+    sourceDigests: { worker: '4'.repeat(64), lockfile: '5'.repeat(64) },
+    toolchain: { esbuild: '0.28.0', wrangler: '4.98.0' },
+    deploymentConfigDigest: '6'.repeat(64),
+    verification: { contract: 'release-verification/v1', result: 'passed' },
+  };
+  return { output, common, retainedN };
+}
+
+async function rewriteChecksums(output: string) {
+  const tree = await hashStaticTree(output);
+  const bytes = `${Object.entries(tree.fileHashes)
+    .filter(([path]) => path !== 'checksums.sha256')
+    .sort(([left], [right]) => Buffer.compare(Buffer.from(left), Buffer.from(right)))
+    .map(([path, hash]) => `${hash}  ${path}`)
+    .join('\n')}\n`;
+  await writeFile(join(output, 'checksums.sha256'), bytes);
+}
+
+describe('installed N/N+1 retention boundaries', () => {
+  it('authenticates published v2 N through createGithubTransport, handoff, CLI, and real State 2', async () => {
+    const { output, common, retainedN } = await vertical();
+    const bundle = await createState2BundleFromStaticPackage(common);
+    const manifest = JSON.parse(await readFile(join(output, 'versions.json'), 'utf8'));
+    expect(await readFile(join(output, 'widget.v1.55.0.js'))).toEqual(retainedN);
+    expect(manifest.schema).toBe('bugdrop.versions-manifest/v2');
+    expect(manifest.artifacts['v1.55.0'].version).toBe('1.55.0');
+    expect(manifest.artifacts['v1.56.0'].version).toBe('1.56.0');
+    expect(manifest.artifacts['v1.55.0'].sha256).toBe(digest(retainedN));
+    expect(bundle.releaseContent.staticPackage.fileHashes['widget.v1.55.0.js']).toBe(
+      digest(retainedN)
+    );
+  });
+
+  it('authenticates compact v2 continuation publication and canonical readback', async () => {
+    const { common } = await vertical();
+    const bundle = await createState2BundleFromStaticPackage(common);
+    expect(bundle.requestPlan.retention.mode).toBe('continue');
+    expect(bundle.finalPlan.requiredAssets).not.toContain('widget.v1.55.0.js');
+    expect(bundle.finalPlan.requiredAssets).toEqual([
+      'checksums.sha256',
+      'final-release-plan.json',
+      'release-content.json',
+      'request-plan.json',
+      'versions.json',
+      'widget.v1.56.0.js',
+    ]);
+    expect(
+      authenticatePublishedAssets({
+        release: {
+          tag: bundle.finalPlan.tag,
+          targetSha: bundle.finalPlan.targetSha,
+          resolvedTagSha: bundle.finalPlan.targetSha,
+          published: true,
+          draft: false,
+          prerelease: false,
+          marker: buildPublicationMarker(bundle.finalPlan),
+        },
+        assets: bundle.assets,
+      })
+    ).toMatchObject({
+      finalPlan: { planIdentity: bundle.finalPlan.planIdentity },
+      requestPlan: { retention: { mode: 'continue' } },
+      assetVerification: { complete: true, checksumsMatch: true },
+    });
+  });
+
+  it('reacquires and replans an expired artifact with total identity equality', async () => {
+    const first = await vertical();
+    const reacquired = await vertical();
+    const originalBundle = await createState2BundleFromStaticPackage(first.common);
+    const rebuiltBundle = await createState2BundleFromStaticPackage(reacquired.common);
+    expect(reacquired.retainedN).toEqual(first.retainedN);
+    expect(rebuiltBundle.requestPlan).toEqual(originalBundle.requestPlan);
+    expect(rebuiltBundle.releaseContent.staticPackage).toEqual(
+      originalBundle.releaseContent.staticPackage
+    );
+    expect(rebuiltBundle.releaseContent.contentIdentity).toBe(
+      originalBundle.releaseContent.contentIdentity
+    );
+    expect(rebuiltBundle.finalPlan.planIdentity).toBe(originalBundle.finalPlan.planIdentity);
+    expect(
+      resolveStaticArtifactRetry({
+        artifactStatus: 'expired',
+        expectedRequestIdentity: originalBundle.requestPlan.requestIdentity,
+        expectedStaticPackageIdentity: originalBundle.releaseContent.staticPackage.contentIdentity,
+        expectedContentIdentity: originalBundle.releaseContent.contentIdentity,
+        expectedPlanIdentity: originalBundle.finalPlan.planIdentity,
+        rebuiltRequestIdentity: rebuiltBundle.requestPlan.requestIdentity,
+        rebuiltStaticPackageIdentity: rebuiltBundle.releaseContent.staticPackage.contentIdentity,
+        rebuiltContentIdentity: rebuiltBundle.releaseContent.contentIdentity,
+        rebuiltPlanIdentity: rebuiltBundle.finalPlan.planIdentity,
+      })
+    ).toMatchObject({
+      kind: 'rebuilt-exact',
+      requestIdentity: originalBundle.requestPlan.requestIdentity,
+      staticPackageIdentity: originalBundle.releaseContent.staticPackage.contentIdentity,
+      contentIdentity: originalBundle.releaseContent.contentIdentity,
+      planIdentity: originalBundle.finalPlan.planIdentity,
+    });
+  });
+
+  it('rejects retained-byte substitution before State 2', async () => {
+    const { output, common } = await vertical();
+    const pristine = await createState2BundleFromStaticPackage(common);
+    await writeFile(join(output, 'widget.v1.55.0.js'), 'substituted');
+    await rewriteChecksums(output);
+    await expect(createState2BundleFromStaticPackage(common)).rejects.toThrow(
+      /BUILDER_RESULT_MISMATCH/
+    );
+    await expect(
+      buildExpectedLive({
+        bundle: pristine,
+        origin: 'https://bugdrop.example',
+        staticPackageDir: output,
+      })
+    ).rejects.toThrow(/STATIC_TREE_MISMATCH/);
+  });
+
+  it('rejects a checksum-consistent current alias substitution at installed State 2', async () => {
+    const { output, common } = await vertical();
+    await writeFile(join(output, 'widget.js'), 'substituted alias');
+    await rewriteChecksums(output);
+    await expect(createState2BundleFromStaticPackage(common)).rejects.toThrow(
+      /BUILDER_RESULT_MISMATCH/
+    );
+  });
+
+  it.each([
+    ['added', async (output: string) => writeFile(join(output, 'injected.txt'), 'injected')],
+    ['removed', async (output: string) => rm(join(output, 'widget.v1.55.0.js'))],
+  ])(
+    'rejects a checksum-consistent file that was %s after the builder result',
+    async (_kind, mutate) => {
+      const { output, common } = await vertical();
+      await mutate(output);
+      await rewriteChecksums(output);
+      await expect(createState2BundleFromStaticPackage(common)).rejects.toThrow(
+        /BUILDER_RESULT_MISMATCH/
+      );
+    }
+  );
+
+  it('rejects an observed legacy stable Release after the authenticated boundary', async () => {
+    await expect(vertical({ postBoundaryLegacy: true })).rejects.toThrow(
+      /RETENTION_HISTORY_INCOMPLETE/
+    );
+  });
+});

--- a/test/release/retention.test.ts
+++ b/test/release/retention.test.ts
@@ -1,0 +1,309 @@
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { canonicalize } from '../../scripts/release/canonical-json.mjs';
+
+import {
+  deriveRetentionRequest,
+  loadRetentionInput,
+  writeRetentionInput,
+} from '../../scripts/release/retention.mjs';
+
+const roots: string[] = [];
+const bytes = Buffer.from('release N exact bytes');
+const sha256 = createHash('sha256').update(bytes).digest('hex');
+const record = {
+  version: '1.5.0',
+  tag: 'v1.5.0',
+  releaseId: '50',
+  targetSha: 'a'.repeat(40),
+  publishedAt: '2026-08-01T00:00:00Z',
+  sourcePlanIdentity: `sha256:${'b'.repeat(64)}`,
+  sourceContentIdentity: `sha256:${'c'.repeat(64)}`,
+  asset: {
+    assetId: '500',
+    name: 'widget.v1.5.0.js',
+    apiPath: '/repos/mean-weasel/bugdrop/releases/assets/500',
+    downloadUrl: 'https://github.com/mean-weasel/bugdrop/releases/download/v1.5.0/widget.v1.5.0.js',
+    sha256,
+  },
+};
+
+afterEach(async () =>
+  Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })))
+);
+
+describe('retention authority and local handoff', () => {
+  it('keeps retention disabled until an explicit bootstrap and continues an immutable lineage', () => {
+    expect(deriveRetentionRequest({ candidateVersion: '1.5.0' }).mode).toBe('disabled');
+    expect(
+      deriveRetentionRequest({ candidateVersion: '1.5.0', retentionBootstrap: true })
+    ).toMatchObject({ mode: 'bootstrap', cutoverVersion: '1.5.0' });
+    expect(
+      deriveRetentionRequest({
+        candidateVersion: '1.7.0',
+        releases: [
+          {
+            version: '1.5.0',
+            published: true,
+            draft: false,
+            prerelease: false,
+            retention: {
+              schema: 'bugdrop.retention-request/v1',
+              mode: 'bootstrap',
+              cutoverVersion: '1.5.0',
+              expectedRetainedVersions: [],
+              releases: [],
+            },
+            retentionRecord: record,
+          },
+        ],
+      })
+    ).toMatchObject({
+      mode: 'continue',
+      cutoverVersion: '1.5.0',
+      expectedRetainedVersions: ['1.5.0'],
+    });
+  });
+
+  it('writes and reauthenticates confined exact bytes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'bugdrop-retention-'));
+    roots.push(root);
+    const retention = {
+      schema: 'bugdrop.retention-request/v1',
+      mode: 'continue',
+      cutoverVersion: '1.5.0',
+      expectedRetainedVersions: ['1.5.0'],
+      releases: [record],
+    };
+    const requestIdentity = `sha256:${'d'.repeat(64)}`;
+    await writeRetentionInput({ root, requestIdentity, retention, assets: { '1.5.0': bytes } });
+    const loaded = await loadRetentionInput(join(root, 'retention-plan.json'), requestIdentity);
+    expect(await readFile(loaded.retainedReleases[0].assetPath)).toEqual(bytes);
+  });
+
+  it('rejects a legacy stable Release after an authenticated bootstrap boundary', () => {
+    expect(() =>
+      deriveRetentionRequest({
+        candidateVersion: '1.7.0',
+        releases: [
+          {
+            version: '1.5.0',
+            published: true,
+            draft: false,
+            prerelease: false,
+            retention: {
+              schema: 'bugdrop.retention-request/v1',
+              mode: 'bootstrap',
+              cutoverVersion: '1.5.0',
+              expectedRetainedVersions: [],
+              releases: [],
+            },
+            retentionRecord: record,
+          },
+          {
+            version: '1.6.0',
+            published: true,
+            draft: false,
+            prerelease: false,
+            retention: null,
+            retentionRecord: null,
+          },
+        ],
+      })
+    ).toThrow(/RETENTION_HISTORY_INCOMPLETE/);
+  });
+
+  it('derives identical numeric history from reversed API order and legitimate SemVer skips', () => {
+    const second = {
+      ...record,
+      version: '1.8.0',
+      tag: 'v1.8.0',
+      releaseId: '80',
+      asset: {
+        ...record.asset,
+        assetId: '800',
+        name: 'widget.v1.8.0.js',
+        apiPath: '/repos/mean-weasel/bugdrop/releases/assets/800',
+        downloadUrl:
+          'https://github.com/mean-weasel/bugdrop/releases/download/v1.8.0/widget.v1.8.0.js',
+      },
+    };
+    const releases = [
+      {
+        version: '1.5.0',
+        published: true,
+        draft: false,
+        prerelease: false,
+        retention: {
+          schema: 'bugdrop.retention-request/v1',
+          mode: 'bootstrap',
+          cutoverVersion: '1.5.0',
+          expectedRetainedVersions: [],
+          releases: [],
+        },
+        retentionRecord: record,
+      },
+      {
+        version: '1.8.0',
+        published: true,
+        draft: false,
+        prerelease: false,
+        retention: {
+          schema: 'bugdrop.retention-request/v1',
+          mode: 'continue',
+          cutoverVersion: '1.5.0',
+          expectedRetainedVersions: ['1.5.0'],
+          releases: [record],
+        },
+        retentionRecord: second,
+      },
+    ];
+    const forward = deriveRetentionRequest({ candidateVersion: '2.0.0', releases });
+    const reverse = deriveRetentionRequest({
+      candidateVersion: '2.0.0',
+      releases: [...releases].reverse(),
+    });
+    expect(reverse).toEqual(forward);
+    expect(forward.expectedRetainedVersions).toEqual(['1.5.0', '1.8.0']);
+  });
+
+  it('rejects a later cumulative record that differs from authenticated prior authority', () => {
+    const current = {
+      ...record,
+      version: '1.6.0',
+      tag: 'v1.6.0',
+      releaseId: '60',
+      asset: {
+        ...record.asset,
+        assetId: '600',
+        name: 'widget.v1.6.0.js',
+        apiPath: '/repos/mean-weasel/bugdrop/releases/assets/600',
+        downloadUrl:
+          'https://github.com/mean-weasel/bugdrop/releases/download/v1.6.0/widget.v1.6.0.js',
+      },
+    };
+    const falsePrior = structuredClone(record);
+    falsePrior.targetSha = '8'.repeat(40);
+    expect(() =>
+      deriveRetentionRequest({
+        candidateVersion: '1.7.0',
+        releases: [
+          {
+            version: '1.5.0',
+            published: true,
+            draft: false,
+            prerelease: false,
+            retention: {
+              schema: 'bugdrop.retention-request/v1',
+              mode: 'bootstrap',
+              cutoverVersion: '1.5.0',
+              expectedRetainedVersions: [],
+              releases: [],
+            },
+            retentionRecord: record,
+          },
+          {
+            version: '1.6.0',
+            published: true,
+            draft: false,
+            prerelease: false,
+            retention: {
+              schema: 'bugdrop.retention-request/v1',
+              mode: 'continue',
+              cutoverVersion: '1.5.0',
+              expectedRetainedVersions: ['1.5.0'],
+              releases: [falsePrior],
+            },
+            retentionRecord: current,
+          },
+        ],
+      })
+    ).toThrow(/RETENTION_CHAIN_MISMATCH/);
+  });
+
+  it('rejects transport metadata that is not an exact request projection', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'bugdrop-retention-tamper-'));
+    roots.push(root);
+    const retention = {
+      schema: 'bugdrop.retention-request/v1',
+      mode: 'continue',
+      cutoverVersion: '1.5.0',
+      expectedRetainedVersions: ['1.5.0'],
+      releases: [record],
+    };
+    const requestIdentity = `sha256:${'d'.repeat(64)}`;
+    await writeRetentionInput({ root, requestIdentity, retention, assets: { '1.5.0': bytes } });
+    const path = join(root, 'retention-plan.json');
+    const input = JSON.parse(await readFile(path, 'utf8'));
+    input.retainedReleases[0].archiveUrl =
+      'https://github.com/mean-weasel/bugdrop/releases/download/v1.5.0/substitute.js';
+    await writeFile(path, `${JSON.stringify(input)}\n`);
+    await expect(loadRetentionInput(path, requestIdentity)).rejects.toThrow(
+      /RETENTION_INPUT_MISMATCH/
+    );
+  });
+
+  it('rejects noncanonical, extra-file, symlinked, oversized, and truncated handoffs', async () => {
+    const retention = {
+      schema: 'bugdrop.retention-request/v1',
+      mode: 'continue',
+      cutoverVersion: '1.5.0',
+      expectedRetainedVersions: ['1.5.0'],
+      releases: [record],
+    };
+    const requestIdentity = `sha256:${'d'.repeat(64)}`;
+    const make = async (label: string) => {
+      const root = await mkdtemp(join(tmpdir(), `bugdrop-retention-${label}-`));
+      roots.push(root);
+      await writeRetentionInput({ root, requestIdentity, retention, assets: { '1.5.0': bytes } });
+      return {
+        root,
+        plan: join(root, 'retention-plan.json'),
+        asset: join(root, record.asset.name),
+      };
+    };
+    const noncanonical = await make('noncanonical');
+    const parsed = JSON.parse(await readFile(noncanonical.plan, 'utf8'));
+    await writeFile(noncanonical.plan, `${JSON.stringify(parsed, null, 2)}\n`);
+    await expect(loadRetentionInput(noncanonical.plan, requestIdentity, retention)).rejects.toThrow(
+      /canonical/
+    );
+
+    const extraField = await make('extra-field');
+    const extraParsed = JSON.parse(await readFile(extraField.plan, 'utf8'));
+    extraParsed.unapproved = true;
+    await writeFile(extraField.plan, `${canonicalize(extraParsed)}\n`);
+    await expect(loadRetentionInput(extraField.plan, requestIdentity, retention)).rejects.toThrow(
+      /fields are not exact/
+    );
+
+    const extra = await make('extra');
+    await writeFile(join(extra.root, 'extra.txt'), 'extra');
+    await expect(loadRetentionInput(extra.plan, requestIdentity, retention)).rejects.toThrow(
+      /file set/
+    );
+
+    const linked = await make('symlink');
+    await rm(linked.asset);
+    await symlink('/dev/null', linked.asset);
+    await expect(loadRetentionInput(linked.plan, requestIdentity, retention)).rejects.toThrow(
+      /bounded regular file|invalid retained file/
+    );
+
+    const oversized = await make('oversized');
+    await writeFile(oversized.asset, Buffer.alloc(16 * 1024 * 1024 + 1));
+    await expect(loadRetentionInput(oversized.plan, requestIdentity, retention)).rejects.toThrow(
+      /SIZE_LIMIT/
+    );
+
+    const truncated = await make('truncated');
+    await writeFile(truncated.asset, bytes.subarray(0, 3));
+    await expect(loadRetentionInput(truncated.plan, requestIdentity, retention)).rejects.toThrow(
+      /HASH_MISMATCH/
+    );
+  });
+});

--- a/test/release/static-assets.test.ts
+++ b/test/release/static-assets.test.ts
@@ -89,6 +89,37 @@ describe('deterministic release static package', () => {
     expect(second.contentIdentity).toBe(first.contentIdentity);
   });
 
+  it('ignores filesystem creation and locale-sensitive name order', async () => {
+    const firstRoot = await tempRoot('filesystem-order-first');
+    const secondRoot = await tempRoot('filesystem-order-second');
+    const firstSource = join(firstRoot, 'source');
+    const secondSource = join(secondRoot, 'source');
+    await mkdir(join(firstSource, 'nested'), { recursive: true });
+    await mkdir(join(secondSource, 'nested'), { recursive: true });
+    const files = [
+      ['z.txt', 'z'],
+      ['ä.txt', 'umlaut'],
+      ['nested/a.txt', 'a'],
+    ];
+    for (const [name, bytes] of files) await writeFile(join(firstSource, name), bytes);
+    for (const [name, bytes] of [...files].reverse())
+      await writeFile(join(secondSource, name), bytes);
+    const disabled = {
+      retentionMode: 'disabled',
+      cutoverVersion: null,
+      expectedRetainedVersions: [],
+      retainedReleases: [],
+    };
+    const first = await createReleaseStaticPackage(
+      await releaseInput(join(firstRoot, 'output'), { ...disabled, sourcePublicDir: firstSource })
+    );
+    const second = await createReleaseStaticPackage(
+      await releaseInput(join(secondRoot, 'output'), { ...disabled, sourcePublicDir: secondSource })
+    );
+    expect(second.fileHashes).toEqual(first.fileHashes);
+    expect(second.contentIdentity).toBe(first.contentIdentity);
+  });
+
   it('copies exact/latest/major/minor aliases from one byte set', async () => {
     const result = await packageOnce('aliases');
     const hashes = result.fileHashes;
@@ -105,6 +136,21 @@ describe('deterministic release static package', () => {
     expect(manifest.artifacts['v1.55.0'].sha256).toBe(await hashFile(RETAINED_ASSET));
     expect(manifest.artifacts).not.toHaveProperty('v1.54.0');
     expect(manifest.current).toBe('1.56.0');
+  });
+
+  it('preserves the historical v1 current-only manifest while retention is disabled', async () => {
+    const result = await packageOnce('disabled-v1', {
+      retentionMode: 'disabled',
+      cutoverVersion: null,
+      expectedRetainedVersions: [],
+      retainedReleases: [],
+    });
+    const manifest = JSON.parse(await readFile(join(result.outputDir, 'versions.json'), 'utf8'));
+    expect(manifest.schema).toBe('bugdrop.versions-manifest/v1');
+    expect(manifest.cutoverVersion).toBe('1.56.0');
+    expect(manifest.artifacts['v1.56.0']).toHaveProperty('archiveUrl');
+    expect(manifest.artifacts['v1.56.0']).not.toHaveProperty('version');
+    expect(manifest.artifacts).not.toHaveProperty('v1.55.0');
   });
 
   it.each([
@@ -190,6 +236,35 @@ describe('artifact retry semantics', () => {
         rebuiltContentIdentity: `sha256:${'f'.repeat(64)}`,
       })
     ).toEqual({ kind: 'new-plan-required', reason: 'content-identity-mismatch' });
+  });
+
+  it('requires every v2 request, tree, content, and plan identity after artifact expiry', () => {
+    const expected = {
+      expectedContentIdentity: `sha256:${'1'.repeat(64)}`,
+      expectedRequestIdentity: `sha256:${'2'.repeat(64)}`,
+      expectedStaticPackageIdentity: `sha256:${'3'.repeat(64)}`,
+      expectedPlanIdentity: `sha256:${'4'.repeat(64)}`,
+    };
+    expect(
+      resolveStaticArtifactRetry({
+        artifactStatus: 'expired',
+        ...expected,
+        rebuiltContentIdentity: expected.expectedContentIdentity,
+        rebuiltRequestIdentity: expected.expectedRequestIdentity,
+        rebuiltStaticPackageIdentity: expected.expectedStaticPackageIdentity,
+        rebuiltPlanIdentity: expected.expectedPlanIdentity,
+      })
+    ).toMatchObject({ kind: 'rebuilt-exact', planIdentity: expected.expectedPlanIdentity });
+    expect(
+      resolveStaticArtifactRetry({
+        artifactStatus: 'expired',
+        ...expected,
+        rebuiltContentIdentity: expected.expectedContentIdentity,
+        rebuiltRequestIdentity: expected.expectedRequestIdentity,
+        rebuiltStaticPackageIdentity: `sha256:${'9'.repeat(64)}`,
+        rebuiltPlanIdentity: expected.expectedPlanIdentity,
+      })
+    ).toEqual({ kind: 'new-plan-required', reason: 'total-identity-mismatch' });
   });
 
   it('fails closed for ambiguous artifact state', () => {

--- a/test/release/verify-live.test.ts
+++ b/test/release/verify-live.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  collectRecoveryIdentity,
   LiveVerificationError,
   observeLiveSnapshot,
   observePreviewSnapshot,
@@ -147,6 +148,56 @@ describe('polling and scheduled observation', () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  it('rejects an oversized live widget before buffering its response body', async () => {
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const path = new URL(String(url)).pathname;
+      if (path === '/api/health') {
+        return Response.json({ status: 'ok', environment: 'production', buildSha: SHA });
+      }
+      if (path === '/widget.js') {
+        return new Response(Buffer.alloc(16 * 1024 * 1024 + 1), {
+          headers: { 'content-length': String(16 * 1024 * 1024 + 1) },
+        });
+      }
+      if (path === '/versions.json') {
+        return Response.json({ current: '1.56.0' });
+      }
+      throw new Error(`unexpected request ${path}`);
+    });
+
+    await expect(
+      collectRecoveryIdentity(expected().origin, fetchImpl as typeof fetch)
+    ).rejects.toMatchObject({ code: 'LIVE_FETCH_TOO_LARGE' });
+  });
+
+  it('cancels a streamed live widget that exceeds its bound without Content-Length', async () => {
+    const chunk = new Uint8Array(8 * 1024 * 1024 + 1);
+    const cancel = vi.fn();
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const path = new URL(String(url)).pathname;
+      if (path === '/api/health') {
+        return Response.json({ status: 'ok', environment: 'production', buildSha: SHA });
+      }
+      if (path === '/widget.js') {
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(chunk);
+              controller.enqueue(chunk);
+            },
+            cancel,
+          })
+        );
+      }
+      throw new Error(`unexpected request ${path}`);
+    });
+
+    await expect(
+      collectRecoveryIdentity(expected().origin, fetchImpl as typeof fetch)
+    ).rejects.toMatchObject({ code: 'LIVE_FETCH_TOO_LARGE' });
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
   it('records scheduled production identity as observation, not plan verification', () => {


### PR DESCRIPTION
## Summary
- add authenticated release-retention lineage and a v2 release authority protocol
- build and verify one canonical static package containing current and retained exact-version assets
- preserve canonical single-root workflow artifacts for dry-run and live consumers
- keep retention disabled by default behind an explicit one-time bootstrap

## Safety
Merging does not activate a production retention boundary. The operator must separately prove non-production Cloudflare capability and authorize the one-time bootstrap. Missing, conflicting, or corrupt history fails closed.

## Verification
- `npm run validate` (803 tests)
- `npm run test:release-workflow` (131 tests plus executable workflow contract)
- `npm run knip`
- `npm run check:actions-node24`
- `git diff --check`
- `codex review --uncommitted` (no actionable defects)

## Integration note
This branch was created fresh from current `origin/main` after PR #272. The retention package was transplanted from draft #273, and its obsolete multi-root upload was replaced with the proven single-root layout carrying `state2-bundle.json`, `builder-result.json`, and `static-package/`.