### PR TITLE
fix: authenticate partial release retries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,18 @@ on:
         required: false
         default: false
         type: boolean
+      resume_controller_sha:
+        description: Stored controller SHA for an authenticated partial-publication retry
+        required: false
+        type: string
+      resume_remote_main_sha:
+        description: Stored remote-main SHA for an authenticated partial-publication retry
+        required: false
+        type: string
+      resume_plan_identity:
+        description: Expected sha256 plan identity for an authenticated partial-publication retry
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -51,9 +63,13 @@ jobs:
     outputs:
       completed: ${{ steps.plan.outputs.completed }}
       controller_sha: ${{ steps.guard.outputs.controller_sha }}
+      identity_main_sha: ${{ steps.guard.outputs.identity_main_sha }}
       plan_identity: ${{ steps.plan.outputs.plan_identity }}
+      plan_controller_sha: ${{ steps.guard.outputs.plan_controller_sha }}
       request_key: ${{ steps.plan.outputs.request_key }}
       request_identity: ${{ steps.plan.outputs.request_identity }}
+      resume_plan_identity: ${{ steps.guard.outputs.resume_plan_identity }}
+      resuming: ${{ steps.guard.outputs.resuming }}
       version: ${{ steps.plan.outputs.version }}
     steps:
       - name: Reject non-main or malformed dispatch before checkout
@@ -62,6 +78,9 @@ jobs:
         env:
           CONTROLLER_SHA: ${{ github.workflow_sha }}
           DISPATCH_REF: ${{ github.ref }}
+          RESUME_CONTROLLER_SHA: ${{ inputs.resume_controller_sha }}
+          RESUME_PLAN_IDENTITY: ${{ inputs.resume_plan_identity }}
+          RESUME_REMOTE_MAIN_SHA: ${{ inputs.resume_remote_main_sha }}
           TARGET_SHA: ${{ inputs.target_sha }}
         run: |
           test "$DISPATCH_REF" = 'refs/heads/main' || {
@@ -76,7 +95,42 @@ jobs:
             echo 'target_sha must be exactly 40 lowercase hexadecimal characters.' >&2
             exit 1
           }
