### PR TITLE
fix: preserve release handoff and safe finalization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -279,6 +279,7 @@ jobs:
         with:
           name: release-plan-${{ steps.bundle.outputs.plan_key }}
           path: ${{ runner.temp }}/release-plan/
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 14
 
@@ -726,6 +727,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout immutable controller
+        if: ${{ needs.deploy-candidate.result != 'skipped' }}
         uses: actions/checkout@v5
         with:
           ref: ${{ needs.guard-and-plan.outputs.controller_sha }}
@@ -733,6 +735,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout immutable candidate source
+        if: ${{ needs.deploy-candidate.result != 'skipped' }}
         uses: actions/checkout@v5
         with:
           ref: ${{ inputs.target_sha }}
@@ -740,15 +743,18 @@ jobs:
           persist-credentials: false
 
       - uses: actions/setup-node@v5
+        if: ${{ needs.deploy-candidate.result != 'skipped' }}
         with:
           node-version: '22'
 
       - name: Install immutable controller and candidate dependencies
+        if: ${{ needs.deploy-candidate.result != 'skipped' }}
         run: |
           npm --prefix controller ci --ignore-scripts
           npm --prefix candidate ci --ignore-scripts
 
       - name: Download exact State 2 and baseline evidence
+        if: ${{ needs.deploy-candidate.result != 'skipped' }}
         uses: actions/download-artifact@v5
         with:
           artifact-ids: ${{ needs.verify-candidate.outputs.artifact_id }},${{ needs.approval-baseline.outputs.artifact_id }}
@@ -756,6 +762,7 @@ jobs:
           merge-multiple: true
 
       - name: Download deployment evidence when available
+        if: ${{ needs.deploy-candidate.result != 'skipped' }}
         continue-on-error: true
         uses: actions/download-artifact@v5
         with:
@@ -769,7 +776,18 @@ jobs:
           BUGDROP_GITHUB_TOKEN: ${{ github.token }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          DEPLOY_JOB_RESULT: ${{ needs.deploy-candidate.result }}
         run: |
+          if [ "$DEPLOY_JOB_RESULT" = 'skipped' ]; then
+            jq -n --arg planIdentity '${{ needs.verify-candidate.outputs.plan_identity }}' \
+              '{protocol: "bugdrop.live-release/v1", status: "no-mutation", rollbackAttempted: false, planIdentity: $planIdentity}' \
+              > finalization.json
+            echo 'status=no-mutation' >> "$GITHUB_OUTPUT"
+            jq -r '"### Finalization — \(.status)\n\nRollback attempted: `\(.rollbackAttempted)`"' finalization.json >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          test -s release-state/baseline.json
+          test -s release-state/expected.json
           if [ ! -s release-state/deployment.json ]; then
             jq -n --arg planIdentity '${{ needs.verify-candidate.outputs.plan_identity }}' \
               '{status: "ambiguous-critical", mutationAttempted: true, planIdentity: $planIdentity}' \
@@ -800,4 +818,5 @@ jobs:
           status='${{ steps.finalize.outputs.status }}'
           test "$status" = 'published-stable' || \
             test "$status" = 'baseline-restored' || \
-            test "$status" = 'rollback-verified'
+            test "$status" = 'rollback-verified' || \
+            test "$status" = 'no-mutation'

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -174,6 +174,7 @@ for literal in \
   'cp "$RUNNER_TEMP/builder-result.json" "$RUNNER_TEMP/release-plan/builder-result.json"' \
   'cp -R "$RUNNER_TEMP/static-package/." "$RUNNER_TEMP/release-plan/static-package/"' \
   'path: ${{ runner.temp }}/release-plan/' \
+  'include-hidden-files: true' \
   'retention-days: 14'; do
   grep -Fq -- "$literal" <<< "$verify_block" || fail "verify-candidate lacks: $literal"
 done
@@ -304,10 +305,19 @@ for literal in \
   'always()' \
   'environment: production' \
   'contents: read' \
+  'DEPLOY_JOB_RESULT: ${{ needs.deploy-candidate.result }}' \
+  'if [ "$DEPLOY_JOB_RESULT" = '\''skipped'\'' ]; then' \
+  'status: "no-mutation", rollbackAttempted: false' \
+  'test -s release-state/baseline.json' \
+  'test -s release-state/expected.json' \
   'node controller/scripts/release/live-release.mjs finalize' \
-  'Require verified stable or restored production'; do
+  'Require verified stable or restored production' \
+  'test "$status" = '\''no-mutation'\'''; do
   grep -Fq -- "$literal" <<< "$final_block" || fail "finalizer lacks: $literal"
 done
+
+[[ $(grep -Fc "if: \${{ needs.deploy-candidate.result != 'skipped' }}" <<< "$final_block") -eq 6 ]] ||
+  fail 'skipped deployment must bypass all recovery setup and artifact downloads'
 
 require_absent 'CAPABILITY_NOT_INSTALLED'
 


### PR DESCRIPTION
## Summary
- preserve hidden files in the immutable release-plan artifact so State 2 static-tree identity survives the job handoff
- record `no-mutation` only when GitHub proves the deploy job was skipped
- keep failed, cancelled, or completed deployment paths fail-closed on missing recovery evidence

## Verification
- `npm run validate` (811 tests)
- `npm run test:release-workflow` (139 release tests plus workflow contract)
- `npm run knip`
- `npm run check:actions-node24`
- `git diff --check`
- `codex review --uncommitted` (clean after two findings were fixed)

## Failure evidence addressed
The failed live release stopped before mutation because `.gitkeep` was omitted by `upload-artifact`, producing a State 2 static-tree mismatch. Production remained unchanged. This patch preserves dotfiles and ensures the cancellation finalizer cannot infer no mutation from missing artifacts alone.