### PR TITLE
fix: authenticate completed release retries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,6 +164,7 @@ jobs:
           OPERATOR_NOTES: ${{ inputs.operator_notes }}
           RATIONALE: ${{ inputs.rationale }}
           RELEASE_REASON: ${{ inputs.release_reason }}
+          RESUME_PLAN_IDENTITY: ${{ steps.guard.outputs.resume_plan_identity }}
           RESUMING: ${{ steps.guard.outputs.resuming }}
           TARGET_SHA: ${{ inputs.target_sha }}
         run: |
@@ -195,12 +196,13 @@ jobs:
             --argjson dryRun "$DRY_RUN" \
             --argjson candidateReachableFromMain "$candidate_reachable" \
             --arg identityMainSha "$IDENTITY_MAIN_SHA" \
+            --arg resumePlanIdentity "$RESUME_PLAN_IDENTITY" \
             --argjson identityMainReachableFromCurrent "$identity_main_reachable_from_current" \
             --argjson retentionBootstrap "$RETENTION_BOOTSTRAP" \
             --argjson controllerReachableFromCurrent "$controller_reachable_from_current" \
             --arg retentionOutputDir "$GITHUB_WORKSPACE/retention-input" \
             --argjson resuming "$RESUMING" \
-            '{$repositoryDir, $eventName, $ref, $workflowSha, $candidateReachableFromMain, $retentionBootstrap, $retentionOutputDir, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, $dryRun}} + (if $resuming then {$identityMainSha, $identityMainReachableFromCurrent, $controllerReachableFromCurrent} else {} end)' \
+            '{$repositoryDir, $eventName, $ref, $workflowSha, $candidateReachableFromMain, $retentionBootstrap, $retentionOutputDir, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, $dryRun}} + (if $resuming then {$identityMainSha, $resumePlanIdentity, $identityMainReachableFromCurrent, $controllerReachableFromCurrent} else {} end)' \
             > request-context.json
           node controller/scripts/release/workflow.mjs guard request-context.json > guard.json
           node controller/scripts/release/github-adapter.mjs plan request-context.json > request-plan.json
@@ -405,6 +407,7 @@ jobs:
       - name: Report verified State 2
         env:
           PLAN_IDENTITY: ${{ needs.verify-candidate.outputs.plan_identity }}
+          RESUMING: ${{ needs.guard-and-plan.outputs.resuming }}
           TARGET_SHA: ${{ inputs.target_sha }}
           TAG: ${{ needs.verify-candidate.outputs.tag }}
         run: |
@@ -413,7 +416,11 @@ jobs:
             echo "Plan: \`$PLAN_IDENTITY\`  "
             echo "Candidate: \`$TARGET_SHA\`  "
             echo "Release: \`$TAG\`"
-            echo 'No production environment, secret, deployment, tag, Release, or notification was accessed.'
+            if [ "$RESUMING" = true ]; then
+              echo 'No production environment, production secret, deployment, tag or Release mutation, or notification was accessed. Existing tag and Release state was inspected read-only.'
+            else
+              echo 'No production environment, secret, deployment, tag, Release, or notification was accessed.'
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
   completed-summary:
@@ -516,6 +523,7 @@ jobs:
           BUMP: ${{ inputs.bump }}
           CONTROLLER_SHA: ${{ needs.guard-and-plan.outputs.plan_controller_sha }}
           IDENTITY_MAIN_SHA: ${{ needs.guard-and-plan.outputs.identity_main_sha }}
+          RESUME_PLAN_IDENTITY: ${{ needs.guard-and-plan.outputs.resume_plan_identity }}
           RETENTION_BOOTSTRAP: ${{ inputs.retention_bootstrap }}
           OPERATOR_NOTES: ${{ inputs.operator_notes }}
           RATIONALE: ${{ inputs.rationale }}
@@ -542,11 +550,12 @@ jobs:
             --arg rationale "$RATIONALE" \
             --arg operatorNotes "$OPERATOR_NOTES" \
             --arg identityMainSha "$IDENTITY_MAIN_SHA" \
+            --arg resumePlanIdentity "$RESUME_PLAN_IDENTITY" \
             --argjson identityMainReachableFromCurrent "$identity_main_reachable_from_current" \
             --argjson retentionBootstrap "$RETENTION_BOOTSTRAP" \
             --argjson controllerReachableFromCurrent "$controller_reachable_from_current" \
             --argjson resuming "$RESUMING" \
