### PR TITLE
feat: support self-hosted production heartbeats

### DIFF
--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -62,25 +62,39 @@ jobs:
         continue-on-error: true
         run: npm ci
 
+      - name: Validate production heartbeat configuration
+        id: config
+        if: always() && steps.install.outcome == 'success'
+        continue-on-error: true
+        env:
+          BUGDROP_HEARTBEAT_WIDGET_ORIGIN: ${{ vars.BUGDROP_HEARTBEAT_WIDGET_ORIGIN }}
+          BUGDROP_HEARTBEAT_VENUE_ORIGIN: ${{ vars.BUGDROP_HEARTBEAT_VENUE_ORIGIN }}
+          BUGDROP_HEARTBEAT_TEST_REPO: ${{ vars.BUGDROP_HEARTBEAT_TEST_REPO }}
+          BUGDROP_HEARTBEAT_EXPECTED_AUTHOR: ${{ vars.BUGDROP_HEARTBEAT_EXPECTED_AUTHOR }}
+          BUGDROP_HEARTBEAT_EXPECTED_LABELS: ${{ vars.BUGDROP_HEARTBEAT_EXPECTED_LABELS }}
+        run: node scripts/production-heartbeat-config.mjs export
+
       - name: Install Chromium
         id: browser
-        if: always() && steps.install.outcome == 'success'
+        if: >-
+          always() && steps.install.outcome == 'success' &&
+          steps.config.outcome == 'success'
         continue-on-error: true
         run: npx playwright install --with-deps chromium
 
       - name: Observe strict production identity
         id: identity
-        if: always() && steps.install.outcome == 'success'
+        if: >-
+          always() && steps.install.outcome == 'success' &&
+          steps.config.outcome == 'success'
         continue-on-error: true
-        env:
-          EXPECTED_WIDGET_ORIGIN: https://bugdrop.neonwatty.workers.dev
         run: |
           identity_json=$(node scripts/release/verify-live.mjs observe)
           worker_sha=$(jq -er '.buildSha | select(test("^[a-f0-9]{40}$"))' <<< "$identity_json")
           widget_sha=$(jq -er '.widgetSha256 | select(test("^[a-f0-9]{64}$"))' <<< "$identity_json")
           fixture_path="$RUNNER_TEMP/bugdrop-production-widget-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.js"
           candidate_path="$fixture_path.candidate"
-          curl --max-time 30 -sSf https://bugdrop.neonwatty.workers.dev/widget.js -o "$candidate_path"
+          curl --max-time 30 -sSf "$EXPECTED_WIDGET_ORIGIN/widget.js" -o "$candidate_path"
           actual_sha=$(shasum -a 256 "$candidate_path" | awk '{print $1}')
           test "$actual_sha" = "$widget_sha"
           mv "$candidate_path" "$fixture_path"
@@ -91,8 +105,6 @@ jobs:
           echo "BUGDROP_CANARY_RESULT_FILE=$RUNNER_TEMP/production-heartbeat-result.json" >> "$GITHUB_ENV"
           echo "BUGDROP_CANARY_ATTEMPT_FILE=$RUNNER_TEMP/production-heartbeat-attempt" >> "$GITHUB_ENV"
           echo "LIVE_TARGET=production" >> "$GITHUB_ENV"
-          echo "PLAYWRIGHT_BASE_URL=https://bugdrop-widget-test.vercel.app" >> "$GITHUB_ENV"
-          echo "EXPECTED_WIDGET_ORIGIN=https://bugdrop.neonwatty.workers.dev" >> "$GITHUB_ENV"
 
       - name: Preflight production heartbeat cleanup
         id: preflight
@@ -101,7 +113,7 @@ jobs:
         run: >-
           node scripts/github-issue-canary.mjs preflight
           --profile production
-          --repo mean-weasel/bugdrop-widget-test
+          --repo "$BUGDROP_CANARY_REPO"
           --prefix "[BugDrop production heartbeat]"
         env:
           BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
@@ -117,8 +129,8 @@ jobs:
           if [ -n "$VERCEL_AUTOMATION_BYPASS_SECRET" ]; then
             bypass_args=(-H "x-vercel-protection-bypass:${VERCEL_AUTOMATION_BYPASS_SECRET}")
           fi
