### PR TITLE
chore: pin GitHub Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: America/Phoenix
+    open-pull-requests-limit: 5
+    rebase-strategy: auto
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      production-minor-patch:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development-minor-patch:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:30'
+      timezone: America/Phoenix
+    open-pull-requests-limit: 5
+    rebase-strategy: auto
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -10,9 +10,9 @@ jobs:
     name: Lint Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,14 @@ jobs:
       full_ci: ${{ steps.scope.outputs.full_ci }}
       diff_base: ${{ steps.scope.outputs.diff_base }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
       - name: Verify previous full CI succeeded
         id: previous-ci
         if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           result-encoding: string
           script: |
@@ -97,7 +97,7 @@ jobs:
             "$PR_BEFORE_SHA" \
             "${{ steps.previous-ci.outputs.result }}"
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -138,11 +138,11 @@ jobs:
     # Keep the required check visible as skipped for docs-only pull requests.
     if: needs.check.outputs.full_ci != 'false'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -175,10 +175,10 @@ jobs:
         if: needs.check.outputs.full_ci == 'false'
         run: echo 'Documentation-only change; required E2E context satisfied without browser tests.'
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         if: needs.check.outputs.full_ci != 'false'
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         if: needs.check.outputs.full_ci != 'false'
         with:
           node-version: '22'
@@ -200,7 +200,7 @@ jobs:
       - name: Cache Playwright browsers
         if: needs.check.outputs.full_ci != 'false'
         id: pw-cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
@@ -222,7 +222,7 @@ jobs:
           CI: true
 
       - name: Upload E2E Report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         if: needs.check.outputs.full_ci != 'false' && failure()
         with:
           name: playwright-report-shard-${{ matrix.shard }}
@@ -240,9 +240,9 @@ jobs:
       matrix:
         browser: [chromium, firefox, webkit]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -259,7 +259,7 @@ jobs:
 
       - name: Cache Playwright browser
         id: pw-cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ matrix.browser }}-${{ steps.pw-version.outputs.version }}
@@ -280,7 +280,7 @@ jobs:
           CI: true
 
       - name: Upload Radix E2E Report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         if: failure()
         with:
           name: playwright-radix-report-${{ matrix.browser }}
@@ -299,11 +299,11 @@ jobs:
       cancel-in-progress: false
       queue: max
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -317,7 +317,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-all-${{ steps.pw-version.outputs.version }}
@@ -490,7 +490,7 @@ jobs:
           BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
 
       - name: Upload preview failure report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         if: failure()
         with:
           name: playwright-preview-critical-report

--- a/.github/workflows/cloudflare-capability.yml
+++ b/.github/workflows/cloudflare-capability.yml
@@ -37,7 +37,7 @@ jobs:
           test "$SHA_A" != "$SHA_B"
 
       - name: Checkout immutable controller
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ github.workflow_sha }}
           path: controller
@@ -54,20 +54,20 @@ jobs:
           git -C controller merge-base --is-ancestor "$SHA_A" "$SHA_B"
 
       - name: Checkout immutable candidate A
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.candidate_a_sha }}
           path: candidate-a
           persist-credentials: false
 
       - name: Checkout immutable candidate B
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.candidate_b_sha }}
           path: candidate-b
           persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
 
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload capability evidence
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: cloudflare-preview-capability-${{ github.run_id }}
           path: capability-proof.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,7 +133,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout immutable controller
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ steps.guard.outputs.controller_sha }}
           path: controller
@@ -141,7 +141,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
           cache: npm
@@ -232,7 +232,7 @@ jobs:
           fi
 
       - name: Upload immutable request plan
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: request-plan-${{ steps.plan.outputs.request_key }}
           path: |
@@ -254,20 +254,20 @@ jobs:
       tag: ${{ steps.bundle.outputs.tag }}
     steps:
       - name: Checkout immutable controller
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ needs.guard-and-plan.outputs.controller_sha }}
           path: controller
           persist-credentials: false
 
       - name: Checkout immutable candidate
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.target_sha }}
           path: candidate
           persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
 
@@ -283,7 +283,7 @@ jobs:
           npm run build
 
       - name: Download authenticated request plan
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: request-plan-${{ needs.guard-and-plan.outputs.request_key }}
           path: request
