### PR TITLE
fix: retry post-deploy authority inspection

### DIFF
--- a/scripts/release/live-release.mjs
+++ b/scripts/release/live-release.mjs
@@ -146,6 +146,26 @@ async function inspectAuthoritative(client, origin, observe = collectRecoveryIde
   };
 }
 
+async function inspectAfterMutation({
+  client,
+  origin,
+  observe,
+  maxAttempts = 12,
+  intervalMs = 5000,
+  sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds)),
+}) {
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await inspectAuthoritative(client, origin, observe);
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxAttempts) await sleep(intervalMs);
+    }
+  }
+  throw lastError;
+}
+
 export async function captureBaseline({ client, expected, observe = collectBaselineIdentity }) {
   const current = await inspectAuthoritative(client, expected.origin, observe);
   return {
@@ -172,9 +192,23 @@ export async function deployCandidate({
   baseline,
   client,
   expected,
+  inspectionAttempts = 12,
+  inspectionIntervalMs = 5000,
   observe = collectRecoveryIdentity,
+  sleep,
   verify = value => pollLiveVerification({ expected: value }),
 }) {
+  if (
+    !Number.isSafeInteger(inspectionAttempts) ||
+    inspectionAttempts < 1 ||
+    inspectionAttempts > 100 ||
+    !Number.isSafeInteger(inspectionIntervalMs) ||
+    inspectionIntervalMs < 0 ||
+    inspectionIntervalMs > 60000 ||
+    (sleep !== undefined && typeof sleep !== 'function')
+  ) {
+    fail('INVALID_LIVE_RELEASE_INPUT', 'post-deploy inspection retry options are invalid');
+  }
   requireAuthorization(authorization, expected);
   if (
     baseline?.status !== 'baseline-captured' ||
@@ -187,7 +221,14 @@ export async function deployCandidate({
   const command = client.deploy();
   let after;
   try {
-    after = await inspectAuthoritative(client, expected.origin, observe);
+    after = await inspectAfterMutation({
+      client,
+      origin: expected.origin,
+      observe,
+      maxAttempts: inspectionAttempts,
+      intervalMs: inspectionIntervalMs,
+      ...(sleep ? { sleep } : {}),
+    });
   } catch {
     return {
       protocol: PROTOCOL,

--- a/test/release/live-release.test.ts
+++ b/test/release/live-release.test.ts
@@ -169,6 +169,54 @@ describe('live release production orchestration', () => {
     });
   });
 
+  it('retries a transient authoritative inspection after the deploy command succeeds', async () => {
+    const cloudflare = client();
+    const baseline = await captureBaseline({
+      client: cloudflare,
+      expected,
+      observe: cloudflare.observe,
+    });
+    cloudflare.inspectStatus.mockImplementationOnce(() => ({ status: 'failed' }));
+    const sleep = vi.fn(async () => {});
+
+    await expect(
+      deployCandidate({
+        authorization,
+        baseline,
+        client: cloudflare,
+        expected,
+        inspectionAttempts: 2,
+        inspectionIntervalMs: 1,
+        observe: cloudflare.observe,
+        sleep,
+        verify: async () => ({ status: 'verified', targetSha: SHA }),
+      })
+    ).resolves.toMatchObject({ status: 'candidate-active' });
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(cloudflare.inspectStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it('rejects invalid inspection retry options before production mutation', async () => {
+    const cloudflare = client();
+    const baseline = await captureBaseline({
+      client: cloudflare,
+      expected,
+      observe: cloudflare.observe,
+    });
+
+    await expect(
+      deployCandidate({
+        authorization,
+        baseline,
+        client: cloudflare,
+        expected,
+        inspectionAttempts: 0,
+        observe: cloudflare.observe,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_LIVE_RELEASE_INPUT' });
+    expect(cloudflare.deploy).not.toHaveBeenCalled();
+  });
+
   it('does not accept a candidate deployment when bounded live proof fails', async () => {
     const cloudflare = client();
     const baseline = await captureBaseline({


### PR DESCRIPTION
## Summary
- retry authoritative Cloudflare and live identity inspection after a successful deploy command
- cap the reconciliation window at 12 attempts with five-second spacing
- validate retry controls before any production mutation
- preserve the existing ambiguous-critical fail-closed outcome after exhaustion

## Incident evidence
Live release run 30949825959 returned `post-deploy-inspection-unavailable` immediately after a successful deploy command. The finalizer verified rollback to the complete bootstrap baseline; production is development/no SHA and no v1.55.1 Release exists.

## Proof
- `npm run validate` (53 files, 821 tests)
- focused release tests (38 tests)
- isolated retention rerun after one local timeout (8 tests)
- `npm run knip`
- `npm run check:actions-node24`
- clean `codex review --uncommitted`