### PR TITLE
fix: harden fresh release publication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,15 +36,15 @@ on:
         default: false
         type: boolean
       resume_controller_sha:
-        description: Stored controller SHA for an authenticated partial-publication retry
+        description: Legacy tombstone; any value is rejected in favor of reviewed reset-and-replay
         required: false
         type: string
       resume_remote_main_sha:
-        description: Stored remote-main SHA for an authenticated partial-publication retry
+        description: Legacy tombstone; any value is rejected in favor of reviewed reset-and-replay
         required: false
         type: string
       resume_plan_identity:
-        description: Expected sha256 plan identity for an authenticated partial-publication retry
+        description: Legacy tombstone; any value is rejected in favor of reviewed reset-and-replay
         required: false
         type: string
 
@@ -63,13 +63,9 @@ jobs:
     outputs:
       completed: ${{ steps.plan.outputs.completed }}
       controller_sha: ${{ steps.guard.outputs.controller_sha }}
-      identity_main_sha: ${{ steps.guard.outputs.identity_main_sha }}
       plan_identity: ${{ steps.plan.outputs.plan_identity }}
-      plan_controller_sha: ${{ steps.guard.outputs.plan_controller_sha }}
       request_key: ${{ steps.plan.outputs.request_key }}
       request_identity: ${{ steps.plan.outputs.request_identity }}
-      resume_plan_identity: ${{ steps.guard.outputs.resume_plan_identity }}
-      resuming: ${{ steps.guard.outputs.resuming }}
       version: ${{ steps.plan.outputs.version }}
     steps:
       - name: Reject non-main or malformed dispatch before checkout
@@ -95,42 +91,11 @@ jobs:
             echo 'target_sha must be exactly 40 lowercase hexadecimal characters.' >&2
             exit 1
           }
-          resume_count=0
-          for value in "$RESUME_CONTROLLER_SHA" "$RESUME_REMOTE_MAIN_SHA" "$RESUME_PLAN_IDENTITY"; do
-            test -z "$value" || resume_count=$((resume_count + 1))
-          done
-          test "$resume_count" = 0 || test "$resume_count" = 3 || {
-            echo 'partial retry requires all three resume inputs or none of them.' >&2
+          if [ -n "$RESUME_CONTROLLER_SHA$RESUME_REMOTE_MAIN_SHA$RESUME_PLAN_IDENTITY" ]; then
+            echo 'Legacy resume inputs are disabled; use reviewed reset-and-replay recovery.' >&2
             exit 1
-          }
-          if [ "$resume_count" = 3 ]; then
-            [[ "$RESUME_CONTROLLER_SHA" =~ ^[0-9a-f]{40}$ ]] || {
-              echo 'resume_controller_sha must be exactly 40 lowercase hexadecimal characters.' >&2
-              exit 1
-            }
-            [[ "$RESUME_REMOTE_MAIN_SHA" =~ ^[0-9a-f]{40}$ ]] || {
-              echo 'resume_remote_main_sha must be exactly 40 lowercase hexadecimal characters.' >&2
-              exit 1
-            }
-            [[ "$RESUME_PLAN_IDENTITY" =~ ^sha256:[0-9a-f]{64}$ ]] || {
-              echo 'resume_plan_identity must be a complete sha256 identity.' >&2
-              exit 1
-            }
-            plan_controller_sha=$RESUME_CONTROLLER_SHA
-            identity_main_sha=$RESUME_REMOTE_MAIN_SHA
-            resuming=true
-          else
-            plan_controller_sha=$CONTROLLER_SHA
-            identity_main_sha=''
-            resuming=false
           fi
-          {
-            echo "controller_sha=$CONTROLLER_SHA"
-            echo "identity_main_sha=$identity_main_sha"
-            echo "plan_controller_sha=$plan_controller_sha"
-            echo "resume_plan_identity=$RESUME_PLAN_IDENTITY"
-            echo "resuming=$resuming"
-          } >> "$GITHUB_OUTPUT"
+          echo "controller_sha=$CONTROLLER_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Checkout immutable controller
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -157,28 +122,17 @@ jobs:
         env:
           BUGDROP_GITHUB_TOKEN: ${{ github.token }}
           BUMP: ${{ inputs.bump }}
-          CONTROLLER_SHA: ${{ steps.guard.outputs.plan_controller_sha }}
+          CONTROLLER_SHA: ${{ steps.guard.outputs.controller_sha }}
           DRY_RUN: ${{ inputs.dry_run }}
-          IDENTITY_MAIN_SHA: ${{ steps.guard.outputs.identity_main_sha }}
           RETENTION_BOOTSTRAP: ${{ inputs.retention_bootstrap }}
           OPERATOR_NOTES: ${{ inputs.operator_notes }}
           RATIONALE: ${{ inputs.rationale }}
           RELEASE_REASON: ${{ inputs.release_reason }}
-          RESUME_PLAN_IDENTITY: ${{ steps.guard.outputs.resume_plan_identity }}
-          RESUMING: ${{ steps.guard.outputs.resuming }}
           TARGET_SHA: ${{ inputs.target_sha }}
         run: |
           candidate_reachable=false
           if git -C "$GITHUB_WORKSPACE/controller" merge-base --is-ancestor "$TARGET_SHA" origin/main; then
             candidate_reachable=true
-          fi
-          identity_main_reachable_from_current=false
-          controller_reachable_from_current=false
-          if [ "$RESUMING" = true ]; then
-            git -C "$GITHUB_WORKSPACE/controller" merge-base --is-ancestor "$IDENTITY_MAIN_SHA" origin/main &&
-              identity_main_reachable_from_current=true
-            git -C "$GITHUB_WORKSPACE/controller" merge-base --is-ancestor "$CONTROLLER_SHA" origin/main &&
-              controller_reachable_from_current=true
           fi
           jq -n \
             --arg repositoryDir "$GITHUB_WORKSPACE/controller" \
@@ -195,14 +149,9 @@ jobs:
             --arg operatorNotes "$OPERATOR_NOTES" \
             --argjson dryRun "$DRY_RUN" \
             --argjson candidateReachableFromMain "$candidate_reachable" \
-            --arg identityMainSha "$IDENTITY_MAIN_SHA" \
-            --arg resumePlanIdentity "$RESUME_PLAN_IDENTITY" \
-            --argjson identityMainReachableFromCurrent "$identity_main_reachable_from_current" \
             --argjson retentionBootstrap "$RETENTION_BOOTSTRAP" \
-            --argjson controllerReachableFromCurrent "$controller_reachable_from_current" \
             --arg retentionOutputDir "$GITHUB_WORKSPACE/retention-input" \
-            --argjson resuming "$RESUMING" \
-            '{$repositoryDir, $eventName, $ref, $workflowSha, $candidateReachableFromMain, $retentionBootstrap, $retentionOutputDir, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, $dryRun}} + (if $resuming then {$identityMainSha, $resumePlanIdentity, $identityMainReachableFromCurrent, $controllerReachableFromCurrent} else {} end)' \
+            '{$repositoryDir, $eventName, $ref, $workflowSha, $candidateReachableFromMain, $retentionBootstrap, $retentionOutputDir, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, $dryRun}}' \
             > request-context.json
           node controller/scripts/release/workflow.mjs guard request-context.json > guard.json
           node controller/scripts/release/github-adapter.mjs plan request-context.json > request-plan.json
@@ -343,23 +292,6 @@ jobs:
             echo "tag=$tag"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Authenticate exact partial-publication retry