-          html=$(curl --max-time 30 -sSf "${bypass_args[@]}" https://bugdrop-widget-test.vercel.app)
-          grep -Fq 'https://bugdrop.neonwatty.workers.dev/widget.js' <<< "$html"
+          html=$(curl --max-time 30 -sSf "${bypass_args[@]}" "$PLAYWRIGHT_BASE_URL")
+          grep -Fq "$EXPECTED_WIDGET_ORIGIN/widget.js" <<< "$html"
 
       - name: Run one production Issue canary
         id: canary
@@ -140,7 +152,7 @@ jobs:
         run: >-
           node scripts/github-issue-canary.mjs verify
           --profile production
-          --repo mean-weasel/bugdrop-widget-test
+          --repo "$BUGDROP_CANARY_REPO"
           --marker "$BUGDROP_CANARY_MARKER"
           --expected-sha "$EXPECTED_WORKER_SHA"
           --result-file "$BUGDROP_CANARY_RESULT_FILE"
@@ -158,7 +170,7 @@ jobs:
           fi
           node scripts/github-issue-canary.mjs cleanup \
             --profile production \
-            --repo mean-weasel/bugdrop-widget-test \
+            --repo "$BUGDROP_CANARY_REPO" \
             --marker "$BUGDROP_CANARY_MARKER"
         env:
           BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
@@ -170,7 +182,7 @@ jobs:
         run: >-
           node scripts/github-issue-canary.mjs sweep
           --profile production
-          --repo mean-weasel/bugdrop-widget-test
+          --repo "$BUGDROP_CANARY_REPO"
           --prefix "[BugDrop production heartbeat]"
         env:
           BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
@@ -191,6 +203,7 @@ jobs:
           CHECKOUT: ${{ steps.checkout.outcome }}
           NODE: ${{ steps.node.outcome }}
           INSTALL: ${{ steps.install.outcome }}
+          CONFIG: ${{ steps.config.outcome }}
           BROWSER: ${{ steps.browser.outcome }}
           IDENTITY: ${{ steps.identity.outcome }}
           PREFLIGHT: ${{ steps.preflight.outcome }}
@@ -201,9 +214,9 @@ jobs:
           SWEEP: ${{ steps.sweep.outcome }}
           CONTROLLED: ${{ steps.controlled.outcome }}
         run: |
-          details="checkout=$CHECKOUT,node=$NODE,install=$INSTALL,browser=$BROWSER,identity=$IDENTITY,preflight=$PREFLIGHT,venue=$VENUE,canary=$CANARY,verify=$VERIFY,cleanup=$CLEANUP,sweep=$SWEEP,controlled=$CONTROLLED"
+          details="checkout=$CHECKOUT,node=$NODE,install=$INSTALL,config=$CONFIG,browser=$BROWSER,identity=$IDENTITY,preflight=$PREFLIGHT,venue=$VENUE,canary=$CANARY,verify=$VERIFY,cleanup=$CLEANUP,sweep=$SWEEP,controlled=$CONTROLLED"
           heartbeat_ok=true
-          for outcome in "$CHECKOUT" "$NODE" "$INSTALL" "$BROWSER" "$IDENTITY" "$PREFLIGHT" "$VENUE" "$CANARY" "$VERIFY" "$CLEANUP" "$SWEEP"; do
+          for outcome in "$CHECKOUT" "$NODE" "$INSTALL" "$CONFIG" "$BROWSER" "$IDENTITY" "$PREFLIGHT" "$VENUE" "$CANARY" "$VERIFY" "$CLEANUP" "$SWEEP"; do
             if [ "$outcome" != success ]; then heartbeat_ok=false; fi
           done
           if [ "$CONTROLLED" = failure ]; then heartbeat_ok=false; fi
@@ -217,6 +230,7 @@ jobs:
             --arg checkout "$CHECKOUT" \
             --arg node "$NODE" \
             --arg install "$INSTALL" \
+            --arg config "$CONFIG" \
             --arg browser "$BROWSER" \
             --arg identity "$IDENTITY" \
             --arg preflight "$PREFLIGHT" \
@@ -227,7 +241,7 @@ jobs:
             --arg sweep "$SWEEP" \
             --arg controlled "$CONTROLLED" \
             --arg heartbeatOk "$heartbeat_ok" \
-            '{schemaVersion: $schemaVersion, runId: $runId, runAttempt: $runAttempt, stages: {checkout: $checkout, node: $node, install: $install, browser: $browser, identity: $identity, preflight: $preflight, venue: $venue, canary: $canary, verify: $verify, cleanup: $cleanup, sweep: $sweep, controlled: $controlled}, heartbeatOk: ($heartbeatOk == "true")}' \
+            '{schemaVersion: $schemaVersion, runId: $runId, runAttempt: $runAttempt, stages: {checkout: $checkout, node: $node, install: $install, config: $config, browser: $browser, identity: $identity, preflight: $preflight, venue: $venue, canary: $canary, verify: $verify, cleanup: $cleanup, sweep: $sweep, controlled: $controlled}, heartbeatOk: ($heartbeatOk == "true")}' \
             > "$diagnostics_tmp"
           test -s "$diagnostics_tmp"
           jq -e '
@@ -238,7 +252,7 @@ jobs:
             (.runAttempt | type == "string" and length > 0) and
             (.heartbeatOk | type == "boolean") and
             (.stages | type == "object") and
-            (.stages | keys == ["browser", "canary", "checkout", "cleanup", "controlled", "identity", "install", "node", "preflight", "sweep", "venue", "verify"]) and
+            (.stages | keys == ["browser", "canary", "checkout", "cleanup", "config", "controlled", "identity", "install", "node", "preflight", "sweep", "venue", "verify"]) and
             ([.stages[] | select(. != "success" and . != "failure" and . != "skipped" and . != "cancelled")] | length == 0)
           ' "$diagnostics_tmp" > /dev/null
           mv "$diagnostics_tmp" "$diagnostics_path"
@@ -263,7 +277,7 @@ jobs:
             (.runAttempt | type == "string" and length > 0) and
             (.heartbeatOk | type == "boolean") and
             (.stages | type == "object") and
-            (.stages | keys == ["browser", "canary", "checkout", "cleanup", "controlled", "identity", "install", "node", "preflight", "sweep", "venue", "verify"]) and
+            (.stages | keys == ["browser", "canary", "checkout", "cleanup", "config", "controlled", "identity", "install", "node", "preflight", "sweep", "venue", "verify"]) and
             ([.stages[] | select(. != "success" and . != "failure" and . != "skipped" and . != "cancelled")] | length == 0)
           ' "$diagnostics_path" > /dev/null
           cp "$diagnostics_path" "$artifact_path/diagnostics.json"
@@ -303,6 +317,7 @@ jobs:
           ARTIFACT_PREPARE_OUTCOME: ${{ needs.heartbeat.outputs.artifact_prepare_outcome }}
           ARTIFACT_OUTCOME: ${{ needs.heartbeat.outputs.artifact_outcome }}
           DETAILS: ${{ needs.heartbeat.outputs.details }}
+          BUGDROP_HEARTBEAT_INCIDENT_REPO: ${{ github.repository }}
         run: |
           outcome=failure
           if [ "$HEARTBEAT_OK" = true ] && [ "$SUMMARIZE_OUTCOME" = success ] && [ "$ARTIFACT_PREPARE_OUTCOME" = success ] && [ "$ARTIFACT_OUTCOME" = success ]; then

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -150,6 +150,20 @@ until separately authorized production setup is complete. Self-hosters should us
 environment. Do not copy its production settings or assume that creating a tag or Release activates
 it. Maintainers of the canonical service should follow [the release runbook](docs/releasing.md).
 
+### Optional Production Heartbeat
+
+Self-hosted deployments do not automatically run BugDrop's production heartbeat. The workflow is
+inert until explicitly enabled, and canonical service defaults are accepted only in the upstream
+`mean-weasel/bugdrop` repository. A private fork or copy must provide its own Worker origin, fixed
+test venue, separate synthetic-Issue repository, GitHub App author, and narrowly scoped verification
+credential.
+
+After the deployment is stable, follow the
+[self-hosted and private repository heartbeat runbook](docs/production-heartbeat.md#self-hosted-and-private-repositories).
+It covers production build identity, private-repository Actions settings, required variables and
+secret, a controlled incident exercise, scheduled soak, and four-hour activation. Do not enable the
+schedule before the manual success, controlled-failure, and recovery runs pass.
+
 ## Configuration
 
 ### Environment Variables

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -162,7 +162,8 @@ After the deployment is stable, follow the
 [self-hosted and private repository heartbeat runbook](docs/production-heartbeat.md#self-hosted-and-private-repositories).
 It covers production build identity, private-repository Actions settings, required variables and
 secret, a controlled incident exercise, scheduled soak, and four-hour activation. Do not enable the
-schedule before the manual success, controlled-failure, and recovery runs pass.
+schedule before the manual success and recovery runs pass and the controlled-failure exercise
+produces its expected failed conclusion and incident.
 
 ## Configuration
 

--- a/docs/production-heartbeat.md
+++ b/docs/production-heartbeat.md
@@ -1,20 +1,27 @@
 # Production Heartbeat Operations
 
 The `Production Heartbeat` workflow exercises the real production widget, creates one synthetic
-Issue in `mean-weasel/bugdrop-widget-test`, independently verifies it, closes every run-marker match,
-proves zero open production-prefix Issues, and reconciles one incident in `mean-weasel/bugdrop`.
+Issue in a dedicated test repository, independently verifies it, closes every run-marker match,
+proves zero open production-prefix Issues, and reconciles one incident in the repository running the
+workflow. The canonical BugDrop installation uses `mean-weasel/bugdrop-widget-test` for synthetic
+Issues and `mean-weasel/bugdrop` for incidents.
 
 Scheduled events are inert unless `BUGDROP_PRODUCTION_HEARTBEAT_MODE` is exactly `daily` or
 `four-hour`. An unset value, `manual`, or an unknown value skips both cron entries. GitHub cron
 timing is approximate.
+
+The workflow is not automatically configured for a fork or private copy. Built-in service origins
+and repository defaults are accepted only when `GITHUB_REPOSITORY` is `mean-weasel/bugdrop`. Every
+other repository must provide a complete self-hosted configuration. This prevents a partially
+configured fork from accidentally exercising the canonical BugDrop service.
 
 ## Prerequisites
 
 - Protect the `production` GitHub environment with required reviewers for release jobs. The heartbeat
   deliberately does not enter that approval-gated environment, because scheduled monitoring must run
   unattended; it uses only the narrowly scoped repository secrets listed below.
-- Configure `BUGDROP_CANARY_GITHUB_TOKEN` as a fine-grained token limited to
-  `mean-weasel/bugdrop-widget-test` with Issues read/write only.
+- Configure `BUGDROP_CANARY_GITHUB_TOKEN` as a fine-grained token limited to the synthetic test
+  repository with Issues read/write only.
 - Configure `VERCEL_AUTOMATION_BYPASS_SECRET` only if the fixed production venue requires it.
 - Confirm production health reports `environment=production` and a full lowercase 40-character
   `buildSha` before authorization.
@@ -24,6 +31,54 @@ timing is approximate.
 Record token ownership and expiry privately. Rotate before expiry, validate replacement read access,
 then use an explicitly authorized disposable Issue to validate write/close access. Never print a
 token or place it in an artifact.
+
+## Self-hosted and private repositories
+
+Self-hosting the application does not require the heartbeat. The heartbeat is an optional
+operational safeguard that must be deliberately configured after the production deployment works.
+The repository containing this workflow may be private, and the synthetic test repository should
+normally be a separate private repository.
+
+Before configuration:
+
+1. Enable GitHub Actions in the self-hosted repository. The workflow file must be on the default
+   branch for scheduled events to run. GitHub disables Actions workflows in a new fork by default.
+2. Create a dedicated synthetic test repository with Issues enabled and create the labels the Worker
+   will apply, normally `bug` and `bugdrop`. Do not use the operational repository or a repository
+   containing real user Issues.
+3. Install the self-hosted BugDrop GitHub App on that test repository. Record its Issue author login,
+   normally `<app-slug>[bot]`.
+4. Deploy a fixed HTTPS test venue whose page loads
+   `https://<your-worker-origin>/widget.js` and targets the synthetic test repository.
+5. Confirm `https://<your-worker-origin>/api/health` reports `environment=production` and a full
+   lowercase 40-character `buildSha`. The deployment process must set `ENVIRONMENT=production` and
+   `BUILD_SHA` to the deployed source commit.
+6. Confirm the self-hosted repository permits the GitHub-maintained Actions used by the workflow and
+   allows its scoped `GITHUB_TOKEN` to write Issues. Private repositories consume the account's
+   applicable GitHub Actions allowance.
+
+Set these repository variables under **Settings > Secrets and variables > Actions > Variables**:
+
+| Variable | Required | Value |
+| --- | --- | --- |
+| `BUGDROP_HEARTBEAT_WIDGET_ORIGIN` | Yes | HTTPS origin of the production Worker, without a path |
+| `BUGDROP_HEARTBEAT_VENUE_ORIGIN` | Yes | HTTPS origin of the fixed test venue, without a path |
+| `BUGDROP_HEARTBEAT_TEST_REPO` | Yes | Dedicated synthetic repository as `owner/repository` |
+| `BUGDROP_HEARTBEAT_EXPECTED_AUTHOR` | Yes | GitHub App Issue author, normally `<app-slug>[bot]` |
+| `BUGDROP_HEARTBEAT_EXPECTED_LABELS` | No | Exact comma-separated labels; defaults to `bug,bugdrop` |
+| `BUGDROP_PRODUCTION_HEARTBEAT_MODE` | Later | Leave unset until staged activation |
+
+Set `BUGDROP_CANARY_GITHUB_TOKEN` as a repository Actions secret. Use a fine-grained credential with
+access to only the synthetic repository and Issues read/write permission. This verifier credential is
+separate from the GitHub App private key held by the Worker. Set `VERCEL_AUTOMATION_BYPASS_SECRET`
+only when the chosen venue requires it. Repository secrets do not copy with a fork and should never
+be exposed to untrusted pull-request workflows.
+
+Incidents are opened in the repository running the workflow using its scoped `GITHUB_TOKEN`; no
+separate incident token or repository variable is required. Keep Issues enabled in that repository.
+For a private installation, the incident, workflow logs, and seven-day diagnostics artifacts remain
+visible only to users who can access that repository. This GitHub Issue is not independent paging:
+a GitHub outage can disrupt both the transaction and the incident channel.
 
 ## Staged activation
 

--- a/docs/production-heartbeat.md
+++ b/docs/production-heartbeat.md
@@ -49,7 +49,11 @@ Before configuration:
 3. Install the self-hosted BugDrop GitHub App on that test repository. Record its Issue author login,
    normally `<app-slug>[bot]`.
 4. Deploy a fixed HTTPS test venue whose page loads
-   `https://<your-worker-origin>/widget.js` and targets the synthetic test repository.
+   `https://<your-worker-origin>/widget.js` and targets the synthetic test repository. If the Worker
+   uses `AUTH_TOKEN_SECRET` or `AUTH_TOKEN_ADDITIONAL_SECRETS`, the venue must also configure
+   `data-auth-token-provider` to return a valid short-lived token during the automated run. Keep the
+   signing secret server-side and protect the provider endpoint with the venue's access control; see
+   [Requiring Host-App Auth Tokens](../SELF_HOSTING.md#requiring-host-app-auth-tokens-recommended-for-private-apps).
 5. Confirm `https://<your-worker-origin>/api/health` reports `environment=production` and a full
    lowercase 40-character `buildSha`. The deployment process must set `ENVIRONMENT=production` and
    `BUILD_SHA` to the deployed source commit.
@@ -65,7 +69,7 @@ Set these repository variables under **Settings > Secrets and variables > Action
 | `BUGDROP_HEARTBEAT_VENUE_ORIGIN` | Yes | HTTPS origin of the fixed test venue, without a path |
 | `BUGDROP_HEARTBEAT_TEST_REPO` | Yes | Dedicated synthetic repository as `owner/repository` |
 | `BUGDROP_HEARTBEAT_EXPECTED_AUTHOR` | Yes | GitHub App Issue author, normally `<app-slug>[bot]` |
-| `BUGDROP_HEARTBEAT_EXPECTED_LABELS` | No | Exact comma-separated labels; defaults to `bug,bugdrop` |
+| `BUGDROP_HEARTBEAT_EXPECTED_LABELS` | No | Exact comma-separated labels including `bugdrop`; defaults to `bug,bugdrop` |
 | `BUGDROP_PRODUCTION_HEARTBEAT_MODE` | Later | Leave unset until staged activation |
 
 Set `BUGDROP_CANARY_GITHUB_TOKEN` as a repository Actions secret. Use a fine-grained credential with

--- a/docs/website/self-hosting.mdx
+++ b/docs/website/self-hosting.mdx
@@ -74,6 +74,8 @@ The guide covers:
 5. **Deploying** -- Publishing the Worker to your Cloudflare account
 6. **Testing** -- Verifying the deployment works end-to-end
 7. **Updating the script tag** -- Pointing your widget to your own Worker URL
+8. **Optional production monitoring** -- Deliberately configuring the production heartbeat for your
+   own origins and private synthetic-Issue repository
 
 ## Updating the Script Tag
 
@@ -103,6 +105,18 @@ If you have configured a custom domain for your Worker:
 ```
 
 All `data-*` attributes work the same regardless of whether you use the hosted or self-hosted version.
+
+## Optional Production Heartbeat
+
+The production heartbeat is not automatically active in a fork or private copy. Once your deployment
+is stable, you can configure it to exercise your own Worker and create, verify, and close a synthetic
+Issue in a separate repository. Canonical BugDrop service defaults are never used by a self-hosted
+repository, and scheduled runs remain inert until you explicitly activate them.
+
+See the
+**[production heartbeat runbook](https://github.com/mean-weasel/bugdrop/blob/main/docs/production-heartbeat.md#self-hosted-and-private-repositories)**
+for the private-repository setup, least-privilege credential, manual incident drill, and staged
+schedule activation.
 
 ## Keeping Up to Date
 

--- a/e2e/issue-canary-routing.spec.ts
+++ b/e2e/issue-canary-routing.spec.ts
@@ -1,0 +1,51 @@
+import { createServer, type Server } from 'node:http';
+
+import { expect, test } from '@playwright/test';
+
+import { routeVenueRequest } from './widget.issue-canary';
+
+const BYPASS_SECRET = 'redirect-leak-regression-sentinel';
+
+test('does not forward the venue bypass header across an origin redirect', async ({ page }) => {
+  let receivedByRedirectTarget: string | undefined;
+  const redirectTarget = await listen((request, response) => {
+    receivedByRedirectTarget = request.headers['x-vercel-protection-bypass'] as string | undefined;
+    response.end('redirected');
+  });
+  const venue = await listen((_request, response) => {
+    response.writeHead(302, { Location: `${redirectTarget.origin}/capture` });
+    response.end();
+  });
+
+  try {
+    await page.route('**/*', route => routeVenueRequest(route, venue.origin, BYPASS_SECRET));
+    const response = await page.goto(venue.origin);
+
+    expect(response?.url()).toBe(`${redirectTarget.origin}/capture`);
+    expect(receivedByRedirectTarget).toBeUndefined();
+  } finally {
+    await Promise.all([close(venue.server), close(redirectTarget.server)]);
+  }
+});
+
+async function listen(
+  handler: Parameters<typeof createServer>[0]
+): Promise<{ origin: string; server: Server }> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Test server has no TCP address');
+  return { origin: `http://127.0.0.1:${address.port}`, server };
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) =>
+    server.close(error => (error ? reject(error) : resolve()))
+  );
+}

--- a/e2e/widget.issue-canary.ts
+++ b/e2e/widget.issue-canary.ts
@@ -1,8 +1,11 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { expect, type Page, type Request } from '@playwright/test';
+import { expect, type Page, type Request, type Route } from '@playwright/test';
 
-import { resolveBrowserCanaryProfile } from '../scripts/github-issue-canary-profiles.mjs';
+import {
+  getCanaryProfile,
+  resolveBrowserCanaryProfile,
+} from '../scripts/github-issue-canary-profiles.mjs';
 import {
   assertExactPreviewWidgetResponse,
   waitForPreviewWidgetResponse,
@@ -31,7 +34,7 @@ type FeedbackResult = {
 
 export async function runIssueCanary(page: Page): Promise<void> {
   const environment = requireCanaryEnvironment();
-  await installVercelBypass(page);
+  await installVercelBypass(page, environment.baseUrl);
 
   const widgetResponsePromise = waitForPreviewWidgetResponse(
     page,
@@ -165,11 +168,12 @@ function requireCanaryEnvironment(): CanaryEnvironment {
   const resultFile = requireEnvironment('BUGDROP_CANARY_RESULT_FILE');
   const profile = resolveBrowserCanaryProfile({
     profile: profileName,
-    repo: 'mean-weasel/bugdrop-widget-test',
+    repo: getCanaryProfile(profileName, process.env).repo,
     venueOrigin: new URL(baseUrl).origin,
     widgetOrigin: expectedWidgetOrigin,
     marker,
     expectedWorkerSha,
+    environment: process.env,
   });
   if (new URL(baseUrl).origin !== baseUrl) {
     throw new Error('PLAYWRIGHT_BASE_URL must be an origin without a path');
@@ -247,15 +251,31 @@ function requireEnvironment(name: string): string {
   return value;
 }
 
-async function installVercelBypass(page: Page): Promise<void> {
+async function installVercelBypass(page: Page, venueOrigin: string): Promise<void> {
   const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
   if (!bypassSecret) return;
-  await page.route('**/*.vercel.app/**', async route => {
-    await route.continue({
-      headers: {
-        ...route.request().headers(),
-        'x-vercel-protection-bypass': bypassSecret,
-      },
-    });
+  await page.route('**/*', async route => {
+    await routeVenueRequest(route, venueOrigin, bypassSecret);
+  });
+}
+
+export function isVenueRequest(requestUrl: string, venueOrigin: string): boolean {
+  return new URL(requestUrl).origin === venueOrigin;
+}
+
+export async function routeVenueRequest(
+  route: Route,
+  venueOrigin: string,
+  bypassSecret: string
+): Promise<void> {
+  if (!isVenueRequest(route.request().url(), venueOrigin)) {
+    await route.fallback();
+    return;
+  }
+  await route.continue({
+    headers: {
+      ...route.request().headers(),
+      'x-vercel-protection-bypass': bypassSecret,
+    },
   });
 }

--- a/e2e/widget.issue-canary.ts
+++ b/e2e/widget.issue-canary.ts
@@ -4,6 +4,7 @@ import { expect, type Page, type Request, type Route } from '@playwright/test';
 
 import {
   getCanaryProfile,
+  isGitHubIssueUrlForRepository,
   resolveBrowserCanaryProfile,
 } from '../scripts/github-issue-canary-profiles.mjs';
 import {
@@ -132,8 +133,10 @@ export async function runIssueCanary(page: Page): Promise<void> {
     Number.isInteger(responseResult.issueNumber) && Number(responseResult.issueNumber) > 0
   ).toBe(true);
   const issueNumber = Number(responseResult.issueNumber);
-  const issueUrl = `https://github.com/${environment.profile.repo}/issues/${issueNumber}`;
-  expect(responseResult.issueUrl).toBe(issueUrl);
+  expect(
+    isGitHubIssueUrlForRepository(responseResult.issueUrl, environment.profile.repo, issueNumber)
+  ).toBe(true);
+  const issueUrl = String(responseResult.issueUrl);
 
   await page.waitForTimeout(1_000);
   expect(rejectedRequest).toBeUndefined();
@@ -272,10 +275,12 @@ export async function routeVenueRequest(
     await route.fallback();
     return;
   }
-  await route.continue({
+  const response = await route.fetch({
     headers: {
       ...route.request().headers(),
       'x-vercel-protection-bypass': bypassSecret,
     },
+    maxRedirects: 0,
   });
+  await route.fulfill({ response });
 }

--- a/e2e/widget.issue-canary.ts
+++ b/e2e/widget.issue-canary.ts
@@ -5,6 +5,7 @@ import { expect, type Page, type Request, type Route } from '@playwright/test';
 import {
   getCanaryProfile,
   isGitHubIssueUrlForRepository,
+  isSameGitHubRepository,
   resolveBrowserCanaryProfile,
 } from '../scripts/github-issue-canary-profiles.mjs';
 import {
@@ -80,11 +81,10 @@ export async function runIssueCanary(page: Page): Promise<void> {
     const payload = outgoing.postDataJSON() as Record<string, unknown>;
     expect(payload.submissionId).toEqual(expect.any(String));
     canarySubmissionId = String(payload.submissionId);
-    expect(payload.repo).toBe(environment.profile.repo);
+    expect(isSameGitHubRepository(payload.repo, environment.profile.repo)).toBe(true);
     expect(payload).toMatchObject({
       kind: 'bugdrop.variant-submission',
       schemaVersion: 1,
-      repo: environment.profile.repo,
       variantId: environment.profile.variantId,
       issue: {
         title: `${environment.profile.titlePrefix} ${environment.marker}`,

--- a/scripts/github-heartbeat-incident.mjs
+++ b/scripts/github-heartbeat-incident.mjs
@@ -14,13 +14,14 @@ export async function transitionHeartbeatIncident({
   runUrl,
   details,
   apiBaseUrl = API_BASE,
+  repo = INCIDENT_REPO,
 }) {
   requireToken(token);
   if (outcome !== 'failure' && outcome !== 'recovery') {
     throw new Error('outcome must be failure or recovery');
   }
   const body = incidentComment({ outcome, runUrl, details });
-  let matches = await listIncidents({ fetchImpl, token, apiBaseUrl });
+  let matches = await listIncidents({ fetchImpl, token, apiBaseUrl, repo });
   if (matches.length > 1) {
     throw new Error(`Expected at most one heartbeat incident; found ${matches.length}`);
   }
@@ -32,12 +33,12 @@ export async function transitionHeartbeatIncident({
         requestJson({
           fetchImpl,
           token,
-          url: issuesUrl(apiBaseUrl),
+          url: issuesUrl(apiBaseUrl, repo),
           method: 'POST',
           body: { title: INCIDENT_TITLE, body },
         }),
       reconcile: async () => {
-        matches = await listIncidents({ fetchImpl, token, apiBaseUrl });
+        matches = await listIncidents({ fetchImpl, token, apiBaseUrl, repo });
         return matches.length === 1 ? matches[0] : undefined;
       },
       token,
@@ -52,33 +53,40 @@ export async function transitionHeartbeatIncident({
       fetchImpl,
       token,
       apiBaseUrl,
+      repo,
       number: incident.number,
       state: 'open',
     });
-    await addComment({ fetchImpl, token, apiBaseUrl, number: incident.number, body });
+    await addComment({ fetchImpl, token, apiBaseUrl, repo, number: incident.number, body });
     return { action: 'reopened', issueNumber: incident.number, state: incident.state };
   }
   if (outcome === 'failure') {
-    await addComment({ fetchImpl, token, apiBaseUrl, number: incident.number, body });
+    await addComment({ fetchImpl, token, apiBaseUrl, repo, number: incident.number, body });
     return { action: 'updated', issueNumber: incident.number, state: incident.state };
   }
   if (incident.state === 'closed') {
     return { action: 'none', issueNumber: incident.number, state: incident.state };
   }
-  await addComment({ fetchImpl, token, apiBaseUrl, number: incident.number, body });
+  await addComment({ fetchImpl, token, apiBaseUrl, repo, number: incident.number, body });
   incident = await setIssueState({
     fetchImpl,
     token,
     apiBaseUrl,
+    repo,
     number: incident.number,
     state: 'closed',
   });
   return { action: 'closed', issueNumber: incident.number, state: incident.state };
 }
 
-export async function listIncidents({ fetchImpl = fetch, token, apiBaseUrl = API_BASE }) {
+export async function listIncidents({
+  fetchImpl = fetch,
+  token,
+  apiBaseUrl = API_BASE,
+  repo = INCIDENT_REPO,
+}) {
   requireToken(token);
-  let next = new URL(issuesUrl(apiBaseUrl));
+  let next = new URL(issuesUrl(apiBaseUrl, repo));
   next.searchParams.set('state', 'all');
   next.searchParams.set('per_page', '100');
   const matches = [];
@@ -91,18 +99,18 @@ export async function listIncidents({ fetchImpl = fetch, token, apiBaseUrl = API
   return matches;
 }
 
-async function addComment({ fetchImpl, token, apiBaseUrl, number, body }) {
+async function addComment({ fetchImpl, token, apiBaseUrl, repo, number, body }) {
   await mutateAndReconcile({
     mutate: () =>
       requestJson({
         fetchImpl,
         token,
-        url: `${issueUrl(apiBaseUrl, number)}/comments`,
+        url: `${issueUrl(apiBaseUrl, repo, number)}/comments`,
         method: 'POST',
         body: { body },
       }),
     reconcile: async () => {
-      let next = new URL(`${issueUrl(apiBaseUrl, number)}/comments`);
+      let next = new URL(`${issueUrl(apiBaseUrl, repo, number)}/comments`);
       next.searchParams.set('per_page', '100');
       while (next) {
         const { response, data } = await requestJson({
@@ -120,13 +128,13 @@ async function addComment({ fetchImpl, token, apiBaseUrl, number, body }) {
   });
 }
 
-async function setIssueState({ fetchImpl, token, apiBaseUrl, number, state }) {
+async function setIssueState({ fetchImpl, token, apiBaseUrl, repo, number, state }) {
   return mutateAndReconcile({
     mutate: () =>
       requestJson({
         fetchImpl,
         token,
-        url: issueUrl(apiBaseUrl, number),
+        url: issueUrl(apiBaseUrl, repo, number),
         method: 'PATCH',
         body: { state, ...(state === 'closed' ? { state_reason: 'completed' } : {}) },
       }),
@@ -134,7 +142,7 @@ async function setIssueState({ fetchImpl, token, apiBaseUrl, number, state }) {
       const { data } = await requestJson({
         fetchImpl,
         token,
-        url: issueUrl(apiBaseUrl, number),
+        url: issueUrl(apiBaseUrl, repo, number),
       });
       return data?.state === state ? data : undefined;
     },
@@ -200,13 +208,22 @@ function incidentComment({ outcome, runUrl, details }) {
   ].join('\n');
 }
 
-function issuesUrl(apiBaseUrl) {
-  return new URL(`/repos/${INCIDENT_REPO}/issues`, apiBaseUrl).toString();
+function issuesUrl(apiBaseUrl, repo) {
+  return new URL(`/repos/${repositoryPath(repo)}/issues`, apiBaseUrl).toString();
 }
 
-function issueUrl(apiBaseUrl, number) {
+function issueUrl(apiBaseUrl, repo, number) {
   if (!Number.isInteger(number) || number < 1) throw new Error('invalid incident Issue number');
-  return new URL(`/repos/${INCIDENT_REPO}/issues/${number}`, apiBaseUrl).toString();
+  return new URL(`/repos/${repositoryPath(repo)}/issues/${number}`, apiBaseUrl).toString();
+}
+
+function repositoryPath(repo) {
+  const value = requireText(repo, 'incident repository');
+  const match = value.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/);
+  if (!match || match.slice(1).some(part => part === '.' || part === '..')) {
+    throw new Error('incident repository must be an owner/repository slug');
+  }
+  return `${encodeURIComponent(match[1])}/${encodeURIComponent(match[2])}`;
 }
 
 function nextLink(value) {
@@ -248,6 +265,7 @@ async function main() {
     outcome,
     runUrl: options['--run-url'],
     details: options['--details'],
+    repo: process.env.BUGDROP_HEARTBEAT_INCIDENT_REPO || process.env.GITHUB_REPOSITORY,
   });
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }

--- a/scripts/github-issue-canary-profiles.mjs
+++ b/scripts/github-issue-canary-profiles.mjs
@@ -29,6 +29,31 @@ const CANARY_PROFILE_NAMES = Object.freeze(Object.keys(PROFILES));
 export const PREVIEW_CANARY_PROFILE = PROFILES.preview;
 export const PRODUCTION_CANARY_PROFILE = PROFILES.production;
 
+export function isGitHubIssueUrlForRepository(value, repo, number) {
+  if (typeof value !== 'string' || !Number.isInteger(number) || number <= 0) return false;
+  const repositoryParts = repo.split('/');
+  if (repositoryParts.length !== 2 || repositoryParts.some(part => !part)) return false;
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  const pathParts = url.pathname.split('/');
+  return (
+    url.origin === 'https://github.com' &&
+    !url.username &&
+    !url.password &&
+    !url.search &&
+    !url.hash &&
+    pathParts.length === 5 &&
+    pathParts[1].toLowerCase() === repositoryParts[0].toLowerCase() &&
+    pathParts[2].toLowerCase() === repositoryParts[1].toLowerCase() &&
+    pathParts[3] === 'issues' &&
+    pathParts[4] === String(number)
+  );
+}
+
 export function getCanaryProfile(name, environment = process.env) {
   const profile = name === 'production' ? runtimeProductionProfile(environment) : PROFILES[name];
   if (!profile) {

--- a/scripts/github-issue-canary-profiles.mjs
+++ b/scripts/github-issue-canary-profiles.mjs
@@ -29,6 +29,14 @@ const CANARY_PROFILE_NAMES = Object.freeze(Object.keys(PROFILES));
 export const PREVIEW_CANARY_PROFILE = PROFILES.preview;
 export const PRODUCTION_CANARY_PROFILE = PROFILES.production;
 
+export function isSameGitHubRepository(left, right) {
+  return (
+    typeof left === 'string' &&
+    typeof right === 'string' &&
+    left.toLowerCase() === right.toLowerCase()
+  );
+}
+
 export function isGitHubIssueUrlForRepository(value, repo, number) {
   if (typeof value !== 'string' || !Number.isInteger(number) || number <= 0) return false;
   const repositoryParts = repo.split('/');

--- a/scripts/github-issue-canary-profiles.mjs
+++ b/scripts/github-issue-canary-profiles.mjs
@@ -20,6 +20,8 @@ const PROFILES = Object.freeze({
     markerPattern: /^bugdrop-production-heartbeat:[0-9]+:[0-9]+:[a-f0-9]{40}$/,
     variantId: 'production-heartbeat',
     dialogTitle: 'Production heartbeat',
+    expectedAuthor: 'neonwatty-bugdrop[bot]',
+    expectedLabels: Object.freeze(['bug', 'bugdrop']),
   }),
 });
 
@@ -27,8 +29,8 @@ const CANARY_PROFILE_NAMES = Object.freeze(Object.keys(PROFILES));
 export const PREVIEW_CANARY_PROFILE = PROFILES.preview;
 export const PRODUCTION_CANARY_PROFILE = PROFILES.production;
 
-export function getCanaryProfile(name) {
-  const profile = PROFILES[name];
+export function getCanaryProfile(name, environment = process.env) {
+  const profile = name === 'production' ? runtimeProductionProfile(environment) : PROFILES[name];
   if (!profile) {
     throw new Error(
       `Unknown canary profile: ${name || '(missing)'}; expected ${CANARY_PROFILE_NAMES.join(' or ')}`
@@ -43,8 +45,9 @@ export function validateCanarySelector({
   marker,
   prefix,
   expectedWorkerSha,
+  environment = process.env,
 }) {
-  const profile = getCanaryProfile(profileName);
+  const profile = getCanaryProfile(profileName, environment);
   requireExact(repo, profile.repo, 'repo', profile.id);
   if (Boolean(marker) === Boolean(prefix)) {
     throw new Error('Exactly one of marker or prefix is required');
@@ -74,8 +77,9 @@ export function resolveBrowserCanaryProfile({
   widgetOrigin,
   marker,
   expectedWorkerSha,
+  environment = process.env,
 }) {
-  const profile = getCanaryProfile(profileName);
+  const profile = getCanaryProfile(profileName, environment);
   requireExact(repo, profile.repo, 'repo', profile.id);
   requireExact(
     normalizeOrigin(venueOrigin, 'venue origin'),
@@ -99,6 +103,45 @@ export function resolveBrowserCanaryProfile({
     throw new Error(`marker does not end with the expected Worker SHA for ${profile.id}`);
   }
   return profile;
+}
+
+function runtimeProductionProfile(environment) {
+  const values = {
+    repo: environment.BUGDROP_CANARY_REPO?.trim(),
+    venueOrigin: environment.PLAYWRIGHT_BASE_URL?.trim(),
+    widgetOrigin: environment.EXPECTED_WIDGET_ORIGIN?.trim(),
+    expectedAuthor: environment.BUGDROP_CANARY_EXPECTED_AUTHOR?.trim(),
+    expectedLabels: environment.BUGDROP_CANARY_EXPECTED_LABELS_JSON?.trim(),
+  };
+  const configured = Object.values(values).some(Boolean);
+  if (!configured) return PROFILES.production;
+  const missing = Object.entries(values)
+    .filter(([, value]) => !value)
+    .map(([name]) => name);
+  if (missing.length > 0) {
+    throw new Error(`Production canary runtime configuration is incomplete: ${missing.join(', ')}`);
+  }
+  let expectedLabels;
+  try {
+    expectedLabels = JSON.parse(values.expectedLabels);
+  } catch {
+    throw new Error('Production canary expected labels must be valid JSON');
+  }
+  if (
+    !Array.isArray(expectedLabels) ||
+    expectedLabels.length === 0 ||
+    expectedLabels.some(label => typeof label !== 'string' || !label)
+  ) {
+    throw new Error('Production canary expected labels must be a non-empty string array');
+  }
+  return Object.freeze({
+    ...PROFILES.production,
+    repo: values.repo,
+    venueOrigin: normalizeOrigin(values.venueOrigin, 'venue origin'),
+    widgetOrigin: normalizeOrigin(values.widgetOrigin, 'widget origin'),
+    expectedAuthor: values.expectedAuthor,
+    expectedLabels: Object.freeze(expectedLabels),
+  });
 }
 
 function normalizeOrigin(value, field) {

--- a/scripts/github-issue-canary.mjs
+++ b/scripts/github-issue-canary.mjs
@@ -158,7 +158,7 @@ export async function verifyCanaryIssue({
   }
   if (candidate.body?.includes('## Screenshot')) failures.push('Issue contains a screenshot');
   if (candidate.state !== 'open') failures.push(`Issue state is ${candidate.state}, not open`);
-  if (candidate.user?.login !== requiredAuthor) {
+  if (!sameGitHubLogin(candidate.user?.login, requiredAuthor)) {
     failures.push(`Issue author is ${candidate.user?.login ?? 'missing'}, not ${requiredAuthor}`);
   }
   const actualLabels = normalizeLabels(candidate.labels);
@@ -590,6 +590,14 @@ function sameStringSet(left, right) {
   return (
     left.length === normalizedRight.length &&
     left.every((value, index) => value === normalizedRight[index])
+  );
+}
+
+function sameGitHubLogin(left, right) {
+  return (
+    typeof left === 'string' &&
+    typeof right === 'string' &&
+    left.toLowerCase() === right.toLowerCase()
   );
 }
 

--- a/scripts/github-issue-canary.mjs
+++ b/scripts/github-issue-canary.mjs
@@ -20,12 +20,13 @@ const DEFAULT_CONSISTENCY_DELAY_MS = 2_000;
 const MAX_CONSISTENCY_ATTEMPTS = 20;
 const MAX_CONSISTENCY_DELAY_MS = 10_000;
 
-export function canaryTitle(marker, profileName = 'preview') {
+export function canaryTitle(marker, profileName = 'preview', environment = process.env) {
   requireNonempty(marker, 'marker');
   const { profile } = validateCanarySelector({
     profile: profileName,
-    repo: getCanaryProfile(profileName).repo,
+    repo: getCanaryProfile(profileName, environment).repo,
     marker,
+    environment,
   });
   return `${profile.titlePrefix} ${marker}`;
 }
@@ -38,8 +39,15 @@ export async function listMatchingIssues({
   marker,
   prefix,
   profile = 'preview',
+  profileEnvironment = process.env,
 }) {
-  const selector = validateCanarySelector({ profile, repo, marker, prefix });
+  const selector = validateCanarySelector({
+    profile,
+    repo,
+    marker,
+    prefix,
+    environment: profileEnvironment,
+  });
   const issues = await listRepositoryIssues({ fetchImpl, apiBaseUrl, repo, token });
   return issues.filter(candidate => {
     if (candidate.pull_request) return false;
@@ -60,19 +68,23 @@ export async function verifyCanaryIssue({
   marker,
   expectedSha,
   result,
-  expectedLabels = DEFAULT_LABELS,
-  expectedAuthor = DEFAULT_AUTHOR,
+  expectedLabels,
+  expectedAuthor,
   consistencyAttempts = DEFAULT_CONSISTENCY_ATTEMPTS,
   consistencyDelayMs = DEFAULT_CONSISTENCY_DELAY_MS,
   sleepImpl = sleep,
   profile = 'preview',
+  profileEnvironment = process.env,
 }) {
   const target = validateCanarySelector({
     profile,
     repo,
     marker,
     expectedWorkerSha: expectedSha,
+    environment: profileEnvironment,
   });
+  const requiredAuthor = expectedAuthor ?? target.profile.expectedAuthor ?? DEFAULT_AUTHOR;
+  const requiredLabels = expectedLabels ?? target.profile.expectedLabels ?? DEFAULT_LABELS;
   requireNonempty(expectedSha, 'expectedSha');
   const consistency = validateConsistencyOptions({
     consistencyAttempts,
@@ -105,6 +117,7 @@ export async function verifyCanaryIssue({
     token,
     marker,
     profile,
+    profileEnvironment,
     consistency,
   });
   const numbers = matches.map(candidate => candidate.number);
@@ -142,13 +155,13 @@ export async function verifyCanaryIssue({
   }
   if (candidate.body?.includes('## Screenshot')) failures.push('Issue contains a screenshot');
   if (candidate.state !== 'open') failures.push(`Issue state is ${candidate.state}, not open`);
-  if (candidate.user?.login !== expectedAuthor) {
-    failures.push(`Issue author is ${candidate.user?.login ?? 'missing'}, not ${expectedAuthor}`);
+  if (candidate.user?.login !== requiredAuthor) {
+    failures.push(`Issue author is ${candidate.user?.login ?? 'missing'}, not ${requiredAuthor}`);
   }
   const actualLabels = normalizeLabels(candidate.labels);
-  if (!sameStringSet(actualLabels, expectedLabels)) {
+  if (!sameStringSet(actualLabels, requiredLabels)) {
     failures.push(
-      `Issue labels are [${actualLabels.join(', ')}], not [${[...expectedLabels].sort().join(', ')}]`
+      `Issue labels are [${actualLabels.join(', ')}], not [${[...requiredLabels].sort().join(', ')}]`
     );
   }
 
@@ -172,12 +185,20 @@ export async function closeMatchingIssues({
   consistencyDelayMs = DEFAULT_CONSISTENCY_DELAY_MS,
   sleepImpl = sleep,
   profile = 'preview',
+  profileEnvironment = process.env,
 }) {
-  const selector = validateCanarySelector({ profile, repo, marker, prefix });
+  const selector = validateCanarySelector({
+    profile,
+    repo,
+    marker,
+    prefix,
+    environment: profileEnvironment,
+  });
   const boundSelector = {
     marker: selector.marker,
     prefix: selector.prefix,
     profile: selector.profile.id,
+    profileEnvironment,
   };
   const consistency = validateConsistencyOptions({
     consistencyAttempts,
@@ -264,6 +285,7 @@ export async function runCli(
       repo: options.repo,
       marker: command === 'verify' || command === 'cleanup' ? options.marker : undefined,
       prefix: command === 'preflight' || command === 'sweep' ? options.prefix : undefined,
+      environment: env,
     });
     requireNonempty(token, 'BUGDROP_CANARY_GITHUB_TOKEN');
     let output;
@@ -283,6 +305,7 @@ export async function runCli(
         consistencyAttempts,
         consistencyDelayMs,
         sleepImpl,
+        profileEnvironment: env,
       });
       output = { verified: true, issueNumber: candidate.number, issueUrl: candidate.html_url };
     } else if (command === 'cleanup') {
@@ -296,6 +319,7 @@ export async function runCli(
         consistencyAttempts,
         consistencyDelayMs,
         sleepImpl,
+        profileEnvironment: env,
       });
     } else if (command === 'preflight' || command === 'sweep') {
       requireNonempty(options.prefix, '--prefix');
@@ -308,6 +332,7 @@ export async function runCli(
         consistencyAttempts,
         consistencyDelayMs,
         sleepImpl,
+        profileEnvironment: env,
       });
     } else {
       throw new Error(`Unknown command: ${command || '(missing)'}`);

--- a/scripts/github-issue-canary.mjs
+++ b/scripts/github-issue-canary.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url';
 import {
   PREVIEW_CANARY_PROFILE,
   getCanaryProfile,
+  isGitHubIssueUrlForRepository,
   validateCanarySelector,
 } from './github-issue-canary-profiles.mjs';
 
@@ -127,7 +128,7 @@ export async function verifyCanaryIssue({
     );
   }
 
-  const canonicalUrl = canonicalIssueUrl(repo, candidate.number);
+  const canonicalUrl = candidate.html_url;
   const failures = [];
   if (matches[0].number !== candidate.number) {
     failures.push(
@@ -137,7 +138,9 @@ export async function verifyCanaryIssue({
   if (!Number.isInteger(candidate.number) || candidate.number <= 0) {
     failures.push('Issue number is not a positive integer');
   }
-  if (candidate.html_url !== canonicalUrl) failures.push('Issue URL is not canonical');
+  if (!isGitHubIssueUrlForRepository(candidate.html_url, repo, candidate.number)) {
+    failures.push('Issue URL is not canonical');
+  }
   if (candidate.title !== `${target.profile.titlePrefix} ${marker}`) {
     failures.push('Issue title does not match exactly');
   }
@@ -549,7 +552,7 @@ function validateBrowserResultReference({ failures, result, marker, expectedSha,
   validateBrowserSubmissionId({ failures, result, marker });
   if (!Number.isInteger(result.issueNumber) || result.issueNumber <= 0) {
     failures.push('Browser result Issue number is not a positive integer');
-  } else if (result.issueUrl !== canonicalIssueUrl(repo, result.issueNumber)) {
+  } else if (!isGitHubIssueUrlForRepository(result.issueUrl, repo, result.issueNumber)) {
     failures.push('Browser result Issue URL is not canonical');
   }
   if (result.workerSha !== expectedSha) failures.push('Browser result Worker SHA differs');
@@ -606,11 +609,6 @@ function parseRepo(repo) {
     throw new Error('repo must use owner/name format');
   }
   return { owner: parts[0], name: parts[1] };
-}
-
-function canonicalIssueUrl(repo, number) {
-  parseRepo(repo);
-  return `https://github.com/${repo}/issues/${number}`;
 }
 
 function issueApiUrl(apiBaseUrl, repo, number) {

--- a/scripts/production-heartbeat-config.mjs
+++ b/scripts/production-heartbeat-config.mjs
@@ -46,9 +46,16 @@ export function resolveProductionHeartbeatConfig({ repository, variables = {} })
   if (sameRepository(testRepo, currentRepository)) {
     throw new Error('BUGDROP_HEARTBEAT_TEST_REPO must be separate from GITHUB_REPOSITORY');
   }
+  const widgetOrigin = httpsOrigin(supplied.widgetOrigin, VARIABLE_NAMES.widgetOrigin);
+  const venueOrigin = httpsOrigin(supplied.venueOrigin, VARIABLE_NAMES.venueOrigin);
+  if (widgetOrigin === venueOrigin) {
+    throw new Error(
+      'BUGDROP_HEARTBEAT_WIDGET_ORIGIN and BUGDROP_HEARTBEAT_VENUE_ORIGIN must differ'
+    );
+  }
   return {
-    widgetOrigin: httpsOrigin(supplied.widgetOrigin, VARIABLE_NAMES.widgetOrigin),
-    venueOrigin: httpsOrigin(supplied.venueOrigin, VARIABLE_NAMES.venueOrigin),
+    widgetOrigin,
+    venueOrigin,
     testRepo,
     expectedAuthor: githubLogin(supplied.expectedAuthor, VARIABLE_NAMES.expectedAuthor),
     expectedLabels: labelList(supplied.expectedLabels || 'bug,bugdrop'),

--- a/scripts/production-heartbeat-config.mjs
+++ b/scripts/production-heartbeat-config.mjs
@@ -115,10 +115,22 @@ function labelList(value) {
     .split(',')
     .map(label => label.trim())
     .filter(Boolean);
-  if (labels.length === 0 || labels.some(label => label.length > 50 || /[\r\n]/.test(label))) {
+  if (
+    labels.length === 0 ||
+    labels.some(label => label.length > 50 || /[\u0000-\u001f\u007f]/.test(label))
+  ) {
     throw new Error('BUGDROP_HEARTBEAT_EXPECTED_LABELS must be a comma-separated label list');
   }
-  return [...new Set(labels)];
+  const uniqueLabels = [...new Set(labels)];
+  if (new Set(uniqueLabels.map(label => label.toLowerCase())).size !== uniqueLabels.length) {
+    throw new Error(
+      'BUGDROP_HEARTBEAT_EXPECTED_LABELS must not repeat labels with different casing'
+    );
+  }
+  if (!uniqueLabels.includes('bugdrop')) {
+    throw new Error('BUGDROP_HEARTBEAT_EXPECTED_LABELS must include bugdrop');
+  }
+  return uniqueLabels;
 }
 
 function text(value) {

--- a/scripts/production-heartbeat-config.mjs
+++ b/scripts/production-heartbeat-config.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import { appendFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+export const CANONICAL_REPOSITORY = 'mean-weasel/bugdrop';
+
+export const CANONICAL_HEARTBEAT_CONFIG = Object.freeze({
+  widgetOrigin: 'https://bugdrop.neonwatty.workers.dev',
+  venueOrigin: 'https://bugdrop-widget-test.vercel.app',
+  testRepo: 'mean-weasel/bugdrop-widget-test',
+  expectedAuthor: 'neonwatty-bugdrop[bot]',
+  expectedLabels: Object.freeze(['bug', 'bugdrop']),
+});
+
+const VARIABLE_NAMES = Object.freeze({
+  widgetOrigin: 'BUGDROP_HEARTBEAT_WIDGET_ORIGIN',
+  venueOrigin: 'BUGDROP_HEARTBEAT_VENUE_ORIGIN',
+  testRepo: 'BUGDROP_HEARTBEAT_TEST_REPO',
+  expectedAuthor: 'BUGDROP_HEARTBEAT_EXPECTED_AUTHOR',
+  expectedLabels: 'BUGDROP_HEARTBEAT_EXPECTED_LABELS',
+});
+
+export function resolveProductionHeartbeatConfig({ repository, variables = {} }) {
+  const currentRepository = repositorySlug(repository, 'GITHUB_REPOSITORY');
+  const supplied = Object.fromEntries(
+    Object.entries(VARIABLE_NAMES).map(([field, name]) => [field, text(variables[name])])
+  );
+  const hasOverrides = Object.values(supplied).some(Boolean);
+
+  if (sameRepository(currentRepository, CANONICAL_REPOSITORY) && !hasOverrides) {
+    return {
+      ...CANONICAL_HEARTBEAT_CONFIG,
+      expectedLabels: [...CANONICAL_HEARTBEAT_CONFIG.expectedLabels],
+    };
+  }
+
+  const missing = Object.entries(VARIABLE_NAMES)
+    .filter(([field]) => field !== 'expectedLabels' && !supplied[field])
+    .map(([, name]) => name);
+  if (missing.length > 0) {
+    throw new Error(`Self-hosted heartbeat configuration is incomplete: ${missing.join(', ')}`);
+  }
+
+  const testRepo = repositorySlug(supplied.testRepo, VARIABLE_NAMES.testRepo);
+  if (sameRepository(testRepo, currentRepository)) {
+    throw new Error('BUGDROP_HEARTBEAT_TEST_REPO must be separate from GITHUB_REPOSITORY');
+  }
+  return {
+    widgetOrigin: httpsOrigin(supplied.widgetOrigin, VARIABLE_NAMES.widgetOrigin),
+    venueOrigin: httpsOrigin(supplied.venueOrigin, VARIABLE_NAMES.venueOrigin),
+    testRepo,
+    expectedAuthor: githubLogin(supplied.expectedAuthor, VARIABLE_NAMES.expectedAuthor),
+    expectedLabels: labelList(supplied.expectedLabels || 'bug,bugdrop'),
+  };
+}
+
+function sameRepository(left, right) {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+export function heartbeatEnvironment(config, repository) {
+  return {
+    EXPECTED_WIDGET_ORIGIN: config.widgetOrigin,
+    PLAYWRIGHT_BASE_URL: config.venueOrigin,
+    BUGDROP_CANARY_REPO: config.testRepo,
+    BUGDROP_CANARY_EXPECTED_AUTHOR: config.expectedAuthor,
+    BUGDROP_CANARY_EXPECTED_LABELS_JSON: JSON.stringify(config.expectedLabels),
+    BUGDROP_HEARTBEAT_INCIDENT_REPO: repositorySlug(repository, 'GITHUB_REPOSITORY'),
+  };
+}
+
+function httpsOrigin(value, name) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${name} must be an HTTPS origin`);
+  }
+  if (url.protocol !== 'https:' || url.origin !== value || url.username || url.password) {
+    throw new Error(`${name} must be an HTTPS origin without a path or credentials`);
+  }
+  return value;
+}
+
+function repositorySlug(value, name) {
+  const normalized = text(value);
+  const parts = normalized.split('/');
+  if (
+    parts.length !== 2 ||
+    parts.some(part => !/^[A-Za-z0-9_.-]+$/.test(part) || part === '.' || part === '..')
+  ) {
+    throw new Error(`${name} must be an owner/repository slug`);
+  }
+  return normalized;
+}
+
+function githubLogin(value, name) {
+  const normalized = text(value);
+  if (!/^[A-Za-z0-9-]+(?:\[bot\])?$/.test(normalized)) {
+    throw new Error(`${name} must be a GitHub login`);
+  }
+  return normalized;
+}
+
+function labelList(value) {
+  const labels = value
+    .split(',')
+    .map(label => label.trim())
+    .filter(Boolean);
+  if (labels.length === 0 || labels.some(label => label.length > 50 || /[\r\n]/.test(label))) {
+    throw new Error('BUGDROP_HEARTBEAT_EXPECTED_LABELS must be a comma-separated label list');
+  }
+  return [...new Set(labels)];
+}
+
+function text(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+async function main() {
+  if (process.argv[2] !== 'export' || !process.env.GITHUB_ENV) {
+    throw new Error('usage: production-heartbeat-config.mjs export (requires GITHUB_ENV)');
+  }
+  const config = resolveProductionHeartbeatConfig({
+    repository: process.env.GITHUB_REPOSITORY,
+    variables: process.env,
+  });
+  const entries = heartbeatEnvironment(config, process.env.GITHUB_REPOSITORY);
+  await appendFile(
+    process.env.GITHUB_ENV,
+    `${Object.entries(entries)
+      .map(([name, value]) => `${name}=${value}`)
+      .join('\n')}\n`,
+    'utf8'
+  );
+  process.stdout.write(
+    `Production heartbeat configuration validated for ${process.env.GITHUB_REPOSITORY}.\n`
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/githubHeartbeatIncident.test.ts
+++ b/test/githubHeartbeatIncident.test.ts
@@ -56,6 +56,12 @@ describe('heartbeat incident discovery', () => {
       );
     await expect(listIncidents({ fetchImpl, token: TOKEN })).resolves.toHaveLength(1);
   });
+
+  it('scopes incident discovery to the configured private operational repository', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(response([]));
+    await listIncidents({ fetchImpl, token: TOKEN, repo: 'acme/private-bugdrop' });
+    expect(String(fetchImpl.mock.calls[0][0])).toContain('/repos/acme/private-bugdrop/issues');
+  });
 });
 
 describe('heartbeat incident lifecycle', () => {

--- a/test/githubIssueCanary.test.ts
+++ b/test/githubIssueCanary.test.ts
@@ -157,6 +157,48 @@ describe('GitHub Issue canary discovery and verification', () => {
     expect(verified.number).toBe(42);
   });
 
+  it('verifies self-hosted production author and labels from the runtime profile', async () => {
+    const repo = 'acme/bugdrop-heartbeat-test';
+    const marker = `bugdrop-production-heartbeat:123:1:${SHA}`;
+    const submissionId = 'submission-95a970ec-e4fa-41da-9a29-f4b62fb941ca';
+    const candidate = issue({
+      html_url: `https://github.com/${repo}/issues/42`,
+      title: `[BugDrop production heartbeat] ${marker}`,
+      body: issue().body.replaceAll(MARKER, marker).replace(`ci:${marker}`, submissionId),
+      labels: [{ name: 'synthetic' }],
+      user: { login: 'acme-bugdrop[bot]' },
+    });
+    const profileEnvironment = {
+      BUGDROP_CANARY_REPO: repo,
+      PLAYWRIGHT_BASE_URL: 'https://heartbeat.example.com',
+      EXPECTED_WIDGET_ORIGIN: 'https://bugdrop.example.com',
+      BUGDROP_CANARY_EXPECTED_AUTHOR: 'acme-bugdrop[bot]',
+      BUGDROP_CANARY_EXPECTED_LABELS_JSON: '["synthetic"]',
+    };
+
+    await expect(
+      verifyCanaryIssue({
+        fetchImpl: issueFetch([candidate], candidate),
+        repo,
+        token: TOKEN,
+        marker,
+        expectedSha: SHA,
+        result: {
+          marker,
+          kind: 'structured',
+          presentation: 'modal',
+          submissionId,
+          issueNumber: 42,
+          issueUrl: `https://github.com/${repo}/issues/42`,
+          workerSha: SHA,
+        },
+        profile: 'production',
+        profileEnvironment,
+        sleepImpl: noWait,
+      })
+    ).resolves.toMatchObject({ number: 42 });
+  });
+
   it.each([
     ['missing rendered identity', renderedResult({ submissionId: undefined })],
     ['non-rendered identity', renderedResult({ submissionId: `ci:${MARKER}` })],

--- a/test/githubIssueCanary.test.ts
+++ b/test/githubIssueCanary.test.ts
@@ -172,7 +172,7 @@ describe('GitHub Issue canary discovery and verification', () => {
       BUGDROP_CANARY_REPO: repo,
       PLAYWRIGHT_BASE_URL: 'https://heartbeat.example.com',
       EXPECTED_WIDGET_ORIGIN: 'https://bugdrop.example.com',
-      BUGDROP_CANARY_EXPECTED_AUTHOR: 'acme-bugdrop[bot]',
+      BUGDROP_CANARY_EXPECTED_AUTHOR: 'ACME-BUGDROP[bot]',
       BUGDROP_CANARY_EXPECTED_LABELS_JSON: '["synthetic"]',
     };
 

--- a/test/githubIssueCanary.test.ts
+++ b/test/githubIssueCanary.test.ts
@@ -199,6 +199,48 @@ describe('GitHub Issue canary discovery and verification', () => {
     ).resolves.toMatchObject({ number: 42 });
   });
 
+  it('accepts GitHub canonical repository casing for a case-aliased configuration', async () => {
+    const configuredRepo = 'ACME/BugDrop-Heartbeat-Test';
+    const canonicalRepo = 'acme/bugdrop-heartbeat-test';
+    const marker = `bugdrop-production-heartbeat:123:1:${SHA}`;
+    const submissionId = 'submission-95a970ec-e4fa-41da-9a29-f4b62fb941ca';
+    const candidate = issue({
+      html_url: `https://github.com/${canonicalRepo}/issues/42`,
+      title: `[BugDrop production heartbeat] ${marker}`,
+      body: issue().body.replaceAll(MARKER, marker).replace(`ci:${marker}`, submissionId),
+      user: { login: 'acme-bugdrop[bot]' },
+    });
+    const profileEnvironment = {
+      BUGDROP_CANARY_REPO: configuredRepo,
+      PLAYWRIGHT_BASE_URL: 'https://heartbeat.example.com',
+      EXPECTED_WIDGET_ORIGIN: 'https://bugdrop.example.com',
+      BUGDROP_CANARY_EXPECTED_AUTHOR: 'acme-bugdrop[bot]',
+      BUGDROP_CANARY_EXPECTED_LABELS_JSON: '["bug","bugdrop"]',
+    };
+
+    await expect(
+      verifyCanaryIssue({
+        fetchImpl: issueFetch([candidate], candidate),
+        repo: configuredRepo,
+        token: TOKEN,
+        marker,
+        expectedSha: SHA,
+        result: {
+          marker,
+          kind: 'structured',
+          presentation: 'modal',
+          submissionId,
+          issueNumber: 42,
+          issueUrl: candidate.html_url,
+          workerSha: SHA,
+        },
+        profile: 'production',
+        profileEnvironment,
+        sleepImpl: noWait,
+      })
+    ).resolves.toMatchObject({ number: 42 });
+  });
+
   it.each([
     ['missing rendered identity', renderedResult({ submissionId: undefined })],
     ['non-rendered identity', renderedResult({ submissionId: `ci:${MARKER}` })],

--- a/test/githubIssueCanaryProfiles.test.ts
+++ b/test/githubIssueCanaryProfiles.test.ts
@@ -5,6 +5,7 @@ import {
   PRODUCTION_CANARY_PROFILE,
   getCanaryProfile,
   isGitHubIssueUrlForRepository,
+  isSameGitHubRepository,
   resolveBrowserCanaryProfile,
   validateCanarySelector,
 } from '../scripts/github-issue-canary-profiles.mjs';
@@ -122,6 +123,12 @@ describe('GitHub Issue canary profiles', () => {
         42
       )
     ).toBe(true);
+  });
+
+  it('matches GitHub repository identity without requiring display casing', () => {
+    expect(isSameGitHubRepository('Acme/Heartbeat-Test', 'acme/heartbeat-test')).toBe(true);
+    expect(isSameGitHubRepository('acme/other', 'acme/heartbeat-test')).toBe(false);
+    expect(isSameGitHubRepository(undefined, 'acme/heartbeat-test')).toBe(false);
   });
 
   it.each([

--- a/test/githubIssueCanaryProfiles.test.ts
+++ b/test/githubIssueCanaryProfiles.test.ts
@@ -82,4 +82,34 @@ describe('GitHub Issue canary profiles', () => {
       resolveBrowserCanaryProfile({ ...valid, expectedWorkerSha: 'b'.repeat(40) })
     ).toThrow('expected Worker SHA');
   });
+
+  it('binds the production profile to a complete self-hosted runtime configuration', () => {
+    const environment = {
+      BUGDROP_CANARY_REPO: 'acme/bugdrop-heartbeat-test',
+      PLAYWRIGHT_BASE_URL: 'https://heartbeat.example.com',
+      EXPECTED_WIDGET_ORIGIN: 'https://bugdrop.example.com',
+      BUGDROP_CANARY_EXPECTED_AUTHOR: 'acme-bugdrop[bot]',
+      BUGDROP_CANARY_EXPECTED_LABELS_JSON: '["bug","bugdrop"]',
+    };
+    const profile = resolveBrowserCanaryProfile({
+      profile: 'production',
+      repo: environment.BUGDROP_CANARY_REPO,
+      venueOrigin: environment.PLAYWRIGHT_BASE_URL,
+      widgetOrigin: environment.EXPECTED_WIDGET_ORIGIN,
+      marker: `bugdrop-production-heartbeat:123:1:${SHA}`,
+      expectedWorkerSha: SHA,
+      environment,
+    });
+    expect(profile).toMatchObject({
+      repo: 'acme/bugdrop-heartbeat-test',
+      expectedAuthor: 'acme-bugdrop[bot]',
+      expectedLabels: ['bug', 'bugdrop'],
+    });
+  });
+
+  it('rejects a partial self-hosted runtime configuration', () => {
+    expect(() => getCanaryProfile('production', { BUGDROP_CANARY_REPO: 'acme/test' })).toThrow(
+      'runtime configuration is incomplete'
+    );
+  });
 });

--- a/test/githubIssueCanaryProfiles.test.ts
+++ b/test/githubIssueCanaryProfiles.test.ts
@@ -4,6 +4,7 @@ import {
   PREVIEW_CANARY_PROFILE,
   PRODUCTION_CANARY_PROFILE,
   getCanaryProfile,
+  isGitHubIssueUrlForRepository,
   resolveBrowserCanaryProfile,
   validateCanarySelector,
 } from '../scripts/github-issue-canary-profiles.mjs';
@@ -111,5 +112,25 @@ describe('GitHub Issue canary profiles', () => {
     expect(() => getCanaryProfile('production', { BUGDROP_CANARY_REPO: 'acme/test' })).toThrow(
       'runtime configuration is incomplete'
     );
+  });
+
+  it('matches canonical GitHub Issue URLs without requiring repository display casing', () => {
+    expect(
+      isGitHubIssueUrlForRepository(
+        'https://github.com/acme/heartbeat-test/issues/42',
+        'Acme/Heartbeat-Test',
+        42
+      )
+    ).toBe(true);
+  });
+
+  it.each([
+    'https://example.com/acme/heartbeat-test/issues/42',
+    'https://github.com/acme/other/issues/42',
+    'https://github.com/acme/heartbeat-test/issues/43',
+    'https://github.com/acme/heartbeat-test/issues/42?tracked=true',
+    'https://github.com/acme/heartbeat-test/issues/42/',
+  ])('rejects non-canonical Issue URL %s', issueUrl => {
+    expect(isGitHubIssueUrlForRepository(issueUrl, 'acme/heartbeat-test', 42)).toBe(false);
   });
 });

--- a/test/issueCanaryVenue.test.ts
+++ b/test/issueCanaryVenue.test.ts
@@ -1,0 +1,56 @@
+import type { Route } from '@playwright/test';
+import { describe, expect, it, vi } from 'vitest';
+
+import { isVenueRequest, routeVenueRequest } from '../e2e/widget.issue-canary';
+
+describe('Issue canary venue routing', () => {
+  it('matches a protected Vercel custom domain and its resources', () => {
+    const venue = 'https://heartbeat.example.com';
+    expect(isVenueRequest(`${venue}/`, venue)).toBe(true);
+    expect(isVenueRequest(`${venue}/assets/app.js`, venue)).toBe(true);
+  });
+
+  it('does not send the venue bypass secret to the Worker or third parties', () => {
+    const venue = 'https://heartbeat.example.com';
+    expect(isVenueRequest('https://bugdrop.example.com/widget.js', venue)).toBe(false);
+    expect(isVenueRequest('https://example.net/analytics.js', venue)).toBe(false);
+  });
+
+  it('falls through non-venue requests to the pinned widget context route', async () => {
+    const fallback = vi.fn(async () => {});
+    const continueRequest = vi.fn(async () => {});
+    const route = {
+      request: () => ({ url: () => 'https://bugdrop.example.com/widget.js' }),
+      fallback,
+      continue: continueRequest,
+    } as unknown as Route;
+
+    await routeVenueRequest(route, 'https://heartbeat.example.com', 'bypass-secret');
+
+    expect(fallback).toHaveBeenCalledOnce();
+    expect(continueRequest).not.toHaveBeenCalled();
+  });
+
+  it('adds the bypass header only to venue requests', async () => {
+    const fallback = vi.fn(async () => {});
+    const continueRequest = vi.fn(async () => {});
+    const route = {
+      request: () => ({
+        url: () => 'https://heartbeat.example.com/',
+        headers: () => ({ accept: 'text/html' }),
+      }),
+      fallback,
+      continue: continueRequest,
+    } as unknown as Route;
+
+    await routeVenueRequest(route, 'https://heartbeat.example.com', 'bypass-secret');
+
+    expect(continueRequest).toHaveBeenCalledWith({
+      headers: {
+        accept: 'text/html',
+        'x-vercel-protection-bypass': 'bypass-secret',
+      },
+    });
+    expect(fallback).not.toHaveBeenCalled();
+  });
+});

--- a/test/issueCanaryVenue.test.ts
+++ b/test/issueCanaryVenue.test.ts
@@ -31,9 +31,12 @@ describe('Issue canary venue routing', () => {
     expect(continueRequest).not.toHaveBeenCalled();
   });
 
-  it('adds the bypass header only to venue requests', async () => {
+  it('fulfills one venue response without carrying the bypass header across redirects', async () => {
     const fallback = vi.fn(async () => {});
     const continueRequest = vi.fn(async () => {});
+    const response = {};
+    const fetchRequest = vi.fn(async () => response);
+    const fulfill = vi.fn(async () => {});
     const route = {
       request: () => ({
         url: () => 'https://heartbeat.example.com/',
@@ -41,16 +44,21 @@ describe('Issue canary venue routing', () => {
       }),
       fallback,
       continue: continueRequest,
+      fetch: fetchRequest,
+      fulfill,
     } as unknown as Route;
 
     await routeVenueRequest(route, 'https://heartbeat.example.com', 'bypass-secret');
 
-    expect(continueRequest).toHaveBeenCalledWith({
+    expect(fetchRequest).toHaveBeenCalledWith({
       headers: {
         accept: 'text/html',
         'x-vercel-protection-bypass': 'bypass-secret',
       },
+      maxRedirects: 0,
     });
+    expect(fulfill).toHaveBeenCalledWith({ response });
+    expect(continueRequest).not.toHaveBeenCalled();
     expect(fallback).not.toHaveBeenCalled();
   });
 });

--- a/test/production-heartbeat-workflow-contract.test.sh
+++ b/test/production-heartbeat-workflow-contract.test.sh
@@ -47,8 +47,23 @@ require 'cancel-in-progress: false'
 require 'timeout-minutes: 30'
 require_absent 'environment: production'
 require 'persist-credentials: false'
-require 'https://bugdrop.neonwatty.workers.dev'
-require 'https://bugdrop-widget-test.vercel.app'
+require 'name: Validate production heartbeat configuration'
+require 'node scripts/production-heartbeat-config.mjs export'
+for variable in \
+  BUGDROP_HEARTBEAT_WIDGET_ORIGIN \
+  BUGDROP_HEARTBEAT_VENUE_ORIGIN \
+  BUGDROP_HEARTBEAT_TEST_REPO \
+  BUGDROP_HEARTBEAT_EXPECTED_AUTHOR \
+  BUGDROP_HEARTBEAT_EXPECTED_LABELS; do
+  require "$variable: \${{ vars.$variable }}"
+done
+require 'curl --max-time 30 -sSf "$EXPECTED_WIDGET_ORIGIN/widget.js"'
+require 'curl --max-time 30 -sSf "${bypass_args[@]}" "$PLAYWRIGHT_BASE_URL"'
+require 'grep -Fq "$EXPECTED_WIDGET_ORIGIN/widget.js"'
+require '--repo "$BUGDROP_CANARY_REPO"'
+require_absent '--repo mean-weasel/bugdrop-widget-test'
+require_absent 'https://bugdrop.neonwatty.workers.dev'
+require_absent 'https://bugdrop-widget-test.vercel.app'
 require 'node scripts/release/verify-live.mjs observe'
 require 'bugdrop-production-heartbeat:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${worker_sha}'
 require 'npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --workers=1 --retries=0'
@@ -76,6 +91,7 @@ require 'ARTIFACT_OUTCOME: ${{ needs.heartbeat.outputs.artifact_outcome }}'
 require 'INCIDENT_JOB: ${{ needs.incident.result }}'
 require 'issues: write'
 require 'GITHUB_TOKEN: ${{ github.token }}'
+require 'BUGDROP_HEARTBEAT_INCIDENT_REPO: ${{ github.repository }}'
 require 'Controlled post-cleanup failure'
 require 'inputs.controlled_failure'
 require 'diagnostics_path="$RUNNER_TEMP/production-heartbeat-diagnostics.json"'
@@ -96,6 +112,8 @@ require_absent 'if-no-files-found: ignore'
 require_absent 'test -f "$diagnostics_path"'
 require_absent '> "$diagnostics_path"'
 require "'{schemaVersion: \$schemaVersion, runId: \$runId, runAttempt: \$runAttempt, stages:"
+require '--arg config "$CONFIG"'
+require '"config"'
 
 summary_block=$(awk '
   /name: Summarize heartbeat stages/ { capture = 1 }

--- a/test/productionHeartbeatConfig.test.ts
+++ b/test/productionHeartbeatConfig.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CANONICAL_HEARTBEAT_CONFIG,
+  heartbeatEnvironment,
+  resolveProductionHeartbeatConfig,
+} from '../scripts/production-heartbeat-config.mjs';
+
+const SELF_HOSTED = {
+  BUGDROP_HEARTBEAT_WIDGET_ORIGIN: 'https://bugdrop.example.com',
+  BUGDROP_HEARTBEAT_VENUE_ORIGIN: 'https://heartbeat.example.com',
+  BUGDROP_HEARTBEAT_TEST_REPO: 'acme/bugdrop-heartbeat-test',
+  BUGDROP_HEARTBEAT_EXPECTED_AUTHOR: 'acme-bugdrop[bot]',
+  BUGDROP_HEARTBEAT_EXPECTED_LABELS: 'bug, bugdrop',
+};
+
+describe('production heartbeat configuration', () => {
+  it('uses canonical defaults only in the canonical repository', () => {
+    expect(resolveProductionHeartbeatConfig({ repository: 'mean-weasel/bugdrop' })).toEqual(
+      CANONICAL_HEARTBEAT_CONFIG
+    );
+    expect(() => resolveProductionHeartbeatConfig({ repository: 'acme/bugdrop' })).toThrow(
+      'configuration is incomplete'
+    );
+  });
+
+  it('accepts a complete self-hosted configuration and exports bounded runtime values', () => {
+    const config = resolveProductionHeartbeatConfig({
+      repository: 'acme/bugdrop',
+      variables: SELF_HOSTED,
+    });
+    expect(heartbeatEnvironment(config, 'acme/bugdrop')).toEqual({
+      EXPECTED_WIDGET_ORIGIN: 'https://bugdrop.example.com',
+      PLAYWRIGHT_BASE_URL: 'https://heartbeat.example.com',
+      BUGDROP_CANARY_REPO: 'acme/bugdrop-heartbeat-test',
+      BUGDROP_CANARY_EXPECTED_AUTHOR: 'acme-bugdrop[bot]',
+      BUGDROP_CANARY_EXPECTED_LABELS_JSON: '["bug","bugdrop"]',
+      BUGDROP_HEARTBEAT_INCIDENT_REPO: 'acme/bugdrop',
+    });
+  });
+
+  it.each([
+    ['partial configuration', { ...SELF_HOSTED, BUGDROP_HEARTBEAT_TEST_REPO: '' }],
+    [
+      'non-HTTPS widget',
+      { ...SELF_HOSTED, BUGDROP_HEARTBEAT_WIDGET_ORIGIN: 'http://bugdrop.example.com' },
+    ],
+    [
+      'origin with a path',
+      { ...SELF_HOSTED, BUGDROP_HEARTBEAT_VENUE_ORIGIN: 'https://heartbeat.example.com/test' },
+    ],
+    [
+      'operational repo reused as test repo',
+      { ...SELF_HOSTED, BUGDROP_HEARTBEAT_TEST_REPO: 'acme/bugdrop' },
+    ],
+    [
+      'case-aliased operational repo reused as test repo',
+      { ...SELF_HOSTED, BUGDROP_HEARTBEAT_TEST_REPO: 'ACME/BugDrop' },
+    ],
+    ['repository traversal', { ...SELF_HOSTED, BUGDROP_HEARTBEAT_TEST_REPO: 'acme/..' }],
+  ])('rejects %s', (_description, variables) => {
+    expect(() =>
+      resolveProductionHeartbeatConfig({ repository: 'acme/bugdrop', variables })
+    ).toThrow();
+  });
+
+  it('does not permit partial overrides of canonical defaults', () => {
+    expect(() =>
+      resolveProductionHeartbeatConfig({
+        repository: 'mean-weasel/bugdrop',
+        variables: { BUGDROP_HEARTBEAT_WIDGET_ORIGIN: 'https://other.example.com' },
+      })
+    ).toThrow('configuration is incomplete');
+  });
+});

--- a/test/productionHeartbeatConfig.test.ts
+++ b/test/productionHeartbeatConfig.test.ts
@@ -64,6 +64,18 @@ describe('production heartbeat configuration', () => {
         BUGDROP_HEARTBEAT_VENUE_ORIGIN: SELF_HOSTED.BUGDROP_HEARTBEAT_WIDGET_ORIGIN,
       },
     ],
+    [
+      'expected labels without the invariant bugdrop label',
+      { ...SELF_HOSTED, BUGDROP_HEARTBEAT_EXPECTED_LABELS: 'synthetic' },
+    ],
+    [
+      'expected labels containing control characters',
+      { ...SELF_HOSTED, BUGDROP_HEARTBEAT_EXPECTED_LABELS: 'bugdrop,synthetic\tlabel' },
+    ],
+    [
+      'case-aliased duplicate expected labels',
+      { ...SELF_HOSTED, BUGDROP_HEARTBEAT_EXPECTED_LABELS: 'bug,BugDrop,bugdrop' },
+    ],
     ['repository traversal', { ...SELF_HOSTED, BUGDROP_HEARTBEAT_TEST_REPO: 'acme/..' }],
   ])('rejects %s', (_description, variables) => {
     expect(() =>

--- a/test/productionHeartbeatConfig.test.ts
+++ b/test/productionHeartbeatConfig.test.ts
@@ -57,6 +57,13 @@ describe('production heartbeat configuration', () => {
       'case-aliased operational repo reused as test repo',
       { ...SELF_HOSTED, BUGDROP_HEARTBEAT_TEST_REPO: 'ACME/BugDrop' },
     ],
+    [
+      'venue and widget sharing an origin',
+      {
+        ...SELF_HOSTED,
+        BUGDROP_HEARTBEAT_VENUE_ORIGIN: SELF_HOSTED.BUGDROP_HEARTBEAT_WIDGET_ORIGIN,
+      },
+    ],
     ['repository traversal', { ...SELF_HOSTED, BUGDROP_HEARTBEAT_TEST_REPO: 'acme/..' }],
   ])('rejects %s', (_description, variables) => {
     expect(() =>


### PR DESCRIPTION
## Summary

- make production heartbeat targets configurable for self-hosted and private repositories
- reserve canonical defaults exclusively for mean-weasel/bugdrop and fail closed on incomplete or unsafe configuration
- route incidents to the repository running the workflow while preserving least-privilege synthetic Issue verification
- document private repository setup, manual drills, staged activation, Actions considerations, and production identity requirements

## Safety properties

- scheduled runs remain inert until explicitly enabled
- the synthetic repository must differ from the operational repository, including case aliases
- bypass secrets are sent only to the configured venue
- non-venue requests fall through to the exact pinned widget fixture
- preview canary behavior remains strict and unchanged

## Verification

- make check
- npm test -- --run (56 files, 851 tests)
- focused self-host heartbeat tests (5 files, 73 tests)
- production heartbeat workflow contract
- Playwright Issue canary test listing
- PR Review Toolkit correctness, tests, silent-failures, contracts-types, and comments-docs roles with fresh validation of every candidate