### PR TITLE
feat: add Cloudflare capability drill

### DIFF
--- a/.github/workflows/cloudflare-capability.yml
+++ b/.github/workflows/cloudflare-capability.yml
@@ -1,0 +1,157 @@
+name: Cloudflare Preview Capability Drill
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_a_sha:
+        description: Earlier immutable main SHA for release A
+        required: true
+        type: string
+      candidate_b_sha:
+        description: Later immutable main SHA for release B
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bugdrop-shared-preview
+  cancel-in-progress: false
+
+jobs:
+  prove:
+    name: Prove preview deploy, retention, rollback, and restoration
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Reject non-main or malformed drill before checkout
+        env:
+          DISPATCH_REF: ${{ github.ref }}
+          SHA_A: ${{ inputs.candidate_a_sha }}
+          SHA_B: ${{ inputs.candidate_b_sha }}
+        run: |
+          test "$DISPATCH_REF" = 'refs/heads/main'
+          [[ "$SHA_A" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$SHA_B" =~ ^[0-9a-f]{40}$ ]]
+          test "$SHA_A" != "$SHA_B"
+
+      - name: Checkout immutable controller
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: controller
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require ordered immutable main candidates
+        env:
+          SHA_A: ${{ inputs.candidate_a_sha }}
+          SHA_B: ${{ inputs.candidate_b_sha }}
+        run: |
+          git -C controller merge-base --is-ancestor "$SHA_A" origin/main
+          git -C controller merge-base --is-ancestor "$SHA_B" origin/main
+          git -C controller merge-base --is-ancestor "$SHA_A" "$SHA_B"
+
+      - name: Checkout immutable candidate A
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.candidate_a_sha }}
+          path: candidate-a
+          persist-credentials: false
+
+      - name: Checkout immutable candidate B
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.candidate_b_sha }}
+          path: candidate-b
+          persist-credentials: false
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Install locked controller and candidate dependencies
+        run: |
+          npm --prefix controller ci --ignore-scripts
+          npm --prefix candidate-a ci --ignore-scripts
+          npm --prefix candidate-b ci --ignore-scripts
+
+      - name: Build capability release A
+        env:
+          SHA_A: ${{ inputs.candidate_a_sha }}
+        run: |
+          timestamp_a=$(node -e 'console.log(new Date(Number(process.argv[1]) * 1000).toISOString().replace(".000Z", "Z"))' "$(git -C candidate-a show -s --format=%ct "$SHA_A")")
+          jq -n '{mode:"bootstrap",cutoverVersion:"9000.0.0",expectedRetainedVersions:[],retainedReleases:[]}' > retention-a.json
+          node controller/scripts/build-widget.js \
+            --mode release \
+            --source-dir candidate-a \
+            --output-dir candidate-a/capability-assets \
+            --version 9000.0.0 \
+            --timestamp "$timestamp_a" \
+            --target-sha "$SHA_A" \
+            --repository "$GITHUB_REPOSITORY" \
+            --current-archive-url 'https://example.invalid/capability/widget.v9000.0.0.js' \
+            --retention-plan retention-a.json
+
+      - name: Build capability release B retaining A
+        env:
+          SHA_A: ${{ inputs.candidate_a_sha }}
+          SHA_B: ${{ inputs.candidate_b_sha }}
+        run: |
+          hash_a=$(sha256sum candidate-a/capability-assets/widget.v9000.0.0.js | awk '{print $1}')
+          published_a=$(node -e 'console.log(new Date(Number(process.argv[1]) * 1000).toISOString().replace(".000Z", "Z"))' "$(git -C candidate-a show -s --format=%ct "$SHA_A")")
+          timestamp_b=$(node -e 'console.log(new Date(Number(process.argv[1]) * 1000).toISOString().replace(".000Z", "Z"))' "$(git -C candidate-b show -s --format=%ct "$SHA_B")")
+          jq -n \
+            --arg assetPath "$GITHUB_WORKSPACE/candidate-a/capability-assets/widget.v9000.0.0.js" \
+            --arg publishedAt "$published_a" \
+            --arg sha256 "$hash_a" \
+            --arg targetSha "$SHA_A" \
+            '{mode:"continue",cutoverVersion:"9000.0.0",expectedRetainedVersions:["9000.0.0"],retainedReleases:[{version:"9000.0.0",targetSha:$targetSha,publishedAt:$publishedAt,archiveUrl:"https://example.invalid/capability/widget.v9000.0.0.js",sha256:$sha256,assetPath:$assetPath}]}' \
+            > retention-b.json
+          node controller/scripts/build-widget.js \
+            --mode release \
+            --source-dir candidate-b \
+            --output-dir candidate-b/capability-assets \
+            --version 9000.0.1 \
+            --timestamp "$timestamp_b" \
+            --target-sha "$SHA_B" \
+            --repository "$GITHUB_REPOSITORY" \
+            --current-archive-url 'https://example.invalid/capability/widget.v9000.0.1.js' \
+            --retention-plan retention-b.json
+
+      - name: Run reversible preview capability drill
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          SHA_A: ${{ inputs.candidate_a_sha }}
+          SHA_B: ${{ inputs.candidate_b_sha }}
+        run: |
+          jq -n \
+            --arg controllerRoot "$GITHUB_WORKSPACE/controller" \
+            --arg controllerConfig "$GITHUB_WORKSPACE/controller/wrangler.toml" \
+            --arg controllerLock "$GITHUB_WORKSPACE/controller/package-lock.json" \
+            --arg candidateARoot "$GITHUB_WORKSPACE/candidate-a" \
+            --arg candidateBRoot "$GITHUB_WORKSPACE/candidate-b" \
+            --arg assetsA "$GITHUB_WORKSPACE/candidate-a/capability-assets" \
+            --arg assetsB "$GITHUB_WORKSPACE/candidate-b/capability-assets" \
+            --arg shaA "$SHA_A" \
+            --arg shaB "$SHA_B" \
+            --arg origin 'https://bugdrop-preview.neonwatty.workers.dev' \
+            '{controllerRoot:$controllerRoot,controllerConfig:$controllerConfig,controllerLock:$controllerLock,candidateARoot:$candidateARoot,candidateBRoot:$candidateBRoot,assetsA:$assetsA,assetsB:$assetsB,shaA:$shaA,shaB:$shaB,versionA:"9000.0.0",versionB:"9000.0.1",origin:$origin}' \
+            > capability-input.json
+          node controller/scripts/release/cloudflare-capability-drill.mjs capability-input.json capability-proof.json
+
+      - name: Report verified non-production capability
+        run: |
+          jq -e '.rollbackProof.status == "verified" and .restoration.verification.status == "verified" and .lostResponse.status == "candidate-active"' capability-proof.json
+          jq -r '"### Cloudflare preview capability verified\n\nWrangler: `\(.wranglerVersion)`  \nA: `\(.releaseA.versionId)`  \nB: `\(.releaseB.versionId)`  \nRollback: `\(.rollbackProof.status)`  \nBaseline restoration: `\(.restoration.verification.status)`"' capability-proof.json >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload capability evidence
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: cloudflare-preview-capability-${{ github.run_id }}
+          path: capability-proof.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -180,6 +180,40 @@ set, and pass the same installed N/N+1 and complete-tree checks. Production roll
 existing restoration of the captured exact Cloudflare baseline; it never rebuilds historical bytes.
 Repository tests prove only the offline installed boundaries, not a live deployment or durable URL.
 