-        if: needs.guard-and-plan.outputs.resuming == 'true'
-        shell: bash
-        env:
-          BUGDROP_GITHUB_TOKEN: ${{ github.token }}
-          EXPECTED_PLAN_IDENTITY: ${{ needs.guard-and-plan.outputs.resume_plan_identity }}
-        run: |
-          test "$(jq -er '.finalPlan.planIdentity' state2-bundle.json)" = "$EXPECTED_PLAN_IDENTITY"
-          jq -n \
-            --arg bundlePath "$GITHUB_WORKSPACE/state2-bundle.json" \
-            --arg repository "$GITHUB_REPOSITORY" \
-            '{$bundlePath, $repository}' > partial-inspection-input.json
-          node controller/scripts/release/live-release.mjs inspect-publication partial-inspection-input.json > partial-inspection.json
-          test "$(jq -er '.planIdentity' partial-inspection.json)" = "$EXPECTED_PLAN_IDENTITY"
-          test "$(jq -er '.status' partial-inspection.json)" = 'partial-resumable'
-          test "$(jq -er '.nextAction.kind' partial-inspection.json)" != 'create-tag'
-
       - name: Upload immutable candidate and State 2 evidence
         id: upload
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -393,7 +325,7 @@ jobs:
         shell: bash
         env:
           ARTIFACT_ID: ${{ needs.verify-candidate.outputs.artifact_id }}
-          CONTROLLER_SHA: ${{ needs.guard-and-plan.outputs.plan_controller_sha }}
+          CONTROLLER_SHA: ${{ needs.guard-and-plan.outputs.controller_sha }}
         run: |
           jq -n \
             --slurpfile bundle approved/state2-bundle.json \
@@ -407,7 +339,6 @@ jobs:
       - name: Report verified State 2
         env:
           PLAN_IDENTITY: ${{ needs.verify-candidate.outputs.plan_identity }}
-          RESUMING: ${{ needs.guard-and-plan.outputs.resuming }}
           TARGET_SHA: ${{ inputs.target_sha }}
           TAG: ${{ needs.verify-candidate.outputs.tag }}
         run: |
@@ -416,11 +347,7 @@ jobs:
             echo "Plan: \`$PLAN_IDENTITY\`  "
             echo "Candidate: \`$TARGET_SHA\`  "
             echo "Release: \`$TAG\`"
-            if [ "$RESUMING" = true ]; then
-              echo 'No production environment, production secret, deployment, tag or Release mutation, or notification was accessed. Existing tag and Release state was inspected read-only.'
-            else
-              echo 'No production environment, secret, deployment, tag, Release, or notification was accessed.'
-            fi
+            echo 'No production environment, secret, deployment, tag, Release, or notification was accessed.'
           } >> "$GITHUB_STEP_SUMMARY"
 
   completed-summary:
@@ -521,24 +448,13 @@ jobs:
         env:
           BUGDROP_GITHUB_TOKEN: ${{ github.token }}
           BUMP: ${{ inputs.bump }}
-          CONTROLLER_SHA: ${{ needs.guard-and-plan.outputs.plan_controller_sha }}
-          IDENTITY_MAIN_SHA: ${{ needs.guard-and-plan.outputs.identity_main_sha }}
-          RESUME_PLAN_IDENTITY: ${{ needs.guard-and-plan.outputs.resume_plan_identity }}
+          CONTROLLER_SHA: ${{ needs.guard-and-plan.outputs.controller_sha }}
           RETENTION_BOOTSTRAP: ${{ inputs.retention_bootstrap }}
           OPERATOR_NOTES: ${{ inputs.operator_notes }}
           RATIONALE: ${{ inputs.rationale }}
           RELEASE_REASON: ${{ inputs.release_reason }}
-          RESUMING: ${{ needs.guard-and-plan.outputs.resuming }}
           TARGET_SHA: ${{ inputs.target_sha }}
         run: |
-          identity_main_reachable_from_current=false
-          controller_reachable_from_current=false
-          if [ "$RESUMING" = true ]; then
-            git -C "$GITHUB_WORKSPACE/controller" merge-base --is-ancestor "$IDENTITY_MAIN_SHA" origin/main &&
-              identity_main_reachable_from_current=true
-            git -C "$GITHUB_WORKSPACE/controller" merge-base --is-ancestor "$CONTROLLER_SHA" origin/main &&
-              controller_reachable_from_current=true
-          fi
           jq -n \
             --arg repositoryDir "$GITHUB_WORKSPACE/controller" \
             --arg repository "$GITHUB_REPOSITORY" \
@@ -549,13 +465,8 @@ jobs:
             --arg releaseReason "$RELEASE_REASON" \
             --arg rationale "$RATIONALE" \
             --arg operatorNotes "$OPERATOR_NOTES" \
-            --arg identityMainSha "$IDENTITY_MAIN_SHA" \
-            --arg resumePlanIdentity "$RESUME_PLAN_IDENTITY" \
-            --argjson identityMainReachableFromCurrent "$identity_main_reachable_from_current" \
             --argjson retentionBootstrap "$RETENTION_BOOTSTRAP" \
-            --argjson controllerReachableFromCurrent "$controller_reachable_from_current" \
-            --argjson resuming "$RESUMING" \
-            '{$repositoryDir, $retentionBootstrap, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, dryRun: false}} + (if $resuming then {$identityMainSha, $resumePlanIdentity, $identityMainReachableFromCurrent, $controllerReachableFromCurrent} else {} end)' \
+            '{$repositoryDir, $retentionBootstrap, dispatch: {$repository, $workflowRef, $targetSha, $controllerSha, $bump, $releaseReason, $rationale, $operatorNotes, dryRun: false}}' \
             > revalidation-context.json
           node controller/scripts/release/github-adapter.mjs plan revalidation-context.json > revalidated-plan.json
           expected_plan=$(jq -er '.finalPlan.planIdentity' approved/state2-bundle.json)
@@ -566,17 +477,6 @@ jobs:
           else
             test "$(jq -er '.requestIdentity' revalidated-plan.json)" = "$expected_request"
             completed='{"kind":"none"}'
-          fi
-          if [ "$RESUMING" = true ]; then
-            test "$expected_plan" = '${{ needs.guard-and-plan.outputs.resume_plan_identity }}'
-            jq -n \
-              --arg bundlePath "$GITHUB_WORKSPACE/approved/state2-bundle.json" \
-              --arg repository "$GITHUB_REPOSITORY" \
-              '{$bundlePath, $repository}' > partial-inspection-input.json
-            node controller/scripts/release/live-release.mjs inspect-publication partial-inspection-input.json > partial-inspection.json
-            test "$(jq -er '.planIdentity' partial-inspection.json)" = "$expected_plan"
-            test "$(jq -er '.status' partial-inspection.json)" = 'partial-resumable'
-            test "$(jq -er '.nextAction.kind' partial-inspection.json)" != 'create-tag'
           fi
           jq -n \
             --slurpfile bundle approved/state2-bundle.json \

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -120,6 +120,15 @@ For `manual-recovery-required`, do not guess a version or run an ad hoc rollback
 deployment, publication, and live identity artifacts; obtain explicit incident authority; then use a
 reviewed recovery action appropriate to the observed state. Preserve the failed run as evidence.
 
+### Reset-and-replay recovery
+
+Partial publication is not executable resume authority. The legacy `resume_controller_sha`,
+`resume_remote_main_sha`, and `resume_plan_identity` workflow inputs remain only as compatibility
+tombstones: any non-empty value is rejected by the first dispatch guard before checkout, planning,
+environment access, or mutation. After preserving incident evidence, use a separately reviewed
+reset-and-replay procedure to restore a pristine publication state. Only then dispatch a fresh release
+with all three legacy resume inputs empty.
+
 ## Notification-Only Retry
 
 Re-running the production release for an already published exact plan is a core no-op and deliberately

--- a/scripts/release/github-publication-adapter.mjs
+++ b/scripts/release/github-publication-adapter.mjs
@@ -223,9 +223,44 @@ export function createGithubPublicationAdapter({
       },
     };
   };
