### PR TITLE
fix: support bootstrap production baseline

### DIFF
--- a/scripts/release/live-release.mjs
+++ b/scripts/release/live-release.mjs
@@ -14,7 +14,11 @@ import {
   validatePublicationBundle,
 } from './publication.mjs';
 import { canonicalize } from './canonical-json.mjs';
-import { collectRecoveryIdentity, pollLiveVerification } from './verify-live.mjs';
+import {
+  collectBaselineIdentity,
+  collectRecoveryIdentity,
+  pollLiveVerification,
+} from './verify-live.mjs';
 import { assertStaticTree } from './static-tree.mjs';
 
 const PROTOCOL = 'bugdrop.live-release/v1';
@@ -142,7 +146,7 @@ async function inspectAuthoritative(client, origin, observe = collectRecoveryIde
   };
 }
 
-export async function captureBaseline({ client, expected, observe = collectRecoveryIdentity }) {
+export async function captureBaseline({ client, expected, observe = collectBaselineIdentity }) {
   const current = await inspectAuthoritative(client, expected.origin, observe);
   return {
     protocol: PROTOCOL,
@@ -277,7 +281,7 @@ export async function finalizeRelease({
   deployment,
   expected,
   publication,
-  observe = collectRecoveryIdentity,
+  observe = collectBaselineIdentity,
   verify = value => pollLiveVerification({ expected: value }),
 }) {
   if (deployment?.mutationAttempted !== true) {

--- a/scripts/release/verify-live.mjs
+++ b/scripts/release/verify-live.mjs
@@ -13,6 +13,7 @@ const MAX_HEALTH_BYTES = 64 * 1024;
 const MAX_MANIFEST_BYTES = 1024 * 1024;
 const MAX_WIDGET_BYTES = 16 * 1024 * 1024;
 const MAX_SNAPSHOT_BYTES = 512 * 1024 * 1024;
+const MAX_BASELINE_OBSERVATION_MS = 2 * 60 * 1000;
 
 export class LiveVerificationError extends Error {
   constructor(code, message, details = {}) {
@@ -203,11 +204,28 @@ async function readBoundedBytes(response, url, maxBytes, budget) {
   budget.used += total;
   return Buffer.concat(chunks, total);
 }
-async function collectSnapshot(origin, filenames, fetchImpl, timeoutMs, manifestErrorCode) {
+async function collectSnapshot(
+  origin,
+  filenames,
+  fetchImpl,
+  timeoutMs,
+  manifestErrorCode,
+  manifestFilenames = () => [],
+  totalTimeoutMs = null
+) {
   const budget = { used: 0 };
+  const deadline = totalTimeoutMs === null ? null : Date.now() + totalTimeoutMs;
+  const requestTimeout = () => {
+    if (deadline === null) return timeoutMs;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      fail('LIVE_FETCH_TIMEOUT', `${origin} snapshot exceeded ${totalTimeoutMs}ms`);
+    }
+    return Math.min(timeoutMs, remaining);
+  };
   const healthUrl = `${origin}/api/health`;
   const healthBytes = await readBoundedBytes(
-    await fetchOk(healthUrl, fetchImpl, timeoutMs),
+    await fetchOk(healthUrl, fetchImpl, requestTimeout()),
     healthUrl,
     MAX_HEALTH_BYTES,
     budget
@@ -220,9 +238,12 @@ async function collectSnapshot(origin, filenames, fetchImpl, timeoutMs, manifest
   }
   const assetHashes = {};
   let manifest;
-  for (const filename of [...new Set(filenames)]) {
+  const queue = [...new Set(filenames)];
+  const seen = new Set(queue);
+  for (let index = 0; index < queue.length; index += 1) {
+    const filename = queue[index];
     const url = `${origin}/${filename}`;
-    const response = await fetchOk(url, fetchImpl, timeoutMs);
+    const response = await fetchOk(url, fetchImpl, requestTimeout());
     const payload = await readBoundedBytes(
       response,
       url,
@@ -236,9 +257,46 @@ async function collectSnapshot(origin, filenames, fetchImpl, timeoutMs, manifest
       } catch {
         fail(manifestErrorCode, 'versions.json is not valid JSON');
       }
+      for (const additional of manifestFilenames(manifest)) {
+        if (!seen.has(additional)) {
+          seen.add(additional);
+          queue.push(additional);
+        }
+      }
     }
   }
   return { assetHashes, health, manifest };
+}
+
+function baselineManifestFilenames(manifest) {
+  if (
+    !manifest ||
+    typeof manifest !== 'object' ||
+    Array.isArray(manifest) ||
+    manifest.latest !== 'widget.js' ||
+    !manifest.versions ||
+    typeof manifest.versions !== 'object' ||
+    Array.isArray(manifest.versions)
+  ) {
+    fail('LIVE_OBSERVATION_FAILED', 'baseline manifest structure is invalid');
+  }
+  const current = match(
+    manifest.current,
+    VERSION_PATTERN,
+    'baseline current version',
+    'LIVE_OBSERVATION_FAILED'
+  );
+  const filenames = Object.values(manifest.versions);
+  if (filenames.length === 0) {
+    fail('LIVE_OBSERVATION_FAILED', 'baseline manifest asset list is empty');
+  }
+  filenames.forEach(filename =>
+    match(filename, ASSET_PATTERN, 'baseline asset filename', 'LIVE_OBSERVATION_FAILED')
+  );
+  if (manifest.versions[`v${current}`] !== `widget.v${current}.js`) {
+    fail('LIVE_OBSERVATION_FAILED', 'baseline exact asset is inconsistent');
+  }
+  return ['widget.js', ...filenames];
 }
 async function collectLiveSnapshot(expectedInput, fetchImpl = fetch, timeoutMs = 10000) {
   const expected = normalizeExpected(expectedInput);
@@ -319,6 +377,39 @@ export function observeLiveSnapshot(origin, snapshot) {
 export function observePreviewSnapshot(origin, snapshot) {
   return observeSnapshotForEnvironment(origin, snapshot, 'preview');
 }
+export function observeBaselineSnapshot(origin, snapshot) {
+  normalizeOrigin(origin);
+  if (snapshot?.health?.status !== 'ok' || typeof snapshot.health.environment !== 'string') {
+    fail('LIVE_OBSERVATION_FAILED', 'health observation is incomplete');
+  }
+  const environment = snapshot.health.environment;
+  const buildSha = snapshot.health.buildSha;
+  if (environment === 'production') {
+    match(buildSha, SHA_PATTERN, 'observed buildSha', 'LIVE_BUILD_SHA_MISMATCH');
+  } else if (environment !== 'development' || (buildSha !== undefined && buildSha !== null)) {
+    fail('LIVE_ENVIRONMENT_MISMATCH', 'baseline identity is neither bootstrap nor production');
+  }
+  const currentVersion = snapshot.manifest?.current;
+  if (typeof currentVersion !== 'string' || !currentVersion) {
+    fail('LIVE_OBSERVATION_FAILED', 'manifest current identity is missing');
+  }
+  const assetHashes = Object.fromEntries(
+    Object.entries(normalizeHashMap(snapshot.assetHashes, 'baseline asset hashes')).sort(
+      ([left], [right]) => (left < right ? -1 : left > right ? 1 : 0)
+    )
+  );
+  return {
+    ...(typeof buildSha === 'string' ? { buildSha } : {}),
+    assetHashes,
+    currentVersion,
+    environment,
+    manifestSha256: observedHash(snapshot, 'versions.json'),
+    origin,
+    status: 'observed',
+    verifiedAgainstPlan: false,
+    widgetSha256: observedHash(snapshot, 'widget.js'),
+  };
+}
 async function collectObservation(origin, fetchImpl = fetch) {
   normalizeOrigin(origin);
   return collectSnapshot(
@@ -351,6 +442,33 @@ export async function collectRecoveryIdentity(origin, fetchImpl = fetch, timeout
       manifestSha256: observed.manifestSha256,
       widgetSha256: observed.widgetSha256,
     }),
+  };
+}
+export async function collectBaselineIdentity(
+  origin,
+  fetchImpl = fetch,
+  timeoutMs = 10000,
+  totalTimeoutMs = MAX_BASELINE_OBSERVATION_MS
+) {
+  normalizeOrigin(origin);
+  const snapshot = await collectSnapshot(
+    origin,
+    ['widget.js', 'versions.json'],
+    fetchImpl,
+    timeoutMs,
+    'LIVE_OBSERVATION_FAILED',
+    baselineManifestFilenames,
+    totalTimeoutMs
+  );
+  const observed = observeBaselineSnapshot(origin, snapshot);
+  return {
+    ...observed,
+    sourceIdentity: canonicalHash({
+      buildSha: observed.buildSha ?? null,
+      currentVersion: observed.currentVersion,
+      environment: observed.environment,
+    }),
+    assetIdentity: canonicalHash({ assetHashes: observed.assetHashes }),
   };
 }
 function expectedFromEnvironment() {

--- a/test/release/verify-live.test.ts
+++ b/test/release/verify-live.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  collectBaselineIdentity,
   collectRecoveryIdentity,
   LiveVerificationError,
+  observeBaselineSnapshot,
   observeLiveSnapshot,
   observePreviewSnapshot,
   pollLiveVerification,
@@ -208,6 +210,125 @@ describe('polling and scheduled observation', () => {
       currentVersion: '1.56.0',
       verifiedAgainstPlan: false,
     });
+  });
+
+  it('captures the healthy unidentified deployment as a bootstrap baseline', async () => {
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const path = new URL(String(url)).pathname;
+      if (path === '/api/health') {
+        return Response.json({ status: 'ok', environment: 'development', buildSha: null });
+      }
+      if (
+        ['/widget.js', '/widget.v1.js', '/widget.v1.55.js', '/widget.v1.55.0.js'].includes(path)
+      ) {
+        return new Response('legacy widget');
+      }
+      if (path === '/versions.json') {
+        return Response.json({
+          current: '1.55.0',
+          latest: 'widget.js',
+          versions: {
+            v1: 'widget.v1.js',
+            'v1.55': 'widget.v1.55.js',
+            'v1.55.0': 'widget.v1.55.0.js',
+          },
+        });
+      }
+      throw new Error(`unexpected request ${path}`);
+    });
+
+    await expect(
+      collectBaselineIdentity(expected().origin, fetchImpl as typeof fetch)
+    ).resolves.toMatchObject({
+      status: 'observed',
+      environment: 'development',
+      currentVersion: '1.55.0',
+      verifiedAgainstPlan: false,
+      assetHashes: {
+        'widget.js': expect.stringMatching(/^[0-9a-f]{64}$/),
+        'widget.v1.js': expect.stringMatching(/^[0-9a-f]{64}$/),
+        'widget.v1.55.js': expect.stringMatching(/^[0-9a-f]{64}$/),
+        'widget.v1.55.0.js': expect.stringMatching(/^[0-9a-f]{64}$/),
+        'versions.json': expect.stringMatching(/^[0-9a-f]{64}$/),
+      },
+      sourceIdentity: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+      assetIdentity: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+    });
+  });
+
+  it('accepts a retained history bounded by the manifest and snapshot byte limits', async () => {
+    const retained = Object.fromEntries(
+      Array.from({ length: 98 }, (_, index) => [`v1.0.${index}`, `widget.v1.0.${index}.js`])
+    );
+    const versions = {
+      ...retained,
+      v200: 'widget.v200.js',
+      'v200.0': 'widget.v200.0.js',
+      'v200.0.0': 'widget.v200.0.0.js',
+    };
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const path = new URL(String(url)).pathname;
+      if (path === '/api/health') {
+        return Response.json({ status: 'ok', environment: 'development' });
+      }
+      if (path === '/versions.json') {
+        return Response.json({ current: '200.0.0', latest: 'widget.js', versions });
+      }
+      if (path.startsWith('/widget')) return new Response('retained widget');
+      throw new Error(`unexpected request ${path}`);
+    });
+
+    await expect(
+      collectBaselineIdentity(expected().origin, fetchImpl as typeof fetch)
+    ).resolves.toMatchObject({
+      environment: 'development',
+      assetHashes: expect.objectContaining({
+        'widget.v1.0.97.js': expect.stringMatching(/^[0-9a-f]{64}$/),
+        'widget.v200.0.0.js': expect.stringMatching(/^[0-9a-f]{64}$/),
+      }),
+    });
+  });
+
+  it('bounds the total time spent fetching a manifest-driven retained history', async () => {
+    const now = vi.spyOn(Date, 'now');
+    let tick = 0;
+    now.mockImplementation(() => tick++);
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const path = new URL(String(url)).pathname;
+      if (path === '/api/health') {
+        return Response.json({ status: 'ok', environment: 'development' });
+      }
+      if (path === '/versions.json') {
+        return Response.json({
+          current: '1.55.0',
+          latest: 'widget.js',
+          versions: { 'v1.55.0': 'widget.v1.55.0.js' },
+        });
+      }
+      return new Response('legacy widget');
+    });
+
+    try {
+      await expect(
+        collectBaselineIdentity(expected().origin, fetchImpl as typeof fetch, 10_000, 2)
+      ).rejects.toMatchObject({ code: 'LIVE_FETCH_TIMEOUT' });
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it.each([
+    ['identified development', { environment: 'development', buildSha: SHA }],
+    ['empty development SHA', { environment: 'development', buildSha: '' }],
+    ['malformed development SHA', { environment: 'development', buildSha: 42 }],
+    ['unidentified production', { environment: 'production', buildSha: undefined }],
+    ['unknown environment', { environment: 'staging', buildSha: undefined }],
+  ])('rejects %s as a restorable baseline', (_name, healthIdentity) => {
+    const observed = snapshot();
+    Object.assign(observed.health, healthIdentity);
+    expect(() => observeBaselineSnapshot('https://bugdrop.example.com', observed)).toThrow(
+      LiveVerificationError
+    );
   });
 
   it.each([


### PR DESCRIPTION
## Summary
- accept the documented legacy development/no-build-SHA identity only for first-cutover baseline capture
- hash every manifest-declared alias and exact asset so rollback proves the complete legacy static baseline
- bound manifest-driven baseline observation to two minutes while retaining byte-bounded, count-unbounded history
- keep candidate and post-deploy production verification strict

## Proof
- `npm run validate` (53 files, 819 tests)
- `npm run knip`
- `npm run check:actions-node24`
- focused release tests (36 tests)
- clean `codex review --uncommitted` after addressing its total-duration finding
- direct read-only observation of the live legacy production endpoint captured development/no SHA plus all five rollback assets