### PR TITLE
fix: stage release assets in candidate trust root

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -416,6 +416,13 @@ jobs:
           artifact-ids: ${{ needs.verify-candidate.outputs.artifact_id }}
           path: approved
 
+      - name: Stage exact static package below candidate trust root
+        run: |
+          test ! -e candidate/.release-static-package
+          install -d candidate/.release-static-package
+          cp -R approved/static-package/. candidate/.release-static-package/
+          diff -qr approved/static-package candidate/.release-static-package
+
       - name: Revalidate exact plan after protected approval
         id: revalidate
         shell: bash
@@ -482,7 +489,7 @@ jobs:
           jq -n \
             --arg bundlePath "$GITHUB_WORKSPACE/approved/state2-bundle.json" \
             --arg origin 'https://bugdrop.neonwatty.workers.dev' \
-            --arg staticPackageDir "$GITHUB_WORKSPACE/approved/static-package" \
+            --arg staticPackageDir "$GITHUB_WORKSPACE/candidate/.release-static-package" \
             '{$bundlePath, $origin, $staticPackageDir}' > expected-input.json
           node controller/scripts/release/live-release.mjs expected expected-input.json > expected.json
           alias_filenames_json=$(jq -c '.aliasFilenames' expected.json)
@@ -513,7 +520,7 @@ jobs:
             --arg controllerConfig "$GITHUB_WORKSPACE/controller/wrangler.toml" \
             --arg controllerLock "$GITHUB_WORKSPACE/controller/package-lock.json" \
             --arg candidateEntrypoint "$GITHUB_WORKSPACE/candidate/src/index.ts" \
-            --arg candidateAssets "$GITHUB_WORKSPACE/approved/static-package" \
+            --arg candidateAssets "$GITHUB_WORKSPACE/candidate/.release-static-package" \
             --arg targetSha '${{ inputs.target_sha }}' \
             --arg expectedPath "$GITHUB_WORKSPACE/expected.json" \
             '{$controllerRoot, $candidateRoot, $controllerConfig, $controllerLock, $candidateEntrypoint, $candidateAssets, $targetSha, $expectedPath}' \
@@ -575,6 +582,13 @@ jobs:
           path: release-state
           merge-multiple: true
 
+      - name: Stage exact static package below candidate trust root
+        run: |
+          test ! -e candidate/.release-static-package
+          install -d candidate/.release-static-package
+          cp -R release-state/static-package/. candidate/.release-static-package/
+          diff -qr release-state/static-package candidate/.release-static-package
+
       - name: Deploy once and reconcile every command outcome
         id: deploy
         shell: bash
@@ -588,7 +602,7 @@ jobs:
             --arg controllerConfig "$GITHUB_WORKSPACE/controller/wrangler.toml" \
             --arg controllerLock "$GITHUB_WORKSPACE/controller/package-lock.json" \
             --arg candidateEntrypoint "$GITHUB_WORKSPACE/candidate/src/index.ts" \
-            --arg candidateAssets "$GITHUB_WORKSPACE/release-state/static-package" \
+            --arg candidateAssets "$GITHUB_WORKSPACE/candidate/.release-static-package" \
             --arg targetSha '${{ inputs.target_sha }}' \
             --arg expectedPath "$GITHUB_WORKSPACE/release-state/expected.json" \
             --arg authorizationPath "$GITHUB_WORKSPACE/release-state/authorization.json" \
@@ -769,6 +783,14 @@ jobs:
           name: release-deployment-${{ needs.verify-candidate.outputs.plan_key }}
           path: release-state
 
+      - name: Stage exact static package below candidate trust root
+        if: ${{ needs.deploy-candidate.result != 'skipped' }}
+        run: |
+          test ! -e candidate/.release-static-package
+          install -d candidate/.release-static-package
+          cp -R release-state/static-package/. candidate/.release-static-package/
+          diff -qr release-state/static-package candidate/.release-static-package
+
       - name: Reinspect publication and restore only the exact baseline when required
         id: finalize
         shell: bash