-  const inspect = async requestedTag => {
-    const tag = match(requestedTag, TAG, 'tag');
-    const tagState = await inspectTag(tag);
+  const hydrateRelease = async (release, tag, tagState) => {
+    if (release.tag_name !== tag || !RELEASE_ID.test(String(release.id ?? ''))) {
+      fail('INVALID_RESPONSE', 'release identity is invalid');
+    }
+    if (!Array.isArray(release.assets)) fail('INVALID_RESPONSE', 'release assets are incomplete');
+    const assets = [];
+    let totalBytes = 0;
+    for (const asset of release.assets) {
+      if (
+        !ASSET.test(asset?.name ?? '') ||
+        !RELEASE_ID.test(String(asset?.id ?? '')) ||
+        typeof asset?.url !== 'string' ||
+        !Number.isSafeInteger(asset?.size) ||
+        asset.size < 0 ||
+        asset.size > MAX_WIDGET_BYTES ||
+        totalBytes + asset.size > MAX_SNAPSHOT_BYTES
+      ) {
+        fail('INVALID_RESPONSE', 'release asset identity is invalid');
+      }
+      assets.push({
+        name: asset.name,
+        bytes: await requestBytes(asset.url, asset.size, String(asset.id)),
+      });
+      totalBytes += asset.size;
+    }
+    return {
+      ...marker(release.body),
+      assets,
+      body: String(release.body ?? ''),
+      draft: release.draft === true,
+      id: String(release.id),
+      prerelease: release.prerelease === true,
+      published: release.draft === false && release.published_at !== null,
+      tag,
+      targetSha: tagState.tagObject?.targetSha,
+    };
+  };
+  const listMatchingReleases = async tag => {
     const matchingReleases = [];
     for (let page = 1; page <= MAX_RELEASE_PAGES; page += 1) {
       const releasePage = await request(
@@ -239,57 +274,54 @@ export function createGithubPublicationAdapter({
         fail('INVALID_RESPONSE', 'release pagination exceeded its authenticated bound');
       }
     }
-    if (matchingReleases.length > 1) {
-      const releases = matchingReleases.map(release => {
-        if (release.tag_name !== tag || !RELEASE_ID.test(String(release.id ?? ''))) {
-          fail('INVALID_RESPONSE', 'release identity is invalid');
-        }
-        return { id: String(release.id), tag };
-      });
-      return { complete: true, ...tagState, releases };
-    }
-    const releases = [];
-    for (const release of matchingReleases) {
+    return matchingReleases;
+  };
+  const duplicateObservation = (matchingReleases, tag, tagState) => {
+    const releases = matchingReleases.map(release => {
       if (release.tag_name !== tag || !RELEASE_ID.test(String(release.id ?? ''))) {
         fail('INVALID_RESPONSE', 'release identity is invalid');
       }
-      if (!Array.isArray(release.assets)) fail('INVALID_RESPONSE', 'release assets are incomplete');
-      const assets = [];
-      let totalBytes = 0;
-      for (const asset of release.assets) {
-        if (
-          !ASSET.test(asset?.name ?? '') ||
-          !RELEASE_ID.test(String(asset?.id ?? '')) ||
-          typeof asset?.url !== 'string' ||
-          !Number.isSafeInteger(asset?.size) ||
-          asset.size < 0 ||
-          asset.size > MAX_WIDGET_BYTES ||
-          totalBytes + asset.size > MAX_SNAPSHOT_BYTES
-        ) {
-          fail('INVALID_RESPONSE', 'release asset identity is invalid');
-        }
-        assets.push({
-          name: asset.name,
-          bytes: await requestBytes(asset.url, asset.size, String(asset.id)),
-        });
-        totalBytes += asset.size;
-      }
-      releases.push({
-        ...marker(release.body),
-        assets,
-        body: String(release.body ?? ''),
-        draft: release.draft === true,
-        id: String(release.id),
-        prerelease: release.prerelease === true,
-        published: release.draft === false && release.published_at !== null,
-        tag,
-        targetSha: tagState.tagObject?.targetSha,
-      });
+      return { id: String(release.id), tag };
+    });
+    return { complete: true, ...tagState, releases };
+  };
+  const inspect = async requestedTag => {
+    const tag = match(requestedTag, TAG, 'tag');
+    const tagState = await inspectTag(tag);
+    const matchingReleases = await listMatchingReleases(tag);
+    if (matchingReleases.length > 1) {
+      return duplicateObservation(matchingReleases, tag, tagState);
+    }
+    const releases = [];
+    for (const release of matchingReleases) {
+      releases.push(await hydrateRelease(release, tag, tagState));
     }
     return { complete: true, ...tagState, releases };
   };
   return {
     inspect,
+    async inspectRelease(requestedReleaseId, requestedTag) {
+      const releaseId = match(String(requestedReleaseId ?? ''), RELEASE_ID, 'releaseId');
+      const tag = match(requestedTag, TAG, 'tag');
+      const tagState = await inspectTag(tag);
+      const release = await request('GET', `/repos/${repository}/releases/${releaseId}`);
+      if (String(release.id ?? '') !== releaseId) {
+        fail('INVALID_RESPONSE', 'exact release ID does not match the requested ID');
+      }
+      const hydrated = await hydrateRelease(release, tag, tagState);
+      const matchingReleases = await listMatchingReleases(tag);
+      if (matchingReleases.length > 1) {
+        return duplicateObservation(matchingReleases, tag, tagState);
+      }
+      if (matchingReleases.length !== 1 || String(matchingReleases[0]?.id ?? '') !== releaseId) {
+        fail('INVALID_RESPONSE', 'global same-tag release identity is not uniquely owned');
+      }
+      return {
+        complete: true,
+        ...tagState,
+        releases: [hydrated],
+      };
+    },
     async createAnnotatedTag(action) {
       const tag = match(action.tag, TAG, 'tag');
       const targetSha = match(action.targetSha, SHA, 'targetSha');
@@ -300,9 +332,10 @@ export function createGithubPublicationAdapter({
       await request('POST', `/repos/${repository}/git/refs`, {
         body: { ref: `refs/tags/${tag}`, sha: objectSha },
       });
+      return { objectSha };
     },
     async createDraft(action) {
-      await request('POST', `/repos/${repository}/releases`, {
+      const created = await request('POST', `/repos/${repository}/releases`, {
         body: {
           body: String(action.body ?? ''),
           draft: true,
@@ -313,6 +346,7 @@ export function createGithubPublicationAdapter({
           target_commitish: match(action.targetSha, SHA, 'targetSha'),
         },
       });
+      return { releaseId: match(String(created.id ?? ''), RELEASE_ID, 'created release ID') };
     },
     async uploadAsset(action) {
       const releaseId = match(String(action.releaseId ?? ''), RELEASE_ID, 'releaseId');

--- a/scripts/release/publication.mjs
+++ b/scripts/release/publication.mjs
@@ -16,6 +16,7 @@ const RECOVERY = Object.freeze({
   preservePublicationState: true,
   production: 'restore-prior-baseline',
 });
+const CONVERGENCE_INSPECTIONS = 4;
 export class PublicationError extends Error {
   constructor(code, message, details = {}) {
     super(`${code}: ${message}`);
@@ -248,7 +249,49 @@ export function classifyPublicationState(expected, observation) {
     },
   };
 }
-const actionKey = action => (action ? `${action.kind}:${action.name ?? ''}` : 'complete');
+function actionKey(action) {
+  if (!action) return 'complete';
+  if (action.kind === 'create-tag' || action.kind === 'create-draft') {
+    return `${action.kind}:${action.tag}`;
+  }
+  if (action.kind === 'upload-asset') {
+    return `${action.kind}:${action.releaseId}:${action.name}`;
+  }
+  if (action.kind === 'publish-draft') return `${action.kind}:${action.releaseId}`;
+  return action.kind;
+}
+function isForwardState(expected, action, state, mutationResult, observation) {
+  if (state.status === 'exact-published') {
+    const releaseId = observation?.releases?.[0]?.id;
+    if (action.kind === 'create-tag') return false;
+    if (action.kind === 'create-draft') return mutationResult?.releaseId === releaseId;
+    return action.releaseId === releaseId;
+  }
+  if (state.status !== 'partial-resumable') return false;
+  const next = state.nextAction;
+  if (action.kind === 'create-tag') {
+    return (
+      next.kind === 'create-draft' &&
+      mutationResult?.objectSha === observation?.tagRef?.objectSha &&
+      observation?.releases?.length === 0
+    );
+  }
+  if (action.kind === 'create-draft') {
+    return (
+      mutationResult?.releaseId === next.releaseId &&
+      (next.kind === 'upload-asset' || next.kind === 'publish-draft')
+    );
+  }
+  if (action.kind === 'upload-asset') {
+    if (next.releaseId !== action.releaseId) return false;
+    if (next.kind === 'publish-draft') return true;
+    if (next.kind !== 'upload-asset') return false;
+    return (
+      expected.requiredAssets.indexOf(next.name) > expected.requiredAssets.indexOf(action.name)
+    );
+  }
+  return false;
+}
 function publicAction(action) {
   if (!action) return null;
   const { bytes: _bytes, body: _body, marker: _marker, ...safe } = action;
@@ -274,16 +317,77 @@ function stopped(expected, state, details = {}) {
 export async function executePublication({ adapter, bundle }) {
   const expected = validatePublicationBundle(bundle);
   const history = [];
+  const attemptedActions = new Set();
   let mutated = false;
-  const inspect = async () => {
+  const inspect = async releaseId => {
     try {
-      return classifyPublicationState(expected, await adapter.inspect(expected.tag));
+      const observation = releaseId
+        ? await adapter.inspectRelease(releaseId, expected.tag)
+        : await adapter.inspect(expected.tag);
+      return { observation, state: classifyPublicationState(expected, observation) };
     } catch (error) {
-      return unknown(error instanceof Error ? error.message : String(error));
+      return {
+        observation: null,
+        state: unknown(error instanceof Error ? error.message : String(error)),
+      };
     }
   };
+  let ownedReleaseId = null;
+  let { observation, state } = await inspect();
+  if (state.status === 'exact-published') {
+    return {
+      status: 'already-published',
+      history,
+      planIdentity: expected.planIdentity,
+      tag: expected.tag,
+    };
+  }
+  if (state.status === 'partial-resumable' && state.nextAction.kind !== 'create-tag') {
+    return stopped(expected, unknown('pre-existing-publication-state'), { history });
+  }
   for (let attempt = 0; attempt < expected.requiredAssets.length + 4; attempt += 1) {
-    const state = await inspect();
+    if (state.status !== 'partial-resumable') return stopped(expected, state, { history });
+    const action = state.nextAction;
+    const key = actionKey(action);
+    if (attemptedActions.has(key)) {
+      return stopped(expected, unknown(`mutation-outcome-unobserved:${key}`), { history });
+    }
+    attemptedActions.add(key);
+    let mutationError;
+    let mutationResult;
+    try {
+      mutationResult = await mutate(adapter, action);
+      mutated = true;
+      history.push({
+        action: publicAction(action),
+        result: 'applied',
+        ...(mutationResult?.releaseId ? { releaseId: mutationResult.releaseId } : {}),
+      });
+      if (action.kind === 'create-draft') ownedReleaseId = mutationResult?.releaseId ?? null;
+    } catch (error) {
+      mutationError = error instanceof Error ? error.message : String(error);
+    }
+    let converged = false;
+    for (let inspection = 0; inspection < CONVERGENCE_INSPECTIONS; inspection += 1) {
+      ({ observation, state } = await inspect(ownedReleaseId));
+      if (state.status === 'conflict') {
+        return stopped(expected, state, { history, ...(mutationError ? { mutationError } : {}) });
+      }
+      if (isForwardState(expected, action, state, mutationResult, observation)) {
+        converged = true;
+        break;
+      }
+    }
+    if (!converged) {
+      return stopped(expected, unknown(`mutation-outcome-unobserved:${key}`), {
+        history,
+        ...(mutationError ? { mutationError } : {}),
+      });
+    }
+    if (mutationError) {
+      mutated = true;
+      history.push({ action: publicAction(action), result: 'confirmed-after-lost-response' });
+    }
     if (state.status === 'exact-published') {
       return {
         status: mutated ? 'published' : 'already-published',
@@ -291,33 +395,6 @@ export async function executePublication({ adapter, bundle }) {
         planIdentity: expected.planIdentity,
         tag: expected.tag,
       };
-    }
-    if (state.status !== 'partial-resumable') return stopped(expected, state, { history });
-    const action = state.nextAction;
-    try {
-      await mutate(adapter, action);
-      mutated = true;
-      history.push({ action: publicAction(action), result: 'applied' });
-    } catch (error) {
-      const after = await inspect();
-      const message = error instanceof Error ? error.message : String(error);
-      if (after.status === 'conflict' || after.status === 'unknown-critical') {
-        return stopped(expected, after, { history, mutationError: message });
-      }
-      if (after.status === 'exact-published' || actionKey(after.nextAction) !== actionKey(action)) {
-        mutated = true;
-        history.push({ action: publicAction(action), result: 'confirmed-after-lost-response' });
-        if (after.status === 'exact-published') {
-          return {
-            status: 'published',
-            history,
-            planIdentity: expected.planIdentity,
-            tag: expected.tag,
-          };
-        }
-        continue;
-      }
-      return stopped(expected, after, { history, mutationError: message });
     }
   }
   return stopped(expected, unknown('transition-limit-exceeded'), { history });

--- a/test/fixtures/release/publication/fake-github.ts
+++ b/test/fixtures/release/publication/fake-github.ts
@@ -71,6 +71,22 @@ export class FakeGitHubPublicationAdapter {
     return clonePublicationState(this.state);
   }
 
+  async inspectRelease(releaseId: string, tag?: string) {
+    this.log.push(`inspect-release:${releaseId}`);
+    if (this.inspectFails || (this.failInspectAfterApplied && this.applied.length)) {
+      throw new Error('inspection unavailable');
+    }
+    const state = clonePublicationState(this.state);
+    const exact = state.releases?.find(release => release.id === releaseId);
+    if (!exact || (tag !== undefined && exact.tag !== tag)) {
+      throw new Error('exact release identity mismatch');
+    }
+    const matching =
+      state.releases?.filter(release => tag === undefined || release.tag === tag) ?? [];
+    state.releases = matching.length > 1 ? matching : [exact];
+    return state;
+  }
+
   private lose(point: LossPoint, phase: 'before' | 'after') {
     const set = phase === 'before' ? this.loseBefore : this.loseAfter;
     if (!set.delete(point)) return;
@@ -93,6 +109,7 @@ export class FakeGitHubPublicationAdapter {
     };
     this.applied.push(point);
     this.lose(point, 'after');
+    return { objectSha };
   }
 
   async createDraft(input: Record<string, unknown>) {
@@ -102,7 +119,7 @@ export class FakeGitHubPublicationAdapter {
     if (this.state.releases?.length) throw new Error('duplicate Release attempted');
     this.state.releases = [
       {
-        id: 'release-1',
+        id: '123',
         tag: input.tag,
         targetSha: input.targetSha,
         draft: true,
@@ -116,6 +133,7 @@ export class FakeGitHubPublicationAdapter {
     ];
     this.applied.push(point);
     this.lose(point, 'after');
+    return { releaseId: '123' };
   }
 
   async uploadAsset(input: { releaseId: string; name: string; bytes: Buffer }) {

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -127,9 +127,8 @@ for literal in \
   '[[ "$CONTROLLER_SHA" =~ ^[0-9a-f]{40}$ ]]' \
   '[[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]' \
   'CONTROLLER_SHA: ${{ github.workflow_sha }}' \
-  'partial retry requires all three resume inputs or none of them.' \
-  'plan_controller_sha=$plan_controller_sha' \
-  '--arg resumePlanIdentity "$RESUME_PLAN_IDENTITY"' \
+  'if [ -n "$RESUME_CONTROLLER_SHA$RESUME_REMOTE_MAIN_SHA$RESUME_PLAN_IDENTITY" ]; then' \
+  'Legacy resume inputs are disabled; use reviewed reset-and-replay recovery.' \
   'node controller/scripts/release/workflow.mjs guard' \
   'node controller/scripts/release/github-adapter.mjs plan' \
   '--arg repositoryDir "$GITHUB_WORKSPACE/controller"' \
@@ -137,8 +136,38 @@ for literal in \
   "echo 'completed=true'"; do
   grep -Fq -- "$literal" <<< "$guard_block" || fail "guard-and-plan lacks: $literal"
 done
-[[ $(grep -Fc 'RESUME_PLAN_IDENTITY:' "$workflow") -eq 3 ]] ||
-  fail 'resume plan identity must be exported to guard, initial planning, and approval revalidation'
+[[ $(grep -Fc 'RESUME_PLAN_IDENTITY:' "$workflow") -eq 1 ]] ||
+  fail 'resume plan identity must exist only in the first pre-checkout guard'
+
+guard_script=$(awk '
+  /- name: Reject non-main or malformed dispatch before checkout/ { found = 1 }
+  found && /^        run: \|$/ { capture = 1; next }
+  capture && /^      - name: Checkout immutable controller$/ { exit }
+  capture { sub(/^          /, ""); print }
+' "$workflow")
+for mask in 0 1 2 3 4 5 6 7; do
+  resume_controller=''
+  resume_main=''
+  resume_plan=''
+  ((mask & 1)) && resume_controller='a'
+  ((mask & 2)) && resume_main='b'
+  ((mask & 4)) && resume_plan='c'
+  if output=$(env \
+    CONTROLLER_SHA="$(printf 'a%.0s' {1..40})" \
+    DISPATCH_REF='refs/heads/main' \
+    GITHUB_OUTPUT=/dev/null \
+    RESUME_CONTROLLER_SHA="$resume_controller" \
+    RESUME_PLAN_IDENTITY="$resume_plan" \
+    RESUME_REMOTE_MAIN_SHA="$resume_main" \
+    TARGET_SHA="$(printf 'b%.0s' {1..40})" \
+    bash -c "$guard_script" 2>&1); then
+    [[ "$mask" -eq 0 ]] || fail "resume combination $mask reached beyond the first guard"
+  else
+    [[ "$mask" -ne 0 ]] || fail 'fresh all-empty dispatch failed the first guard'
+    grep -Fq 'Legacy resume inputs are disabled; use reviewed reset-and-replay recovery.' <<< "$output" ||
+      fail "resume combination $mask did not return the stable reset-and-replay rejection"
+  fi
+done
 
 for literal in \
   "request_key=\$(jq -er '.planIdentity[7:]' request-plan.json)" \
@@ -190,15 +219,13 @@ for literal in \
   'retention-days: 14'; do
   grep -Fq -- "$literal" <<< "$verify_block" || fail "verify-candidate lacks: $literal"
 done
-for literal in \
-  "if: needs.guard-and-plan.outputs.resuming == 'true'" \
-  'node controller/scripts/release/live-release.mjs inspect-publication' \
-  "test \"\$(jq -er '.status' partial-inspection.json)\" = 'partial-resumable'"; do
-  grep -Fq -- "$literal" <<< "$verify_block" || fail "partial retry verification lacks: $literal"
+for removed_resume_path in \
+  'RESUMING' \
+  'resumePlanIdentity' \
+  'Authenticate exact partial-publication retry' \
+  'partial-inspection'; do
+  require_absent "$removed_resume_path"
 done
-[[ $(grep -Fc 'test "$(jq -er '\''.nextAction.kind'\'' partial-inspection.json)" != '\''create-tag'\''' "$workflow") -eq 2 ]] ||
-  fail 'partial retry must reject pristine publication state before dry-run success and mutation'
-require_literal 'Existing tag and Release state was inspected read-only.'
 if grep -Fq -- '{$requestPlan:' <<< "$verify_block"; then
   fail 'slurped request plan must be a literal requestPlan field, not a dynamic object key'
 fi

--- a/test/release/github-publication-adapter.test.ts
+++ b/test/release/github-publication-adapter.test.ts
@@ -160,6 +160,197 @@ describe('GitHub publication inspection', () => {
     );
   });
 
+  it('hydrates one same-invocation release by exact ID and separately proves global uniqueness', async () => {
+    const publicationMarker = { planIdentity: `sha256:${'4'.repeat(64)}` };
+    const bodyMarker = `<!-- bugdrop-publication ${Buffer.from(JSON.stringify(publicationMarker)).toString('base64url')} -->`;
+    const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/git/ref/tags/v1.2.3')) {
+        return response({ object: { type: 'tag', sha: TAG_OBJECT_SHA } });
+      }
+      if (url.pathname.endsWith(`/git/tags/${TAG_OBJECT_SHA}`)) {
+        return response({ message: 'annotation', object: { type: 'commit', sha: SHA } });
+      }
+      if (url.pathname.endsWith('/releases/456')) {
+        const release = {
+          id: 456,
+          tag_name: 'v1.2.3',
+          body: bodyMarker,
+          draft: true,
+          prerelease: false,
+          published_at: null,
+          assets: [],
+        };
+        return response(release);
+      }
+      if (url.pathname.endsWith('/releases')) {
+        return response([{ id: 456, tag_name: 'v1.2.3' }]);
+      }
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+
+    await expect(adapter(fetchImpl).inspectRelease('456', 'v1.2.3')).resolves.toMatchObject({
+      complete: true,
+      releases: [{ id: '456', tag: 'v1.2.3', marker: publicationMarker, draft: true }],
+    });
+    const paths = fetchImpl.mock.calls.map(([input]) => new URL(String(input)).pathname);
+    expect(paths.indexOf('/repos/mean-weasel/bugdrop/releases/456')).toBeLessThan(
+      paths.indexOf('/repos/mean-weasel/bugdrop/releases')
+    );
+  });
+
+  it('returns complete duplicate identities after exact-ID hydration', async () => {
+    const paths: string[] = [];
+    const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      paths.push(url.pathname);
+      if (url.pathname.endsWith('/git/ref/tags/v1.2.3')) {
+        return response({ object: { type: 'tag', sha: TAG_OBJECT_SHA } });
+      }
+      if (url.pathname.endsWith(`/git/tags/${TAG_OBJECT_SHA}`)) {
+        return response({ message: 'annotation', object: { type: 'commit', sha: SHA } });
+      }
+      if (url.pathname.endsWith('/releases/456')) {
+        return response({
+          id: 456,
+          tag_name: 'v1.2.3',
+          body: '',
+          draft: true,
+          prerelease: false,
+          published_at: null,
+          assets: [],
+        });
+      }
+      if (url.pathname.endsWith('/releases')) {
+        return response([
+          { id: 456, tag_name: 'v1.2.3' },
+          { id: 789, tag_name: 'v1.2.3' },
+        ]);
+      }
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+
+    await expect(adapter(fetchImpl).inspectRelease('456', 'v1.2.3')).resolves.toMatchObject({
+      complete: true,
+      releases: [
+        { id: '456', tag: 'v1.2.3' },
+        { id: '789', tag: 'v1.2.3' },
+      ],
+    });
+    expect(paths.indexOf('/repos/mean-weasel/bugdrop/releases/456')).toBeLessThan(
+      paths.indexOf('/repos/mean-weasel/bugdrop/releases')
+    );
+  });
+
+  it.each([
+    ['zero global matches', []],
+    ['an alternate global ID', [{ id: 789, tag_name: 'v1.2.3' }]],
+  ])('rejects %s after exact-ID hydration', async (_name, globalMatches) => {
+    const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/git/ref/tags/v1.2.3')) {
+        return response({ object: { type: 'tag', sha: TAG_OBJECT_SHA } });
+      }
+      if (url.pathname.endsWith(`/git/tags/${TAG_OBJECT_SHA}`)) {
+        return response({ message: 'annotation', object: { type: 'commit', sha: SHA } });
+      }
+      if (url.pathname.endsWith('/releases/456')) {
+        return response({
+          id: 456,
+          tag_name: 'v1.2.3',
+          body: '',
+          draft: true,
+          prerelease: false,
+          published_at: null,
+          assets: [],
+        });
+      }
+      if (url.pathname.endsWith('/releases')) return response(globalMatches);
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+
+    await expect(adapter(fetchImpl).inspectRelease('456', 'v1.2.3')).rejects.toBeInstanceOf(
+      GithubPublicationAdapterError
+    );
+  });
+
+  it('rejects a mismatched exact-ID response before global listing', async () => {
+    const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/git/ref/tags/v1.2.3')) {
+        return response({ object: { type: 'tag', sha: TAG_OBJECT_SHA } });
+      }
+      if (url.pathname.endsWith(`/git/tags/${TAG_OBJECT_SHA}`)) {
+        return response({ message: 'annotation', object: { type: 'commit', sha: SHA } });
+      }
+      if (url.pathname.endsWith('/releases/456')) {
+        return response({ id: 789, tag_name: 'v1.2.3', assets: [] });
+      }
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+
+    await expect(adapter(fetchImpl).inspectRelease('456', 'v1.2.3')).rejects.toBeInstanceOf(
+      GithubPublicationAdapterError
+    );
+    expect(
+      fetchImpl.mock.calls.some(([input]) => new URL(String(input)).pathname.endsWith('/releases'))
+    ).toBe(false);
+  });
+
+  it('rejects unavailable global same-tag evidence after exact hydration', async () => {
+    const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/git/ref/tags/v1.2.3')) {
+        return response({ object: { type: 'tag', sha: TAG_OBJECT_SHA } });
+      }
+      if (url.pathname.endsWith(`/git/tags/${TAG_OBJECT_SHA}`)) {
+        return response({ message: 'annotation', object: { type: 'commit', sha: SHA } });
+      }
+      if (url.pathname.endsWith('/releases/456')) {
+        return response({
+          id: 456,
+          tag_name: 'v1.2.3',
+          body: '',
+          draft: true,
+          prerelease: false,
+          published_at: null,
+          assets: [],
+        });
+      }
+      if (url.pathname.endsWith('/releases')) return response({ message: 'unavailable' }, 500);
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+
+    await expect(adapter(fetchImpl).inspectRelease('456', 'v1.2.3')).rejects.toBeInstanceOf(
+      GithubPublicationAdapterError
+    );
+  });
+
+  it('rejects an exact-ID release whose tag differs from the expected publication', async () => {
+    const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/git/ref/tags/v1.2.3')) {
+        return response({ object: { type: 'tag', sha: TAG_OBJECT_SHA } });
+      }
+      if (url.pathname.endsWith(`/git/tags/${TAG_OBJECT_SHA}`)) {
+        return response({ message: 'annotation', object: { type: 'commit', sha: SHA } });
+      }
+      return response({
+        id: 456,
+        tag_name: 'v9.9.9',
+        body: '',
+        draft: true,
+        prerelease: false,
+        published_at: null,
+        assets: [],
+      });
+    });
+
+    await expect(adapter(fetchImpl).inspectRelease('456', 'v1.2.3')).rejects.toBeInstanceOf(
+      GithubPublicationAdapterError
+    );
+  });
+
   it('uses pagination authority and accepts an exactly full final bounded page', async () => {
     let releasePageCalls = 0;
     const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
@@ -240,11 +431,13 @@ describe('GitHub publication mutations', () => {
         ? response({ sha: TAG_OBJECT_SHA }, 201)
         : response({ ref: 'refs/tags/v1.2.3' }, 201);
     });
-    await adapter(fetchImpl).createAnnotatedTag({
-      tag: 'v1.2.3',
-      targetSha: SHA,
-      annotation: 'exact annotation',
-    });
+    await expect(
+      adapter(fetchImpl).createAnnotatedTag({
+        tag: 'v1.2.3',
+        targetSha: SHA,
+        annotation: 'exact annotation',
+      })
+    ).resolves.toEqual({ objectSha: TAG_OBJECT_SHA });
     expect(calls).toEqual([
       {
         method: 'POST',
@@ -277,12 +470,14 @@ describe('GitHub publication mutations', () => {
       return response({ id: 123 }, 201);
     });
     const client = adapter(fetchImpl);
-    await client.createDraft({
-      tag: 'v1.2.3',
-      targetSha: SHA,
-      name: 'BugDrop 1.2.3',
-      body: 'notes',
-    });
+    await expect(
+      client.createDraft({
+        tag: 'v1.2.3',
+        targetSha: SHA,
+        name: 'BugDrop 1.2.3',
+        body: 'notes',
+      })
+    ).resolves.toEqual({ releaseId: '123' });
     await client.uploadAsset({ releaseId: '123', name: 'widget.js', bytes: Buffer.from('asset') });
     await client.publishDraft({ releaseId: '123' });
     expect(calls.map(call => [call.method, call.url])).toEqual([

--- a/test/release/publication.test.ts
+++ b/test/release/publication.test.ts
@@ -100,6 +100,76 @@ async function publishedAdapter() {
   return { adapter, bundle };
 }
 
+type DelayedMutation = 'create-tag' | 'create-draft' | 'upload-asset' | 'publish-draft';
+type InspectionObservation = FakeGitHubPublicationAdapter['state'] | Error;
+
+function queueMutationInspections(
+  adapter: FakeGitHubPublicationAdapter,
+  point: DelayedMutation,
+  observations: (
+    before: FakeGitHubPublicationAdapter['state'],
+    after: FakeGitHubPublicationAdapter['state']
+  ) => InspectionObservation[]
+) {
+  const method = {
+    'create-tag': 'createAnnotatedTag',
+    'create-draft': 'createDraft',
+    'upload-asset': 'uploadAsset',
+    'publish-draft': 'publishDraft',
+  }[point] as 'createAnnotatedTag' | 'createDraft' | 'uploadAsset' | 'publishDraft';
+  const mutate = adapter[method].bind(adapter) as (input: never) => Promise<unknown>;
+  const inspect = adapter.inspect.bind(adapter);
+  const inspectRelease = adapter.inspectRelease.bind(adapter);
+  let queued: InspectionObservation[] = [];
+
+  adapter[method] = (async (input: never) => {
+    const before = clonePublicationState(adapter.state);
+    const appliedBefore = adapter.applied.length;
+    try {
+      return await mutate(input);
+    } finally {
+      if (adapter.applied.length > appliedBefore) {
+        queued = observations(before, clonePublicationState(adapter.state));
+      }
+    }
+  }) as (typeof adapter)[typeof method];
+  const queuedInspection = async (log: string, fallback: () => Promise<unknown>) => {
+    const observation = queued.shift();
+    if (!observation) return fallback();
+    adapter.log.push(log);
+    if (observation instanceof Error) throw observation;
+    return clonePublicationState(observation);
+  };
+  adapter.inspect = async () => queuedInspection('inspect', inspect) as ReturnType<typeof inspect>;
+  adapter.inspectRelease = async (releaseId: string, tag?: string) =>
+    queuedInspection(`inspect-release:${releaseId}`, () =>
+      inspectRelease(releaseId, tag)
+    ) as ReturnType<typeof inspectRelease>;
+  return adapter;
+}
+
+function delayMutationVisibility(
+  adapter: FakeGitHubPublicationAdapter,
+  point: DelayedMutation,
+  inspections: number
+) {
+  const count = Number.isFinite(inspections) ? inspections : 10;
+  return queueMutationInspections(adapter, point, before =>
+    Array.from({ length: count }, () => clonePublicationState(before))
+  );
+}
+
+async function preexistingDraftAdapter(bundle = publicationBundle()) {
+  const published = new FakeGitHubPublicationAdapter();
+  await expect(executePublication({ adapter: published, bundle })).resolves.toMatchObject({
+    status: 'published',
+  });
+  const state = clonePublicationState(published.state);
+  state.releases![0].draft = true;
+  state.releases![0].published = false;
+  return new FakeGitHubPublicationAdapter({ state });
+}
+
 describe('complete publication and exact retry', () => {
   it('creates only the canonical tag, matched draft, absent assets, and explicit publish', async () => {
     const { adapter, bundle } = await publishedAdapter();
@@ -113,7 +183,12 @@ describe('complete publication and exact retry', () => {
       ...bundle.finalPlan.requiredAssets.map(name => `upload-asset:${name}`),
       'publish-draft',
     ]);
-    expect(adapter.log.filter(item => item === 'inspect').length).toBe(adapter.applied.length + 1);
+    expect(adapter.log.filter(item => item.startsWith('inspect')).length).toBe(
+      adapter.applied.length + 1
+    );
+    expect(adapter.log.filter(item => item === 'inspect-release:123')).toHaveLength(
+      adapter.applied.length - 1
+    );
     expect(adapter.log.join(' ')).not.toMatch(/force|move|delete|overwrite|increment/);
   });
 
@@ -127,7 +202,7 @@ describe('complete publication and exact retry', () => {
     expect(adapter.applied).toEqual(before);
   });
 
-  it.each(['create-tag', 'create-draft', 'upload-asset', 'publish-draft'] as const)(
+  it.each(['upload-asset', 'publish-draft'] as const)(
     'recovers an applied %s mutation after its response is lost',
     async point => {
       const bundle = publicationBundle();
@@ -138,27 +213,426 @@ describe('complete publication and exact retry', () => {
       expect(adapter.applied.filter(item => item.startsWith(point))).toHaveLength(
         point === 'upload-asset' ? bundle.finalPlan.requiredAssets.length : 1
       );
+      expect(adapter.log.filter(item => item.startsWith(point))).toHaveLength(
+        point === 'upload-asset' ? bundle.finalPlan.requiredAssets.length : 1
+      );
+    }
+  );
+
+  it.each(['create-tag', 'create-draft'] as const)(
+    'fails closed after an applied %s response is lost without claiming fresh ownership',
+    async point => {
+      const bundle = publicationBundle();
+      const adapter = new FakeGitHubPublicationAdapter({ loseAfter: [point] });
+      await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+        status: 'unknown-critical',
+        reason: expect.stringContaining('mutation-outcome-unobserved'),
+      });
+      expect(adapter.log.filter(item => item.startsWith(point))).toHaveLength(1);
+      if (point === 'create-tag') expect(adapter.log).not.toContain('create-draft');
+      if (point === 'create-draft') {
+        expect(adapter.log.some(item => item.startsWith('upload-asset'))).toBe(false);
+      }
+    }
+  );
+
+  it('fails closed when a lost tag response is followed by the correct tag becoming visible', async () => {
+    const bundle = publicationBundle();
+    const adapter = delayMutationVisibility(
+      new FakeGitHubPublicationAdapter({ loseAfter: ['create-tag'] }),
+      'create-tag',
+      2
+    );
+
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining('mutation-outcome-unobserved:create-tag'),
+    });
+    expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.applied.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(0);
+    expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(0);
+    expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
+  });
+
+  it('fails closed when an unapplied lost tag is followed by a matching tag observation', async () => {
+    const bundle = publicationBundle();
+    const expected = validatePublicationBundle(bundle);
+    const adapter = new FakeGitHubPublicationAdapter({ loseBefore: ['create-tag'] });
+    const inspect = adapter.inspect.bind(adapter);
+    let inspections = 0;
+    adapter.inspect = async () => {
+      inspections += 1;
+      if (inspections === 1) return inspect();
+      adapter.log.push('inspect');
+      return {
+        complete: true,
+        tagRef: { objectSha: '7'.repeat(40) },
+        tagObject: {
+          kind: 'annotated',
+          objectSha: '7'.repeat(40),
+          targetType: 'commit',
+          targetSha: bundle.finalPlan.targetSha,
+          annotation: expected.tagAnnotation,
+        },
+        releases: [],
+      };
+    };
+
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining('mutation-outcome-unobserved:create-tag'),
+    });
+    expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.applied.filter(item => item === 'create-tag')).toHaveLength(0);
+    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(0);
+    expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(0);
+    expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
+  });
+
+  it('fails closed on a mismatched tag object after one successful tag mutation', async () => {
+    const bundle = publicationBundle();
+    const adapter = queueMutationInspections(
+      new FakeGitHubPublicationAdapter(),
+      'create-tag',
+      (_before, after) => {
+        const mismatch = clonePublicationState(after);
+        mismatch.tagRef!.objectSha = '8'.repeat(40);
+        return [mismatch];
+      }
+    );
+
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'conflict',
+      reason: 'tag-identity-mismatch',
+    });
+    expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.applied.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(0);
+    expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(0);
+    expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
+  });
+
+  it.each(['create-tag', 'create-draft', 'upload-asset', 'publish-draft'] as const)(
+    'converges delayed %s visibility without repeating the mutation',
+    async point => {
+      const bundle = publicationBundle();
+      const adapter = delayMutationVisibility(new FakeGitHubPublicationAdapter(), point, 2);
+      await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+        status: 'published',
+      });
+      expect(adapter.applied.filter(item => item.startsWith(point))).toHaveLength(
+        point === 'upload-asset' ? bundle.finalPlan.requiredAssets.length : 1
+      );
+      expect(adapter.log.filter(item => item.startsWith(point))).toHaveLength(
+        point === 'upload-asset' ? bundle.finalPlan.requiredAssets.length : 1
+      );
+    }
+  );
+
+  it.each(['upload-asset', 'publish-draft'] as const)(
+    'converges a lost %s response through delayed visibility without repeating the mutation',
+    async point => {
+      const bundle = publicationBundle();
+      const adapter = delayMutationVisibility(
+        new FakeGitHubPublicationAdapter({ loseAfter: [point] }),
+        point,
+        2
+      );
+      await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+        status: 'published',
+      });
+      expect(adapter.applied.filter(item => item.startsWith(point))).toHaveLength(
+        point === 'upload-asset' ? bundle.finalPlan.requiredAssets.length : 1
+      );
     }
   );
 
   it.each(['create-tag', 'create-draft', 'upload-asset', 'publish-draft'] as const)(
-    'returns a safe partial after an unapplied %s response loss and resumes exactly',
+    'fails closed when successful %s visibility never converges',
+    async point => {
+      const bundle = publicationBundle();
+      const adapter = delayMutationVisibility(
+        new FakeGitHubPublicationAdapter(),
+        point,
+        Number.POSITIVE_INFINITY
+      );
+      await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+        status: 'unknown-critical',
+        reason: expect.stringContaining('mutation-outcome-unobserved'),
+        recovery: { automaticGitHubCleanup: false },
+      });
+      expect(adapter.applied.filter(item => item.startsWith(point))).toHaveLength(1);
+      expect(adapter.log.filter(item => item.startsWith(point))).toHaveLength(1);
+      if (point === 'create-tag') {
+        expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(0);
+        expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(0);
+        expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
+      }
+    }
+  );
+
+  it('fails closed when exact-ID inspection returns a different release', async () => {
+    const bundle = publicationBundle();
+    const adapter = queueMutationInspections(
+      new FakeGitHubPublicationAdapter(),
+      'create-draft',
+      (_before, after) => {
+        const mismatch = clonePublicationState(after);
+        mismatch.releases![0].id = '456';
+        return Array.from({ length: 4 }, () => clonePublicationState(mismatch));
+      }
+    );
+
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining('mutation-outcome-unobserved:create-draft'),
+    });
+    expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(1);
+    expect(adapter.applied.filter(item => item === 'create-draft')).toHaveLength(1);
+    expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(0);
+    expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
+  });
+
+  it('detects a duplicate appearing after draft creation before the first upload', async () => {
+    const bundle = publicationBundle();
+    const adapter = queueMutationInspections(
+      new FakeGitHubPublicationAdapter(),
+      'create-draft',
+      (_before, after) => {
+        const duplicate = clonePublicationState(after.releases![0]);
+        duplicate.id = '456';
+        after.releases!.push(duplicate);
+        return [after];
+      }
+    );
+
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'conflict',
+      reason: 'duplicate-release',
+    });
+    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(1);
+    expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(0);
+    expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
+  });
+
+  it('detects a duplicate appearing between asset uploads before the next upload', async () => {
+    const bundle = publicationBundle();
+    const adapter = queueMutationInspections(
+      new FakeGitHubPublicationAdapter(),
+      'upload-asset',
+      (_before, after) => {
+        const duplicate = clonePublicationState(after.releases![0]);
+        duplicate.id = '456';
+        after.releases!.push(duplicate);
+        return [after];
+      }
+    );
+
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'conflict',
+      reason: 'duplicate-release',
+    });
+    expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(1);
+    expect(adapter.applied.filter(item => item.startsWith('upload-asset'))).toHaveLength(1);
+    expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
+  });
+
+  it('detects a duplicate after the final asset before publish', async () => {
+    const bundle = publicationBundle();
+    const adapter = queueMutationInspections(
+      new FakeGitHubPublicationAdapter(),
+      'upload-asset',
+      (_before, after) => {
+        if (after.releases![0].assets.length !== bundle.finalPlan.requiredAssets.length) return [];
+        const duplicate = clonePublicationState(after.releases![0]);
+        duplicate.id = '456';
+        after.releases!.push(duplicate);
+        return [after];
+      }
+    );
+
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'conflict',
+      reason: 'duplicate-release',
+    });
+    expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(
+      bundle.finalPlan.requiredAssets.length
+    );
+    expect(adapter.applied.filter(item => item.startsWith('upload-asset'))).toHaveLength(
+      bundle.finalPlan.requiredAssets.length
+    );
+    expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
+  });
+
+  it('fails closed on a tag-only regression after one publish mutation', async () => {
+    const bundle = publicationBundle();
+    const adapter = queueMutationInspections(
+      new FakeGitHubPublicationAdapter(),
+      'publish-draft',
+      (_before, after) => {
+        const tagOnly = clonePublicationState(after);
+        tagOnly.releases = [];
+        return Array.from({ length: 4 }, () => clonePublicationState(tagOnly));
+      }
+    );
+
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining('mutation-outcome-unobserved:publish-draft'),
+    });
+    expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(1);
+    expect(adapter.applied.filter(item => item === 'publish-draft')).toHaveLength(1);
+    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(1);
+    expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(
+      bundle.finalPlan.requiredAssets.length
+    );
+  });
+
+  it('fails closed on an earlier-asset regression after one later upload mutation', async () => {
+    const bundle = publicationBundle();
+    const required = bundle.finalPlan.requiredAssets;
+    const current = required[2];
+    const earlier = required[1];
+    const adapter = queueMutationInspections(
+      new FakeGitHubPublicationAdapter(),
+      'upload-asset',
+      (before, after) => {
+        if (before.releases![0].assets.some(asset => asset.name === current)) return [];
+        if (!after.releases![0].assets.some(asset => asset.name === current)) return [];
+        const regressive = clonePublicationState(after);
+        regressive.releases![0].assets = regressive.releases![0].assets.filter(
+          asset => asset.name !== earlier
+        );
+        return Array.from({ length: 4 }, () => clonePublicationState(regressive));
+      }
+    );
+
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining(`mutation-outcome-unobserved:upload-asset:123:${current}`),
+    });
+    expect(adapter.log.filter(item => item === `upload-asset:${current}`)).toHaveLength(1);
+    expect(adapter.applied.filter(item => item === `upload-asset:${current}`)).toHaveLength(1);
+    expect(adapter.log.filter(item => item === `upload-asset:${earlier}`)).toHaveLength(1);
+    expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
+  });
+
+  it('does not repeat a mutation when every observation retains the same action key', async () => {
+    const bundle = publicationBundle();
+    const adapter = queueMutationInspections(
+      new FakeGitHubPublicationAdapter(),
+      'create-draft',
+      before => Array.from({ length: 4 }, () => clonePublicationState(before))
+    );
+
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining('mutation-outcome-unobserved:create-draft'),
+    });
+    expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(1);
+    expect(adapter.applied.filter(item => item === 'create-draft')).toHaveLength(1);
+    expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(0);
+    expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
+  });
+
+  it.each(['create-tag', 'create-draft', 'upload-asset', 'publish-draft'] as const)(
+    'fails closed after an unapplied %s response loss without retrying the mutation',
     async point => {
       const bundle = publicationBundle();
       const adapter = new FakeGitHubPublicationAdapter({ loseBefore: [point] });
       await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
-        status: 'partial-resumable',
+        status: 'unknown-critical',
+        reason: expect.stringContaining('mutation-outcome-unobserved'),
         recovery: { production: 'restore-prior-baseline', automaticGitHubCleanup: false },
       });