@@ -362,7 +362,7 @@ jobs:
 
       - name: Upload immutable candidate and State 2 evidence
         id: upload
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: release-plan-${{ steps.bundle.outputs.plan_key }}
           path: ${{ runner.temp }}/release-plan/
@@ -377,14 +377,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout immutable controller
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ needs.guard-and-plan.outputs.controller_sha }}
           path: controller
           persist-credentials: false
 
       - name: Download exact State 2 artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           artifact-ids: ${{ needs.verify-candidate.outputs.artifact_id }}
           path: approved
@@ -478,7 +478,7 @@ jobs:
       widget_sha256: ${{ steps.expected.outputs.widget_sha256 }}
     steps:
       - name: Checkout immutable controller
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ needs.guard-and-plan.outputs.controller_sha }}
           path: controller
@@ -487,13 +487,13 @@ jobs:
           fetch-tags: true
 
       - name: Checkout immutable candidate source
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.target_sha }}
           path: candidate
           persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
 
@@ -503,7 +503,7 @@ jobs:
           npm --prefix candidate ci --ignore-scripts
 
       - name: Download exact approved State 2 artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           artifact-ids: ${{ needs.verify-candidate.outputs.artifact_id }}
           path: approved
@@ -651,7 +651,7 @@ jobs:
       - name: Upload exact approval and baseline evidence
         if: steps.revalidate.outputs.proceed == 'true'
         id: upload
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: release-baseline-${{ needs.verify-candidate.outputs.plan_key }}
           path: |
@@ -673,20 +673,20 @@ jobs:
       artifact_id: ${{ steps.upload.outputs.artifact-id }}
     steps:
       - name: Checkout immutable controller
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ needs.guard-and-plan.outputs.controller_sha }}
           path: controller
           persist-credentials: false
 
       - name: Checkout immutable candidate source
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.target_sha }}
           path: candidate
           persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
 
@@ -696,7 +696,7 @@ jobs:
           npm --prefix candidate ci --ignore-scripts
 
       - name: Download exact State 2 and approved baseline artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           artifact-ids: ${{ needs.verify-candidate.outputs.artifact_id }},${{ needs.approval-baseline.outputs.artifact_id }}
           path: release-state
@@ -737,7 +737,7 @@ jobs:
       - name: Upload authoritative deployment outcome
         if: always()
         id: upload
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: release-deployment-${{ needs.verify-candidate.outputs.plan_key }}
           path: deployment.json
@@ -776,13 +776,13 @@ jobs:
       notify: ${{ steps.publish.outputs.notify }}
     steps:
       - name: Checkout immutable controller
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ needs.guard-and-plan.outputs.controller_sha }}
           path: controller
           persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
 
@@ -790,7 +790,7 @@ jobs:
         run: npm --prefix controller ci --ignore-scripts
 
       - name: Download exact State 2 and approved authorization
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           artifact-ids: ${{ needs.verify-candidate.outputs.artifact_id }},${{ needs.approval-baseline.outputs.artifact_id }}
           path: release-state
@@ -818,7 +818,7 @@ jobs:
       - name: Upload authoritative publication outcome
         if: always()
         id: upload
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: release-publication-${{ needs.verify-candidate.outputs.plan_key }}
           path: publication.json
@@ -863,7 +863,7 @@ jobs:
     steps:
       - name: Checkout immutable controller
         if: ${{ needs.deploy-candidate.result != 'skipped' }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ needs.guard-and-plan.outputs.controller_sha }}
           path: controller
@@ -871,13 +871,13 @@ jobs:
 
       - name: Checkout immutable candidate source
         if: ${{ needs.deploy-candidate.result != 'skipped' }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.target_sha }}
           path: candidate
           persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         if: ${{ needs.deploy-candidate.result != 'skipped' }}
         with:
           node-version: '22'
@@ -890,7 +890,7 @@ jobs:
 
       - name: Download exact State 2 and baseline evidence
         if: ${{ needs.deploy-candidate.result != 'skipped' }}
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           artifact-ids: ${{ needs.verify-candidate.outputs.artifact_id }},${{ needs.approval-baseline.outputs.artifact_id }}
           path: release-state
