### PR TITLE
ci: add reporting-only Codecov coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,8 @@ jobs:
     name: Unit Tests & Build
     runs-on: ubuntu-latest
     needs: check
+    permissions:
+      contents: read
     # Keep the required check visible as skipped for docs-only pull requests.
     if: needs.check.outputs.full_ci != 'false'
     steps:
@@ -154,10 +156,49 @@ jobs:
         run: npm run verify:legacy-compat
 
       - name: Run unit tests
-        run: make test
+        run: npm test -- --coverage
 
       - name: Build all
         run: make build-all
+
+      - name: Preserve unit coverage report
+        uses: actions/upload-artifact@v5
+        with:
+          name: unit-coverage-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage/lcov.info
+          if-no-files-found: error
+          retention-days: 1
+
+  # Reporting-only coverage upload. Keep OIDC isolated from pull-request code execution.
+  coverage:
+    name: Coverage Upload
+    runs-on: ubuntu-latest
+    needs: [check, test]
+    if: ${{ needs.check.outputs.full_ci != 'false' && needs.test.result == 'success' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Download unit coverage report
+        uses: actions/download-artifact@v5
+        with:
+          name: unit-coverage-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage
+
+      - name: Upload coverage to Codecov (reporting only)
+        continue-on-error: true
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: coverage/lcov.info
+          disable_search: true
+          plugins: noop
+          flags: unit
+          use_oidc: true
+          fail_ci_if_error: false
 
   # E2E tests with sharding for speed
   e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         run: make build-all
 
       - name: Preserve unit coverage report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: unit-coverage-${{ github.run_id }}-${{ github.run_attempt }}
           path: coverage/lcov.info
@@ -184,7 +184,7 @@ jobs:
           persist-credentials: false
 
       - name: Download unit coverage report
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: unit-coverage-${{ github.run_id }}-${{ github.run_attempt }}
           path: coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         run: make build-all
 
       - name: Preserve unit coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: unit-coverage-${{ github.run_id }}-${{ github.run_attempt }}
           path: coverage/lcov.info
@@ -179,12 +179,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
       - name: Download unit coverage report
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: unit-coverage-${{ github.run_id }}-${{ github.run_attempt }}
           path: coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        threshold: 0%
+        informational: true
+        only_pulls: true
+        paths:
+          - 'src/**'
+
+comment: false
+
+github_checks:
+  annotations: false

--- a/scripts/check-github-actions.mjs
+++ b/scripts/check-github-actions.mjs
@@ -21,9 +21,12 @@ const approvedReleases = new Map([
   ['actions/cache@caa296126883cff596d87d8935842f9db880ef25', 'v5.1.0'],
   ['actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09', 'v5.1.0'],
   ['actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0', 'v5.0.0'],
+  ['actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3', 'v8.0.0'],
   ['actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd', 'v8.0.0'],
   ['actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444', 'v5.0.0'],
   ['actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4', 'v5.0.0'],
+  ['actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f', 'v7.0.0'],
+  ['codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f', 'v7.0.0'],
 ]);
 
 const failures = [];

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 ci_workflow="$repo_root/.github/workflows/ci.yml"
+coverage_config="$repo_root/vitest.config.ts"
+codecov_config="$repo_root/codecov.yml"
 live_workflow="$repo_root/.github/workflows/live-tests.yml"
 canary_spec="$repo_root/e2e/widget.issue-canary.spec.ts"
 canary_engine="$repo_root/e2e/widget.issue-canary.ts"
@@ -62,6 +64,58 @@ require_literal "$ci_workflow" 'run: npm run verify:legacy-compat'
 unit_block=$(job_block "$ci_workflow" test)
 grep -Fq 'fetch-depth: 0' <<< "$unit_block" ||
   fail 'the provenance job must fetch tag history before verification'
+grep -Fq 'run: npm test -- --coverage' <<< "$unit_block" ||
+  fail 'the required unit job must generate coverage'
+grep -Fq 'path: coverage/lcov.info' <<< "$unit_block" ||
+  fail 'the required unit job must preserve the LCOV report'
+grep -Fq 'if-no-files-found: error' <<< "$unit_block" ||
+  fail 'a missing LCOV report must fail the required unit job'
+if grep -Fq 'id-token: write' <<< "$unit_block"; then
+  fail 'pull-request code execution must not receive OIDC permission'
+fi
+
+coverage_block=$(job_block "$ci_workflow" coverage)
+grep -Fq 'name: Coverage Upload' <<< "$coverage_block" || fail 'coverage upload job is missing'
+grep -Fq 'needs: [check, test]' <<< "$coverage_block" ||
+  fail 'coverage upload must wait for the required unit job'
+grep -Fq "needs.check.outputs.full_ci != 'false'" <<< "$coverage_block" ||
+  fail 'documentation-only changes must not upload coverage'
+grep -Fq "needs.test.result == 'success'" <<< "$coverage_block" ||
+  fail 'coverage upload must require successful unit tests and build'
+grep -Fq 'contents: read' <<< "$coverage_block" || fail 'coverage upload needs read-only checkout'
+grep -Fq 'id-token: write' <<< "$coverage_block" || fail 'coverage upload lacks OIDC permission'
+grep -Fq 'persist-credentials: false' <<< "$coverage_block" ||
+  fail 'coverage checkout must not persist repository credentials'
+grep -Fq 'codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0' <<< "$coverage_block" ||
+  fail 'Codecov action must use the reviewed immutable v7.0.0 commit'
+grep -Fq 'files: coverage/lcov.info' <<< "$coverage_block" ||
+  fail 'Codecov upload must select the exact LCOV report'
+grep -Fq 'disable_search: true' <<< "$coverage_block" ||
+  fail 'Codecov must not discover unintended reports'
+grep -Fq 'plugins: noop' <<< "$coverage_block" ||
+  fail 'Codecov discovery plugins must remain disabled'
+grep -Fq 'use_oidc: true' <<< "$coverage_block" || fail 'Codecov upload must use OIDC'
+grep -Fq 'fail_ci_if_error: false' <<< "$coverage_block" ||
+  fail 'the reporting-only rollout must remain fail-open'
+grep -Fq 'continue-on-error: true' <<< "$coverage_block" ||
+  fail 'the reporting-only rollout must tolerate action-level failures'
+if grep -Fq 'CODECOV_TOKEN' "$ci_workflow"; then
+  fail 'Codecov must not use a long-lived repository token'
+fi
+[[ $(grep -Fc 'id-token: write' "$ci_workflow") -eq 1 ]] ||
+  fail 'OIDC permission must exist only on the coverage upload job'
+
+require_literal "$coverage_config" "include: ['src/**/*.ts', 'scripts/**/*.{js,mjs,ts}']"
+require_literal "$coverage_config" "reporter: ['text', 'json', 'json-summary', 'html', 'lcov']"
+require_literal "$coverage_config" "'**/*.d.ts'"
+require_literal "$codecov_config" 'target: auto'
+require_literal "$codecov_config" 'threshold: 1%'
+require_literal "$codecov_config" 'target: 80%'
+require_literal "$codecov_config" "- 'src/**'"
+require_literal "$codecov_config" 'comment: false'
+require_literal "$codecov_config" 'annotations: false'
+[[ $(grep -Fc 'informational: true' "$codecov_config") -eq 2 ]] ||
+  fail 'project and patch Codecov statuses must both remain informational'
 
 e2e_block=$(job_block "$ci_workflow" e2e)
 if grep -Eq '^    if:' <<< "$e2e_block"; then

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -68,8 +68,8 @@ grep -Fq 'run: npm test -- --coverage' <<< "$unit_block" ||
   fail 'the required unit job must generate coverage'
 grep -Fq 'path: coverage/lcov.info' <<< "$unit_block" ||
   fail 'the required unit job must preserve the LCOV report'
-grep -Fq 'uses: actions/upload-artifact@v7' <<< "$unit_block" ||
-  fail 'coverage artifact upload must use the current Node 24 action'
+grep -Fq 'uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0' <<< "$unit_block" ||
+  fail 'coverage artifact upload must use the reviewed immutable Node 24 action'
 grep -Fq 'if-no-files-found: error' <<< "$unit_block" ||
   fail 'a missing LCOV report must fail the required unit job'
 if grep -Fq 'id-token: write' <<< "$unit_block"; then
@@ -88,8 +88,8 @@ grep -Fq 'contents: read' <<< "$coverage_block" || fail 'coverage upload needs r
 grep -Fq 'id-token: write' <<< "$coverage_block" || fail 'coverage upload lacks OIDC permission'
 grep -Fq 'persist-credentials: false' <<< "$coverage_block" ||
   fail 'coverage checkout must not persist repository credentials'
-grep -Fq 'uses: actions/download-artifact@v8' <<< "$coverage_block" ||
-  fail 'coverage artifact download must use the current Node 24 action'
+grep -Fq 'uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0' <<< "$coverage_block" ||
+  fail 'coverage artifact download must use the reviewed immutable Node 24 action'
 grep -Fq 'codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0' <<< "$coverage_block" ||
   fail 'Codecov action must use the reviewed immutable v7.0.0 commit'
 grep -Fq 'files: coverage/lcov.info' <<< "$coverage_block" ||

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -68,6 +68,8 @@ grep -Fq 'run: npm test -- --coverage' <<< "$unit_block" ||
   fail 'the required unit job must generate coverage'
 grep -Fq 'path: coverage/lcov.info' <<< "$unit_block" ||
   fail 'the required unit job must preserve the LCOV report'
+grep -Fq 'uses: actions/upload-artifact@v7' <<< "$unit_block" ||
+  fail 'coverage artifact upload must use the current Node 24 action'
 grep -Fq 'if-no-files-found: error' <<< "$unit_block" ||
   fail 'a missing LCOV report must fail the required unit job'
 if grep -Fq 'id-token: write' <<< "$unit_block"; then
@@ -86,6 +88,8 @@ grep -Fq 'contents: read' <<< "$coverage_block" || fail 'coverage upload needs r
 grep -Fq 'id-token: write' <<< "$coverage_block" || fail 'coverage upload lacks OIDC permission'
 grep -Fq 'persist-credentials: false' <<< "$coverage_block" ||
   fail 'coverage checkout must not persist repository credentials'
+grep -Fq 'uses: actions/download-artifact@v8' <<< "$coverage_block" ||
+  fail 'coverage artifact download must use the current Node 24 action'
 grep -Fq 'codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0' <<< "$coverage_block" ||
   fail 'Codecov action must use the reviewed immutable v7.0.0 commit'
 grep -Fq 'files: coverage/lcov.info' <<< "$coverage_block" ||

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,8 +9,9 @@ export default defineConfig({
     exclude: ['e2e/**', 'node_modules/**'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/', 'test/', 'e2e/', 'dist/', '*.config.ts'],
+      include: ['src/**/*.ts', 'scripts/**/*.{js,mjs,ts}'],
+      reporter: ['text', 'json', 'json-summary', 'html', 'lcov'],
+      exclude: ['**/*.d.ts', 'node_modules/**', 'test/**', 'e2e/**', 'dist/**', '**/*.config.ts'],
     },
   },
 });


### PR DESCRIPTION
## Summary

- generate complete Vitest V8 coverage for `src/**` and production `scripts/**`
- preserve an exact LCOV artifact from the existing required unit/build job
- upload through a separate least-privilege job using Codecov OIDC for same-repository runs and the pinned action's tokenless public-fork path
- add reporting-only project and patch statuses without changing required checks, branch rules, secrets, accounts, or installed apps

## Security and CI behavior

- the job that executes pull-request code has only `contents: read`
- `id-token: write` exists only on the post-test upload job
- checkout credentials are not persisted in the upload job
- report discovery and plugins are disabled; only `coverage/lcov.info` is accepted
- Codecov v7.0.0 is pinned to commit `fb8b3582c8e4def4969c97caa2f19720cb33a72f`
- documentation-only changes skip coverage generation and upload
- normal pull requests and merge groups generate coverage
- public forks are detected by the pinned action and use Codecov's documented tokenless fork upload path
- a missing LCOV report fails the existing required unit/build job, while Codecov service/auth failures remain non-blocking

## Reporting-only rollout

- project target: automatic base comparison with a 1% tolerance, informational
- patch target: 80% for `src/**`, informational
- PR comments and line annotations: disabled
- badge: intentionally deferred until the main-branch baseline is stable
- `Coverage Upload` is not added to the repository's six required checks

The patch status is scoped to `src/**` because subprocess-driven release scripts are exercised by tests but are not attributed to Vitest's parent V8 process. Those scripts remain visible in overall project coverage without generating misleading patch feedback.

## Baseline

The previous touched-files-only view reported:

- statements: 71.63%
- branches: 69.94%
- functions: 74.40%
- lines: 72.76%

The complete source inventory reports:

- statements: 63.30% (4769/7533)
- branches: 63.25% (3493/5522)
- functions: 65.81% (849/1290)
- lines: 64.10% (4397/6859)

The first real Codecov upload was accepted and processed for this PR. Codecov's own LCOV
normalization reports 55.03% across 78 files (7,308 coverable lines). Its PR record currently
has no base totals or patch comparison because the repository does not yet have a `main` report;
the merge-queue run will establish that baseline.

## Verification

```bash
npm ci
npm test -- --coverage
curl --fail --silent --show-error --data-binary @codecov.yml https://codecov.io/validate
make check
npm run verify:legacy-compat
make build-all
bash test/ci-workflow-contract.test.sh
npm run format:check
git diff --check
```

The exact pinned action was also run locally with `dry_run=true`, `disable_search=true`, and `plugins=noop`; its signed CLI found exactly one coverage report and performed no upload.

## Follow-up decisions

After several successful main/PR uploads, decide separately whether to:

1. enable conditional PR comments
2. make project or `src/**` patch status required
3. add a README badge

If Codecov reports that repository-side onboarding is required, that remains an explicit owner action; this PR does not install an app, create an account, or add a secret.
