### PR TITLE
fix: observe draft releases during publication

### DIFF
--- a/scripts/release/github-publication-adapter.mjs
+++ b/scripts/release/github-publication-adapter.mjs
@@ -7,6 +7,8 @@ const RELEASE_ID = /^[1-9]\d*$/;
 const TOKEN = /^[A-Za-z0-9_.-]{16,4096}$/;
 const MAX_ASSET_BYTES = 16 * 1024 * 1024;
 const MAX_RELEASE_BYTES = 512 * 1024 * 1024;
+const RELEASES_PER_PAGE = 100;
+const MAX_RELEASE_PAGES = 100;
 const ASSET_TIMEOUT_MS = 30_000;
 
 export class GithubPublicationAdapterError extends Error {
@@ -116,7 +118,15 @@ export function createGithubPublicationAdapter({
     }
     if (response.status === 204) return null;
     try {
-      return record(await response.json(), url.pathname);
+      const value = await response.json();
+      if (options.array) {
+        if (!Array.isArray(value)) fail('INVALID_RESPONSE', `${url.pathname} response is invalid`);
+        return {
+          data: value,
+          hasNext: /<[^>]+>;\s*rel="next"/.test(response.headers.get('link') ?? ''),
+        };
+      }
+      return record(value, url.pathname);
     } catch (error) {
       if (error instanceof GithubPublicationAdapterError) throw error;
       fail('INVALID_RESPONSE', `${url.pathname} did not return JSON`);
@@ -216,15 +226,30 @@ export function createGithubPublicationAdapter({
   const inspect = async requestedTag => {
     const tag = match(requestedTag, TAG, 'tag');
     const tagState = await inspectTag(tag);
-    const release = await request(
-      'GET',
-      `/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`,
-      {
-        missing: true,
+    const matchingReleases = [];
+    for (let page = 1; page <= MAX_RELEASE_PAGES; page += 1) {
+      const releasePage = await request(
+        'GET',
+        `/repos/${repository}/releases?per_page=${RELEASES_PER_PAGE}&page=${page}`,
+        { array: true }
+      );
+      matchingReleases.push(...releasePage.data.filter(item => item?.tag_name === tag));
+      if (!releasePage.hasNext) break;
+      if (page === MAX_RELEASE_PAGES) {
+        fail('INVALID_RESPONSE', 'release pagination exceeded its authenticated bound');
       }
-    );
+    }
+    if (matchingReleases.length > 1) {
+      const releases = matchingReleases.map(release => {
+        if (release.tag_name !== tag || !RELEASE_ID.test(String(release.id ?? ''))) {
+          fail('INVALID_RESPONSE', 'release identity is invalid');
+        }
+        return { id: String(release.id), tag };
+      });
+      return { complete: true, ...tagState, releases };
+    }
     const releases = [];
-    if (release) {
+    for (const release of matchingReleases) {
       if (release.tag_name !== tag || !RELEASE_ID.test(String(release.id ?? ''))) {
         fail('INVALID_RESPONSE', 'release identity is invalid');
       }

--- a/test/release/github-publication-adapter.test.ts
+++ b/test/release/github-publication-adapter.test.ts
@@ -37,23 +37,25 @@ describe('GitHub publication inspection', () => {
       if (url.pathname.endsWith(`/git/tags/${TAG_OBJECT_SHA}`)) {
         return response({ message: 'annotation', object: { type: 'commit', sha: SHA } });
       }
-      if (url.pathname.endsWith('/releases/tags/v1.2.3')) {
-        return response({
-          id: 123,
-          tag_name: 'v1.2.3',
-          body: `notes\n\n${bodyMarker}`,
-          draft: false,
-          prerelease: false,
-          published_at: '2026-08-03T12:00:00Z',
-          assets: [
-            {
-              id: 7,
-              name: 'widget.v1.2.3.js',
-              url: `${API}/repos/mean-weasel/bugdrop/releases/assets/7`,
-              size: Buffer.byteLength('widget-bytes'),
-            },
-          ],
-        });
+      if (url.pathname.endsWith('/releases') && url.searchParams.get('page') === '1') {
+        return response([
+          {
+            id: 123,
+            tag_name: 'v1.2.3',
+            body: `notes\n\n${bodyMarker}`,
+            draft: false,
+            prerelease: false,
+            published_at: '2026-08-03T12:00:00Z',
+            assets: [
+              {
+                id: 7,
+                name: 'widget.v1.2.3.js',
+                url: `${API}/repos/mean-weasel/bugdrop/releases/assets/7`,
+                size: Buffer.byteLength('widget-bytes'),
+              },
+            ],
+          },
+        ]);
       }
       if (url.pathname === '/repos/mean-weasel/bugdrop/releases/assets/7') {
         return new Response(null, {
@@ -98,13 +100,129 @@ describe('GitHub publication inspection', () => {
   });
 
   it('returns a complete empty observation for an unused tag', async () => {
-    const fetchImpl = vi.fn(async () => response({ message: 'Not Found' }, 404));
+    const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      return url.pathname.endsWith('/releases')
+        ? response([])
+        : response({ message: 'Not Found' }, 404);
+    });
     await expect(adapter(fetchImpl).inspect('v9.9.9')).resolves.toEqual({
       complete: true,
       tagObject: null,
       tagRef: null,
       releases: [],
     });
+  });
+
+  it('observes drafts that the release-by-tag endpoint omits', async () => {
+    const publicationMarker = { planIdentity: `sha256:${'4'.repeat(64)}` };
+    const bodyMarker = `<!-- bugdrop-publication ${Buffer.from(JSON.stringify(publicationMarker)).toString('base64url')} -->`;
+    const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/git/ref/tags/v1.2.3')) {
+        return response({ object: { type: 'tag', sha: TAG_OBJECT_SHA } });
+      }
+      if (url.pathname.endsWith(`/git/tags/${TAG_OBJECT_SHA}`)) {
+        return response({ message: 'annotation', object: { type: 'commit', sha: SHA } });
+      }
+      if (url.pathname.endsWith('/releases')) {
+        return response([
+          {
+            id: 456,
+            tag_name: 'v1.2.3',
+            body: bodyMarker,
+            draft: true,
+            prerelease: false,
+            published_at: null,
+            assets: [],
+          },
+        ]);
+      }
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+
+    await expect(adapter(fetchImpl).inspect('v1.2.3')).resolves.toMatchObject({
+      complete: true,
+      releases: [
+        {
+          id: '456',
+          draft: true,
+          published: false,
+          marker: publicationMarker,
+          tag: 'v1.2.3',
+          targetSha: SHA,
+        },
+      ],
+    });
+    expect(fetchImpl).not.toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: expect.stringContaining('/releases/tags/') }),
+      expect.anything()
+    );
+  });
+
+  it('uses pagination authority and accepts an exactly full final bounded page', async () => {
+    let releasePageCalls = 0;
+    const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/releases')) {
+        releasePageCalls += 1;
+        const page = Number(url.searchParams.get('page'));
+        return response(
+          Array.from({ length: 100 }, (_, index) => ({
+            id: page * 100 + index,
+            tag_name: 'v1.2.2',
+          })),
+          200,
+          page < 100
+            ? { link: `<${API}/repos/mean-weasel/bugdrop/releases?page=${page + 1}>; rel="next"` }
+            : undefined
+        );
+      }
+      return response({ message: 'Not Found' }, 404);
+    });
+
+    await expect(adapter(fetchImpl).inspect('v1.2.3')).resolves.toMatchObject({
+      complete: true,
+      releases: [],
+    });
+    expect(releasePageCalls).toBe(100);
+  });
+
+  it('reports duplicate same-tag identities without downloading their assets', async () => {
+    const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/releases')) {
+        return response(
+          [501, 502].map(id => ({
+            id,
+            tag_name: 'v1.2.3',
+            assets: [
+              {
+                id: id + 100,
+                name: 'large.zip',
+                size: 1024,
+                url: `${API}/repos/mean-weasel/bugdrop/releases/assets/${id + 100}`,
+              },
+            ],
+          }))
+        );
+      }
+      if (url.pathname.includes('/releases/assets/')) {
+        throw new Error('duplicate assets must not be downloaded');
+      }
+      return response({ message: 'Not Found' }, 404);
+    });
+
+    await expect(adapter(fetchImpl).inspect('v1.2.3')).resolves.toMatchObject({
+      complete: true,
+      releases: [
+        { id: '501', tag: 'v1.2.3' },
+        { id: '502', tag: 'v1.2.3' },
+      ],
+    });
+    expect(
+      fetchImpl.mock.calls.some(([input]) => new URL(String(input)).pathname.includes('/assets/'))
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- inspect the authenticated paginated Releases collection so draft Releases are visible
- use the GitHub `Link: rel="next"` signal as pagination authority with a bounded fail-closed limit
- return duplicate same-tag identities before asset hydration so ambiguous publication state is detected without unnecessary asset downloads

## Incident

The v1.55.1 publication attempt created multiple identical drafts because GitHub's release-by-tag endpoint omits drafts. The controller therefore repeatedly concluded no Release existed and recreated it until the transition bound was exhausted.

This repair was proven read-only against the live incident state: the adapter observed all eight v1.55.1 draft IDs, all with zero assets. No release state was mutated.

## Verification

- `npm test -- --run` — 53 files, 824 tests passed
- `npm run check:actions-node24` — passed
- `npm run knip` — passed with the existing 16 configuration hints
- `git diff --check` — passed
- independent read-only review — no actionable findings

## Recovery boundary

This PR does not modify the existing v1.55.1 annotated tag or any draft Release. Manual duplicate-draft reconciliation will occur only after this change passes the protected merge queue and live preview canary.