@@ -799,7 +821,7 @@ jobs:
             --arg controllerConfig "$GITHUB_WORKSPACE/controller/wrangler.toml" \
             --arg controllerLock "$GITHUB_WORKSPACE/controller/package-lock.json" \
             --arg candidateEntrypoint "$GITHUB_WORKSPACE/candidate/src/index.ts" \
-            --arg candidateAssets "$GITHUB_WORKSPACE/release-state/static-package" \
+            --arg candidateAssets "$GITHUB_WORKSPACE/candidate/.release-static-package" \
             --arg targetSha '${{ inputs.target_sha }}' \
             --arg expectedPath "$GITHUB_WORKSPACE/release-state/expected.json" \
             --arg baselinePath "$GITHUB_WORKSPACE/release-state/baseline.json" \

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -239,6 +239,10 @@ for literal in \
   'needs: [guard-and-plan, verify-candidate, capability-gate]' \
   'environment: production' \
   'artifact-ids: ${{ needs.verify-candidate.outputs.artifact_id }}' \
+  'Stage exact static package below candidate trust root' \
+  'diff -qr approved/static-package candidate/.release-static-package' \
+  '--arg staticPackageDir "$GITHUB_WORKSPACE/candidate/.release-static-package"' \
+  '--arg candidateAssets "$GITHUB_WORKSPACE/candidate/.release-static-package"' \
   'Revalidate exact plan after protected approval' \
   'node controller/scripts/release/workflow.mjs authorize' \
   'Capture exact production baseline before mutation' \
@@ -257,6 +261,8 @@ deploy_block=$(job_block deploy-candidate)
 for literal in \
   "needs.approval-baseline.outputs.proceed == 'true'" \
   'environment: production' \
+  'diff -qr release-state/static-package candidate/.release-static-package' \
+  '--arg candidateAssets "$GITHUB_WORKSPACE/candidate/.release-static-package"' \
   'node controller/scripts/release/live-release.mjs deploy' \
   'Require exact candidate deployment' \
   "test '\${{ steps.deploy.outputs.status }}' = 'candidate-active'"; do
@@ -310,13 +316,15 @@ for literal in \
   'status: "no-mutation", rollbackAttempted: false' \
   'test -s release-state/baseline.json' \
   'test -s release-state/expected.json' \
+  'diff -qr release-state/static-package candidate/.release-static-package' \
+  '--arg candidateAssets "$GITHUB_WORKSPACE/candidate/.release-static-package"' \
   'node controller/scripts/release/live-release.mjs finalize' \
   'Require verified stable or restored production' \
   'test "$status" = '\''no-mutation'\'''; do
   grep -Fq -- "$literal" <<< "$final_block" || fail "finalizer lacks: $literal"
 done
 
-[[ $(grep -Fc "if: \${{ needs.deploy-candidate.result != 'skipped' }}" <<< "$final_block") -eq 6 ]] ||
+[[ $(grep -Fc "if: \${{ needs.deploy-candidate.result != 'skipped' }}" <<< "$final_block") -eq 7 ]] ||
   fail 'skipped deployment must bypass all recovery setup and artifact downloads'
 
 require_absent 'CAPABILITY_NOT_INSTALLED'


### PR DESCRIPTION
## Summary
- stage the exact immutable static package beneath the checked-out candidate trust root
- byte-compare every staged tree with its downloaded source before baseline, deployment, or recovery
- pass the same trusted child path through expected-identity, baseline, deploy, and finalization contracts

## Verification
- `npm run validate` (811 tests)
- `npm run test:release-workflow` (139 release tests plus workflow contract)
- `npm run knip`
- `npm run check:actions-node24`
- `git diff --check`
- `codex review --uncommitted` (clean)

## Failure evidence addressed
Live release run 30943010157 passed authenticated State 2 identity but stopped before mutation with `UNSAFE_PATH: candidateAssets must be a file below its trusted root`. Its skipped-deployment finalizer recorded `no-mutation`, and production remained `environment=development`, `buildSha=null`.