@@ -899,7 +899,7 @@ jobs:
       - name: Download deployment evidence when available
         if: ${{ needs.deploy-candidate.result != 'skipped' }}
         continue-on-error: true
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: release-deployment-${{ needs.verify-candidate.outputs.plan_key }}
           path: release-state

--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -75,9 +75,9 @@ jobs:
     name: Notify Discord
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
 
@@ -97,7 +97,7 @@ jobs:
       - name: Restore successful automatic notification marker
         if: inputs.automatic && !inputs.dry_run
         id: dedupe
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: .discord-release-dedup/${{ steps.identity.outputs.notification_key }}
           key: discord-release-${{ steps.identity.outputs.notification_key }}
@@ -128,7 +128,7 @@ jobs:
 
       - name: Save successful automatic notification marker
         if: inputs.automatic && !inputs.dry_run && steps.dedupe.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: .discord-release-dedup/${{ steps.identity.outputs.notification_key }}
           key: discord-release-${{ steps.identity.outputs.notification_key }}

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -91,11 +91,11 @@ jobs:
       LIVE_TARGET: ${{ github.event_name == 'schedule' && 'preview' || inputs.target || 'preview' }}
       PLAYWRIGHT_BASE_URL: ${{ inputs.target == 'production' && 'https://bugdrop-widget-test.vercel.app' || 'https://bugdrop-widget-test-git-preview-jermwatts-projects.vercel.app' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -204,7 +204,7 @@ jobs:
           BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
 
       - name: Upload test report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         if: failure()
         with:
           name: playwright-live-report

--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Check out heartbeat code
         id: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         continue-on-error: true
         with:
           persist-credentials: false
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Node
         id: node
         if: always()
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         continue-on-error: true
         with:
           node-version: '22'
@@ -274,7 +274,7 @@ jobs:
         id: artifact
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: production-heartbeat-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/production-heartbeat-artifact-${{ github.run_id }}-${{ github.run_attempt }}/
@@ -291,7 +291,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout bugdrop
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Checkout bugdrop-web
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           repository: mean-weasel/bugdrop-web
           path: bugdrop-web

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ knip:
 
 check-actions-node24:
 	npm run check:actions-node24
+	bash test/github-actions-pinning.test.sh
 
 check-ci-scope:
 	bash test/ci-scope.test.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.50.0",
         "vitest": "^4.1.10",
-        "wrangler": "^4.98.0"
+        "wrangler": "^4.98.0",
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "knip": "knip",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "check:actions-node24": "node -e \"const {execSync}=require('node:child_process'); const out=execSync('rg -n \\\\\\\"actions/(checkout|setup-node|cache|upload-artifact)@v4|cloudflare/wrangler-action\\\\\\\" .github/workflows || true',{encoding:'utf8'}); if(out.trim()){ console.error(out); process.exit(1); } console.log('GitHub Actions are Node 24-ready');\"",
+    "check:actions-node24": "node scripts/check-github-actions.mjs",
     "validate": "npm run lint && npm run format:check && npm run typecheck && npm run test",
     "prepare": "husky"
   },
@@ -94,7 +94,8 @@
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.50.0",
     "vitest": "^4.1.10",
-    "wrangler": "^4.98.0"
+    "wrangler": "^4.98.0",
+    "yaml": "^2.8.3"
   },
   "dependencies": {
     "hono": "^4.13.0",

--- a/scripts/check-github-actions.mjs
+++ b/scripts/check-github-actions.mjs
@@ -1,0 +1,100 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { isScalar, LineCounter, parseDocument, visit } from 'yaml';
+
+const workflowRoot = resolve(process.argv[2] ?? '.github/workflows');
+const workflowFiles = (await readdir(workflowRoot)).filter(file => /\.ya?ml$/.test(file)).sort();
+
+const minimumMajor = new Map([
+  ['actions/cache', 5],
+  ['actions/cache/restore', 5],
+  ['actions/cache/save', 5],
+  ['actions/checkout', 5],
+  ['actions/download-artifact', 5],
+  ['actions/setup-node', 5],
+  ['actions/upload-artifact', 5],
+]);
+
+const approvedReleases = new Map([
+  ['actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25', 'v5.1.0'],
+  ['actions/cache/save@caa296126883cff596d87d8935842f9db880ef25', 'v5.1.0'],
+  ['actions/cache@caa296126883cff596d87d8935842f9db880ef25', 'v5.1.0'],
+  ['actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09', 'v5.1.0'],
+  ['actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0', 'v5.0.0'],
+  ['actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd', 'v8.0.0'],
+  ['actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444', 'v5.0.0'],
+  ['actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4', 'v5.0.0'],
+]);
+
+const failures = [];
+let externalActionCount = 0;
+
+for (const file of workflowFiles) {
+  const source = await readFile(resolve(workflowRoot, file), 'utf8');
+  const lineCounter = new LineCounter();
+  const document = parseDocument(source, { lineCounter });
+
+  document.errors.forEach(error => failures.push(`${file}: ${error.message}`));
+
+  visit(document, {
+    Pair(_key, pair) {
+      if (!isScalar(pair.key)) {
+        const line = lineCounter.linePos(pair.key.range?.[0] ?? 0).line;
+        failures.push(`${file}:${line}: workflow mapping keys must be literal strings`);
+        return;
+      }
+      if (pair.key.value !== 'uses') return;
+
+      const location = `${file}:${lineCounter.linePos(pair.key.range[0]).line}`;
+      if (!isScalar(pair.value) || typeof pair.value.value !== 'string') {
+        failures.push(`${location}: uses must be a literal action reference`);
+        return;
+      }
+
+      const spec = pair.value.value;
+      if (spec.startsWith('./')) return;
+
+      externalActionCount += 1;
+      const version = pair.value.comment?.trim();
+      const separator = spec.lastIndexOf('@');
+      const action = separator === -1 ? spec : spec.slice(0, separator);
+      const reference = separator === -1 ? '' : spec.slice(separator + 1);
+      const hasFullSha = /^[0-9a-f]{40}$/.test(reference);
+      const hasExactVersion = /^v\d+\.\d+\.\d+$/.test(version ?? '');
+
+      if (!hasFullSha) {
+        failures.push(`${location}: ${action} is not pinned to a full commit SHA`);
+      }
+      if (!hasExactVersion) {
+        failures.push(`${location}: ${action} needs an exact version comment such as # v5.1.0`);
+      }
+      if (
+        hasFullSha &&
+        hasExactVersion &&
+        approvedReleases.get(`${action}@${reference}`) !== version
+      ) {
+        failures.push(`${location}: ${action}@${reference} is not approved as ${version}`);
+      }
+      if (action === 'cloudflare/wrangler-action') {
+        failures.push(`${location}: use the repository-pinned Wrangler CLI, not wrangler-action`);
+      }
+
+      const requiredMajor = minimumMajor.get(action);
+      const actualMajor = Number(version?.match(/^v(\d+)\./)?.[1]);
+      if (requiredMajor && actualMajor < requiredMajor) {
+        failures.push(
+          `${location}: ${action} v${actualMajor} is below the Node 24-ready v${requiredMajor} floor`
+        );
+      }
+    },
+  });
+}
+
+if (failures.length > 0) {
+  console.error(failures.join('\n'));
+  process.exit(1);
+}
+
+console.log(
+  `${externalActionCount} external GitHub Action references are SHA-pinned and Node 24-ready`
+);

--- a/test/github-actions-pinning.test.sh
+++ b/test/github-actions-pinning.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+checker="$repo_root/scripts/check-github-actions.mjs"
+fixture_root=$(mktemp -d /tmp/bugdrop-actions-pinning-test.XXXXXX)
+trap 'rm -rf "$fixture_root"' EXIT
+
+write_workflow() {
+  local reference=$1
+  local version=$2
+  local uses_key=${3:-uses}
+  printf '%s\n' \
+    'name: fixture' \
+    'jobs:' \
+    '  check:' \
+    '    runs-on: ubuntu-latest' \
+    '    steps:' \
+    "      - ${uses_key}: actions/checkout@${reference} # ${version}" \
+    > "$fixture_root/fixture.yml"
+}
+
+expect_failure() {
+  local expected=$1
+  if node "$checker" "$fixture_root" > "$fixture_root/output" 2>&1; then
+    echo "Action checker unexpectedly accepted an unsafe fixture" >&2
+    exit 1
+  fi
+  grep -Fq "$expected" "$fixture_root/output" || {
+    cat "$fixture_root/output" >&2
+    exit 1
+  }
+}
+
+write_workflow fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 v5.1.0
+node "$checker" "$fixture_root" > /dev/null
+
+write_workflow v5 v5.1.0
+expect_failure 'not pinned to a full commit SHA'
+
+write_workflow fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 v5
+expect_failure 'needs an exact version comment'
+
+write_workflow fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 v4.2.2
+expect_failure 'below the Node 24-ready v5 floor'
+
+write_workflow v5 v5.1.0 'uses '
+expect_failure 'not pinned to a full commit SHA'
+
+write_workflow v5 v5.1.0 "'uses'"
+expect_failure 'not pinned to a full commit SHA'
+
+printf '%s\n' \
+  'name: &uses_key uses' \
+  'jobs:' \
+  '  check:' \
+  '    runs-on: ubuntu-latest' \
+  '    steps:' \
+  '      - ? *uses_key' \
+  '        : actions/checkout@v5 # v5.1.0' \
+  > "$fixture_root/fixture.yml"
+expect_failure 'workflow mapping keys must be literal strings'
+
+write_workflow 11bd71901bbe5b1630ceea73d27597364c9af683 v5.1.0
+expect_failure 'is not approved as v5.1.0'
+
+echo 'GitHub Actions pinning guard checks passed'

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -119,7 +119,7 @@ for job in \
 done
 
 guard_block=$(job_block guard-and-plan)
-first_checkout_line=$(line_of 'uses: actions/checkout@v5')
+first_checkout_line=$(line_of 'uses: actions/checkout@')
 guard_line=$(line_of 'Reject non-main or malformed dispatch before checkout')
 [[ "$guard_line" -lt "$first_checkout_line" ]] || fail 'main/SHA guard must run before checkout'
 for literal in \
@@ -153,7 +153,7 @@ require_absent 'echo "request_key=$(jq'
 require_absent 'echo "version=$(jq'
 require_absent 'echo "plan_key=$(jq'
 
-checkout_count=$(grep -Fc 'uses: actions/checkout@v5' "$workflow")
+checkout_count=$(grep -Fc 'uses: actions/checkout@' "$workflow")
 persist_count=$(grep -Fc 'persist-credentials: false' "$workflow")
 [[ "$checkout_count" -ge 6 ]] || fail "expected immutable controller/candidate checkouts; found $checkout_count"
 [[ "$persist_count" -eq "$checkout_count" ]] || fail 'every checkout must discard credentials'


### PR DESCRIPTION
## Summary

- pin all 66 external GitHub Actions references to full, verified commit SHAs with exact release annotations
- add weekly Dependabot updates for npm and GitHub Actions, grouping minor and patch updates while leaving major updates separate
- replace the tag-only Node runtime check with a YAML-aware, fail-closed policy that verifies SHA pins, exact annotations, approved SHA/release pairs, and Node 24-ready action majors
- add negative regression coverage for mutable refs, malformed annotations, stale majors, SHA/comment mismatches, quoted and spaced YAML keys, and aliased mapping keys

## Why

This closes the fixable OpenSSF Scorecard action-pinning gap without weakening the repository's existing release-workflow contracts. The approved-release map deliberately requires human verification when Dependabot proposes a new action commit, preventing a version comment from being treated as proof of the referenced code.

## Validation

- `make check` — 362 release tests plus lint, formatting, typecheck, dependency audit, workflow guards, and contract tests
- `npm test` — 834 unit tests across 54 files
- `bash -n test/github-actions-pinning.test.sh`
- `git diff --check origin/main`
- independently resolved each approved release tag from the official upstream repository and matched it to the pinned SHA
- pre-PR correctness, test, contract, comments/documentation, and simplification reviews completed; all confirmed findings were fixed and affected reviewers reported no remaining candidates

## Operational note

Dependabot can open action update PRs, but a maintainer must verify the proposed upstream tag/SHA pair and update `approvedReleases` in the same PR before the guard will pass. No repository settings, apps, publishing configuration, or external security controls are changed here.