-      await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
-        status: 'published',
-      });
-      expect(new Set(adapter.state.releases!.map(release => release.tag)).size).toBe(1);
-      expect(new Set(adapter.state.releases![0].assets.map(asset => asset.name)).size).toBe(
-        bundle.finalPlan.requiredAssets.length
-      );
+      expect(adapter.log.filter(item => item.startsWith(point))).toHaveLength(1);
+      if (point === 'create-tag') {
+        expect(adapter.log).not.toContain('create-draft');
+        expect(adapter.applied).toEqual([]);
+      }
     }
   );
+
+  it('ignores transient inspection failures and regressions until forward state is visible', async () => {
+    const bundle = publicationBundle();
+    const adapter = queueMutationInspections(
+      new FakeGitHubPublicationAdapter(),
+      'create-draft',
+      (before, after) => [
+        new Error('transient inspection failure'),
+        clonePublicationState(before),
+        clonePublicationState(after),
+      ]
+    );
+
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'published',
+    });
+    expect(adapter.applied.filter(item => item === 'create-draft')).toHaveLength(1);
+  });
+
+  it('fails closed when transient inspection failures never yield forward state', async () => {
+    const bundle = publicationBundle();
+    const adapter = queueMutationInspections(
+      new FakeGitHubPublicationAdapter(),
+      'create-draft',
+      before => [
+        new Error('transient inspection failure'),
+        clonePublicationState(before),
+        new Error('transient inspection failure'),
+        clonePublicationState(before),
+      ]
+    );
+
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining('mutation-outcome-unobserved'),
+    });
+    expect(adapter.applied.filter(item => item === 'create-draft')).toHaveLength(1);
+    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(1);
+  });
+});
+
+describe('pre-existing publication state', () => {
+  it('fails closed on an initial exact tag without mutating', async () => {
+    const { adapter: published, bundle } = await publishedAdapter();
+    const state = clonePublicationState(published.state);
+    state.releases = [];
+    const adapter = new FakeGitHubPublicationAdapter({ state });
+
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: 'pre-existing-publication-state',
+    });
+    expect(adapter.applied).toEqual([]);
+    expect(adapter.log).not.toContain('create-draft');
+  });
+
+  it('fails closed on an initial missing-asset draft without mutating', async () => {
+    const bundle = publicationBundle();
+    const adapter = await preexistingDraftAdapter(bundle);
+    adapter.state.releases![0].assets = adapter.state.releases![0].assets.filter(
+      asset => asset.name !== bundle.finalPlan.requiredAssets[0]
+    );
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: 'pre-existing-publication-state',
+    });
+    expect(adapter.applied).toEqual([]);
+  });
+
+  it('fails closed on an initial publish-ready draft without mutating', async () => {
+    const bundle = publicationBundle();
+    const adapter = await preexistingDraftAdapter(bundle);
+    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: 'pre-existing-publication-state',
+    });
+    expect(adapter.applied).toEqual([]);
+  });
 });
 
 describe('conflicts, unknown state, and bundle authentication', () => {


### PR DESCRIPTION
## Summary

- bound post-mutation GitHub publication convergence so create-draft, asset upload, and publish actions cannot repeat while their outcomes remain ambiguous
- require same-invocation tag and draft response identities, exact Release hydration, and fresh global same-tag uniqueness before every downstream mutation
- fail closed on every pre-existing partial publication state and convert legacy resume inputs into pre-checkout reset-and-replay tombstones
- preserve full-SHA GitHub Action pinning and document the reviewed reset-and-replay recovery boundary

## Test plan

- `npm run check:actions-node24`
- `bash test/github-actions-pinning.test.sh`
- `bash test/release-workflow-contract.test.sh`
- `npx vitest run test/release/publication.test.ts test/release/github-publication-adapter.test.ts test/release/live-release.test.ts`
- `npm run validate`
- `git diff --check origin/main...HEAD`

## Risk

This changes the production release controller's fail-closed publication and legacy-resume behavior. Temporary or ambiguous GitHub visibility may stop a release for reviewed reset-and-replay instead of continuing automatically; this is intentional. Legacy resume fields remain visible for compatibility but every non-empty value is rejected before checkout. The change does not authorize cleanup, tag or Release deletion, workflow dispatch, publication, or production mutation.