+## Cloudflare capability proof
+
+Before setting `RELEASE_CLOUDFLARE_CAPABILITY_VALIDATED=true`, dispatch **Cloudflare Preview
+Capability Drill** from `main` with two ordered full SHAs from `main`. The workflow shares the
+`bugdrop-shared-preview` concurrency lock with merge-queue preview deployment. It captures the exact
+preview baseline, builds release A and release B from separate immutable checkouts, requires B to
+retain A's exact bytes, deploys A then B, treats B's command result as lost and reconciles it by live
+inspection, rolls back to A, and finally restores and verifies the captured baseline. Never use the
+production Worker for this proof.
+
+The controller-pinned Wrangler 4.98.0 command shapes are `deployments status`, `deployments list`,
+`versions list`, `versions view <version-id>`, `deploy <candidate-entrypoint> --assets
+<candidate-assets> --var BUILD_SHA:<full-sha>`, and `rollback <version-id> --message <bounded-message>
+--yes`. Every command also receives controller-owned `--config <absolute-wrangler.toml> --env
+<preview|production>` and never receives `--name`. Commands run without a shell, with a two-minute
+process timeout and an environment reduced to runner basics plus only the Cloudflare account and API
+token.
+
+Accepted deployment status JSON has one deployment `id`, `created_on`, `source`, `strategy`, and
+exactly one `versions[]` entry at 100 percent with `version_id`. Accepted version JSON has matching
+`id`, `metadata.created_on`, `metadata.source`, `resources.script.etag`, one optional full-SHA
+`BUILD_SHA` binding, the `ASSETS` binding, and boolean asset runtime fields. Live reads have a
+15-second request timeout and a bounded response size; convergence permits 30 two-second polls. The
+workflow itself is bounded to 30 minutes.
+
+The required evidence is the successful run URL and `cloudflare-preview-capability-<run-id>` artifact
+showing A and B version IDs, B's retained A filename, `candidate-active` lost-response reconciliation,
+bounded deployment/version list counts containing the active baseline, verified rollback, and
+verified baseline restoration. If the artifact is absent, restoration is not
+verified, or any field is ambiguous, leave both release gates false. Preserve the run, inspect the
+captured baseline version ID, and perform only an explicitly authorized locked-controller rollback to
+that ID followed by independent health, widget, and manifest hash verification; do not guess a
+version or switch to an ad hoc Wrangler command.
+
 ## WP8 Boundary
 
 This runbook documents repository behavior; it does not authorize production setup or prove a live

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "release:live": "node scripts/release/live-release.mjs",
     "test": "vitest run",
     "test:release": "vitest run test/release",
-    "test:release-workflow": "vitest run test/release/git-observer.test.ts test/release/github-adapter.test.ts test/release/github-publication-adapter.test.ts test/release/cloudflare-adapter.test.ts test/release/cloudflare-client.test.ts test/release/live-release.test.ts test/release/workflow.test.ts && bash test/release-workflow-contract.test.sh",
+    "test:release-workflow": "vitest run test/release/git-observer.test.ts test/release/github-adapter.test.ts test/release/github-publication-adapter.test.ts test/release/cloudflare-adapter.test.ts test/release/cloudflare-client.test.ts test/release/cloudflare-capability-drill.test.ts test/release/live-release.test.ts test/release/workflow.test.ts && bash test/release-workflow-contract.test.sh",
     "test:static-assets": "vitest run test/release/static-assets.test.ts",
     "test:watch": "vitest",
     "test:e2e": "playwright test",