-            '{$repositoryDir, $retentionBootstrap, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, dryRun: false}} + (if $resuming then {$identityMainSha, $identityMainReachableFromCurrent, $controllerReachableFromCurrent} else {} end)' \
+            '{$repositoryDir, $retentionBootstrap, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, dryRun: false}} + (if $resuming then {$identityMainSha, $resumePlanIdentity, $identityMainReachableFromCurrent, $controllerReachableFromCurrent} else {} end)' \
             > revalidation-context.json
           node controller/scripts/release/github-adapter.mjs plan revalidation-context.json > revalidated-plan.json
           expected_plan=$(jq -er '.finalPlan.planIdentity' approved/state2-bundle.json)

--- a/scripts/release/github-adapter.mjs
+++ b/scripts/release/github-adapter.mjs
@@ -598,6 +598,29 @@ export async function createRequestPlanFromGithub({
     retentionBootstrap: context?.retentionBootstrap,
   });
   assertInput(dispatch.repository, dispatch.targetSha);
+  let recovery = null;
+  if (
+    context.identityMainSha !== undefined ||
+    context.resumePlanIdentity !== undefined ||
+    context.identityMainReachableFromCurrent !== undefined ||
+    context.controllerReachableFromCurrent !== undefined
+  ) {
+    if (
+      !SHA_PATTERN.test(context.identityMainSha ?? '') ||
+      !/^sha256:[0-9a-f]{64}$/.test(context.resumePlanIdentity ?? '') ||
+      context.identityMainReachableFromCurrent !== true ||
+      context.controllerReachableFromCurrent !== true
+    ) {
+      fail(
+        'UNAUTHENTICATED_PARTIAL_SOURCE',
+        'stored controller, remote-main, and plan identities must remain authenticated'
+      );
+    }
+    recovery = {
+      identityMainSha: context.identityMainSha,
+      planIdentity: context.resumePlanIdentity,
+    };
+  }
   const state = await observeGithubState({
     transport,
     repository: dispatch.repository,
@@ -623,6 +646,17 @@ export async function createRequestPlanFromGithub({
       releases: [hydrated],
       containsTarget: () => false,
     });
+    if (
+      recovery &&
+      (hydrated.finalPlan.planIdentity !== recovery.planIdentity ||
+        hydrated.requestPlan.source.controllerSha !== dispatch.controllerSha ||
+        hydrated.requestPlan.source.remoteMainSha !== recovery.identityMainSha)
+    ) {
+      fail(
+        'COMPLETED_PLAN_CONFLICT',
+        'published plan differs from the authenticated recovery identity'
+      );
+    }
     return {
       status: 'completed',
       planIdentity: completed.planIdentity,
@@ -636,20 +670,7 @@ export async function createRequestPlanFromGithub({
     requestRecord(transport, `/repos/${dispatch.repository}/commits/main`, 'remote main'),
     observeMergeQueuePreflight(transport, dispatch.repository, dispatch.targetSha),
   ]);
-  let identityMainSha = remoteMain.sha;
-  if (context.identityMainSha !== undefined) {
-    if (
-      !SHA_PATTERN.test(context.identityMainSha) ||
-      context.identityMainReachableFromCurrent !== true ||
-      context.controllerReachableFromCurrent !== true
-    ) {
-      fail(
-        'UNAUTHENTICATED_PARTIAL_SOURCE',
-        'stored controller and remote-main identities must remain reachable from current main'
-      );
-    }
-    identityMainSha = context.identityMainSha;
-  }
+  const identityMainSha = recovery?.identityMainSha ?? remoteMain.sha;
   const git = gitObserver({
     repositoryDir: context.repositoryDir,
     previousSha: frontier.targetSha,

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -123,6 +123,7 @@ for literal in \
   'CONTROLLER_SHA: ${{ github.workflow_sha }}' \
   'partial retry requires all three resume inputs or none of them.' \
   'plan_controller_sha=$plan_controller_sha' \
+  '--arg resumePlanIdentity "$RESUME_PLAN_IDENTITY"' \
   'node controller/scripts/release/workflow.mjs guard' \
   'node controller/scripts/release/github-adapter.mjs plan' \
   '--arg repositoryDir "$GITHUB_WORKSPACE/controller"' \
@@ -130,6 +131,8 @@ for literal in \
   "echo 'completed=true'"; do
   grep -Fq -- "$literal" <<< "$guard_block" || fail "guard-and-plan lacks: $literal"
 done
+[[ $(grep -Fc 'RESUME_PLAN_IDENTITY:' "$workflow") -eq 3 ]] ||
+  fail 'resume plan identity must be exported to guard, initial planning, and approval revalidation'
 
 for literal in \
   "request_key=\$(jq -er '.planIdentity[7:]' request-plan.json)" \
@@ -189,6 +192,7 @@ for literal in \
 done
 [[ $(grep -Fc 'test "$(jq -er '\''.nextAction.kind'\'' partial-inspection.json)" != '\''create-tag'\''' "$workflow") -eq 2 ]] ||
   fail 'partial retry must reject pristine publication state before dry-run success and mutation'
+require_literal 'Existing tag and Release state was inspected read-only.'
 if grep -Fq -- '{$requestPlan:' <<< "$verify_block"; then
   fail 'slurped request plan must be a literal requestPlan field, not a dynamic object key'
 fi

--- a/test/release/github-adapter.test.ts
+++ b/test/release/github-adapter.test.ts
@@ -445,6 +445,7 @@ describe('GitHub release-state observation', () => {
         controllerReachableFromCurrent: true,
         identityMainReachableFromCurrent: true,
         identityMainSha: storedMain,
+        resumePlanIdentity: `sha256:${'e'.repeat(64)}`,
         repositoryDir: '/controller',
         dispatch: {
           repository: REPOSITORY,
@@ -640,6 +641,58 @@ describe('GitHub release-state observation', () => {
       tag: bundle.finalPlan.tag,
       targetSha: bundle.finalPlan.targetSha,
     });
+    expect(gitObserver).not.toHaveBeenCalled();
+
+    const recoveryContext = {
+      ...workflowContext(false),
+      controllerReachableFromCurrent: true,
+      identityMainReachableFromCurrent: true,
+      identityMainSha: bundle.requestPlan.source.remoteMainSha,
+      resumePlanIdentity: bundle.finalPlan.planIdentity,
+    };
+    await expect(
+      createRequestPlanFromGithub({
+        transport,
+        gitObserver,
+        context: recoveryContext,
+      })
+    ).resolves.toMatchObject({
+      status: 'completed',
+      planIdentity: bundle.finalPlan.planIdentity,
+    });
+    await expect(
+      createRequestPlanFromGithub({
+        transport,
+        gitObserver,
+        context: {
+          ...recoveryContext,
+          resumePlanIdentity: `sha256:${'f'.repeat(64)}`,
+        },
+      })
+    ).rejects.toThrow(/COMPLETED_PLAN_CONFLICT/);
+    await expect(
+      createRequestPlanFromGithub({
+        transport,
+        gitObserver,
+        context: {
+          ...recoveryContext,
+          identityMainSha: 'd'.repeat(40),
+        },
+      })
+    ).rejects.toThrow(/COMPLETED_PLAN_CONFLICT/);
+    await expect(
+      createRequestPlanFromGithub({
+        transport,
+        gitObserver,
+        context: {
+          ...recoveryContext,
+          dispatch: {
+            ...recoveryContext.dispatch,
+            controllerSha: 'e'.repeat(40),
+          },
+        },
+      })
+    ).rejects.toThrow(/COMPLETED_PLAN_CONFLICT/);
     expect(gitObserver).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- authenticate the complete stored controller, remote-main, and plan identity tuple even when the target Release is already published
- reject stale or mistyped recovery evidence instead of reporting an authenticated completed no-op
- accurately distinguish read-only tag/Release inspection from mutation in resumed dry-run summaries
- export the resume plan identity into every workflow step that consumes it

## Review provenance

This follows PR #282, which merged through the protected queue before its requested PR Review Toolkit pass began. The toolkit found two independently validated defects:

1. the completed-release early return preceded recovery tuple authentication
2. a resumed dry-run summary claimed no tag or Release was accessed after read-only inspection

A final regression review also caught and fixed a missing initial-step environment binding before this commit.

## Verification

- native Codex review plus independent correctness, tests, silent-failure, contracts, and comments/help-text roles
- fresh independent validation for every reported candidate
- final native review: no actionable defects
- final focused correctness and tests reviews: no candidates
- `npm run test:release-workflow` — 8 files, 144 tests, workflow contract green
- `npm test` — 53 files, 824 tests
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run check:actions-node24`
- `npm run knip` — only the existing 16 configuration hints
- `git diff --check`

## Burden-of-proof case

The completed-publication adapter test proves the exact recovery tuple remains a successful no-op, while mismatched plan identity, stored remote-main SHA, or stored controller SHA each fail closed without invoking local Git planning.