-          echo "controller_sha=$CONTROLLER_SHA" >> "$GITHUB_OUTPUT"
+          resume_count=0
+          for value in "$RESUME_CONTROLLER_SHA" "$RESUME_REMOTE_MAIN_SHA" "$RESUME_PLAN_IDENTITY"; do
+            test -z "$value" || resume_count=$((resume_count + 1))
+          done
+          test "$resume_count" = 0 || test "$resume_count" = 3 || {
+            echo 'partial retry requires all three resume inputs or none of them.' >&2
+            exit 1
+          }
+          if [ "$resume_count" = 3 ]; then
+            [[ "$RESUME_CONTROLLER_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+              echo 'resume_controller_sha must be exactly 40 lowercase hexadecimal characters.' >&2
+              exit 1
+            }
+            [[ "$RESUME_REMOTE_MAIN_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+              echo 'resume_remote_main_sha must be exactly 40 lowercase hexadecimal characters.' >&2
+              exit 1
+            }
+            [[ "$RESUME_PLAN_IDENTITY" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+              echo 'resume_plan_identity must be a complete sha256 identity.' >&2
+              exit 1
+            }
+            plan_controller_sha=$RESUME_CONTROLLER_SHA
+            identity_main_sha=$RESUME_REMOTE_MAIN_SHA
+            resuming=true
+          else
+            plan_controller_sha=$CONTROLLER_SHA
+            identity_main_sha=''
+            resuming=false
+          fi
+          {
+            echo "controller_sha=$CONTROLLER_SHA"
+            echo "identity_main_sha=$identity_main_sha"
+            echo "plan_controller_sha=$plan_controller_sha"
+            echo "resume_plan_identity=$RESUME_PLAN_IDENTITY"
+            echo "resuming=$resuming"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout immutable controller
         uses: actions/checkout@v5
@@ -103,17 +157,27 @@ jobs:
         env:
           BUGDROP_GITHUB_TOKEN: ${{ github.token }}
           BUMP: ${{ inputs.bump }}
-          CONTROLLER_SHA: ${{ steps.guard.outputs.controller_sha }}
+          CONTROLLER_SHA: ${{ steps.guard.outputs.plan_controller_sha }}
           DRY_RUN: ${{ inputs.dry_run }}
+          IDENTITY_MAIN_SHA: ${{ steps.guard.outputs.identity_main_sha }}
           RETENTION_BOOTSTRAP: ${{ inputs.retention_bootstrap }}
           OPERATOR_NOTES: ${{ inputs.operator_notes }}
           RATIONALE: ${{ inputs.rationale }}
           RELEASE_REASON: ${{ inputs.release_reason }}
+          RESUMING: ${{ steps.guard.outputs.resuming }}
           TARGET_SHA: ${{ inputs.target_sha }}
         run: |
           candidate_reachable=false
           if git -C "$GITHUB_WORKSPACE/controller" merge-base --is-ancestor "$TARGET_SHA" origin/main; then
             candidate_reachable=true
+          fi
+          identity_main_reachable_from_current=false
+          controller_reachable_from_current=false
+          if [ "$RESUMING" = true ]; then
+            git -C "$GITHUB_WORKSPACE/controller" merge-base --is-ancestor "$IDENTITY_MAIN_SHA" origin/main &&
+              identity_main_reachable_from_current=true
+            git -C "$GITHUB_WORKSPACE/controller" merge-base --is-ancestor "$CONTROLLER_SHA" origin/main &&
+              controller_reachable_from_current=true
           fi
           jq -n \
             --arg repositoryDir "$GITHUB_WORKSPACE/controller" \
@@ -130,9 +194,13 @@ jobs:
             --arg operatorNotes "$OPERATOR_NOTES" \
             --argjson dryRun "$DRY_RUN" \
             --argjson candidateReachableFromMain "$candidate_reachable" \
+            --arg identityMainSha "$IDENTITY_MAIN_SHA" \
+            --argjson identityMainReachableFromCurrent "$identity_main_reachable_from_current" \
             --argjson retentionBootstrap "$RETENTION_BOOTSTRAP" \
+            --argjson controllerReachableFromCurrent "$controller_reachable_from_current" \
             --arg retentionOutputDir "$GITHUB_WORKSPACE/retention-input" \
-            '{$repositoryDir, $eventName, $ref, $workflowSha, $candidateReachableFromMain, $retentionBootstrap, $retentionOutputDir, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, $dryRun}}' \
+            --argjson resuming "$RESUMING" \
+            '{$repositoryDir, $eventName, $ref, $workflowSha, $candidateReachableFromMain, $retentionBootstrap, $retentionOutputDir, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, $dryRun}} + (if $resuming then {$identityMainSha, $identityMainReachableFromCurrent, $controllerReachableFromCurrent} else {} end)' \
             > request-context.json
           node controller/scripts/release/workflow.mjs guard request-context.json > guard.json
           node controller/scripts/release/github-adapter.mjs plan request-context.json > request-plan.json
@@ -273,6 +341,23 @@ jobs:
             echo "tag=$tag"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Authenticate exact partial-publication retry
+        if: needs.guard-and-plan.outputs.resuming == 'true'
+        shell: bash
+        env:
+          BUGDROP_GITHUB_TOKEN: ${{ github.token }}
+          EXPECTED_PLAN_IDENTITY: ${{ needs.guard-and-plan.outputs.resume_plan_identity }}
+        run: |
+          test "$(jq -er '.finalPlan.planIdentity' state2-bundle.json)" = "$EXPECTED_PLAN_IDENTITY"
+          jq -n \
+            --arg bundlePath "$GITHUB_WORKSPACE/state2-bundle.json" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            '{$bundlePath, $repository}' > partial-inspection-input.json
+          node controller/scripts/release/live-release.mjs inspect-publication partial-inspection-input.json > partial-inspection.json
+          test "$(jq -er '.planIdentity' partial-inspection.json)" = "$EXPECTED_PLAN_IDENTITY"
+          test "$(jq -er '.status' partial-inspection.json)" = 'partial-resumable'
+          test "$(jq -er '.nextAction.kind' partial-inspection.json)" != 'create-tag'
+
       - name: Upload immutable candidate and State 2 evidence
         id: upload
         uses: actions/upload-artifact@v5
@@ -306,7 +391,7 @@ jobs:
         shell: bash
         env:
           ARTIFACT_ID: ${{ needs.verify-candidate.outputs.artifact_id }}
-          CONTROLLER_SHA: ${{ needs.guard-and-plan.outputs.controller_sha }}
+          CONTROLLER_SHA: ${{ needs.guard-and-plan.outputs.plan_controller_sha }}
         run: |
           jq -n \
             --slurpfile bundle approved/state2-bundle.json \
@@ -429,13 +514,23 @@ jobs:
         env:
           BUGDROP_GITHUB_TOKEN: ${{ github.token }}
           BUMP: ${{ inputs.bump }}
-          CONTROLLER_SHA: ${{ needs.guard-and-plan.outputs.controller_sha }}
+          CONTROLLER_SHA: ${{ needs.guard-and-plan.outputs.plan_controller_sha }}
+          IDENTITY_MAIN_SHA: ${{ needs.guard-and-plan.outputs.identity_main_sha }}
           RETENTION_BOOTSTRAP: ${{ inputs.retention_bootstrap }}
           OPERATOR_NOTES: ${{ inputs.operator_notes }}
           RATIONALE: ${{ inputs.rationale }}
           RELEASE_REASON: ${{ inputs.release_reason }}
+          RESUMING: ${{ needs.guard-and-plan.outputs.resuming }}
           TARGET_SHA: ${{ inputs.target_sha }}
         run: |
+          identity_main_reachable_from_current=false
+          controller_reachable_from_current=false
+          if [ "$RESUMING" = true ]; then
+            git -C "$GITHUB_WORKSPACE/controller" merge-base --is-ancestor "$IDENTITY_MAIN_SHA" origin/main &&
+              identity_main_reachable_from_current=true
+            git -C "$GITHUB_WORKSPACE/controller" merge-base --is-ancestor "$CONTROLLER_SHA" origin/main &&
+              controller_reachable_from_current=true
+          fi
           jq -n \
             --arg repositoryDir "$GITHUB_WORKSPACE/controller" \
             --arg repository "$GITHUB_REPOSITORY" \
@@ -446,8 +541,12 @@ jobs:
             --arg releaseReason "$RELEASE_REASON" \
             --arg rationale "$RATIONALE" \
             --arg operatorNotes "$OPERATOR_NOTES" \
+            --arg identityMainSha "$IDENTITY_MAIN_SHA" \
+            --argjson identityMainReachableFromCurrent "$identity_main_reachable_from_current" \
             --argjson retentionBootstrap "$RETENTION_BOOTSTRAP" \
-            '{$repositoryDir, $retentionBootstrap, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, dryRun: false}}' \
+            --argjson controllerReachableFromCurrent "$controller_reachable_from_current" \
+            --argjson resuming "$RESUMING" \
+            '{$repositoryDir, $retentionBootstrap, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, dryRun: false}} + (if $resuming then {$identityMainSha, $identityMainReachableFromCurrent, $controllerReachableFromCurrent} else {} end)' \
             > revalidation-context.json
           node controller/scripts/release/github-adapter.mjs plan revalidation-context.json > revalidated-plan.json
           expected_plan=$(jq -er '.finalPlan.planIdentity' approved/state2-bundle.json)
@@ -458,6 +557,17 @@ jobs:
           else
             test "$(jq -er '.requestIdentity' revalidated-plan.json)" = "$expected_request"
             completed='{"kind":"none"}'
+          fi
+          if [ "$RESUMING" = true ]; then
+            test "$expected_plan" = '${{ needs.guard-and-plan.outputs.resume_plan_identity }}'
+            jq -n \
+              --arg bundlePath "$GITHUB_WORKSPACE/approved/state2-bundle.json" \
+              --arg repository "$GITHUB_REPOSITORY" \
+              '{$bundlePath, $repository}' > partial-inspection-input.json
+            node controller/scripts/release/live-release.mjs inspect-publication partial-inspection-input.json > partial-inspection.json
+            test "$(jq -er '.planIdentity' partial-inspection.json)" = "$expected_plan"
+            test "$(jq -er '.status' partial-inspection.json)" = 'partial-resumable'
+            test "$(jq -er '.nextAction.kind' partial-inspection.json)" != 'create-tag'
           fi
           jq -n \
             --slurpfile bundle approved/state2-bundle.json \

--- a/scripts/release/github-adapter.mjs
+++ b/scripts/release/github-adapter.mjs
@@ -636,11 +636,25 @@ export async function createRequestPlanFromGithub({
     requestRecord(transport, `/repos/${dispatch.repository}/commits/main`, 'remote main'),
     observeMergeQueuePreflight(transport, dispatch.repository, dispatch.targetSha),
   ]);
+  let identityMainSha = remoteMain.sha;
+  if (context.identityMainSha !== undefined) {
+    if (
+      !SHA_PATTERN.test(context.identityMainSha) ||
+      context.identityMainReachableFromCurrent !== true ||
+      context.controllerReachableFromCurrent !== true
+    ) {
+      fail(
+        'UNAUTHENTICATED_PARTIAL_SOURCE',
+        'stored controller and remote-main identities must remain reachable from current main'
+      );
+    }
+    identityMainSha = context.identityMainSha;
+  }
   const git = gitObserver({
     repositoryDir: context.repositoryDir,
     previousSha: frontier.targetSha,
     targetSha: dispatch.targetSha,
-    mainSha: remoteMain.sha,
+    mainSha: identityMainSha,
     controllerSha: dispatch.controllerSha,
   });
   const inventory = buildReleaseInventory({
@@ -788,7 +802,7 @@ export async function createRequestPlanFromGithub({
     nextTag,
     generatedNotes: inventory.generatedNotes,
     controllerSha: dispatch.controllerSha,
-    remoteMainSha: remoteMain.sha,
+    remoteMainSha: identityMainSha,
     inventory,
     retentionBootstrap: context.retentionBootstrap === true,
     retention,

--- a/scripts/release/live-release.mjs
+++ b/scripts/release/live-release.mjs
@@ -469,6 +469,14 @@ async function runCli() {
         token: process.env.BUGDROP_GITHUB_TOKEN,
       }),
     });
+  } else if (mode === 'inspect-publication') {
+    output = await inspectPublication({
+      bundle: await jsonFile(input.bundlePath),
+      adapter: createGithubPublicationAdapter({
+        repository: input.repository,
+        token: process.env.BUGDROP_GITHUB_TOKEN,
+      }),
+    });
   } else if (mode === 'finalize') {
     const bundle = await jsonFile(input.bundlePath);
     const publication = await inspectPublication({

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -67,7 +67,8 @@ top_level_events=$(awk '
 [[ "$top_level_events" == 'workflow_dispatch:' ]] ||
   fail "workflow_dispatch must be the only trigger; found: $top_level_events"
 
-for input in target_sha bump release_reason rationale operator_notes dry_run retention_bootstrap; do
+for input in target_sha bump release_reason rationale operator_notes dry_run retention_bootstrap \
+  resume_controller_sha resume_remote_main_sha resume_plan_identity; do
   require_literal "      $input:"
 done
 for literal in \
@@ -120,6 +121,8 @@ for literal in \
   '[[ "$CONTROLLER_SHA" =~ ^[0-9a-f]{40}$ ]]' \
   '[[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]' \
   'CONTROLLER_SHA: ${{ github.workflow_sha }}' \
+  'partial retry requires all three resume inputs or none of them.' \
+  'plan_controller_sha=$plan_controller_sha' \
   'node controller/scripts/release/workflow.mjs guard' \
   'node controller/scripts/release/github-adapter.mjs plan' \
   '--arg repositoryDir "$GITHUB_WORKSPACE/controller"' \
@@ -178,6 +181,14 @@ for literal in \
   'retention-days: 14'; do
   grep -Fq -- "$literal" <<< "$verify_block" || fail "verify-candidate lacks: $literal"
 done
+for literal in \
+  "if: needs.guard-and-plan.outputs.resuming == 'true'" \
+  'node controller/scripts/release/live-release.mjs inspect-publication' \
+  "test \"\$(jq -er '.status' partial-inspection.json)\" = 'partial-resumable'"; do
+  grep -Fq -- "$literal" <<< "$verify_block" || fail "partial retry verification lacks: $literal"
+done
+[[ $(grep -Fc 'test "$(jq -er '\''.nextAction.kind'\'' partial-inspection.json)" != '\''create-tag'\''' "$workflow") -eq 2 ]] ||
+  fail 'partial retry must reject pristine publication state before dry-run success and mutation'
 if grep -Fq -- '{$requestPlan:' <<< "$verify_block"; then
   fail 'slurped request plan must be a literal requestPlan field, not a dynamic object key'
 fi

--- a/test/release/github-adapter.test.ts
+++ b/test/release/github-adapter.test.ts
@@ -355,6 +355,7 @@ describe('GitHub release-state observation', () => {
   });
 
   it('builds a deterministic request plan from complete authenticated observations', async () => {
+    const storedMain = 'd'.repeat(40);
     const entries = observationEntries();
     entries[`/repos/${REPOSITORY}/compare/${SHA.release}...${SHA.target}`] = {
       data: {
@@ -422,24 +423,28 @@ describe('GitHub release-state observation', () => {
         hasNext: false,
       },
     });
+    const gitObserver = vi.fn(() => ({
+      commits: [{ sha: SHA.target, subject: 'Ship guarded workflow' }],
+      changedPaths: ['src/index.ts'],
+      excludedNewerMainCommits: [],
+      candidateCommitTimestamp: '2026-08-03T00:00:00Z',
+      candidateBehindMainBy: 0,
+      facts: {
+        candidateRef: 'refs/heads/main',
+        targetExists: true,
+        targetReachableFromMain: true,
+        previousReleaseAncestor: true,
+        targetStrictlyLater: true,
+        controllerReachableFromMain: true,
+      },
+    }));
     const plan = await createRequestPlanFromGithub({
       transport: transportFor(entries),
-      gitObserver: () => ({
-        commits: [{ sha: SHA.target, subject: 'Ship guarded workflow' }],
-        changedPaths: ['src/index.ts'],
-        excludedNewerMainCommits: [],
-        candidateCommitTimestamp: '2026-08-03T00:00:00Z',
-        candidateBehindMainBy: 0,
-        facts: {
-          candidateRef: 'refs/heads/main',
-          targetExists: true,
-          targetReachableFromMain: true,
-          previousReleaseAncestor: true,
-          targetStrictlyLater: true,
-          controllerReachableFromMain: true,
-        },
-      }),
+      gitObserver,
       context: {
+        controllerReachableFromCurrent: true,
+        identityMainReachableFromCurrent: true,
+        identityMainSha: storedMain,
         repositoryDir: '/controller',
         dispatch: {
           repository: REPOSITORY,
@@ -456,12 +461,15 @@ describe('GitHub release-state observation', () => {
     });
     expect(plan).toMatchObject({
       request: { previousTag: 'v1.55.0', nextTag: 'v1.55.1', targetSha: SHA.target },
-      source: { controllerSha: SHA.release, remoteMainSha: SHA.target },
+      source: { controllerSha: SHA.release, remoteMainSha: storedMain },
       attestation: {
         expectedAliases: ['widget.js', 'widget.v1.js', 'widget.v1.55.js'],
         expectedAssetNames: ['widget.v1.55.1.js', 'versions.json'],
       },
     });
+    expect(gitObserver).toHaveBeenCalledWith(
+      expect.objectContaining({ mainSha: storedMain, controllerSha: SHA.release })
+    );
     expect(plan.inventory.pullRequests).toHaveLength(1);
   });
 


### PR DESCRIPTION
## Summary

- add an explicit, all-or-none recovery identity for partial release retries
- keep the current protected workflow SHA as the only executable controller
- reproduce the authenticated stored plan identity while independently verifying the existing partial publication before approval
- reject pristine publication state so this path cannot initiate a new release

## Incident context

The original v1.55.1 production attempt deployed and passed production E2E, then failed while observing a draft GitHub Release. The draft observer fix is already merged. A normal retry dry run correctly made no mutations, but planning silently substituted newer main/controller commits, changing the authenticated release identity.

This change separates current executable authority from stored release identity. It enables the exact existing partial v1.55.1 publication to resume without moving its tag, changing its target, or regenerating its plan.

## Live read-only proof

- stored source reproduces request identity \`sha256:3f9971e09985edc14ffdc1d2f0af97eeb68d7e64fb72863ce48c7dc9ecaf7413\`
- final plan identity reproduces \`sha256:dddc604a68028685397d83334f23baca5b74eb9ac4237d34646adfb69e84a772\`
- target/controller/identity main remain \`0be367b862d0f9d16712305e9eab250ea03d2dea\`
- authoritative publication inspection reports \`partial-resumable\`, next action \`upload-asset\`, on the sole retained empty draft
- production release capability gate remains disabled

## Verification

- \`npm test\` — 53 files, 824 tests
- \`npm run typecheck\`
- \`npm run check:actions-node24\`
- \`npm run knip\` — only the existing 16 configuration hints
- workflow contract tests
- two independent read-only reviews; final review found no actionable issues
- \`git diff --check\`