--- a/scripts/release/cloudflare-adapter.mjs
+++ b/scripts/release/cloudflare-adapter.mjs
@@ -62,7 +62,9 @@ function boundedText(value, field) {
 }
 
 export function parseEnvironmentTarget(configBytes, environment, expectedTarget) {
-  if (environment !== 'production') fail('INVALID_ENVIRONMENT', 'environment must be production');
+  if (!['preview', 'production'].includes(environment)) {
+    fail('INVALID_ENVIRONMENT', 'environment must be preview or production');
+  }
   match(expectedTarget, SAFE_NAME, 'expectedTarget');
   const source = Buffer.isBuffer(configBytes) ? configBytes.toString('utf8') : configBytes;
   if (typeof source !== 'string') fail('INVALID_CONTROLLER_CONFIG', 'config bytes are missing');
@@ -223,6 +225,26 @@ export function parseVersionView(value, expectedVersionId) {
       serveDirectly: runtimeAssets.serve_directly,
     },
   };
+}
+
+export function parseDeploymentList(value) {
+  const deployments = json(value, 'deployment list');
+  if (!Array.isArray(deployments) || deployments.length === 0 || deployments.length > 100) {
+    fail('INVALID_CLOUDFLARE_RESPONSE', 'deployment list is empty or unbounded');
+  }
+  return deployments.map(parseDeploymentStatus);
+}
+
+export function parseVersionList(value) {
+  const versions = json(value, 'version list');
+  if (!Array.isArray(versions) || versions.length === 0 || versions.length > 100) {
+    fail('INVALID_CLOUDFLARE_RESPONSE', 'version list is empty or unbounded');
+  }
+  return versions.map(item => ({
+    versionId: match(item?.id, SAFE_ID, 'version.id', 'INVALID_CLOUDFLARE_RESPONSE'),
+    createdOn: timestamp(item?.metadata?.created_on, 'version.metadata.created_on'),
+    source: boundedText(item?.metadata?.source, 'version.metadata.source'),
+  }));
 }
 
 export function reconcileDeployment(input) {

--- a/scripts/release/cloudflare-capability-drill.mjs
+++ b/scripts/release/cloudflare-capability-drill.mjs
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { canonicalHash, canonicalize } from './canonical-json.mjs';
+import { reconcileDeployment, verifyRollback } from './cloudflare-adapter.mjs';
+import { createPreviewCloudflareClient } from './cloudflare-client.mjs';
+
+const SHA = /^[0-9a-f]{40}$/;
+const VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const MAX_BYTES = 16 * 1024 * 1024;
+
+class CapabilityError extends Error {
+  constructor(code, message) {
+    super(`${code}: ${message}`);
+    Object.assign(this, { code, name: 'CapabilityError' });
+  }
+}
+
+const fail = (code, message) => {
+  throw new CapabilityError(code, message);
+};
+const digest = bytes => createHash('sha256').update(bytes).digest('hex');
+const pause = milliseconds =>
+  new Promise(resolvePromise => setTimeout(resolvePromise, milliseconds));
+
+function requireMatch(value, pattern, field) {
+  if (!pattern.test(value ?? '')) fail('INVALID_INPUT', `${field} is invalid`);
+  return value;
+}
+
+function requireResult(result, field) {
+  if (result?.status !== 'succeeded' || !result.value) {
+    fail('INSPECTION_FAILED', `${field} did not return authoritative state`);
+  }
+  return result.value;
+}
+
+function failureCode(error, fallback = 'CAPABILITY_DRILL_FAILED') {
+  return /^[A-Z0-9_]{1,64}$/.test(error?.code ?? '') ? error.code : fallback;
+}
+
+async function fetchBytes(url, limit = MAX_BYTES) {
+  const response = await fetch(url, { redirect: 'error', signal: AbortSignal.timeout(15_000) });
+  if (!response.ok)
+    fail('LIVE_FETCH_FAILED', `${new URL(url).pathname} returned ${response.status}`);
+  const declared = Number(response.headers.get('content-length') ?? 0);
+  if (declared > limit) fail('LIVE_RESPONSE_OVERSIZE', `${new URL(url).pathname} is oversized`);
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (!bytes.length || bytes.length > limit) {
+    fail('LIVE_RESPONSE_OVERSIZE', `${new URL(url).pathname} is empty or oversized`);
+  }
+  return bytes;
+}
+
+async function snapshot(origin, filenames = []) {
+  const healthBytes = await fetchBytes(`${origin}/api/health`, 64 * 1024);
+  const manifestBytes = await fetchBytes(`${origin}/versions.json`, 1024 * 1024);
+  let health;
+  let manifest;
+  try {
+    health = JSON.parse(healthBytes.toString('utf8'));
+    manifest = JSON.parse(manifestBytes.toString('utf8'));
+  } catch {
+    fail('LIVE_JSON_INVALID', 'health or manifest is not JSON');
+  }
+  const assetHashes = { 'versions.json': digest(manifestBytes) };
+  for (const filename of [...new Set(['widget.js', ...filenames])]) {
+    assetHashes[filename] = digest(await fetchBytes(`${origin}/${filename}`));
+  }
+  return { health, manifest, assetHashes };
+}
+
+function assetIdentity(value) {
+  return canonicalHash({
+    manifest: value.assetHashes['versions.json'],
+    widget: value.assetHashes['widget.js'],
+  });
+}
+
+function verifyReleaseSnapshot(value, expected) {
+  if (
+    value.health?.status !== 'ok' ||
+    value.health?.environment !== 'preview' ||
+    value.health?.buildSha !== expected.sha ||
+    value.manifest?.authoritative !== true ||
+    value.manifest?.mode !== 'release' ||
+    value.manifest?.current !== expected.version
+  ) {
+    fail(
+      'LIVE_IDENTITY_MISMATCH',
+      `preview does not identify capability release ${expected.version}`
+    );
+  }
+  for (const name of expected.currentNames) {
+    if (value.assetHashes[name] !== expected.currentHash) {
+      fail('LIVE_ASSET_MISMATCH', `${name} differs from capability release ${expected.version}`);
+    }
+  }
+  for (const [name, hash] of Object.entries(expected.retained)) {
+    if (value.assetHashes[name] !== hash)
+      fail('LIVE_RETENTION_MISMATCH', `${name} was not retained`);
+  }
+  return {
+    assetIdentity: assetIdentity(value),
+    buildSha: value.health.buildSha,
+    sourceIdentity: value.health.buildSha,
+  };
+}
+
+async function waitForRelease(origin, expected) {
+  const filenames = [...expected.currentNames, ...Object.keys(expected.retained)];
+  let lastError;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    try {
+      const value = await snapshot(origin, filenames);
+      return { value, identity: verifyReleaseSnapshot(value, expected) };
+    } catch (error) {
+      lastError = error;
+      await pause(2_000);
+    }
+  }
+  throw lastError ?? new CapabilityError('LIVE_TIMEOUT', 'preview did not converge');
+}
+
+async function inspect(client) {
+  const deployment = requireResult(client.inspectStatus(), 'deployment status');
+  const version = requireResult(client.inspectVersion(deployment.versionId), 'version view');
+  return { deployment, version };
+}
+
+function client(input, candidateRoot, assets, sha, createClient) {
+  return createClient({
+    accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+    apiToken: process.env.CLOUDFLARE_API_TOKEN,
+    controllerRoot: resolve(input.controllerRoot),
+    candidateRoot: resolve(candidateRoot),
+    controllerConfig: resolve(input.controllerConfig),
+    candidateEntrypoint: resolve(candidateRoot, 'src/index.ts'),
+    candidateAssets: resolve(assets),
+    controllerConfigBytes: input.controllerConfigBytes,
+    controllerLockBytes: input.controllerLockBytes,
+    targetSha: sha,
+  });
+}
+
+async function expectedRelease(root, version, sha, retained = {}) {
+  const [major, minor] = version.split('.');
+  const exact = `widget.v${version}.js`;
+  return {
+    version,
+    sha,
+    currentHash: digest(await readFile(resolve(root, exact))),
+    currentNames: ['widget.js', `widget.v${major}.js`, `widget.v${major}.${minor}.js`, exact],
+    retained,
+  };
+}
+
+async function restoreBaseline({ baseline, baselineSnapshot, clientA, origin }) {
+  const command = clientA.rollback(
+    baseline.deployment.versionId,
+    'restore preview capability baseline'
+  );
+  let last;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    try {
+      const observed = await inspect(clientA);
+      const live = await snapshot(origin);
+      last = verifyRollback({
+        baseline: {
+          versionId: baseline.deployment.versionId,
+          scriptEtag: baseline.version.scriptEtag,
+          sourceIdentity: baselineSnapshot.health.buildSha,
+          assetIdentity: assetIdentity(baselineSnapshot),
+        },
+        after: observed.deployment,
+        version: observed.version,
+        live: {
+          sourceIdentity: live.health?.buildSha,
+          assetIdentity: assetIdentity(live),
+        },
+      });
+      if (last.status === 'verified') return { commandStatus: command.status, verification: last };
+    } catch (error) {
+      last = { status: 'inspection-error', code: error?.code ?? 'UNKNOWN' };
+    }
+    await pause(2_000);
+  }
+  fail('BASELINE_RESTORE_FAILED', canonicalize(last));
+}
+
+export async function runCapabilityDrill(raw, dependencies = {}) {
+  const input = {
+    ...raw,
+    shaA: requireMatch(raw.shaA, SHA, 'shaA'),
+    shaB: requireMatch(raw.shaB, SHA, 'shaB'),
+    versionA: requireMatch(raw.versionA, VERSION, 'versionA'),
+    versionB: requireMatch(raw.versionB, VERSION, 'versionB'),
+    origin: new URL(raw.origin).origin,
+    controllerConfigBytes: await readFile(resolve(raw.controllerConfig)),
+    controllerLockBytes: await readFile(resolve(raw.controllerLock)),
+  };
+  if (input.origin !== raw.origin || input.shaA === input.shaB)
+    fail('INVALID_INPUT', 'origin or SHAs are unsafe');
+  const createClient = dependencies.createClient ?? createPreviewCloudflareClient;
+  const takeSnapshot = dependencies.snapshot ?? snapshot;
+  const waitRelease = dependencies.waitForRelease ?? waitForRelease;
+  const restore = dependencies.restoreBaseline ?? restoreBaseline;
+  const clientA = client(input, input.candidateARoot, input.assetsA, input.shaA, createClient);
+  const clientB = client(input, input.candidateBRoot, input.assetsB, input.shaB, createClient);
+  const expectedA = await expectedRelease(input.assetsA, input.versionA, input.shaA);
+  const retainedName = `widget.v${input.versionA}.js`;
+  const expectedB = await expectedRelease(input.assetsB, input.versionB, input.shaB, {
+    [retainedName]: expectedA.currentHash,
+  });
+  const baseline = await inspect(clientA);
+  const deploymentList = requireResult(clientA.inspectDeployments(), 'deployment list');
+  const versionList = requireResult(clientA.inspectVersions(), 'version list');
+  if (
+    !deploymentList.some(item => item.deploymentId === baseline.deployment.deploymentId) ||
+    !versionList.some(item => item.versionId === baseline.version.versionId)
+  ) {
+    fail('LIST_CAPABILITY_MISMATCH', 'list commands do not contain the active preview identities');
+  }
+  const baselineSnapshot = await takeSnapshot(input.origin);
+  if (baseline.version.buildSha !== baselineSnapshot.health?.buildSha) {
+    fail('BASELINE_IDENTITY_MISMATCH', 'preview metadata and live health disagree before mutation');
+  }
+  let mutated = false;
+  const evidence = {
+    schema: 'bugdrop.cloudflare-capability-proof/v1',
+    wranglerVersion: clientA.wranglerVersion,
+    listProof: { deployments: deploymentList.length, versions: versionList.length },
+    baseline: {
+      versionId: baseline.deployment.versionId,
+      buildSha: baseline.version.buildSha,
+      assetIdentity: assetIdentity(baselineSnapshot),
+    },
+  };
+  let drillError;
+  try {
+    const deployA = clientA.deploy();
+    mutated = true;
+    const observedA = await inspect(clientA);
+    const liveA = await waitRelease(input.origin, expectedA);
+    const reconcileA = reconcileDeployment({
+      commandStatus: deployA.status,
+      before: baseline.deployment,
+      after: observedA.deployment,
+      version: observedA.version,
+      expectedBuildSha: input.shaA,
+      live: { ...liveA.identity, sourceVerified: true, assetVerified: true },
+    });
+    if (reconcileA.status !== 'candidate-active')
+      fail('A_RECONCILE_FAILED', canonicalize(reconcileA));
+
+    clientB.deploy();
+    const observedB = await inspect(clientB);
+    const liveB = await waitRelease(input.origin, expectedB);
+    const lostResponse = reconcileDeployment({
+      commandStatus: 'unknown',
+      before: observedA.deployment,
+      after: observedB.deployment,
+      version: observedB.version,
+      expectedBuildSha: input.shaB,
+      live: { ...liveB.identity, sourceVerified: true, assetVerified: true },
+    });
+    if (lostResponse.status !== 'candidate-active')
+      fail('B_RECONCILE_FAILED', canonicalize(lostResponse));
+
+    clientB.rollback(observedA.deployment.versionId, 'verify preview release rollback');
+    const rolledBack = await inspect(clientA);
+    const rolledBackLive = await waitRelease(input.origin, expectedA);
+    const rollbackProof = verifyRollback({
+      baseline: {
+        versionId: observedA.deployment.versionId,
+        scriptEtag: observedA.version.scriptEtag,
+        sourceIdentity: liveA.identity.sourceIdentity,
+        assetIdentity: liveA.identity.assetIdentity,
+      },
+      after: rolledBack.deployment,
+      version: rolledBack.version,
+      live: rolledBackLive.identity,
+    });
+    if (rollbackProof.status !== 'verified') fail('ROLLBACK_FAILED', canonicalize(rollbackProof));
+    Object.assign(evidence, {
+      releaseA: {
+        versionId: observedA.deployment.versionId,
+        buildSha: input.shaA,
+        assetIdentity: liveA.identity.assetIdentity,
+      },
+      releaseB: {
+        versionId: observedB.deployment.versionId,
+        buildSha: input.shaB,
+        assetIdentity: liveB.identity.assetIdentity,
+        retained: retainedName,
+      },
+      lostResponse,
+      rollbackProof,
+    });
+  } catch (error) {
+    drillError = error;
+    evidence.failure = { code: failureCode(error) };
+  } finally {
+    if (mutated) {
+      try {
+        evidence.restoration = await restore({
+          baseline,
+          baselineSnapshot,
+          clientA,
+          origin: input.origin,
+        });
+      } catch (error) {
+        evidence.restoration = { status: 'failed', code: failureCode(error, 'RESTORATION_FAILED') };
+        drillError = error;
+      }
+    }
+  }
+  if (drillError) {
+    const error =
+      drillError instanceof Error
+        ? drillError
+        : new CapabilityError('CAPABILITY_DRILL_FAILED', 'capability drill failed');
+    error.capabilityEvidence = evidence;
+    throw error;
+  }
+  return evidence;
+}
+
+async function main() {
+  const [inputPath, outputPath] = process.argv.slice(2);
+  if (!inputPath || !outputPath)
+    fail('INVALID_CLI', 'usage: capability-drill INPUT.json OUTPUT.json');
+  try {
+    const evidence = await runCapabilityDrill(
+      JSON.parse(await readFile(resolve(inputPath), 'utf8'))
+    );
+    await writeFile(resolve(outputPath), `${canonicalize(evidence)}\n`, { flag: 'wx' });
+  } catch (error) {
+    if (error?.capabilityEvidence) {
+      await writeFile(resolve(outputPath), `${canonicalize(error.capabilityEvidence)}\n`, {
+        flag: 'wx',
+      });
+    }
+    throw error;
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  main().catch(error => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release/cloudflare-client.mjs
+++ b/scripts/release/cloudflare-client.mjs
@@ -2,6 +2,8 @@ import { spawnSync } from 'node:child_process';
 
 import {
   parseDeploymentStatus,
+  parseDeploymentList,
+  parseVersionList,
   parseVersionView,
   createWranglerPlan,
   executeWrangler,
@@ -41,17 +43,19 @@ function safeEnvironment(source) {
   );
 }
 
-export function createProductionCloudflareClient({
+function createCloudflareClient({
   accountId,
   apiToken,
+  environment,
+  expectedTarget,
   baseEnv = process.env,
   spawn = spawnSync,
   ...planInput
 }) {
   const plan = createWranglerPlan({
     ...planInput,
-    environment: 'production',
-    expectedTarget: 'bugdrop',
+    environment,
+    expectedTarget,
   });
   const commandEnv = {
     ...safeEnvironment(baseEnv),
@@ -66,9 +70,27 @@ export function createProductionCloudflareClient({
     environment: plan.environment,
     wranglerVersion: plan.wranglerVersion,
     inspectStatus: () => execute(plan.status, parseDeploymentStatus),
+    inspectDeployments: () => execute(plan.deployments, parseDeploymentList),
+    inspectVersions: () => execute(plan.versions, parseVersionList),
     inspectVersion: versionId =>
       execute(plan.viewVersion(versionId), value => parseVersionView(value, versionId)),
     deploy: () => execute(plan.deploy),
     rollback: (versionId, message) => execute(plan.rollback(versionId, message)),
   };
+}
+
+export function createProductionCloudflareClient(input) {
+  return createCloudflareClient({
+    ...input,
+    environment: 'production',
+    expectedTarget: 'bugdrop',
+  });
+}
+
+export function createPreviewCloudflareClient(input) {
+  return createCloudflareClient({
+    ...input,
+    environment: 'preview',
+    expectedTarget: 'bugdrop-preview',
+  });
 }

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 workflow="$repo_root/.github/workflows/deploy.yml"
+capability_workflow="$repo_root/.github/workflows/cloudflare-capability.yml"
+ci_workflow="$repo_root/.github/workflows/ci.yml"
 workflows_dir="$repo_root/.github/workflows"
 
 fail() {
@@ -322,6 +324,27 @@ wrangler_deploy_matches=$(grep -RInF --include='*.yml' --include='*.yaml' -- 'wr
   fail "only preview CI may deploy before WP7: $wrangler_deploy_matches"
 [[ "$wrangler_deploy_matches" == *'.github/workflows/ci.yml:'*'wrangler deploy --env preview'* ]] ||
   fail "remaining Wrangler deploy is not preview-only: $wrangler_deploy_matches"
+
+[[ -s "$capability_workflow" ]] || fail 'Cloudflare capability workflow is missing'
+for literal in \
+  'workflow_dispatch:' \
+  'group: bugdrop-shared-preview' \
+  'cancel-in-progress: false' \
+  'test "$DISPATCH_REF" = '\''refs/heads/main'\''' \
+  'git -C controller merge-base --is-ancestor "$SHA_A" "$SHA_B"' \
+  'persist-credentials: false' \
+  'node controller/scripts/release/cloudflare-capability-drill.mjs' \
+  'CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}' \
+  'CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}' \
+  'if: always()'; do
+  grep -Fq -- "$literal" "$capability_workflow" ||
+    fail "Cloudflare capability workflow lacks: $literal"
+done
+grep -Fq 'group: bugdrop-shared-preview' "$ci_workflow" ||
+  fail 'merge-queue preview and capability drill must share one mutation lock'
+if grep -Eq 'environment: production|contents: write|issues: write|DISCORD_|BUGDROP_CANARY_' "$capability_workflow"; then
+  fail 'Cloudflare capability workflow receives unrelated or production authority'
+fi
 
 (
   cd "$repo_root"

--- a/test/release/cloudflare-adapter.test.ts
+++ b/test/release/cloudflare-adapter.test.ts
@@ -9,6 +9,8 @@ import {
   createWranglerPlan,
   executeWrangler,
   parseDeploymentStatus,
+  parseDeploymentList,
+  parseVersionList,
   parseEnvironmentTarget,
   parseVersionView,
   reconcileDeployment,
@@ -94,7 +96,7 @@ describe('controller-owned Cloudflare command plan', () => {
 
   it.each([
     ['wrong target', { controllerConfigBytes: config('other-worker') }],
-    ['wrong environment', { environment: 'preview' }],
+    ['wrong environment', { environment: 'staging' }],
     ['wrong Wrangler', { controllerLockBytes: lock('4.99.0') }],
     ['controller escape', { controllerConfig: '/untrusted/wrangler.toml' }],
     ['candidate source escape', { candidateEntrypoint: '/trusted/controller/src/index.ts' }],
@@ -119,6 +121,17 @@ describe('controller-owned Cloudflare command plan', () => {
       parseEnvironmentTarget('[env.production]\nname=target_from_input', 'production', 'bugdrop')
     ).toThrow('unsafe');
   });
+
+  it('pins the preview target for the non-production capability drill', () => {
+    const result = plan({
+      controllerConfigBytes: Buffer.from('[env.preview]\nname="bugdrop-preview"\n'),
+      environment: 'preview',
+      expectedTarget: 'bugdrop-preview',
+    });
+    expect(result).toMatchObject({ environment: 'preview', target: 'bugdrop-preview' });
+    expect(result.deploy.args).toContain('preview');
+    expect(result.deploy.args).not.toContain('--name');
+  });
 });
 
 describe('authoritative Cloudflare observations', () => {
@@ -131,6 +144,32 @@ describe('authoritative Cloudflare observations', () => {
       strategy: 'percentage',
     });
   });
+
+  it('normalizes bounded deployment and version lists', async () => {
+    const deployment = await fixture('status-active');
+    expect(parseDeploymentList([deployment])).toEqual([parseDeploymentStatus(deployment)]);
+    expect(
+      parseVersionList([
+        {
+          id: 'version-current',
+          metadata: { created_on: '2026-08-03T12:00:00Z', source: 'wrangler' },
+        },
+      ])
+    ).toEqual([
+      {
+        versionId: 'version-current',
+        createdOn: '2026-08-03T12:00:00Z',
+        source: 'wrangler',
+      },
+    ]);
+  });
+
+  it.each([[], Array.from({ length: 101 }, () => ({}))])(
+    'rejects empty or unbounded deployment lists',
+    value => {
+      expect(() => parseDeploymentList(value)).toThrow(CloudflareAdapterError);
+    }
+  );
 
   it.each([
     ['split traffic', async () => fixture('status-split')],

--- a/test/release/cloudflare-capability-drill.test.ts
+++ b/test/release/cloudflare-capability-drill.test.ts
@@ -1,0 +1,197 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { runCapabilityDrill } from '../../scripts/release/cloudflare-capability-drill.mjs';
+
+const SHA_A = '1'.repeat(40);
+const SHA_B = '2'.repeat(40);
+const SHA_BASELINE = '0'.repeat(40);
+const VERSION_A = '9000.0.0';
+const VERSION_B = '9000.0.1';
+const BASELINE_SNAPSHOT = {
+  health: { buildSha: SHA_BASELINE },
+  assetHashes: { 'versions.json': 'manifest-baseline', 'widget.js': 'widget-baseline' },
+};
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map(path => rm(path, { recursive: true })));
+});
+
+function deployment(versionId: string) {
+  return {
+    deploymentId: `deployment-${versionId}`,
+    versionId,
+    createdOn: '2026-08-04T12:00:00Z',
+    source: 'wrangler',
+    strategy: 'percentage',
+  };
+}
+
+function version(versionId: string, buildSha: string) {
+  return {
+    versionId,
+    buildSha,
+    scriptEtag: `etag-${versionId}`,
+    createdOn: '2026-08-04T12:00:00Z',
+    source: 'wrangler',
+    assets: { rawRunWorkerFirst: true, serveDirectly: false },
+  };
+}
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'bugdrop-cloudflare-drill-'));
+  temporaryRoots.push(root);
+  const controllerRoot = join(root, 'controller');
+  const candidateARoot = join(root, 'candidate-a');
+  const candidateBRoot = join(root, 'candidate-b');
+  const assetsA = join(candidateARoot, 'public');
+  const assetsB = join(candidateBRoot, 'public');
+  await Promise.all([
+    mkdir(controllerRoot),
+    mkdir(assetsA, { recursive: true }),
+    mkdir(assetsB, { recursive: true }),
+  ]);
+  const controllerConfig = join(controllerRoot, 'wrangler.toml');
+  const controllerLock = join(controllerRoot, 'package-lock.json');
+  await Promise.all([
+    writeFile(controllerConfig, '[env.preview]\nname = "bugdrop-preview"\n'),
+    writeFile(
+      controllerLock,
+      JSON.stringify({ packages: { 'node_modules/wrangler': { version: '4.98.0' } } })
+    ),
+    writeFile(join(assetsA, `widget.v${VERSION_A}.js`), 'candidate-a'),
+    writeFile(join(assetsB, `widget.v${VERSION_B}.js`), 'candidate-b'),
+  ]);
+
+  const statusA = [deployment('baseline'), deployment('candidate-a'), deployment('candidate-a')];
+  const statusB = [deployment('candidate-b')];
+  const createClient = vi.fn(input => {
+    const statuses = input.targetSha === SHA_A ? statusA : statusB;
+    return {
+      wranglerVersion: '4.98.0',
+      inspectStatus: vi.fn(() => ({ status: 'succeeded', value: statuses.shift() })),
+      inspectVersion: vi.fn((versionId: string) => ({
+        status: 'succeeded',
+        value: version(
+          versionId,
+          versionId === 'baseline' ? SHA_BASELINE : versionId === 'candidate-a' ? SHA_A : SHA_B
+        ),
+      })),
+      inspectDeployments: vi.fn(() => ({
+        status: 'succeeded',
+        value: [deployment('baseline')],
+      })),
+      inspectVersions: vi.fn(() => ({
+        status: 'succeeded',
+        value: [version('baseline', SHA_BASELINE)],
+      })),
+      deploy: vi.fn(() => ({ status: 'succeeded' })),
+      rollback: vi.fn(() => ({ status: 'succeeded' })),
+    };
+  });
+  const input = {
+    controllerRoot,
+    controllerConfig,
+    controllerLock,
+    candidateARoot,
+    candidateBRoot,
+    assetsA,
+    assetsB,
+    shaA: SHA_A,
+    shaB: SHA_B,
+    versionA: VERSION_A,
+    versionB: VERSION_B,
+    origin: 'https://preview.example',
+  };
+  return { createClient, input };
+}
+
+describe('Cloudflare capability drill', () => {
+  it('proves lost-response reconciliation, rollback, and final restoration', async () => {
+    const { createClient, input } = await fixture();
+    const restoreBaseline = vi.fn(async () => ({
+      commandStatus: 'succeeded',
+      verification: { status: 'verified' },
+    }));
+    const evidence = await runCapabilityDrill(input, {
+      createClient,
+      snapshot: vi.fn(async () => BASELINE_SNAPSHOT),
+      waitForRelease: vi.fn(async (_origin, expected) => ({
+        value: {},
+        identity: {
+          buildSha: expected.sha,
+          sourceIdentity: expected.sha,
+          assetIdentity: `assets-${expected.version}`,
+        },
+      })),
+      restoreBaseline,
+    });
+
+    expect(evidence).toMatchObject({
+      schema: 'bugdrop.cloudflare-capability-proof/v1',
+      lostResponse: { status: 'candidate-active', versionId: 'candidate-b' },
+      rollbackProof: { status: 'verified' },
+      restoration: { verification: { status: 'verified' } },
+    });
+    expect(restoreBaseline).toHaveBeenCalledOnce();
+  });
+
+  it('restores the baseline when live verification fails after mutation', async () => {
+    const { createClient, input } = await fixture();
+    const restoreBaseline = vi.fn(async () => ({ verification: { status: 'verified' } }));
+
+    let failure: Error & { capabilityEvidence?: Record<string, unknown> };
+    try {
+      await runCapabilityDrill(input, {
+        createClient,
+        snapshot: vi.fn(async () => BASELINE_SNAPSHOT),
+        waitForRelease: vi.fn(async () => {
+          throw new Error('preview did not converge');
+        }),
+        restoreBaseline,
+      });
+      throw new Error('expected the capability drill to fail');
+    } catch (error) {
+      failure = error as Error & { capabilityEvidence?: Record<string, unknown> };
+    }
+    expect(failure).toMatchObject({
+      message: 'preview did not converge',
+      capabilityEvidence: {
+        baseline: { versionId: 'baseline', buildSha: SHA_BASELINE },
+        failure: { code: 'CAPABILITY_DRILL_FAILED' },
+        restoration: { verification: { status: 'verified' } },
+      },
+    });
+    expect(restoreBaseline).toHaveBeenCalledOnce();
+  });
+
+  it('retains the exact baseline identity when restoration also fails', async () => {
+    const { createClient, input } = await fixture();
+    let failure: Error & { capabilityEvidence?: Record<string, unknown> };
+    try {
+      await runCapabilityDrill(input, {
+        createClient,
+        snapshot: vi.fn(async () => BASELINE_SNAPSHOT),
+        waitForRelease: vi.fn(async () => {
+          throw new Error('preview did not converge');
+        }),
+        restoreBaseline: vi.fn(async () => {
+          throw Object.assign(new Error('restoration failed'), { code: 'BASELINE_RESTORE_FAILED' });
+        }),
+      });
+      throw new Error('expected the capability drill to fail');
+    } catch (error) {
+      failure = error as Error & { capabilityEvidence?: Record<string, unknown> };
+    }
+    expect(failure.capabilityEvidence).toMatchObject({
+      baseline: { versionId: 'baseline', buildSha: SHA_BASELINE },
+      failure: { code: 'CAPABILITY_DRILL_FAILED' },
+      restoration: { status: 'failed', code: 'BASELINE_RESTORE_FAILED' },
+    });
+  });
+});

--- a/test/release/cloudflare-client.test.ts
+++ b/test/release/cloudflare-client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   CloudflareClientError,
+  createPreviewCloudflareClient,
   createProductionCloudflareClient,
 } from '../../scripts/release/cloudflare-client.mjs';
 
@@ -146,5 +147,12 @@ describe('production Cloudflare client', () => {
     expect(createProductionCloudflareClient(input({ environment: 'preview' })).environment).toBe(
       'production'
     );
+  });
+
+  it('uses the same locked client boundary for the preview capability target', () => {
+    const client = createPreviewCloudflareClient(
+      input({ controllerConfigBytes: Buffer.from('[env.preview]\nname="bugdrop-preview"\n') })
+    );
+    expect(client).toMatchObject({ environment: 'preview', target: 'bugdrop-preview' });
   });
 });


### PR DESCRIPTION
## Summary
- add a bounded preview-only Cloudflare capability drill using the locked release controller
- prove deploy, retained assets, lost-response reconciliation, rollback, and unconditional baseline restoration
- preserve sanitized recovery evidence on failure and document the live proof gate

## Validation
- npm run validate (811 tests)
- npm run test:release-workflow (139 tests plus workflow contracts)
- npm run knip
- npm run check:actions-node24
- actionlint .github/workflows/cloudflare-capability.yml
- codex review --uncommitted (clean after fixes)