### PR TITLE
test: expand risk-weighted coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,9 @@
+parsers:
+  javascript:
+    enable_partials: true
+  lcov:
+    partials_as_hits: false
+
 coverage:
   status:
     project:
@@ -13,6 +19,34 @@ coverage:
         only_pulls: true
         paths:
           - 'src/**'
+
+component_management:
+  default_rules:
+    flag_regexes:
+      - '^unit$'
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+        informational: true
+  individual_components:
+    - component_id: widget
+      name: Widget
+      paths:
+        - 'src/widget/**'
+    - component_id: backend
+      name: Backend
+      paths:
+        - 'src/index.ts'
+        - 'src/defaults.ts'
+        - 'src/types.ts'
+        - 'src/lib/**'
+        - 'src/middleware/**'
+        - 'src/routes/**'
+    - component_id: scripts
+      name: Scripts
+      paths:
+        - 'scripts/**'
 
 comment: false
 

--- a/docs/goals/expand-test-coverage-safely/goal.md
+++ b/docs/goals/expand-test-coverage-safely/goal.md
@@ -1,0 +1,129 @@
+# Expand BugDrop Test Coverage Safely
+
+## Objective
+
+Increase BugDrop's risk-weighted automated test coverage in successive reversible packages, beginning with GitHub authentication and persistence boundaries, while preserving real-browser behavior and establishing trustworthy component-level Codecov reporting.
+
+## Original Request
+
+"In a fresh work tree off main GitHub make a detailed implementation plan using GoalBuddyPrep for expanding our test coverage safely and efficiently."
+
+## Intake Summary
+
+- Input shape: `existing_plan`
+- Audience: BugDrop maintainers and contributors
+- Authority: `requested`
+- Proof type: `test`
+- Completion proof: All required repository gates and targeted real-browser tests pass; current-main coverage improves from the recorded baseline without excluding difficult files or weakening Codecov partial handling; direct tests prove the critical GitHub/JWT, submission, capture/privacy, and interaction boundaries; a final Judge maps receipts to the oracle.
+- Goal oracle: A commit-pinned coverage comparison plus passing unit, type, lint, build, and Playwright gates demonstrates at least 72% Vitest line coverage and 67% branch coverage, closes the named critical zero-coverage gaps, and shows no behavioral regression or coverage gaming.
+- Likely misfire: Raising the aggregate percentage with brittle jsdom/canvas mocks, broad exclusions, or script-heavy tests while GitHub credentials, submission, capture cleanup, and real pointer/canvas behavior remain weak.
+- Blind spots considered: Codecov treats partial lines more strictly than Vitest; Playwright currently does not contribute coverage; subprocess scripts can be false negatives; release tooling masks weaker product coverage; source refactors change the denominator; fork and merge-queue reporting must remain safe.
+- Existing plan facts: Two independent audits prioritized GitHub/JWT first, followed by submission/form lifecycle, privacy/capture leaf modules, interaction primitives, selective bootstrap seam extraction, and branch-hardening. Preserve strict Codecov partial handling, keep reporting informational until representative PR/merge-queue/public-fork evidence exists, and use targeted Playwright tests as the browser oracle.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`From a commit-pinned current-main baseline of Vitest 64.23% lines / 63.52% branches and Codecov 55.25%, receipts show risk-weighted direct tests, Vitest >=72% lines and >=67% branches without exclusions or weakened partial semantics, all repository gates pass, targeted Playwright tests preserve real-browser behavior, and a final Judge records full_outcome_complete: true.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, a passing tiny slice, or a clean-looking board is not enough. The goal finishes only when a final Judge/PM audit maps receipts and verification back to this oracle and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`existing_plan`
+
+## Current Tranche
+
+Validate the audit-derived plan against fresh `origin/main`, then complete successive safe test packages: direct GitHub/JWT contracts; submission and form lifecycle; privacy/capture leaves; interaction primitives with real-browser proof; trustworthy component reporting; and only then a bounded bootstrap-seam extraction or branch-hardening package if needed to meet the oracle. Continue until the full tranche is proven complete.
+
+## Implementation Roadmap
+
+### Phase 0: Validate truth before writing
+
+The active Judge reproduces both native Vitest and strict Codecov semantics on the execution commit, inventories existing tests and measurement blind spots, and converts the first Worker card from planned filenames to verified paths. The baseline receipt must include commit SHA, totals, component totals, and an explanation of partial lines. No threshold is tightened in this phase.
+
+### Phase 1: Secure the external GitHub boundary
+
+Add direct cryptographic and HTTP-contract tests for `src/lib/jwt.ts` and `src/lib/github.ts`. Use ephemeral RSA keys, frozen time, decoded claim assertions, actual signature verification, exact fetch contracts, installation-token failure cases, public/private repository behavior, issue-label `422` classification, branch creation, concurrent first uploads, collision handling, sanitization, and upload failures. Expected gain: roughly 1.3–1.6 native line points, with a larger risk reduction than the number suggests.
+
+### Phase 2: Submission lifecycle and privacy/capture leaves
+
+Test submission payload/authentication/redaction, malformed responses, duplicate-submit prevention, cancellation, retries, disposal, and reset. Then cover console serialization/redaction/bounds, capture rejection and surface validation, timeout/canvas failures, guaranteed track cleanup, screenshot-option decisions, and annotation modal teardown. Expected cumulative gain after Phase 2: roughly 3–4 native line points over baseline.
+
+### Phase 3: Interaction primitives with browser proof
+
+Add focused state-machine tests for picker target resolution, desktop/touch/coarse-pointer paths, cancellation and listener cleanup, area normalization/clamping/minimum size, annotation scaling/undo/outside-canvas completion, and teardown. DOM/canvas mocks may prove state transitions only; existing Playwright tests remain the behavioral oracle and at least one real output or pixel assertion must cover annotation/capture changes. Expected cumulative native line coverage: approximately 71–72%.
+
+### Phase 4: Make reporting representative
+
+After a read-only topology Scout and policy Judge, expose separate Codecov components for widget, backend, and scripts. Preserve partials-as-misses. If browser instrumentation produces correct source maps without duplicate bundle paths or unsafe fork credentials, upload it under a distinct `e2e` flag rather than blending it with `unit`. Keep statuses informational until representative PR, merge-queue, docs-only, and public-fork evidence exists.
+
+### Phase 5: Conditional structural and branch hardening
+
+Only if the oracle is still unmet and a Judge finds behaviorally useful seams, extract a small coherent portion of the widget bootstrap—configuration parsing, metadata/redaction, persistence, upload validation, trigger position, or payload construction—behind direct tests. Do not build a monolithic jsdom import harness. Then target meaningful partial branches in API/structured-feedback routes and release publication code, prioritizing malformed external responses, idempotency, concurrency, and ambiguous state. These tasks may be skipped with a Judge receipt if they would add more refactor risk than test value.
+
+### Phase 6: Full proof and threshold recommendation
+
+Run the complete repository gate, full browser suite, coverage report parsing, and adversarial disproof checks. The final Judge verifies no exclusions, assertion-light execution tests, weakened Codecov settings, or script-heavy denominator masking were used. It recommends—but does not externally apply—future blocking thresholds based on stable evidence.
+
+## Non-Negotiable Constraints
+
+- Follow `AGENTS.md` and `CLAUDE.md`, including fresh-main hygiene and burden of proof.
+- Begin from `origin/main` commit `e0c5ece8edbbe5692cb5c540555fe6f3154130a7`; rebase or recreate from newer `origin/main` before implementation if main advances materially.
+- Do not weaken production behavior, skip hard files, add coverage exclusions, set Codecov partials as hits, or write assertion-light execution tests merely to increase a percentage.
+- Preserve existing Playwright coverage and require targeted real-browser proof for pointer, canvas, capture, Shadow DOM, mobile, or screenshot behavior.
+- Keep changes reversible and split production refactors from pure test additions when practical.
+- Do not install apps, create accounts or secrets, change branch protection, push, open a PR, or mutate external services without explicit owner approval.
+- Use current repository pinning, CI event, fork, docs-only, merge-queue, and required-check policies as constraints for any Codecov reporting changes.
+- Run `codex-pr-review-toolkit:review-pull-request` against the base before any pull request is merged.
+
+## Verification Policy
+
+Package-level commands are narrow for fast feedback, followed by the full oracle commands at phase boundaries:
+
+```bash
+npm test -- --coverage
+npm run lint
+npm run format:check
+npm run typecheck
+npm run build:widget
+npm run test:e2e
+make check
+```
+
+Coverage evidence must parse `coverage/coverage-summary.json` and `coverage/lcov.info`, record the commit SHA, compare line and branch deltas by product component, and retain Codecov's hit/partial/miss interpretation. A green upload step alone is not proof that Codecov processed the report.
+
+## Stop Rule
+
+Stop only when a final audit proves the full original outcome is complete.
+
+Do not stop after planning, discovery, or Judge selection if the user asks to start the execution goal and a safe Worker task can be activated.
+
+Do not stop after a single verified Worker package when the broader owner outcome still has safe local follow-up work. Advance the board to the next highest-leverage safe Worker package unless a phase, risk, rejected-verification, ambiguity, or final-completion review is due.
+
+If an exact human approval phrase is the only remaining blocker and no safe local work remains, preserve it in the blocked receipt, set `waiting_for_user_approval: true`, set the goal blocked, and clear the active task.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. Each Worker should finish a coherent behavioral boundary, not a single helper or percentage-only microtask. Judge reviews occur at security, browser-behavior, measurement-policy, and final boundaries.
+
+## Board Health
+
+The PM owns board health. If the board looks stale or inconsistent, run:
+
+```bash
+node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.4.3/skills/goal-prep/scripts/check-goal-state.mjs docs/goals/expand-test-coverage-safely
+```
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/expand-test-coverage-safely/state.yaml`
+
+## Run Command
+
+```text
+Codex: /goal Follow docs/goals/expand-test-coverage-safely/goal.md.
+Claude Code: /goalbuddy Follow docs/goals/expand-test-coverage-safely/goal.md.
+```

--- a/docs/goals/expand-test-coverage-safely/state.yaml
+++ b/docs/goals/expand-test-coverage-safely/state.yaml
@@ -1,0 +1,2485 @@
+# GoalBuddy v2 state.yaml
+version: 2
+
+goal:
+  title: "Expand BugDrop Test Coverage Safely"
+  slug: "expand-test-coverage-safely"
+  kind: existing_plan
+  tranche: "Validate the existing audit plan, then complete successive safe verified coverage packages until the risk-weighted oracle is met."
+  status: done
+  oracle:
+    signal: "Commit-pinned coverage improves from 64.23% lines / 63.52% branches to at least 72% lines / 67% branches while critical gaps close and all unit, static, build, and targeted browser gates pass."
+    cadence: "after each Worker package and at final audit"
+    final_proof: "Receipt-backed baseline/delta report, targeted adversarial proof, full gate results, real-browser evidence, and final Judge full_outcome_complete: true."
+  intake:
+    original_request: "Prepare a detailed GoalBuddy implementation plan in a fresh worktree off GitHub main for safely and efficiently expanding test coverage."
+    interpreted_outcome: "A validated, executable board drives risk-first coverage improvements without gaming metrics or regressing browser behavior."
+    input_shape: existing_plan
+    audience: "BugDrop maintainers and contributors"
+    authority: requested
+    proof_type: test
+    completion_proof: "All planned high-risk boundaries have direct meaningful tests, the coverage oracle is met, and repository plus browser verification remains green."
+    likely_misfire: "Increase aggregate coverage through brittle mocks, exclusions, or low-risk script tests while production-critical gaps remain."
+    blind_spots_considered:
+      - "Codecov counts partial lines more strictly than Vitest."
+      - "Playwright behavior is currently absent from uploaded unit LCOV."
+      - "Subprocess execution can appear as zero Vitest coverage."
+      - "Release scripts can mask weak product-code coverage."
+      - "Coverage-driven source extraction can introduce regressions."
+      - "Public forks, docs-only PRs, and merge queue events need reporting proof."
+    existing_plan_facts:
+      - "Current main e0c5ece: 56 files and 895 tests pass; Vitest 64.23% lines and 63.52% branches."
+      - "Current Codecov main: 55.25%, with 762 partial lines."
+      - "Direct GitHub/JWT tests are the highest-risk first package."
+      - "Submission/form, capture/privacy, interaction primitives, bootstrap seams, and branch debt follow in that order subject to Judge validation."
+      - "Keep Codecov reporting informational until representative event/fork evidence exists."
+      - "Trusted post-T014 baseline: 58 files and 909 tests pass; Vitest is 65.92% lines (4660/7069) and 64.27% branches (3692/5744)."
+      - "Trusted post-T004 baseline: 60 files and 923 tests pass; Vitest is 66.72% lines (4717/7069) and 65.16% branches (3743/5744)."
+      - "Trusted post-T017 baseline: 64 files and 949 tests plus three targeted Chromium cases pass; Vitest is 69.17% lines and 66.36% branches."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  exact_human_approval_can_terminal_wait: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/expand-test-coverage-safely/"
+    command: "node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.4.3/skills/goal-prep/surfaces/local-goal-board/scripts/local-goal-board.mjs --goal docs/goals/expand-test-coverage-safely"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate the two-audit coverage plan against fresh origin/main and specify the largest safe first implementation package."
+    inputs:
+      - "goal.md existing plan facts and oracle"
+      - "origin/main at execution time"
+      - "Vitest, Playwright, CI, and Codecov configuration"
+    constraints:
+      - "Read-only."
+      - "Preserve risk priority over percentage maximization."
+      - "Reproduce the current-main baseline and distinguish genuine gaps from measurement blind spots."
+    expected_output:
+      - "Validated or corrected baseline"
+      - "Decision on first Worker package"
+      - "Exact allowed_files"
+      - "Exact verification and adversarial disproof commands"
+      - "Stop conditions and deferred risks"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "Fresh remote main, local HEAD, and origin/main all resolve to e0c5ece8edbbe5692cb5c540555fe6f3154130a7. Commit-pinned CI and its LCOV artifact validate 64.23% lines and 63.52% branches; Codecov independently reports 55.25% with 762 partials. JWT is genuinely untested and GitHub is only incidentally executed while route tests mock the boundary. The largest safe first slice is the complete JWT/GitHub contract package in two new tests. It needs no production seam; any collision or concurrent-branch defect must stop the Worker rather than be characterized as acceptable behavior."
+      worker_package:
+        objective: "Add direct, network-free tests for the complete GitHub authentication and persistence boundary: cryptographically verify PKCS#8 and PKCS#1 RS256 JWTs with frozen claims and malformed-key failures; assert exact installation lookup/token, issue, visibility, branch, screenshot, attachment, sanitization, and failure contracts; actively disprove safety under concurrent first upload and same-millisecond filename collision. Do not change production code or coverage configuration."
+        allowed_files:
+          - test/jwt.test.ts
+          - test/github.test.ts
+        verify:
+          - "test \"$(git ls-remote origin refs/heads/main | cut -f1)\" = \"$(git rev-parse HEAD)\""
+          - "npx vitest run test/jwt.test.ts test/github.test.ts --coverage"
+          - "npx vitest run test/jwt.test.ts -t 'cryptographically verifies RS256 and rejects altered signing input'"
+          - "npx vitest run test/github.test.ts -t 'fails closed when the observed URL, method, authorization header, API version, or body is mutated'"
+          - "npx vitest run test/github.test.ts -t 'does not silently accept concurrent first-upload or same-millisecond collisions'"
+          - "npm run typecheck"
+          - "npm run lint"
+          - "npx prettier --check test/jwt.test.ts test/github.test.ts"
+          - "npm test -- --coverage"
+          - "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+          - "git diff --check"
+          - "git diff --exit-code e0c5ece8edbbe5692cb5c540555fe6f3154130a7 -- src/lib/jwt.ts src/lib/github.ts vitest.config.ts playwright.config.ts codecov.yml .github/workflows/ci.yml"
+        stop_if:
+          - "Remote main no longer equals the execution commit; return for PM reorientation."
+          - "A production source change or new seam is required for deterministic contract testing."
+          - "The concurrency or timestamp-collision disproof demonstrates unsafe current behavior; preserve the failing test, do not encode the defect as expected success, and return the smallest production-fix proposal."
+          - "The real GitHub response contract is ambiguous, including classification of concurrent branch-creation 422 responses."
+          - "Ephemeral RSA generation, PKCS#1 conversion, or public-key signature verification cannot be deterministic on Node 22."
+          - "Any test attempts a real network request."
+          - "Verification fails twice for the same unexplained reason."
+          - "Either allowed file contains overlapping user changes."
+      evidence:
+        - kind: commit_pin
+          detail: "git ls-remote origin refs/heads/main, git rev-parse origin/main, and git rev-parse HEAD all returned e0c5ece8edbbe5692cb5c540555fe6f3154130a7."
+        - kind: native_baseline
+          detail: "GitHub Actions run 31106093302, Unit Tests & Build job 92631752105: 56 files and 895 tests passed; coverage was 63.44% statements, 63.52% branches, 66.26% functions, and 64.23% lines."
+        - kind: lcov_counts
+          detail: "Downloaded artifact unit-coverage-31106093302-1: 4535/7060 lines, 3644/5736 branches, and 878/1325 functions. Recursive components were scripts 2516/3332 lines and 2192/3111 branches; src 2019/3728 lines and 1452/2625 branches; src/widget 1267/2799 lines and 910/1925 branches; src/lib 78/202 lines and 60/112 branches."
+        - kind: critical_gap
+          detail: "LCOV records src/lib/jwt.ts at 0/48 lines and 0/10 branches, and src/lib/github.ts at 3/74 lines and 0/33 branches. No test directly references their exported functions; test/api.test.ts and test/structuredFeedback.test.ts mock the GitHub module."
+        - kind: codecov_baseline
+          detail: "Codecov API report for the pinned SHA returned 80 files, 7531 line statuses, 4161 hits, 2608 misses, 762 partials, and 55.25% coverage. Its pinned file totals are JWT 0/48 and GitHub 3/75."
+        - kind: measurement_blind_spot
+          detail: "Vitest excludes e2e/** and CI uploads only coverage/lcov.info under the unit flag. Playwright executes the real bundle but contributes no uploaded coverage; Codecov therefore reports src/widget/index.ts as 0/639 despite browser execution."
+        - kind: semantic_difference
+          detail: "The LCOV artifact has 7060 DA lines plus 482 branch-only source lines; Codecov parses branch-aware line states into a 7531-line denominator and keeps 762 partials separate from hits. The 64.23% and 55.25% figures are not interchangeable."
+        - kind: fresh_main_gates
+          detail: "Pinned merge-group run 31106093302 passed unit/build, both E2E shards, Chromium/Firefox/WebKit Radix E2E, deploy preview, live preview, and reporting-only coverage upload."
+        - kind: adversarial_source_inspection
+          detail: "uploadScreenshotAsAsset and uploadAttachmentAsAsset derive names solely from Date.now(), while ensureScreenshotBranch independently checks then creates the branch. Same-millisecond names and concurrent first creation are realistic failure modes that must be disproved before claiming risk closure."
+        - kind: read_only_proof
+          detail: "Final repository status matched the initial status exactly: only the pre-existing untracked GoalBuddy directory was present."
+      blocked_tasks: []
+      missing_evidence:
+        - "An independent local rerun was not performed because this read-only worktree has no node_modules and Judge may not install dependencies; the exact-commit CI execution and downloadable LCOV artifact provide the baseline execution proof."
+        - "No trustworthy Playwright-to-src/widget coverage mapping exists; browser coverage must remain a separate deferred reporting question."
+        - "The intended recovery contract for concurrent branch creation and filename collision is not established; T002 must stop if its disproof exposes a production defect."
+      required_board_updates:
+        - "Record T001 done with this corrected, count-backed baseline."
+        - "Activate T002 using this exact worker_package, including the commit-pin, mutation-focused commands, prettier check, and collision stop condition."
+        - "Preserve the 64.23% line / 63.52% branch oracle and the distinct Codecov 55.25% baseline; do not compare them as equivalent denominators."
+        - "Keep Playwright coverage, Codecov components, thresholds, and production collision fixes deferred until their scheduled Judge boundaries or a T002 stop receipt requires reorientation."
+  - id: T002
+    type: worker
+    assignee: Worker
+    status: blocked
+    reasoning_hint: medium
+    objective: "Add direct, network-free tests for the complete GitHub authentication and persistence boundary: cryptographically verify PKCS#8 and PKCS#1 RS256 JWTs with frozen claims and malformed-key failures; assert exact installation lookup/token, issue, visibility, branch, screenshot, attachment, sanitization, and failure contracts; actively disprove safety under concurrent first upload and same-millisecond filename collision. Do not change production code or coverage configuration."
+    inputs:
+      - "T001 validated plan and exact paths"
+      - "src/lib/jwt.ts"
+      - "src/lib/github.ts"
+      - "Existing route tests that mock the GitHub boundary"
+    constraints:
+      - "Test production behavior without changing it."
+      - "Use real ephemeral RSA key pairs and verify signatures cryptographically."
+      - "Assert exact URLs, methods, authorization headers, bodies, and error classification."
+      - "Cover concurrent first upload or timestamp collision as the strongest realistic failure mode."
+      - "Do not make network calls."
+    expected_output:
+      - "JWT tests for PKCS#8, PKCS#1, claims, signature, frozen clock, and malformed key failures"
+      - "GitHub tests for installation lookup/token, public/private visibility, label 422 handling, branch paths, sanitization, concurrency, and upload failures"
+      - "Before/after file and component coverage receipt"
+      - "A deliberate signature/header/method mutation is detected by the new tests"
+    allowed_files:
+      - "test/jwt.test.ts"
+      - "test/github.test.ts"
+    verify:
+      - "test \"$(git ls-remote origin refs/heads/main | cut -f1)\" = \"$(git rev-parse HEAD)\""
+      - "npx vitest run test/jwt.test.ts test/github.test.ts --coverage"
+      - "npx vitest run test/jwt.test.ts -t 'cryptographically verifies RS256 and rejects altered signing input'"
+      - "npx vitest run test/github.test.ts -t 'fails closed when the observed URL, method, authorization header, API version, or body is mutated'"
+      - "npx vitest run test/github.test.ts -t 'does not silently accept concurrent first-upload or same-millisecond collisions'"
+      - "npm run typecheck"
+      - "npm run lint"
+      - "npx prettier --check test/jwt.test.ts test/github.test.ts"
+      - "npm test -- --coverage"
+      - "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+      - "git diff --check"
+      - "git diff --exit-code e0c5ece8edbbe5692cb5c540555fe6f3154130a7 -- src/lib/jwt.ts src/lib/github.ts vitest.config.ts playwright.config.ts codecov.yml .github/workflows/ci.yml"
+    stop_if:
+      - "Remote main no longer equals the execution commit; return for PM reorientation."
+      - "A production source change or new seam is required for deterministic contract testing."
+      - "The concurrency or timestamp-collision disproof demonstrates unsafe current behavior; preserve the failing test, do not encode the defect as expected success, and return the smallest production-fix proposal."
+      - "The real GitHub response contract is ambiguous, including classification of concurrent branch-creation 422 responses."
+      - "Ephemeral RSA generation, PKCS#1 conversion, or public-key signature verification cannot be deterministic on Node 22."
+      - "Any test attempts a real network request."
+      - "Verification fails twice for the same unexplained reason."
+      - "Either allowed file contains overlapping user changes."
+    receipt:
+      result: blocked
+      changed_files:
+        - test/github.test.ts
+      commands:
+        - cmd: "test \"$(git ls-remote origin refs/heads/main | cut -f1)\" = \"$(git rev-parse HEAD)\""
+          status: passed
+        - cmd: "npx vitest run test/github.test.ts -t 'does not silently accept concurrent first-upload or same-millisecond collisions'"
+          status: "failed: concurrent first uploads do not both fulfill when GitHub returns 422 for the racing branch creation"
+      summary: "Preserved an adversarial, network-free failing test. Two concurrent first uploads both observe the screenshot branch as missing; one creates it while the other receives 422 and fails. This triggers the mandated stop condition before the broader package. Smallest proposed source fix: recover from the specific already-existing-ref response by rechecking the branch, and add collision-resistant asset naming or bounded conflict retry for same-millisecond uploads."
+      deviations:
+        - "Stopped before JWT and remaining GitHub contract tests because the required concurrency disproof exposed unsafe production behavior."
+      remaining_blockers:
+        - "Concurrent first-upload branch creation is unsafe."
+        - "The exact GitHub 422 classification/recovery contract requires PM/Judge clarification."
+        - "Same-millisecond asset names remain timestamp-only and collision-prone."
+      verification_attempts: 1
+      stopped_because: "The concurrency disproof demonstrated unsafe current behavior; per T002 stop_if, the failing test was preserved and no production source was changed."
+  - id: T003
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit the GitHub/JWT package at the security boundary and authorize or correct the next phase."
+    inputs:
+      - "T002 receipt and diff"
+      - "Targeted and full verification output"
+    constraints:
+      - "Read-only."
+      - "Reject token-shape-only tests, incomplete HTTP assertions, or tests that pass after a realistic security mutation."
+    expected_output:
+      - "Security-boundary verdict"
+      - "Missing adversarial cases"
+      - "Coverage delta and risk reduction"
+      - "Authorization or correction for T004"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "The defect is confirmed, so T004 is not authorized. Recovery must require status 422, an exactly parsed \"Reference already exists\" message, and a successful ref recheck; unrelated 422s must fail. Collision-resistant naming belongs in the same package because both defects affect concurrent asset persistence. Since T002 stopped before its JWT and HTTP-contract work, the safe slice combines the narrow GitHub production repair with completion of the original boundary tests, followed by another Judge gate."
+      worker_package:
+        objective: "Repair and fully test the GitHub/JWT security boundary without changing public APIs: make branch initialization fail closed on non-404 lookup failures; recover from concurrent creation only when a 422 JSON response has message exactly \"Reference already exists\" and a subsequent fetch confirms the screenshot ref; reject every other 422 or failed recheck; add cryptographically strong per-upload entropy to both screenshot and attachment paths while retaining timestamps and sanitized attachment names; preserve and split the failing concurrency/collision test; and complete the original network-free JWT and GitHub contract suite with exact URL, method, authorization, API-version, body, error-classification, visibility, sanitization, and mutation assertions."
+        allowed_files:
+          - src/lib/github.ts
+          - test/github.test.ts
+          - test/jwt.test.ts
+        verify:
+          - "test \"$(git ls-remote origin refs/heads/main | cut -f1)\" = \"$(git rev-parse HEAD)\""
+          - "npx vitest run test/github.test.ts -t 'recovers only from the exact already-existing-ref race after confirming the branch'"
+          - "npx vitest run test/github.test.ts -t 'rejects unrelated or malformed 422 responses and failed branch rechecks'"
+          - "npx vitest run test/github.test.ts -t 'uses distinct screenshot and attachment paths in the same millisecond'"
+          - "npx vitest run test/github.test.ts -t 'fails closed when the observed URL, method, authorization header, API version, or body is mutated'"
+          - "npx vitest run test/jwt.test.ts -t 'cryptographically verifies RS256 and rejects altered signing input'"
+          - "npx vitest run test/jwt.test.ts test/github.test.ts --coverage"
+          - "npm run typecheck"
+          - "npm run lint"
+          - "npx prettier --check src/lib/github.ts test/github.test.ts test/jwt.test.ts"
+          - "npm test -- --coverage"
+          - "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+          - "git diff --check"
+          - "git diff --exit-code e0c5ece8edbbe5692cb5c540555fe6f3154130a7 -- src/lib/jwt.ts vitest.config.ts playwright.config.ts codecov.yml .github/workflows/ci.yml"
+        stop_if:
+          - "Remote main no longer equals e0c5ece8edbbe5692cb5c540555fe6f3154130a7."
+          - "Recovery accepts every 422, uses substring matching, or treats a successful ref recheck alone as proof that the 422 was the already-existing-ref response."
+          - "Collision resistance requires a new dependency, public API change, or production change outside src/lib/github.ts."
+          - "JWT tests require changing src/lib/jwt.ts or introducing a test-only production seam."
+          - "Any test can reach the real network or lacks a default unexpected-request failure."
+          - "Any allowed file contains overlapping user changes."
+          - "Verification fails twice for the same unexplained reason."
+      evidence:
+        - kind: commit_pin
+          detail: "HEAD and the live origin/main ref both resolve to e0c5ece8edbbe5692cb5c540555fe6f3154130a7."
+        - kind: reproduced_failure
+          detail: "The targeted Vitest command ran one test and failed at the assertion requiring both concurrent first uploads to fulfill."
+        - kind: production_race
+          detail: "ensureScreenshotBranch performs an independent missing-ref check and rejects every failed create-ref response, including the racing caller's 422."
+        - kind: collision_source
+          detail: "Both uploadScreenshotAsAsset and uploadAttachmentAsAsset derive paths solely from Date.now(); same-millisecond calls can address the same GitHub contents path."
+        - kind: preserved_red_test
+          detail: "The new test requires both race scenarios to fulfill and unique upload paths; it does not encode either defect as successful behavior."
+        - kind: test_contract_gap
+          detail: "The race mock always returns 404 for the screenshot-ref lookup, so it cannot yet support the required post-422 confirmation. It also lacks exact branch-create method, headers, API-version, and body assertions."
+        - kind: incomplete_boundary
+          detail: "T002 created only test/github.test.ts. No JWT tests, complete GitHub HTTP assertions, full verification, or coverage delta exist."
+      blocked_tasks:
+        - T004
+      missing_evidence:
+        - "A split regression proving the branch becomes visible on the post-422 recheck."
+        - "Rejection tests for unrelated 422 JSON, malformed 422 bodies, and failed post-422 ref rechecks."
+        - "Fail-closed proof for an initial screenshot-ref lookup returning a status other than 404."
+        - "Independent same-millisecond uniqueness proof for screenshots and attachments."
+        - "Exact HTTP assertions for branch lookup, repository lookup, default-ref lookup, branch creation, and contents upload."
+        - "The complete PKCS#8, PKCS#1, claims, signature-mutation, frozen-clock, and malformed-key JWT suite."
+        - "Targeted and full green verification output plus component and aggregate coverage deltas."
+      required_board_updates:
+        - "Record T003 done with this decision while keeping full_outcome_complete false."
+        - "Keep T002 blocked and preserve its failing test and stop receipt; do not relabel the exposed behavior as success."
+        - "Do not activate T004. Insert a single Worker task using this worker_package so the production repair and unfinished security-boundary tests land together."
+        - "After that Worker receipt, require a Judge milestone review of the exact 422 classification, no-network proof, mutation resistance, full gates, and coverage delta before T004 can be considered."
+        - "Keep T004 queued until that follow-up Judge explicitly authorizes it."
+  - id: T014
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Repair and fully test the GitHub/JWT security boundary without changing public APIs: make branch initialization fail closed on non-404 lookup failures; recover from concurrent creation only when a 422 JSON response has message exactly 'Reference already exists' and a subsequent fetch confirms the screenshot ref; reject every other 422 or failed recheck; add cryptographically strong per-upload entropy to both screenshot and attachment paths while retaining timestamps and sanitized attachment names; preserve and split the failing concurrency/collision test; and complete the original network-free JWT and GitHub contract suite with exact URL, method, authorization, API-version, body, error-classification, visibility, sanitization, and mutation assertions."
+    inputs:
+      - "T002 blocked receipt and preserved failing test"
+      - "T003 security Judge decision"
+      - "src/lib/github.ts and src/lib/jwt.ts"
+    constraints:
+      - "No public API changes or new dependencies."
+      - "Only the exact parsed already-existing-reference 422 plus a successful recheck may recover."
+      - "Every unexpected request must fail the test; no real network access."
+      - "Do not edit src/lib/jwt.ts or coverage configuration."
+    expected_output:
+      - "Narrow concurrency recovery and collision-resistant asset paths"
+      - "Complete cryptographically verified JWT suite"
+      - "Exact GitHub HTTP contract and mutation-resistant tests"
+      - "Full green verification and coverage delta"
+    allowed_files:
+      - "src/lib/github.ts"
+      - "test/github.test.ts"
+      - "test/jwt.test.ts"
+    verify:
+      - "test \"$(git ls-remote origin refs/heads/main | cut -f1)\" = \"$(git rev-parse HEAD)\""
+      - "npx vitest run test/github.test.ts -t 'recovers only from the exact already-existing-ref race after confirming the branch'"
+      - "npx vitest run test/github.test.ts -t 'rejects unrelated or malformed 422 responses and failed branch rechecks'"
+      - "npx vitest run test/github.test.ts -t 'uses distinct screenshot and attachment paths in the same millisecond'"
+      - "npx vitest run test/github.test.ts -t 'fails closed when the observed URL, method, authorization header, API version, or body is mutated'"
+      - "npx vitest run test/jwt.test.ts -t 'cryptographically verifies RS256 and rejects altered signing input'"
+      - "npx vitest run test/jwt.test.ts test/github.test.ts --coverage"
+      - "npm run typecheck"
+      - "npm run lint"
+      - "npx prettier --check src/lib/github.ts test/github.test.ts test/jwt.test.ts"
+      - "npm test -- --coverage"
+      - "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+      - "git diff --check"
+      - "git diff --exit-code e0c5ece8edbbe5692cb5c540555fe6f3154130a7 -- src/lib/jwt.ts vitest.config.ts playwright.config.ts codecov.yml .github/workflows/ci.yml"
+    stop_if:
+      - "Remote main no longer equals e0c5ece8edbbe5692cb5c540555fe6f3154130a7."
+      - "Recovery accepts every 422, uses substring matching, or treats a successful ref recheck alone as proof that the 422 was the already-existing-ref response."
+      - "Collision resistance requires a new dependency, public API change, or production change outside src/lib/github.ts."
+      - "JWT tests require changing src/lib/jwt.ts or introducing a test-only production seam."
+      - "Any test can reach the real network or lacks a default unexpected-request failure."
+      - "Any allowed file contains overlapping user changes."
+      - "Verification fails twice for the same unexplained reason."
+    receipt:
+      result: done
+      changed_files:
+        - src/lib/github.ts
+        - test/github.test.ts
+        - test/jwt.test.ts
+      commands:
+        - cmd: "test \"$(git ls-remote origin refs/heads/main | cut -f1)\" = \"$(git rev-parse HEAD)\""
+          status: pass
+        - cmd: "npx vitest run test/github.test.ts -t 'recovers only from the exact already-existing-ref race after confirming the branch'"
+          status: pass
+        - cmd: "npx vitest run test/github.test.ts -t 'rejects unrelated or malformed 422 responses and failed branch rechecks'"
+          status: pass
+        - cmd: "npx vitest run test/github.test.ts -t 'uses distinct screenshot and attachment paths in the same millisecond'"
+          status: pass
+        - cmd: "npx vitest run test/github.test.ts -t 'fails closed when the observed URL, method, authorization header, API version, or body is mutated'"
+          status: pass
+        - cmd: "npx vitest run test/jwt.test.ts -t 'cryptographically verifies RS256 and rejects altered signing input'"
+          status: pass
+        - cmd: "npx vitest run test/jwt.test.ts test/github.test.ts --coverage"
+          status: pass
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "npm run lint"
+          status: pass
+        - cmd: "npx prettier --check src/lib/github.ts test/github.test.ts test/jwt.test.ts"
+          status: pass
+        - cmd: "npm test -- --coverage"
+          status: pass
+        - cmd: "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "git diff --exit-code e0c5ece8edbbe5692cb5c540555fe6f3154130a7 -- src/lib/jwt.ts vitest.config.ts playwright.config.ts codecov.yml .github/workflows/ci.yml"
+          status: pass
+      summary: "Implemented fail-closed branch lookup, exact parsed 422 race recovery with required ref confirmation, and UUID-backed asset paths. Added strict network-free GitHub contracts and real PKCS#8/PKCS#1 RSA JWT verification. Two genuinely concurrent first uploads completed with narrow race recovery. Targeted tests passed 14/14; the full suite passed 909/909. Coverage rose from 64.23% to 65.92% lines and 63.52% to 64.27% branches."
+      deviations:
+        - "Lint passed with six pre-existing warnings in generated coverage files."
+      remaining_blockers: []
+      verification_attempts: 1
+  - id: T015
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit the repaired GitHub/JWT boundary, exact 422 classification, collision resistance, no-network proof, mutation resistance, full gates, and coverage delta before authorizing T004."
+    inputs:
+      - "T014 receipt and diff"
+      - "T002 preserved failing-test evidence"
+      - "T003 recovery contract"
+    constraints:
+      - "Read-only."
+      - "Reject broad 422 recovery, substring classification, weak entropy, token-shape-only JWT tests, or unexpected-request fallthrough."
+      - "Require targeted and full green verification."
+    expected_output:
+      - "Security repair verdict"
+      - "Exact oracle and coverage delta"
+      - "Missing evidence or explicit authorization for T004"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "T014 soundly repairs the boundary. Recovery requires status 422, an exactly parsed \"Reference already exists\" message, and a successful ref recheck; initial non-404 lookups and all other 422 cases fail closed. Both asset types use cryptographic UUID entropy. Tests reject unexpected requests, assert complete HTTP contracts, and cryptographically verify PKCS#8/PKCS#1 JWTs plus an altered signing input. Independent targeted, static, formatting, diff, and 909-test coverage gates passed. T004 is authorized."
+      worker_package:
+        objective: "Add direct, deterministic, network-free tests for submission transport and feedback-form lifecycle: assert exact request URLs, methods, headers, authentication, and payloads; prove URL and metadata privacy redaction; cover secure-identifier success, fallback, malformed response, and failure behavior; and exercise busy-state duplicate suppression, cancellation, retry, disposal, listener cleanup, and reset through public behavior. Do not change production code or weaken validation."
+        allowed_files:
+          - test/variantSubmission.test.ts
+          - test/variantForm.test.ts
+          - test/variantManager.test.ts
+        verify:
+          - "test \"$(git ls-remote origin refs/heads/main | cut -f1)\" = \"$(git rev-parse HEAD)\""
+          - "npx vitest run test/variantSubmission.test.ts test/variantForm.test.ts test/variantManager.test.ts --coverage"
+          - "npm run typecheck"
+          - "npm run lint"
+          - "npx prettier --check test/variantSubmission.test.ts test/variantForm.test.ts test/variantManager.test.ts"
+          - "npm test -- --coverage"
+          - "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+          - "git diff --check"
+          - "git diff --exit-code e0c5ece8edbbe5692cb5c540555fe6f3154130a7 -- src/widget/variants/submission.ts src/widget/variants/form.ts src/widget/variants/manager.ts"
+        stop_if:
+          - "Remote main no longer equals e0c5ece8edbbe5692cb5c540555fe6f3154130a7."
+          - "A production seam, source change, or API-contract change is required."
+          - "The expected URL or metadata redaction policy is ambiguous."
+          - "Any test can reach the real network or lacks an unexpected-request failure."
+          - "Tests require private implementation assertions instead of public behavior and durable state transitions."
+          - "An allowed file contains overlapping user changes."
+          - "Verification fails twice for the same unexplained reason."
+      evidence:
+        - kind: exact_422_recovery
+          detail: "src/lib/github.ts recovers only when create-ref returns 422 and parsed JSON message equals \"Reference already exists\"; it then performs and requires an okay screenshot-ref recheck."
+        - kind: adversarial_422_tests
+          detail: "Tests reject \"Validation Failed\", a message containing extra text, malformed JSON, and the exact message followed by a 404 recheck."
+        - kind: fail_closed_lookup
+          detail: "An initial screenshot-ref response other than 404 now throws immediately; the test proves a 403 causes exactly one request."
+        - kind: collision_resistance
+          detail: "Screenshot and attachment paths include crypto.randomUUID() in addition to Date.now(); four same-millisecond uploads produced four distinct paths."
+        - kind: no_network_contract
+          detail: "Both GitHub test groups install default fetch mocks that throw on unexpected requests. Ordered request helpers assert URL, method, complete headers, API version, authorization, and JSON bodies."
+        - kind: jwt_cryptography
+          detail: "Tests generate an ephemeral 2048-bit RSA pair, verify PKCS#8 and converted PKCS#1 signatures with the public key, assert frozen claims, reject malformed keys, and prove altered signing input fails verification."
+        - kind: independent_targeted_verification
+          detail: "npx vitest run test/github.test.ts test/jwt.test.ts passed 2 files and 14 tests."
+        - kind: independent_full_verification
+          detail: "npm test -- --coverage passed 58 files and 909 tests. Typecheck, lint, Prettier, commit pin, diff-check, and protected-file diff checks also passed."
+        - kind: coverage_delta
+          detail: "Coverage moved from 64.23% to 65.92% lines (+1.69 points) and 63.52% to 64.27% branches (+0.75 points). Current counts are 4660/7069 lines and 3692/5744 branches."
+        - kind: boundary_coverage
+          detail: "src/lib/github.ts is 100% for lines, branches, functions, and statements. src/lib/jwt.ts is 93.75% lines, 70% branches, 100% functions, and 94% statements."
+      blocked_tasks: []
+      missing_evidence:
+        - "T004 submission and lifecycle risk coverage has not yet been implemented."
+        - "The overall 72% line / 67% branch oracle remains unmet; current coverage is 65.92% / 64.27%."
+        - "Targeted real-browser proof remains scheduled for the later browser-interaction package; T014 changed only the backend GitHub boundary."
+      required_board_updates:
+        - "Record T015 done with decision approved and full_outcome_complete false."
+        - "Authorize T004 using this worker_package and update its authorization input from T003 to T015."
+        - "Record 65.92% lines and 64.27% branches as the trusted post-T014 baseline."
+        - "Preserve the T002 blocked receipt and T014 repair receipt as the defect-discovery and closure chain."
+        - "Keep T005 and later tasks queued behind T004."
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Add direct, deterministic, network-free tests for submission transport and feedback-form lifecycle: assert exact request URLs, methods, headers, authentication, and payloads; prove URL and metadata privacy redaction; cover secure-identifier success, fallback, malformed response, and failure behavior; and exercise busy-state duplicate suppression, cancellation, retry, disposal, listener cleanup, and reset through public behavior. Do not change production code or weaken validation."
+    inputs:
+      - "T015 authorization"
+      - "src/widget/variants/submission.ts"
+      - "src/widget/variants/form.ts"
+      - "src/widget/variants/manager.ts"
+    constraints:
+      - "Prefer public behavior and durable state transitions over private implementation assertions."
+      - "Prove URL and metadata redaction and fail-closed handling of malformed server data."
+      - "Do not weaken validation to make tests pass."
+    expected_output:
+      - "Exact submission request and authentication tests"
+      - "Secure identifier success/fallback/failure tests"
+      - "Busy, duplicate, cancel, retry, disposal, and reset lifecycle tests"
+      - "Before/after component coverage receipt"
+    allowed_files:
+      - "test/variantSubmission.test.ts"
+      - "test/variantForm.test.ts"
+      - "test/variantManager.test.ts"
+    verify:
+      - "test \"$(git ls-remote origin refs/heads/main | cut -f1)\" = \"$(git rev-parse HEAD)\""
+      - "npx vitest run test/variantSubmission.test.ts test/variantForm.test.ts test/variantManager.test.ts --coverage"
+      - "npm run typecheck"
+      - "npm run lint"
+      - "npx prettier --check test/variantSubmission.test.ts test/variantForm.test.ts test/variantManager.test.ts"
+      - "npm test -- --coverage"
+      - "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+      - "git diff --check"
+      - "git diff --exit-code e0c5ece8edbbe5692cb5c540555fe6f3154130a7 -- src/widget/variants/submission.ts src/widget/variants/form.ts src/widget/variants/manager.ts"
+    stop_if:
+      - "Remote main no longer equals e0c5ece8edbbe5692cb5c540555fe6f3154130a7."
+      - "A production seam, source change, or API-contract change is required."
+      - "The expected URL or metadata redaction policy is ambiguous."
+      - "Any test can reach the real network or lacks an unexpected-request failure."
+      - "Tests require private implementation assertions instead of public behavior and durable state transitions."
+      - "An allowed file contains overlapping user changes."
+      - "Verification fails twice for the same unexplained reason."
+    receipt:
+      result: done
+      changed_files:
+        - test/variantSubmission.test.ts
+        - test/variantForm.test.ts
+        - test/variantManager.test.ts
+      commands:
+        - cmd: "test \"$(git ls-remote origin refs/heads/main | cut -f1)\" = \"$(git rev-parse HEAD)\""
+          status: pass
+        - cmd: "npx vitest run test/variantSubmission.test.ts test/variantForm.test.ts test/variantManager.test.ts --coverage"
+          status: pass
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "npm run lint"
+          status: pass
+        - cmd: "npx prettier --check test/variantSubmission.test.ts test/variantForm.test.ts test/variantManager.test.ts"
+          status: pass
+        - cmd: "npm test -- --coverage"
+          status: pass
+        - cmd: "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "git diff --exit-code e0c5ece8edbbe5692cb5c540555fe6f3154130a7 -- src/widget/variants/submission.ts src/widget/variants/form.ts src/widget/variants/manager.ts"
+          status: pass
+        - cmd: "npx vitest run test/variantSubmission.test.ts -t 'sends the exact URL, method, headers, authentication, payload, and redacted metadata|rejects malformed successful Issue responses'"
+          status: pass
+      summary: "Added 14 deterministic tests covering exact authenticated transport/payload, query/hash redaction, secure-ID UUID/fallback/failure paths, malformed responses, busy suppression, retry, cancellation, disposal, listener cleanup, and reset. Default fetch mocks reject unexpected requests. Full verification passed: 60 files, 923 tests; coverage is 4717/7069 lines (66.72%) and 3743/5744 branches (65.16%), improving the trusted baseline by 57 lines and 51 branches. Adversarial privacy/malformed-response isolation passed 5 tests."
+      deviations:
+        - "Initial lint found two unsafe optional-chain assertions and initial Prettier check found formatting differences; both were corrected using apply_patch, then the complete verification sequence passed. Lint retains six generated coverage-file warnings and zero errors."
+      remaining_blockers: []
+      verification_attempts: 2
+  - id: T005
+    type: worker
+    assignee: Worker
+    status: blocked
+    reasoning_hint: medium
+    objective: "Add deterministic privacy, console, viewport-capture, screenshot-option, and annotation-flow tests with cleanup proof on every error path."
+    inputs:
+      - "T004 receipt"
+      - "src/widget/console-logs.ts"
+      - "src/widget/viewport-capture.ts"
+      - "src/widget/screenshot-options.ts"
+      - "src/widget/annotation-flow.ts"
+    constraints:
+      - "Exercise serialization failures, rejection paths, delayed events, and cleanup—not only success paths."
+      - "Assert media tracks and listeners are cleaned exactly once."
+      - "Do not treat canvas mocks as proof of visual correctness."
+    expected_output:
+      - "Idempotent console wrapping, redaction, bounded immutable snapshots, and hostile-value serialization tests"
+      - "Capture unavailable/rejected/wrong-surface/no-frame/no-context/timeout tests"
+      - "Screenshot option and annotation lifecycle tests"
+      - "Before/after component coverage receipt"
+    allowed_files:
+      - "test/consoleLogs.test.ts"
+      - "test/viewportCapture.test.ts"
+      - "test/screenshotOptions.test.ts"
+      - "test/annotationFlow.test.ts"
+    verify:
+      - "npx vitest run test/consoleLogs.test.ts test/viewportCapture.test.ts test/screenshotOptions.test.ts test/annotationFlow.test.ts --coverage"
+      - "npm run typecheck"
+      - "npm test -- --coverage"
+    stop_if:
+      - "A browser-specific fact cannot be represented faithfully in the unit environment."
+      - "Production changes are required."
+      - "Verification fails twice for the same unexplained reason."
+    receipt:
+      result: blocked
+      changed_files:
+        - test/consoleLogs.test.ts
+        - test/viewportCapture.test.ts
+        - test/screenshotOptions.test.ts
+        - test/annotationFlow.test.ts
+      commands:
+        - cmd: "npx vitest run test/consoleLogs.test.ts test/viewportCapture.test.ts test/screenshotOptions.test.ts test/annotationFlow.test.ts --coverage"
+          status: fail
+      summary: "Added the four assigned deterministic test files. The first targeted run passed 21/23 tests but proved a production cleanup defect: when video.play() never settles, the outer capture timeout rejects while captureVideoFrame remains suspended before finally, leaving the media track unstopped. Stopped immediately because repairing this requires an unallowed source change."
+      deviations:
+        - "Remaining verification commands were not run after the production-change stop condition triggered."
+        - "One console truncation assertion also needs test-data correction because the long token-like input is redacted before truncation."
+      blockers:
+        - "Viewport timeout does not stop the media track or clear video.srcObject when video.play() remains pending."
+        - "The console truncation fixture requires a test-only correction if work resumes."
+      remaining_blockers:
+        - "Viewport timeout cleanup requires a production change outside allowed_files."
+        - "The console truncation fixture requires correction."
+      attempts: 1
+      verification_attempts: 1
+      stopped_because: "A required failure-cleanup test demonstrated that production changes are required, triggering T005 stop_if."
+  - id: T016
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit the preserved viewport-capture timeout leak and define the smallest fail-safe cleanup repair before privacy/capture coverage resumes."
+    inputs:
+      - "T005 blocked receipt and preserved failing tests"
+      - "src/widget/viewport-capture.ts"
+      - "Capture timeout orchestration and existing browser coverage"
+    constraints:
+      - "Read-only."
+      - "Do not normalize a leaked MediaStream track as expected behavior."
+      - "Distinguish cleanup ownership between the outer timeout and inner frame capture."
+      - "Keep the repair bounded and require exact-once cleanup."
+    expected_output:
+      - "Confirmed or rejected defect"
+      - "Smallest Worker package with exact allowed_files"
+      - "Race-safe verification and stop conditions"
+      - "Decision on resuming the remaining T005 tests"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "Confirmed. withCaptureTimeout rejects after 15 seconds but conveys no cancellation; captureVideoFrame owns cleanup only in a finally reached after waitForVideoFrame, whose first await can remain pending forever at video.play(). The preserved reproduction returns the timeout with stop count zero and an uncleared srcObject. A bounded repair may add timeout-only abort signaling, keep all stream/video cleanup in one idempotent inner owner, and drain late settlement or rejection. The console failure is fixture-only: x.repeat(1200) is intentionally redacted to [redacted], so spaced non-secret text can test truncation. T017 may finish the four preserved suites; T018 remains required."
+      worker_package:
+        objective: "Repair viewport timeout cleanup without changing public APIs or unrelated capture behavior. Extend the shared timeout helper with an optional timeout-only cancellation hook that runs before timeout rejection and never runs after ordinary settlement. In viewport capture, use that hook only to abort the operation; keep stream, video, frame-callback, and event-listener cleanup in one idempotent inner owner established immediately when a stream arrives. Make every wait abort-aware so stalled video.play() cannot hold finally open. Stop every acquired track exactly once, assign video.srcObject = null exactly once when it was attached, and prevent drawing after cancellation. Observe late getDisplayMedia and play fulfillment or rejection without unhandled rejections or duplicate cleanup. Preserve the timeout error. Correct the console truncation fixture with long spaced non-secret text, then complete all four preserved T005 suites."
+        allowed_files:
+          - src/widget/capture-timeout.ts
+          - src/widget/viewport-capture.ts
+          - test/viewportCapture.test.ts
+          - test/consoleLogs.test.ts
+          - test/screenshotOptions.test.ts
+          - test/annotationFlow.test.ts
+        cleanup_contract:
+          outer_owner: "withCaptureTimeout owns only the 15-second deadline and invokes an optional cancellation hook exactly once before rejecting with the existing localized timeout error. It must not directly stop streams or detach videos."
+          inner_owner: "viewport capture owns every acquired MediaStream, video attachment, frame callback, and loadeddata/canplay/error listener. One guarded cleanup function handles success, validation failure, timeout abort, and all later inner outcomes."
+          exact_once: "Each acquired track.stop() is called once. video.srcObject is set to null once if and only if the stream was attached. Validation must throw without separately stopping tracks; the shared cleanup owner performs that stop."
+          late_outcomes: "If getDisplayMedia resolves after timeout, immediately create the cleanup owner, detect the already-aborted signal, stop the stream, and do not call play or draw. If play settles or rejects after timeout, keep both handlers attached, perform no capture work, emit no unhandled rejection, and leave cleanup counts unchanged."
+        verify:
+          - "npx vitest run test/viewportCapture.test.ts -t 'cleans tracks and srcObject exactly once when stalled playback times out|observes late playback resolution and rejection without double cleanup|stops a stream that arrives after timeout'"
+          - "npx vitest run test/viewportCapture.test.ts --coverage"
+          - "npx vitest run test/consoleLogs.test.ts test/viewportCapture.test.ts test/screenshotOptions.test.ts test/annotationFlow.test.ts --coverage"
+          - "npm run typecheck"
+          - "npm run lint"
+          - "npx prettier --check src/widget/capture-timeout.ts src/widget/viewport-capture.ts test/consoleLogs.test.ts test/viewportCapture.test.ts test/screenshotOptions.test.ts test/annotationFlow.test.ts"
+          - "npm run build:widget"
+          - "npx playwright test e2e/widget.spec.ts --project=chromium --grep 'offers native viewport capture on very complex secure-context pages|returns to screenshot options after native viewport capture fails|rejects non-browser native capture surfaces before annotation'"
+          - "npm test -- --coverage"
+          - "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+          - "git diff --check"
+          - "git diff --exit-code -- e2e/widget.spec.ts src/widget/screenshot.ts src/widget/capture-flow.ts src/widget/capture-loading.ts src/widget/screenshot-options.ts"
+        stop_if:
+          - "Any production or test change is required outside allowed_files."
+          - "The repair changes the public API, timeout duration, localized timeout result, or non-viewport behavior of existing withCaptureTimeout callers."
+          - "The timeout hook cannot be limited to the actual timeout branch or can suppress the timeout rejection when cancellation fails."
+          - "Any success, wrong-surface, stalled-play, late-stream, late-play-resolution, or late-play-rejection case double-stops a track or clears srcObject more than once."
+          - "A late inner fulfillment draws a frame, changes the already-returned timeout result, or a late rejection is reported as unhandled."
+          - "Prompt cleanup still depends on the never-settling play promise reaching its own finally."
+          - "The browser gates disagree with unit cleanup behavior or require a test-only production seam, shortened production timeout, or edit to e2e/widget.spec.ts."
+          - "The 21 currently green preserved tests require unrelated production changes or semantic weakening."
+          - "An allowed file differs from the T005-preserved snapshot because of overlapping user work."
+          - "Verification fails twice for the same unexplained reason."
+      evidence:
+        - kind: executed_reproduction
+          detail: "The targeted viewport test failed after timeout with track.stop at zero calls; the timeout was returned but cleanup did not run."
+        - kind: preserved_suite
+          detail: "The four T005 files executed 23 tests: 21 passed and two failed, exactly the viewport cleanup defect and console truncation fixture."
+        - kind: source_trace
+          detail: "viewport-capture races the acquisition/frame promise against the timeout, but awaits video.play() before reaching its only finally cleanup."
+        - kind: timeout_ownership
+          detail: "capture-timeout only rejects and clears its timer; it provides no cancellation signal or hook."
+        - kind: late_stream_risk
+          detail: "A getDisplayMedia continuation remains live after Promise.race settles and can acquire a stream after the result is abandoned."
+        - kind: fixture_diagnosis
+          detail: "The long x-only fixture is intentionally redacted; spaced non-secret prose isolates truncation."
+        - kind: browser_coverage
+          detail: "Existing Chromium tests cover real viewport success, immediate acquisition failure/retry, and wrong-surface cleanup, but not never-settling play."
+        - kind: read_only_proof
+          detail: "Final git status matched the initial status; Judge made no changes."
+      parallel_safety:
+        safe: false
+        rationale: "T017 is one coherent resource-ownership repair; no concurrent writer may touch these files before T018."
+      blocked_tasks:
+        - T005
+        - T006
+      missing_evidence:
+        - "No repair exists yet; the viewport regression remains red."
+        - "Browser cases were inspected but not rerun under the read-only role."
+        - "Post-repair coverage delta and full verification remain for T017."
+        - "Late resolution/rejection proof must be explicit in unit tests."
+      required_board_updates:
+        - "Record T016 done."
+        - "Copy the complete worker package into T017 and activate it."
+        - "Keep T005 as historical blocked discovery evidence."
+        - "Keep T018 as mandatory post-repair Judge gate."
+        - "Do not activate T006 before T018 approval."
+  - id: T017
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Repair viewport timeout cleanup without changing public APIs or unrelated capture behavior. Extend the shared timeout helper with an optional timeout-only cancellation hook that runs before timeout rejection and never after ordinary settlement. In viewport capture, use that hook only to abort the operation; keep stream, video, frame-callback, and listener cleanup in one idempotent inner owner established immediately when a stream arrives. Make every wait abort-aware so stalled video.play() cannot hold finally open. Stop every acquired track exactly once, clear video.srcObject exactly once when attached, prevent drawing after cancellation, and observe late stream/play fulfillment or rejection without unhandled rejections or duplicate cleanup. Correct the console truncation fixture and complete all four T005 suites."
+    inputs:
+      - "T016 Worker package"
+      - "T005 preserved tests"
+    constraints:
+      - "Preserve the failing timeout regression and assert exact-once cleanup."
+      - "Do not broaden into visual behavior or unrelated capture refactoring."
+      - "The outer timeout owns only deadline/cancellation signaling; viewport capture owns all resource cleanup."
+      - "Late stream or play outcomes must be observed without capture work or unhandled rejection."
+    expected_output:
+      - "Green timeout leak regression"
+      - "Completed console, screenshot-option, and annotation-flow tests"
+      - "Targeted and full coverage delta"
+    allowed_files:
+      - "src/widget/capture-timeout.ts"
+      - "src/widget/viewport-capture.ts"
+      - "test/viewportCapture.test.ts"
+      - "test/consoleLogs.test.ts"
+      - "test/screenshotOptions.test.ts"
+      - "test/annotationFlow.test.ts"
+    verify:
+      - "npx vitest run test/viewportCapture.test.ts -t 'cleans tracks and srcObject exactly once when stalled playback times out|observes late playback resolution and rejection without double cleanup|stops a stream that arrives after timeout'"
+      - "npx vitest run test/viewportCapture.test.ts --coverage"
+      - "npx vitest run test/consoleLogs.test.ts test/viewportCapture.test.ts test/screenshotOptions.test.ts test/annotationFlow.test.ts --coverage"
+      - "npm run typecheck"
+      - "npm run lint"
+      - "npx prettier --check src/widget/capture-timeout.ts src/widget/viewport-capture.ts test/consoleLogs.test.ts test/viewportCapture.test.ts test/screenshotOptions.test.ts test/annotationFlow.test.ts"
+      - "npm run build:widget"
+      - "npx playwright test e2e/widget.spec.ts --project=chromium --grep 'offers native viewport capture on very complex secure-context pages|returns to screenshot options after native viewport capture fails|rejects non-browser native capture surfaces before annotation'"
+      - "npm test -- --coverage"
+      - "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+      - "git diff --check"
+      - "git diff --exit-code -- e2e/widget.spec.ts src/widget/screenshot.ts src/widget/capture-flow.ts src/widget/capture-loading.ts src/widget/screenshot-options.ts"
+    stop_if:
+      - "Any production or test change is required outside allowed_files."
+      - "The repair changes the public API, timeout duration, localized timeout result, or non-viewport behavior of existing withCaptureTimeout callers."
+      - "The timeout hook cannot be limited to the actual timeout branch or can suppress the timeout rejection when cancellation fails."
+      - "Any path double-stops a track or clears srcObject more than once."
+      - "A late outcome draws, changes the returned timeout result, or produces an unhandled rejection."
+      - "Prompt cleanup still depends on the never-settling play promise reaching its own finally."
+      - "Browser gates disagree or require an e2e edit or test-only production seam."
+      - "The 21 green preserved tests require unrelated semantic changes."
+      - "An allowed file has overlapping user work."
+      - "Verification fails twice for the same unexplained reason."
+    receipt:
+      result: done
+      changed_files:
+        - src/widget/capture-timeout.ts
+        - src/widget/viewport-capture.ts
+        - test/consoleLogs.test.ts
+        - test/viewportCapture.test.ts
+        - test/screenshotOptions.test.ts
+        - test/annotationFlow.test.ts
+      commands:
+        - cmd: "npx vitest run test/viewportCapture.test.ts -t 'cleans tracks and srcObject exactly once when stalled playback times out|observes late playback resolution and rejection without double cleanup|stops a stream that arrives after timeout'"
+          status: pass
+        - cmd: "npx vitest run test/viewportCapture.test.ts --coverage"
+          status: pass
+        - cmd: "npx vitest run test/consoleLogs.test.ts test/viewportCapture.test.ts test/screenshotOptions.test.ts test/annotationFlow.test.ts --coverage"
+          status: pass
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "npm run lint"
+          status: pass
+        - cmd: "npx prettier --check src/widget/capture-timeout.ts src/widget/viewport-capture.ts test/consoleLogs.test.ts test/viewportCapture.test.ts test/screenshotOptions.test.ts test/annotationFlow.test.ts"
+          status: pass
+        - cmd: "npm run build:widget"
+          status: pass
+        - cmd: "npx playwright test e2e/widget.spec.ts --project=chromium --grep 'offers native viewport capture on very complex secure-context pages|returns to screenshot options after native viewport capture fails|rejects non-browser native capture surfaces before annotation'"
+          status: pass
+        - cmd: "npm test -- --coverage"
+          status: pass
+        - cmd: "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "git diff --exit-code -- e2e/widget.spec.ts src/widget/screenshot.ts src/widget/capture-flow.ts src/widget/capture-loading.ts src/widget/screenshot-options.ts"
+          status: pass
+      summary: "Implemented timeout-only cancellation and one idempotent viewport resource owner. Stalled playback, late stream arrival, and late play fulfillment/rejection now stop tracks and clear attachments exactly once without drawing or changing the timeout error. Completed 26 focused privacy/capture tests. Full verification passed: 64 files, 949 tests, three Chromium cases, 69.17% lines and 66.36% branches."
+      deviations:
+        - "Initial typecheck, lint, and Prettier checks exposed small test/type issues that were corrected before the complete final verification sequence."
+        - "A strengthened delayed-event assertion initially revealed premature test synchronization; it now waits for real listener registration and proves each readiness listener is removed exactly once."
+        - "Lint passed with six pre-existing warnings from generated coverage files."
+      blockers: []
+      remaining_blockers: []
+      attempts: 2
+      verification_attempts: 2
+  - id: T018
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit viewport timeout cleanup, exact-once resource release, completed privacy/capture tests, and coverage delta before authorizing T006."
+    inputs:
+      - "T017 receipt and diff"
+      - "T005 defect discovery receipt"
+      - "T016 cleanup contract"
+    constraints:
+      - "Read-only."
+      - "Require the preserved timeout regression and full verification."
+      - "Reject cleanup that leaves an unobserved inner rejection or double-stops tracks."
+    expected_output:
+      - "Cleanup verdict"
+      - "Missing evidence or explicit authorization for T006"
+      - "Trusted post-repair baseline"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "Approved. The timeout helper invokes cancellation only from its timer and preserves the localized timeout if the hook throws. Viewport capture creates one guarded resource owner immediately after stream acquisition; abort cleans synchronously, inner finally becomes a no-op, and validation no longer double-stops. Abort-aware play, frame, and event waits retain late handlers, cancel callbacks and timers, remove listeners, and recheck cancellation before drawing. Independent focused reruns passed five adversarial and 26 package tests; the full rerun passed 64 files and 949 tests at 69.17% lines and 66.36% branches. Playwright artifacts report the three unchanged Chromium cases passed. T006 is authorized; the 72%/67% oracle remains unmet."
+      evidence:
+        - kind: ownership_audit
+          detail: "capture-timeout.ts adds only an optional callback invoked inside the 15-second timer. Successful capture clears the timer without invoking it, and callback exceptions are caught before the unchanged localized timeout rejection."
+        - kind: single_cleanup_owner
+          detail: "viewport-capture.ts creates one CaptureResourceOwner immediately after stream acquisition. Its cleaned guard makes abort cleanup and inner finally mutually idempotent; wrong-surface validation now throws without independently stopping tracks."
+        - kind: exact_once_resources
+          detail: "The stalled-play regression asserts one track stop, exactly two srcObject writes—stream then null—and no draw. Late play fulfillment and rejection retain the same cleanup counts and never draw."
+        - kind: late_stream_handling
+          detail: "A stream arriving after timeout creates its owner against an already-aborted signal, is stopped immediately, never attaches to video, never calls play, and never draws."
+        - kind: late_rejection_handling
+          detail: "play rejection is converted through an attached rejection handler before racing with abort. The independent Vitest run completed without unhandled-error output after exercising both late resolution and late rejection."
+        - kind: listener_cleanup
+          detail: "Readiness settlement clears its timer and removes loadeddata, canplay, error, and abort listeners. The delayed-loadeddata test waits for actual registration and asserts each video listener is removed exactly once. Frame waits cancel their registered callback and timer on settlement or abort."
+        - kind: focused_verification
+          detail: "Independent adversarial rerun passed five selected timeout, late-outcome, and listener cases. The four preserved T005 suites independently passed 26/26 tests with coverage enabled."
+        - kind: full_verification
+          detail: "Independent npm test -- --coverage passed 64 files and 949 tests. Independent typecheck, lint, Prettier, diff-check, and prohibited-file checks passed; lint emitted only six generated-coverage warnings."
+        - kind: trusted_baseline
+          detail: "coverage-summary.json records 4927/7123 lines, 69.17%; 3824/5762 branches, 66.36%; 963/1348 functions, 71.43%; and 5343/7837 statements, 68.17%."
+        - kind: browser_verification
+          detail: "T017 ran the exact three unchanged Chromium cases for native viewport success, acquisition failure/retry, and wrong-surface cleanup. The retained Playwright artifact reports status passed with no failed tests."
+        - kind: scope_and_complexity
+          detail: "Production changes are limited to capture-timeout.ts and viewport-capture.ts. The latter remains 228 lines, under the repository's 300-line limit; prohibited capture, screenshot, E2E, and configuration files have no T017 diff."
+        - kind: next_risk_slice
+          detail: "Current coverage shows picker.ts at 1/151 lines, area-picker.ts at 1/103, annotator.ts at 7/149, and picker-target.ts at 3/26, with zero covered functions in all four. T006 remains the risk-prioritized next vertical slice."
+      parallel_safety:
+        safe: false
+        rationale: "T006 combines four interacting unit surfaces with one shared browser oracle. Run it as one Worker package; do not concurrently edit e2e/widget.spec.ts."
+      blocked_tasks: []
+      missing_evidence:
+        - "The original 72% line and 67% branch oracle is not yet met."
+        - "Picker, area-picker, annotator, and picker-target still lack direct unit suites; T006 supplies that evidence."
+        - "The full widget Chromium suite and post-T006 coverage delta remain pending."
+      required_board_updates:
+        - "Record T018 done with decision approved."
+        - "Record 69.17% lines (4927/7123) and 66.36% branches (3824/5762) as the trusted post-T017 baseline."
+        - "Populate T006 with this exact worker_package and activate it."
+        - "Keep T005 as historical defect-discovery evidence and T017 as the verified repair receipt."
+        - "Keep T007 as the mandatory cumulative risk, browser-proof, and coverage Judge gate after T006."
+        - "Do not claim the full outcome complete until the 72%/67% oracle and remaining final gates are satisfied."
+      worker_package: null
+      subgoal_contract: null
+  - id: T006
+    type: worker
+    assignee: Worker
+    status: blocked
+    reasoning_hint: medium
+    objective: "Add direct deterministic tests for picker, area-picker, annotator, and picker-target state transitions without changing production code. Cover desktop, touch, and coarse-pointer selection; nested and SVG target normalization; owned-node exclusion; click suppression; cancellation and teardown; area clamping, minimum size, coordinate translation, and pointer cleanup; annotator coordinate scaling, tool output, undo ordering, unfinished-draft cancellation, and idempotent destruction. Use jsdom only for state and cleanup contracts. Preserve and run real bundled-widget Chromium cases for SVG/nested targets, mobile touch selection, click suppression, area geometry, annotation output, undo, and cropped screenshot behavior. Reuse existing output/pixel assertions when they already prove the browser contract; edit e2e/widget.spec.ts only for a demonstrated gap. Report per-file and aggregate coverage deltas."
+    inputs:
+      - "T005 receipt"
+      - "src/widget/picker.ts"
+      - "src/widget/area-picker.ts"
+      - "src/widget/annotator.ts"
+      - "src/widget/picker-target.ts"
+      - "Existing Playwright widget tests"
+    constraints:
+      - "Unit mocks cover state transitions and cleanup only."
+      - "Preserve real bundled-widget Playwright tests for pointer, canvas, Shadow DOM, mobile, and screenshot behavior."
+      - "Include at least one output- or pixel-level browser assertion for annotation/capture behavior."
+      - "Avoid duplicating every E2E case in jsdom."
+    expected_output:
+      - "Desktop/touch/coarse-pointer selection and nested/SVG target tests"
+      - "Cancellation, click suppression, clamping, minimum-size, coordinate-scaling, undo, and teardown tests"
+      - "Targeted Playwright proof against the real bundle"
+      - "Before/after component coverage receipt"
+    allowed_files:
+      - "test/picker.test.ts"
+      - "test/areaPicker.test.ts"
+      - "test/annotator.test.ts"
+      - "test/pickerTarget.test.ts"
+      - "e2e/widget.spec.ts"
+    verify:
+      - "npx vitest run test/picker.test.ts test/areaPicker.test.ts test/annotator.test.ts test/pickerTarget.test.ts --coverage"
+      - "npx vitest run test/picker.test.ts test/areaPicker.test.ts -t 'suppresses the selecting click|cancels and removes every listener|clamps selection and rejects undersized areas|normalizes touch and coarse-pointer input'"
+      - "npx vitest run test/annotator.test.ts test/pickerTarget.test.ts -t 'scales pointer coordinates to canvas pixels|undoes mixed completed annotations in order|cancels unfinished drafts|resolves nested SVG and clickable ancestors'"
+      - "npm run typecheck"
+      - "npm run lint"
+      - "npx prettier --check test/picker.test.ts test/areaPicker.test.ts test/annotator.test.ts test/pickerTarget.test.ts e2e/widget.spec.ts"
+      - "npm run build:widget"
+      - "npx playwright test e2e/widget.spec.ts --project=chromium --grep 'element picker handles nested SVG child elements without errors|area picker accepts touch drag selection on mobile|element picker prevents selected mobile tap from reaching the page|element picker selects nearest clickable ancestor from nested content|undo preserves mixed annotation history in the submitted screenshot|area-cropped capture preserves masks inside the selected region'"
+      - "npx playwright test e2e/widget.spec.ts --project=chromium"
+      - "npm test -- --coverage"
+      - "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+      - "git diff --check"
+      - "git diff --exit-code -- src/widget/picker.ts src/widget/area-picker.ts src/widget/annotator.ts src/widget/picker-target.ts playwright.config.ts vitest.config.ts"
+    stop_if:
+      - "Any production source, configuration, or file outside allowed_files must change."
+      - "A jsdom mock becomes the only oracle for pointer geometry, canvas pixels, Shadow DOM, SVG hit-testing, touch activation, or bundled-widget behavior."
+      - "Tests assert private implementation structure instead of public state transitions, emitted canvas output, listener cleanup, or durable DOM behavior."
+      - "The unit model requires fabricated PointerEvent, layout, or canvas behavior that disagrees with Chromium."
+      - "Existing output-level Chromium assertions cannot prove annotation or capture behavior and the missing proof cannot be added narrowly within e2e/widget.spec.ts."
+      - "A targeted Playwright regression requires broad widget bootstrap refactoring."
+      - "Coverage gains come primarily from import execution or trivial getters rather than picker, area, annotator, and target-resolution branches."
+      - "An allowed file contains overlapping user changes."
+      - "Verification fails twice for the same unexplained reason."
+    receipt:
+      result: blocked
+      changed_files:
+        - test/picker.test.ts
+        - test/areaPicker.test.ts
+        - test/annotator.test.ts
+        - test/pickerTarget.test.ts
+      commands:
+        - cmd: "npx vitest run test/picker.test.ts test/areaPicker.test.ts test/annotator.test.ts test/pickerTarget.test.ts --coverage"
+          status: fail
+        - cmd: "npx vitest run test/picker.test.ts test/areaPicker.test.ts test/annotator.test.ts test/pickerTarget.test.ts --coverage"
+          status: fail
+        - cmd: "npx vitest run test/picker.test.ts test/areaPicker.test.ts test/annotator.test.ts test/pickerTarget.test.ts --coverage"
+          status: fail
+      summary: "Added bounded public-contract suites in four allowed files; e2e/widget.spec.ts remained unchanged because existing named Chromium tests provide touch and pixel proof. After two fix attempts, focused verification still had one assertion mismatch: the redaction-aware prompt says private fields may be masked, not ‘redact.’ Per-file/aggregate coverage, browser proof, and remaining gates are unavailable because the mandated stop condition fired. No production/config/out-of-scope file was edited by this worker."
+      remaining_blockers:
+        - "Focused Vitest verification has one failing prompt-text assertion in test/areaPicker.test.ts."
+        - "Verification remained red after two fix attempts, so all later required commands were not run."
+        - "Coverage deltas and Chromium verification were not produced."
+      verification_attempts: 3
+      stopped_because: "Verification remained failing after the maximum two fix attempts."
+  - id: T007
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review cumulative risk reduction, assertion quality, browser proof, and coverage deltas before measurement or structural work."
+    inputs:
+      - "T002 through T006 receipts and diffs"
+      - "Current coverage reports"
+      - "Targeted Playwright results"
+    constraints:
+      - "Read-only."
+      - "Reject percentage gains caused primarily by low-value execution or brittle mocks."
+      - "Decide whether the 72%/67% oracle remains meaningful after denominator changes."
+    expected_output:
+      - "Phase verdict"
+      - "Risk-weighted gap list"
+      - "Trusted baseline for reporting work"
+      - "Decision whether structural extraction is justified later"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "The focused failure independently reproduces: 13/14 tests pass; only toContain('redact') fails against the public prompt ‘Marked private fields may be masked if included.’ Source and browser evidence show the wording is intentional, so no product contract is broken. Other tests exercise returned targets, coordinates, teardown, canvas calls/history, and disabled-role handling, while existing Chromium tests provide touch, nested SVG, pixel-mask, and submitted-image undo proof. With the bad case skipped, line coverage reaches 86.09% picker, 92.23% area-picker, 94.63% annotator, and 96.15% picker-target, demonstrating behavior-driven gains. Authorize one fixture/title correction plus deferred gates; the phase remains incomplete and the trusted aggregate baseline stays 69.17%/66.36%."
+      phase_verdict: not_complete_pending_bounded_t006_repair
+      trusted_baseline:
+        source: "T018 independently verified post-T017 full run"
+        test_files: 64
+        tests: 949
+        lines:
+          covered: 4927
+          total: 7123
+          pct: 69.17
+        branches:
+          covered: 3824
+          total: 5762
+          pct: 66.36
+      structural_extraction_decision: deferred_until_t006_is_green_and_the_cumulative_phase_gate_is_repeated
+      risk_weighted_gaps:
+        - priority: 1
+          gap: "T006 remains unverified as a complete package because its focused suite is red and all static, browser, full-unit, and aggregate-coverage gates were skipped."
+        - priority: 2
+          gap: "The aggregate oracle remains below 72% lines and 67% branches at the trusted 69.17%/66.36% baseline."
+        - priority: 3
+          gap: "No trusted post-T006 aggregate denominator or delta exists yet; the current focused coverage artifact is not an aggregate baseline."
+      evidence:
+        - kind: independent_reproduction
+          detail: "The exact four-file focused command failed 1/14. The sole failure was test/areaPicker.test.ts expecting substring redact; actual text was the intended masked-fields guidance."
+        - kind: fixture_only_diagnosis
+          detail: "area-picker.ts selects t().areaPickerRedactionInstruction when redactionsAvailable is true. The test passes that option and renders the intended branch; only its vocabulary assertion is wrong."
+        - kind: no_metric_gaming
+          detail: "An independent 13-test run excluding only the bad fixture passed and covered picker at 130/151 lines, area-picker at 95/103, annotator at 141/149, and picker-target at 25/26. Assertions drive state transitions and outputs rather than merely importing modules."
+        - kind: browser_output_oracle
+          detail: "Existing unchanged Chromium tests exercise real touch drag selection, mobile tap suppression, nested SVG and clickable-ancestor targeting, pixel counts, submitted data URLs, annotation undo persistence, and masked area-crop output."
+        - kind: cumulative_scope
+          detail: "T006 added only its four authorized test files and did not edit E2E, production, coverage, or Playwright configuration."
+        - kind: read_only_proof
+          detail: "Final tracked and untracked status matched the initial T007 status; Judge made no source, test, board, or external-state changes."
+      subgoal_contract: null
+      parallel_safety:
+        safe: false
+        rationale: "The correction is one file, but its completion proof includes the shared full widget browser suite. Do not run another writer or browser-suite mutation in parallel."
+      blocked_tasks:
+        - T006
+        - T008
+      missing_evidence:
+        - "A green 14-test focused T006 run after correcting the fixture."
+        - "T006 typecheck, lint, formatting, and full unit results."
+        - "Current targeted and full widget Chromium results for the cumulative T006 state."
+        - "Trusted post-T006 aggregate and per-file coverage counts."
+        - "The final milestone Judge phase verdict after T006 completion."
+      required_board_updates:
+        - "Record T007 done as an approved bounded correction gate, not as phase completion."
+        - "Keep T006 blocked."
+        - "Create and activate T019 as a Worker using the exact worker_package."
+        - "After T019, create a read-only milestone Judge gate before T008."
+      worker_package: null
+  - id: T019
+    type: worker
+    assignee: Worker
+    status: blocked
+    reasoning_hint: medium
+    objective: "Correct only the inaccurate area-picker fixture and overbroad test names. In test/areaPicker.test.ts, replace the unrelated redact substring assertion with the actual English public guidance Marked private fields may be masked if included. Rename that test to shows coarse-pointer cancellation with redaction-aware guidance, because it proves coarse-pointer UI and cancellation rather than touch-event normalization. Rename the reverse-drag test to rejects undersized reverse drags before translating page coordinates, because it does not prove viewport clamping. Do not change production copy, event fixtures, geometry assertions, other tests, or E2E code. Then execute every deferred T006 unit, static, coverage, targeted Chromium, and full widget Chromium gate and report exact aggregate and per-file coverage."
+    inputs:
+      - "T006 blocked receipt and four new test files"
+      - "T007 independent fixture-only diagnosis"
+      - "Existing unchanged Chromium widget tests"
+    constraints:
+      - "Only test/areaPicker.test.ts may change."
+      - "Do not weaken geometry, teardown, output, target-resolution, disabled-state, or history assertions."
+      - "Run every verification gate exactly."
+    expected_output:
+      - "Green 14-test interaction package"
+      - "Static, full unit, and browser-suite proof"
+      - "Trusted aggregate and per-file coverage"
+    allowed_files:
+      - "test/areaPicker.test.ts"
+    verify:
+      - "npx vitest run test/areaPicker.test.ts -t 'shows coarse-pointer cancellation with redaction-aware guidance'"
+      - "npx vitest run test/picker.test.ts test/areaPicker.test.ts test/annotator.test.ts test/pickerTarget.test.ts --coverage"
+      - "npx vitest run test/picker.test.ts test/areaPicker.test.ts -t 'suppresses the selecting click|cancels and removes every listener|rejects undersized reverse drags before translating page coordinates|shows coarse-pointer cancellation with redaction-aware guidance'"
+      - "npx vitest run test/annotator.test.ts test/pickerTarget.test.ts -t 'scales pointer coordinates to canvas pixels|undoes mixed completed annotations in order|cancels unfinished drafts|resolves nested SVG and clickable ancestors'"
+      - "npm run typecheck"
+      - "npm run lint"
+      - "npx prettier --check test/picker.test.ts test/areaPicker.test.ts test/annotator.test.ts test/pickerTarget.test.ts e2e/widget.spec.ts"
+      - "npm run build:widget"
+      - "npx playwright test e2e/widget.spec.ts --project=chromium --grep 'element picker handles nested SVG child elements without errors|area picker accepts touch drag selection on mobile|element picker prevents selected mobile tap from reaching the page|element picker selects nearest clickable ancestor from nested content|undo preserves mixed annotation history in the submitted screenshot|area-cropped capture preserves masks inside the selected region'"
+      - "npx playwright test e2e/widget.spec.ts --project=chromium"
+      - "npm test -- --coverage"
+      - "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+      - "node -e \"const fs=require('fs');const s=JSON.parse(fs.readFileSync('coverage/coverage-summary.json','utf8'));for(const f of ['picker.ts','area-picker.ts','annotator.ts','picker-target.ts']){const k=Object.keys(s).find(x=>x.endsWith('/src/widget/'+f));if(!k)throw new Error('missing coverage for '+f);console.log(f,JSON.stringify(s[k]));}\""
+      - "git diff --check"
+      - "git diff --exit-code -- e2e/widget.spec.ts src/widget/picker.ts src/widget/area-picker.ts src/widget/annotator.ts src/widget/picker-target.ts playwright.config.ts vitest.config.ts"
+    stop_if:
+      - "The normal English prompt no longer contains Marked private fields may be masked if included, making the product-copy contract genuinely ambiguous."
+      - "Any production, configuration, browser-test, or test file other than test/areaPicker.test.ts must change."
+      - "Any focused test still fails after the exact fixture and title corrections."
+      - "A test must weaken geometry, teardown, output, target-resolution, disabled-state, or history assertions to pass."
+      - "The targeted Chromium cases do not provide current touch, nested-target, click-suppression, pixel-mask, and submitted-image undo proof."
+      - "The full widget Chromium suite exposes a product regression."
+      - "Per-file gains collapse to import-only execution or aggregate gains come primarily from unrelated modules."
+      - "An allowed file contains overlapping user changes."
+      - "Verification fails twice for the same unexplained reason."
+    receipt:
+      result: blocked
+      changed_files:
+        - test/areaPicker.test.ts
+      commands:
+        - cmd: "npx vitest run test/areaPicker.test.ts -t 'shows coarse-pointer cancellation with redaction-aware guidance'"
+          status: pass
+        - cmd: "npx vitest run test/picker.test.ts test/areaPicker.test.ts test/annotator.test.ts test/pickerTarget.test.ts --coverage"
+          status: pass
+        - cmd: "npx vitest run test/picker.test.ts test/areaPicker.test.ts -t 'suppresses the selecting click|cancels and removes every listener|rejects undersized reverse drags before translating page coordinates|shows coarse-pointer cancellation with redaction-aware guidance'"
+          status: pass
+        - cmd: "npx vitest run test/annotator.test.ts test/pickerTarget.test.ts -t 'scales pointer coordinates to canvas pixels|undoes mixed completed annotations in order|cancels unfinished drafts|resolves nested SVG and clickable ancestors'"
+          status: pass
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "npm run lint"
+          status: pass
+        - cmd: "npx prettier --check test/picker.test.ts test/areaPicker.test.ts test/annotator.test.ts test/pickerTarget.test.ts e2e/widget.spec.ts"
+          status: pass
+        - cmd: "npm run build:widget"
+          status: pass
+        - cmd: "npx playwright test e2e/widget.spec.ts --project=chromium --grep 'element picker handles nested SVG child elements without errors|area picker accepts touch drag selection on mobile|element picker prevents selected mobile tap from reaching the page|element picker selects nearest clickable ancestor from nested content|undo preserves mixed annotation history in the submitted screenshot|area-cropped capture preserves masks inside the selected region'"
+          status: pass
+        - cmd: "npx playwright test e2e/widget.spec.ts --project=chromium"
+          status: fail
+      summary: "Applied exactly the authorized fixture wording and two title corrections in the sole allowed file. Unit interaction proof passed 14/14; targeted Chromium passed 6/6, including touch, click suppression, nested targeting, mask pixels, and submitted-image undo. The 204-test full Chromium gate repeatedly lost localhost:8787 with ERR_CONNECTION_RESET/REFUSED, causing cascading navigation failures. T019 stopped before full coverage and diff audits; no production, config, E2E, or other test file was changed by this task."
+      remaining_blockers:
+        - "Full Chromium widget verification repeatedly failed because its local web server became unavailable; runner output was truncated before an exact final pass/fail count."
+        - "Full coverage, aggregate/per-file summaries, delta from 69.17% lines/66.36% branches, and final diff audits were not reached due to the stop condition."
+        - "Focused coverage only: picker.ts 86.09% lines/74.60% branches; area-picker.ts 100%/78.57%; annotator.ts 94.63%/81.25%; picker-target.ts 96.15%/100%. These are not trusted aggregate deltas."
+      verification_attempts: 2
+      stopped_because: "The full Chromium verification failed repeatedly for the same unresolved local-server connection-reset/refusal condition."
+  - id: T020
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit the completed T006/T019 interaction package, independently verify assertion quality, browser proof, coverage delta, and cumulative risk reduction, then issue the final phase verdict before T008."
+    inputs:
+      - "T006, T007, and T019 receipts and diffs"
+      - "Current full coverage report"
+      - "Targeted and full Chromium widget results"
+    constraints:
+      - "Read-only."
+      - "Reject metric gaming, brittle private-structure assertions, or missing real-browser proof."
+      - "Do not authorize T008 unless the interaction package and trusted baseline are sound."
+    expected_output:
+      - "Final interaction-phase verdict"
+      - "Trusted post-T019 baseline and delta"
+      - "Risk-weighted remaining gaps"
+      - "Structural-extraction decision and explicit T008 authorization"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      phase_verdict: not_complete_pending_isolated_full_chromium_gate
+      rationale: "The latest full report contains 204 tests: 62 passed, then 142 failed exclusively with connection refusal; no assertion failed. Its start postdates workerd's start, showing the full run reused the targeted command's server; that process exited as refusals began. A manually owned server then passed the targeted six plus three formerly refused cases 9/9 with four workers and stayed healthy. This is local webServer reuse/teardown orchestration, not a product regression or resource exhaustion. Focused 14/14, typecheck, scope, and full 68-file/963-test coverage independently pass at 74.60% lines and 68.72% branches. Authorize a no-edit isolated full-browser Worker; T008 stays blocked."
+      failure_classification:
+        class: local_test_orchestration
+        product_regression: false
+        resource_exhaustion_proven: false
+        diagnosis: "The local Playwright configuration permits reuseExistingServer. The full command attached to the preceding targeted command's still-listening workerd during teardown, then lost that process. A separately owned server remained healthy under four-worker execution."
+      trusted_baseline:
+        status: independently_proven_unit_baseline_phase_pending_browser
+        test_files: 68
+        tests: 963
+        statements:
+          covered: 5748
+          total: 7837
+          pct: 73.34
+        branches:
+          covered: 3960
+          total: 5762
+          pct: 68.72
+        functions:
+          covered: 1034
+          total: 1348
+          pct: 76.7
+        lines:
+          covered: 5314
+          total: 7123
+          pct: 74.6
+        delta_from_t018:
+          covered_lines: 387
+          line_percentage_points: 5.43
+          covered_branches: 136
+          branch_percentage_points: 2.36
+        oracle_status: "Unit coverage exceeds 72% line and 67% branch targets, pending isolated full Chromium gate."
+      structural_extraction_decision: "not_justified_for_coverage; direct behavior tests already exceed the unit oracle without production extraction."
+      evidence:
+        - kind: retained_full_report
+          detail: "Decoded Playwright report shows 204 total, 62 passes, 142 failures, zero flaky/skipped."
+        - kind: uniform_failure_shape
+          detail: "All 142 failures were connection refused; zero assertion, pixel, output, or product errors."
+        - kind: server_lifecycle
+          detail: "The reused workerd started during the preceding targeted command and stopped as refusals began."
+        - kind: independent_server_probe
+          detail: "An explicitly owned server passed the six target cases plus three original-boundary cases 9/9 under four workers and zero retries, then remained healthy."
+        - kind: independent_unit_oracle
+          detail: "Full coverage independently passed 68 files and 963 tests at 5314/7123 lines and 3960/5762 branches."
+        - kind: no_metric_gaming
+          detail: "Interaction files reached 86.09%, 100%, 94.63%, and 96.15% lines through state/output assertions."
+        - kind: scope
+          detail: "T019 changed only test/areaPicker.test.ts; prohibited files have no T019 diff."
+      subgoal_contract: null
+      parallel_safety:
+        safe: false
+        rationale: "T021 must exclusively own port 8787 and the complete Chromium report."
+      blocked_tasks:
+        - T008
+      missing_evidence:
+        - "Clean 204/204 Chromium run under one fresh exclusively owned server."
+        - "Final remaining gate receipt."
+        - "Final milestone Judge verdict."
+      required_board_updates:
+        - "Record T020 done."
+        - "Record 74.60% lines and 68.72% branches pending browser acceptance."
+        - "Create and activate T021 with exact package."
+        - "After T021 create read-only milestone Judge before T008."
+      worker_package: null
+  - id: T021
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Perform a no-edit verification recovery. Require port 8787 to be unused, then run all 204 Chromium widget tests under Playwright's CI-mode webServer ownership so reuseExistingServer is false. Use four workers to match repository CI concurrency and zero retries so failures cannot be hidden. Do not split, grep, shard, skip, or weaken the full browser oracle. After the full browser pass, run the remaining full unit coverage, exact coverage summaries, static, formatting, and prohibited-diff gates. Report server lifecycle, complete browser counts, aggregate/per-file coverage, and final scope."
+    inputs:
+      - "T020 orchestration diagnosis and exact recovery package"
+      - "Current 68-file/963-test coverage baseline"
+    constraints:
+      - "No files may change."
+      - "Exclusively own port 8787."
+      - "Four workers, zero retries, all 204 tests."
+    expected_output:
+      - "204/204 Chromium proof"
+      - "Final static, coverage, and scope receipt"
+    # GoalBuddy's Worker schema requires at least one allowed path; this is a
+    # verification-only task and the no-edit constraint/stop gate still applies.
+    allowed_files:
+      - "test/areaPicker.test.ts"
+    verify:
+      - "! lsof -nP -iTCP:8787 -sTCP:LISTEN"
+      - "CI=1 npx playwright test e2e/widget.spec.ts --project=chromium --workers=4 --retries=0"
+      - "! lsof -nP -iTCP:8787 -sTCP:LISTEN"
+      - "npm test -- --coverage"
+      - "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+      - "node -e \"const fs=require('fs');const s=JSON.parse(fs.readFileSync('coverage/coverage-summary.json','utf8'));for(const f of ['picker.ts','area-picker.ts','annotator.ts','picker-target.ts']){const k=Object.keys(s).find(x=>x.endsWith('/src/widget/'+f));if(!k)throw new Error('missing coverage for '+f);console.log(f,JSON.stringify(s[k]));}\""
+      - "npm run typecheck"
+      - "npm run lint"
+      - "npx prettier --check test/picker.test.ts test/areaPicker.test.ts test/annotator.test.ts test/pickerTarget.test.ts e2e/widget.spec.ts"
+      - "git diff --check"
+      - "git diff --exit-code -- e2e/widget.spec.ts src/widget/picker.ts src/widget/area-picker.ts src/widget/annotator.ts src/widget/picker-target.ts playwright.config.ts vitest.config.ts"
+    stop_if:
+      - "Port 8787 is already occupied before execution; do not kill or reuse an unknown process."
+      - "Playwright cannot start and exclusively own its CI-mode webServer."
+      - "Any of the 204 Chromium tests fails any product-behavior contract."
+      - "The isolated server exits or becomes unreachable during the full run; preserve output and return as a genuine infrastructure blocker."
+      - "Any retry, grep, shard, skip, max-failure shortcut, or worker count below four is proposed."
+      - "Any source, test, E2E, configuration, or tracked file must change."
+      - "The full unit result differs from 68 files and 963 tests for an unexplained reason."
+      - "Aggregate coverage differs from 5314/7123 lines or 3960/5762 branches without a source/test-scope explanation."
+      - "Coverage gains cease to be concentrated in the four interaction modules or indicate import-only execution."
+      - "Verification fails twice for the same unexplained reason."
+    receipt:
+      result: done
+      changed_files:
+        - test/areaPicker.test.ts
+      commands:
+        - cmd: "! lsof -nP -iTCP:8787 -sTCP:LISTEN"
+          status: pass
+        - cmd: "CI=1 npx playwright test e2e/widget.spec.ts --project=chromium --workers=4 --retries=0"
+          status: pass
+        - cmd: "! lsof -nP -iTCP:8787 -sTCP:LISTEN"
+          status: pass
+        - cmd: "npm test -- --coverage"
+          status: pass
+        - cmd: "node -e \"const c=require('./coverage/coverage-summary.json').total; console.log(JSON.stringify(c))\""
+          status: pass
+        - cmd: "node -e \"const fs=require('fs');const s=JSON.parse(fs.readFileSync('coverage/coverage-summary.json','utf8'));for(const f of ['picker.ts','area-picker.ts','annotator.ts','picker-target.ts']){const k=Object.keys(s).find(x=>x.endsWith('/src/widget/'+f));if(!k)throw new Error('missing coverage for '+f);console.log(f,JSON.stringify(s[k]));}\""
+          status: pass
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "npm run lint"
+          status: pass
+        - cmd: "npx prettier --check test/picker.test.ts test/areaPicker.test.ts test/annotator.test.ts test/pickerTarget.test.ts e2e/widget.spec.ts"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "git diff --exit-code -- e2e/widget.spec.ts src/widget/picker.ts src/widget/area-picker.ts src/widget/annotator.ts src/widget/picker-target.ts playwright.config.ts vitest.config.ts"
+          status: pass
+      summary: "Verification-only task made no edits; changed_files names the schema-required allowed path but initial/final git status matched exactly. Port 8787 was unused before and after Playwright's exclusively owned server. Chromium passed 204/204 in 1.9m with 4 workers, 0 retries. Unit coverage passed 68 files/963 tests: lines 5314/7123=74.60% (+5.43pp), branches 3960/5762=68.72% (+2.36pp). Per-file lines/branches: picker 86.09/74.60; area-picker 100/78.57; annotator 94.63/81.25; picker-target 96.15/100. All remaining gates passed."
+      remaining_blockers: []
+      verification_attempts: 1
+      stopped_because: null
+  - id: T022
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit T021's isolated 204-test Chromium run and final gates, then issue the final interaction-phase verdict and explicit T008 authorization."
+    inputs:
+      - "T020 diagnosis"
+      - "T021 no-edit verification receipt"
+      - "Current coverage and browser reports"
+    constraints:
+      - "Read-only."
+      - "Require complete 204/204 proof and stable server lifecycle."
+      - "Reject skipped/retried/sharded browser proof."
+    expected_output:
+      - "Final interaction-phase verdict"
+      - "Trusted baseline and delta"
+      - "Explicit T008 authorization or blocker"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "Approved: the interaction phase is complete and T008 is authorized. The retained report independently decodes to 204 unique Chromium tests, one passed result each, retry 0, no annotations, skips, flaky, or unexpected results, with four actual workers; current discovery also lists exactly 204. Independent Vitest rerun passes 68/963. Coverage records 5314/7123 lines (74.60%) and 3960/5762 branches (68.72%); the four interaction modules account for all 387 newly covered lines. Tests assert behavior, cleanup, canvas output, pixels, and submissions. T021 made no edit; its changed_files path is only the documented schema placeholder."
+      evidence:
+        - kind: browser_artifact
+          detail: "Playwright report records 204 total/expected, 204 passed, zero unexpected/flaky/skipped, Chromium only, actualWorkers 4, and 114863.496 ms."
+        - kind: retry_and_skip_disproof
+          detail: "204 unique IDs, one result per test, retry 0 for all, no annotations or non-passed outcomes."
+        - kind: suite_cardinality
+          detail: "Independent CI-mode discovery lists exactly 204 tests; retained artifact contains all 204."
+        - kind: server_lifecycle
+          detail: "Unused-port checks passed before/after and independent lsof confirms port 8787 unused."
+        - kind: independent_unit_verification
+          detail: "Fresh npm test passed 68 files and 963 tests."
+        - kind: coverage_oracle
+          detail: "5314/7123 lines 74.60%, 3960/5762 branches 68.72%, 5748/7837 statements 73.34%, 1034/1348 functions 76.70%."
+        - kind: coverage_concentration
+          detail: "Picker 130/151, area-picker 103/103, annotator 141/149, picker-target 25/26; their 387-line increase exactly equals aggregate increase."
+        - kind: assertion_quality
+          detail: "Tests assert target selection, click suppression, teardown, geometry, canvas output, undo, disabled targets, touch, SVG, submitted pixels, and masked crop pixels."
+        - kind: scope
+          detail: "Prohibited-file diff passes and T021 made no edit."
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks: []
+      missing_evidence:
+        - "Reporting/design tranche beginning T008 remains."
+      required_board_updates:
+        - "Record T022 done."
+        - "Authorize T008."
+        - "Retain structural extraction not justified for coverage."
+  - id: T008
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: low
+    objective: "Map the safest component and optional browser-coverage reporting design without changing CI or Codecov policy."
+    inputs:
+      - "T007 trusted baseline"
+      - "vitest.config.ts"
+      - "codecov.yml"
+      - ".github/workflows"
+      - "Playwright configuration and bundle source maps"
+    constraints:
+      - "Read-only."
+      - "Account for pull_request, merge_group, docs-only, and public-fork behavior."
+      - "Preserve pinned-action and least-privilege policy."
+      - "Do not install apps, create secrets, or mutate external state."
+    expected_output:
+      - "Component map for widget, backend, and scripts"
+      - "Source-map proof or blockers for a separate e2e flag"
+      - "Event/fork/merge-queue safety matrix"
+      - "Exact proposed files and verification"
+    receipt:
+      result: done
+      summary: "Existing unit LCOV supports trustworthy, non-overlapping widget, backend, and scripts components. Component-only reporting can remain informational and use the current isolated OIDC uploader. Browser LCOV is not trustworthy yet: production/E2E bundles emit no source map, and a read-only sourcemap probe exposed worktree-dependent dependency paths. Canonical src/widget paths are achievable without duplicates, but require filtering, normalization, and Chromium conversion proof. Docs-only runs skip coverage; merge_group runs full coverage; public-fork OIDC upload availability remains unproven and safely fail-open. Judge should authorize components independently and defer e2e upload until canonical-LCOV and representative event evidence exists."
+      evidence:
+        - kind: component_partition
+          detail: "Current lcov.info has 82 unique SF records, zero duplicates: widget 46 files, backend 10, scripts 26; partitions exhaust report."
+        - kind: component_counts
+          detail: "Widget 1921/2853 lines 67.33%, 1178/1943 branches 60.63%; backend 877/938 lines 93.50%, 590/708 branches 83.33%; scripts 2516/3332 lines 75.51%, 2192/3111 branches 70.46%."
+        - kind: trustworthy_paths
+          detail: "Widget src/widget/**; scripts scripts/**; backend explicit src/index.ts, src/defaults.ts, src/types.ts, src/lib/**, src/middleware/**, src/routes/** to avoid overlap."
+        - kind: existing_upload_isolation
+          detail: "PR code runs without OIDC; only coverage/lcov.info crosses via pinned artifact. Reporting job alone gets id-token:write, persist-credentials:false, disable_search:true, plugins:noop, unit flag, fail-open."
+        - kind: docs_only_behavior
+          detail: "ci-scope skips unit/upload for safe docs-only pull requests; merge_group is always full CI."
+        - kind: event_matrix
+          detail: "Product PR and merge_group run/report; docs-only safely skips; public-fork tests need no secrets while OIDC processing remains unproven and fail-open; no push coverage event."
+        - kind: actual_bundle_blocker
+          detail: "build-widget uses write:false, minify:true, no sourcemap, and emits one widget.js; current E2E has no source map for source-level LCOV."
+        - kind: sourcemap_probe
+          detail: "External-map probe produced canonical widget paths but dependency paths through sibling worktree node_modules, requiring filtering and checkout-independent normalization."
+        - kind: duplicate_risk
+          detail: "Valid e2e must reuse canonical src/widget paths and omit public/widget.js/node_modules, or duplication occurs."
+        - kind: browser_scope
+          detail: "No browser coverage collector/converter exists; initial coverage must be Chromium-only while other engines remain behavior proof."
+        - kind: policy_verification
+          detail: "CI workflow contract and Node24 action checks passed; 70 external references SHA-pinned and compatible."
+        - kind: read_only_proof
+          detail: "No Scout writes; inspected files remained clean."
+      facts:
+        - component_map: "[object Object]"
+        - candidate_component_only_files: "codecov.yml,test/ci-workflow-contract.test.sh"
+        - judge_handoff: "Authorize informational components now. Defer browser upload until generated LCOV proves only canonical src/widget SF records, no bundle/dependency records, no duplicates, stable checkout paths, and representative event behavior."
+      contradictions:
+        - claim: "Bundle source maps are existing input."
+          observed: "Actual builder emits none; only synthetic probe assessed feasibility."
+        - claim: "Separate e2e flag prevents duplicates."
+          observed: "Flags distinguish uploads but path correctness still requires canonical filtered records."
+      ambiguity_requiring_judge:
+        - "Authorize component-only config before external processing evidence?"
+        - "Whether future e2e contributes aggregate or stays separate."
+        - "Public-fork OIDC success vs safe failure cannot be locally proven."
+        - "Normal artifact source map vs separate coverage build."
+      commands:
+        - "bash test/ci-workflow-contract.test.sh"
+        - "npm run check:actions-node24"
+        - "LCOV partition/duplicate audit"
+        - "read-only esbuild sourcemap probe"
+        - "git diff audits"
+      note_needed: false
+  - id: T009
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Choose a trustworthy reporting-only measurement package or explicitly defer it if source mapping or fork safety is not proven."
+    inputs:
+      - "T008 receipt"
+      - "Current Codecov hit/partial/miss behavior"
+    constraints:
+      - "Read-only."
+      - "Keep partials-as-misses."
+      - "Keep statuses informational during this tranche."
+      - "Do not blend browser and unit flags silently."
+    expected_output:
+      - "implement | defer decision"
+      - "Exact allowed_files and verify commands if implementing"
+      - "Proof requirements for source paths and public forks"
+      - "Future threshold recommendation criteria"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "Approve component-only implementation; defer e2e upload. Current LCOV has 82 unique records partitioning exactly into widget 46, backend 10, and scripts 26 without overlap. Explicit JavaScript partial detection plus LCOV partials_as_hits:false preserves strict semantics. The uploader already uses the official Codecov action at a full SHA, isolated OIDC, least privilege, and fail-open behavior; docs-only skips while merge_group runs fully. Public-fork processing remains unproven, so every status stays informational. T010 must allow test/ci-workflow-contract.test.sh for durable structural invariants. Browser reporting remains deferred because canonical source mapping is unproven."
+      evidence:
+        - kind: component_partition
+          detail: "82 unique SF paths: widget 46, backend 10, scripts 26, other 0, duplicates 0."
+        - kind: validated_component_design
+          detail: "Official validator accepted parser settings, unit-only default component rule, informational status, and exact paths."
+        - kind: partial_semantics
+          detail: "Explicit javascript partials enabled and lcov partials_as_hits false preserve strict denominator semantics."
+        - kind: event_behavior
+          detail: "merge_group full CI; safe docs-only skip; all uncertain events fail safe to full CI."
+        - kind: fork_and_permission_safety
+          detail: "PR code has no OIDC; only reporting job gets contents:read/id-token:write, no persisted credentials, upload fail-open."
+        - kind: action_supply_chain
+          detail: "Official Codecov v7 action is full-SHA pinned and Node24 policy passes."
+        - kind: scope_correction
+          detail: "Workflow contract test must be allowed to enforce new component/parser contracts; workflow/dependency/config files otherwise removed."
+        - kind: browser_coverage_defer
+          detail: "No normal source map or converter and probe exposed checkout-dependent paths; distinct flag alone is insufficient."
+      subgoal_contract: null
+      parallel_safety:
+        safe: false
+        rationale: "One coherent two-file policy/config slice."
+      blocked_tasks: []
+      missing_evidence:
+        - "Representative external Codecov component processing across events."
+        - "Canonical e2e LCOV and non-blending decision."
+        - "Blocking threshold evidence; statuses remain informational."
+      required_board_updates:
+        - "Record component-only implement and e2e defer."
+        - "Replace T010 with exact worker package."
+        - "Keep statuses informational."
+      worker_package: null
+  - id: T010
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Implement trustworthy unit-only Codecov components without changing CI execution or dependencies. In codecov.yml, explicitly preserve parsers.javascript.enable_partials: true and parsers.lcov.partials_as_hits: false. Add component_management with default flag_regexes containing only ^unit$, one project status using target:auto, threshold:1%, and informational:true, and stable components widget, backend, and scripts. Use exact paths: widget src/widget/**; backend src/index.ts, src/defaults.ts, src/types.ts, src/lib/**, src/middleware/**, src/routes/**; scripts scripts/**. Preserve existing project/patch statuses, comment:false, and annotations:false. Extend test/ci-workflow-contract.test.sh to structurally enforce these parser, flag, status, ID, and exact path contracts plus existing OIDC, fail-open, event, and action-pin invariants. Do not add browser coverage or change the workflow/action."
+    inputs:
+      - "T009 decision and exact scope"
+    constraints:
+      - "No external account, app, secret, branch-protection, or required-check changes."
+      - "Do not make coverage blocking."
+      - "Use the official Node 24-compatible Codecov action pinned to a full commit if an action change is necessary."
+      - "Unit and e2e reports must remain distinguishable."
+    expected_output:
+      - "Component-level reporting for widget, backend, and scripts when authorized"
+      - "Separate e2e flag only when source maps resolve to src/widget without duplicates"
+      - "Static and local verification receipt"
+    allowed_files:
+      - "codecov.yml"
+      - "test/ci-workflow-contract.test.sh"
+    verify:
+      - "curl --fail --silent --show-error --request POST --header 'Content-Type: text/yaml' --data-binary @codecov.yml https://api.codecov.io/validate"
+      - "bash test/ci-workflow-contract.test.sh"
+      - "bash test/ci-scope.test.sh"
+      - "npm run check:actions-node24"
+      - "npm test -- --coverage"
+      - "node -e \"const fs=require('fs');const rs=fs.readFileSync('coverage/lcov.info','utf8').split('end_of_record').map(x=>x.trim()).filter(Boolean);const sf=rs.map(r=>r.match(/^SF:(.+)$/m)?.[1]).filter(Boolean);const classify=p=>p.startsWith('src/widget/')?'widget':p.startsWith('scripts/')?'scripts':/^(src\\/(index|defaults|types)\\.ts|src\\/(lib|middleware|routes)\\/)/.test(p)?'backend':'other';const counts=sf.reduce((a,p)=>(a[classify(p)]++,a),{widget:0,backend:0,scripts:0,other:0});if(sf.length!==82||new Set(sf).size!==82||counts.widget!==46||counts.backend!==10||counts.scripts!==26||counts.other!==0)throw new Error(JSON.stringify({records:sf.length,unique:new Set(sf).size,counts}));console.log(JSON.stringify({records:sf.length,unique:new Set(sf).size,counts}));\""
+      - "node -e \"const c=require('./coverage/coverage-summary.json').total;if(c.lines.covered!==5314||c.lines.total!==7123||c.branches.covered!==3960||c.branches.total!==5762)throw new Error(JSON.stringify(c));console.log(JSON.stringify(c));\""
+      - "make check"
+      - "npx prettier --check codecov.yml"
+      - "git diff --check"
+      - "git diff --exit-code -- vitest.config.ts playwright.config.ts .github/workflows/ci.yml package.json package-lock.json scripts/check-github-actions.mjs"
+    stop_if:
+      - "Any file outside codecov.yml and test/ci-workflow-contract.test.sh must change."
+      - "Either allowed file contains overlapping user changes not already represented by T008/T009."
+      - "The official Codecov validator rejects or normalizes differently from three exact components and unit-only rule."
+      - "Partials are disabled, counted as hits, or any ignore, exclusion, fix, denominator, project-status, patch-status, comment, or annotation behavior changes."
+      - "Any component is not restricted to exact unit flag, paths overlap or fail to exhaust 82 records, or IDs/path sets differ."
+      - "Any e2e instrumentation, source map, collector, converter, e2e flag, dependency, package, Playwright, Vitest, workflow, or action change is proposed."
+      - "Public-fork support would require a token, secret, app, broader permission, pull_request_target, persisted credentials, or removal of fail-open behavior."
+      - "Docs-only skipping, merge_group full execution, OIDC isolation, official pin, or Node24 verification changes or fails."
+      - "Full unit result differs from 68 files/963 tests or 5314/7123 lines and 3960/5762 branches without explanation."
+      - "Verification fails twice for the same unexplained reason."
+    receipt:
+      result: done
+      changed_files:
+        - codecov.yml
+        - test/ci-workflow-contract.test.sh
+      commands:
+        - cmd: "curl --fail --silent --show-error --request POST --header 'Content-Type: text/yaml' --data-binary @codecov.yml https://api.codecov.io/validate"
+          status: pass
+        - cmd: "bash test/ci-workflow-contract.test.sh"
+          status: pass
+        - cmd: "bash test/ci-scope.test.sh"
+          status: pass
+        - cmd: "npm run check:actions-node24"
+          status: pass
+        - cmd: "npm test -- --coverage"
+          status: pass
+        - cmd: "LCOV exact partition audit"
+          status: pass
+        - cmd: "coverage exact denominator audit"
+          status: pass
+        - cmd: "make check"
+          status: pass
+        - cmd: "npx prettier --check codecov.yml"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "prohibited-file diff audit"
+          status: pass
+      summary: "Added strict JavaScript/LCOV partial semantics and three informational, unit-only components: widget, backend, scripts. Official Codecov validator returned Valid and normalized exact IDs, paths, ^unit$ rule, and statuses. CI contracts, scope behavior, all 70 Node24 action pins, 68 files/963 tests, exact 5314/7123 lines and 3960/5762 branches, 82-record 46/10/26 LCOV partition, 394 release checks, and static/security gates pass. Only two allowed files changed."
+      remaining_blockers: []
+      verification_attempts: 2
+      stopped_because: null
+  - id: T011
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Decide whether a bounded widget-bootstrap seam extraction or targeted branch-hardening package is necessary and safer than stopping at the achieved risk coverage."
+    inputs:
+      - "T007 phase verdict"
+      - "T010 receipt or defer decision"
+      - "Current oracle delta"
+    constraints:
+      - "Read-only."
+      - "Do not authorize refactoring solely to inflate coverage."
+      - "Prefer pure configuration, redaction, persistence, validation, position, or payload seams with existing browser oracles."
+    expected_output:
+      - "extract | branch-harden | no-additional-structural-work decision"
+      - "Largest safe useful Worker scope"
+      - "Exact allowed_files, verification, and rollback boundary"
+      - "Updated oracle projection"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "Select no-additional-structural-work. Independent rerun remains 68/963 at 74.60% lines and 68.72% branches, above the 72/67 oracle, while T010's strict component contract passes. Strongest native gaps are widget/index.ts and crop-screenshot.ts, but index is browser orchestration exercised by 204 Chromium tests and crop has translated/masked pixel proof. Extraction or canvas mocking would now be coverage-driven. Preserve denominators and advance through no-edit T012 to final proof."
+      evidence:
+        - kind: decision
+          detail: no-additional-structural-work
+        - kind: independent_oracle
+          detail: "68 files/963 tests, 5314/7123 lines 74.60%, 3960/5762 branches 68.72%."
+        - kind: reporting_audit
+          detail: "T010 exact two-file strict component contract independently passes."
+        - kind: strongest_gap_widget_bootstrap
+          detail: "index.ts native zero but 204 browser cases cover orchestration; extraction files do not exist and would expose private seams solely for coverage."
+        - kind: strongest_gap_crop
+          detail: "crop correctness depends on real Image/canvas geometry and has real pixel assertions; jsdom mocks weaker."
+        - kind: remaining_branch_risk
+          detail: "Remaining modal/capture/form/JWT/feedback branches already have direct or cross-browser proof and no defect evidence."
+        - kind: scope_proof
+          detail: "No source/E2E/config diff and git diff check passes."
+        - kind: oracle_projection
+          detail: "No-edit transition leaves exact 74.60/68.72 and component denominators unchanged."
+      subgoal_contract: null
+      parallel_safety:
+        safe: false
+        rationale: "No writer beyond schema-compatible verification transition."
+      blocked_tasks: []
+      missing_evidence:
+        - "T013 final oracle/component/strict interpretation/adversarial audit."
+        - "T999 final owner outcome mapping."
+        - "External Codecov processing is future threshold evidence."
+      required_board_updates:
+        - "Record no-additional work."
+        - "Replace T012 with no-edit package."
+        - "Activate T013 after no-op receipt."
+      worker_package: null
+  - id: T012
+    type: worker
+    assignee: Worker
+    status: blocked
+    reasoning_hint: medium
+    objective: "Record the T011 no-additional-structural-work decision without editing any file. Confirm trusted coverage and retained browser artifacts remain present, confirm the T010 reporting contract remains green, and return a no-op receipt. src/widget/index.ts is listed only because GoalBuddy Worker schema requires one allowed path; it must not be edited, and any changed_files entry must be labeled schema-only."
+    inputs:
+      - "T011 decision and exact scope"
+    constraints:
+      - "No monolithic jsdom import harness."
+      - "No broad production rewrite."
+      - "Separate pure extraction from behavior changes."
+      - "If T011 selects no additional work, record a no-op receipt and do not edit files."
+    expected_output:
+      - "One coherent tested seam or one meaningful adversarial branch package"
+      - "Before/after component and total coverage"
+      - "Targeted real-browser proof for widget source changes"
+      - "Rollback-friendly diff"
+    allowed_files:
+      - "src/widget/index.ts"
+    verify:
+      - "git status --short"
+      - "node -e \"const c=require('./coverage/coverage-summary.json').total;if(c.lines.covered!==5314||c.lines.total!==7123||c.lines.pct!==74.6||c.branches.covered!==3960||c.branches.total!==5762||c.branches.pct!==68.72)throw new Error(JSON.stringify(c));console.log(JSON.stringify(c));\""
+      - "node -e \"const fs=require('fs');const h=fs.readFileSync('playwright-report/index.html','utf8');const m=h.match(/data:application\\/zip;base64,([A-Za-z0-9+/=]+)/);if(!m)throw new Error('embedded report missing');process.stdout.write(Buffer.from(m[1],'base64'))\" | bsdtar -xOf - report.json | node -e \"let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const r=JSON.parse(s);if(r.stats.total!==204||r.stats.expected!==204||r.stats.unexpected!==0||r.stats.flaky!==0||r.stats.skipped!==0||r.metadata.actualWorkers!==4)throw new Error(JSON.stringify({stats:r.stats,metadata:r.metadata}));console.log(JSON.stringify({stats:r.stats,metadata:r.metadata}));})\""
+      - "bash test/ci-workflow-contract.test.sh"
+      - "git diff --check"
+      - "git diff --exit-code -- src/widget/index.ts src/widget/crop-screenshot.ts e2e/widget.spec.ts vitest.config.ts playwright.config.ts"
+      - "git status --short"
+    stop_if:
+      - "Any repository state must change."
+      - "src/widget/index.ts would be edited; it is schema placeholder only."
+      - "Initial and final git status differ."
+      - "Coverage artifact differs from exact trusted denominator without explanation."
+      - "Browser artifact no longer proves 204 expected passes, zero unexpected/flaky/skipped, four workers."
+      - "T010 Codecov workflow contract fails."
+      - "Any extraction or branch-hardening is proposed despite T011."
+    receipt:
+      result: blocked
+      changed_files: []
+      commands:
+        - cmd: "git status --short"
+          status: pass
+        - cmd: "exact coverage artifact audit"
+          status: pass
+        - cmd: "decode retained Playwright report and require 204 expected passes/four workers"
+          status: fail
+        - cmd: "git status --short"
+          status: pass
+      summary: "No files edited; src/widget/index.ts remained schema-only. Initial/final status matched. Coverage remains 5314/7123 lines and 3960/5762 branches. Retained Playwright report was overwritten and now shows 204 skipped/listed rather than the successful 204-pass artifact. Stopped immediately; later gates not run."
+      remaining_blockers:
+        - "Regenerate and retain trustworthy 204/204 four-worker Chromium report."
+      verification_attempts: 1
+      stopped_because: "Retained browser artifact no longer proves the required pass result."
+  - id: T023
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit T012's overwritten Playwright artifact, classify evidence loss versus regression, and decide whether T013 may regenerate the full browser artifact as part of final oracle proof."
+    inputs:
+      - "T011 no-additional-work decision"
+      - "T012 blocked no-edit receipt"
+      - "T021/T022 successful browser receipts"
+      - "Current Playwright report"
+    constraints:
+      - "Read-only."
+      - "Do not treat a stale or overwritten report as proof."
+      - "Require final retained 204/204 artifact before completion."
+    expected_output:
+      - "Evidence-loss classification"
+      - "Exact T013 browser-proof requirements"
+      - "Authorization or blocker for T013"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "Authorize T013 to regenerate final browser artifact. This is evidence loss, not product regression: T021 204/204 report was independently decoded before T022's --list check replaced it. Current report is 46 ms, zero results/workers, 204 discovered/skipped. Product/E2E/Playwright files unchanged. T013 must run fresh CI-owned four-worker zero-retry 204-case command as final Playwright invocation, verify port lifecycle, decode every result, hash retained HTML, and run no later Playwright command."
+      evidence:
+        - kind: classification
+          detail: "evidence_loss_from_playwright_list_report; product_regression:false"
+        - kind: successful_prior_artifact
+          detail: "Prior 204 total/expected passes, zero unexpected/flaky/skipped, four workers, unique retry-0 result each."
+        - kind: exact_overwrite_source
+          detail: "T022 --list with HTML reporter overwrote report after independent decode."
+        - kind: current_artifact_shape
+          detail: "46ms metadata-empty report with 204 skipped and zero result objects exactly matches listing."
+        - kind: no_regression_scope
+          detail: "Playwright/E2E/widget files unchanged; T012 no edits; later changes only Codecov contract."
+        - kind: canonical_t013_command
+          detail: "env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL CI=1 npx playwright test e2e/widget.spec.ts --project=chromium --workers=4 --retries=0"
+        - kind: server_lifecycle_requirements
+          detail: "Port 8787 unused immediately before/after; no kill/reuse."
+        - kind: artifact_decode_requirements
+          detail: "Chromium only; total=expected=204; other counts zero; ok; errors empty; four workers; 204 unique IDs; one passed retry-0 result each; no skip annotations."
+        - kind: retention_requirements
+          detail: "Record start, duration, mtime, bytes, SHA256 and recheck after all non-Playwright gates."
+      subgoal_contract: null
+      parallel_safety:
+        safe: false
+        rationale: "T013 exclusively owns port/report."
+      blocked_tasks: []
+      missing_evidence:
+        - "Fresh retained artifact"
+        - "T013 final proof"
+        - "T999 completion mapping"
+      required_board_updates:
+        - "Record evidence-loss classification."
+        - "Authorize T013 and exact artifact procedure."
+        - "No T999 completion without decoded retained report."
+  - id: T013
+    type: pm
+    assignee: PM
+    status: done
+    reasoning_hint: high
+    objective: "Run the full oracle suite, produce a commit-pinned coverage/component delta, and actively try to disprove the completed tranche."
+    inputs:
+      - "All Worker and Judge receipts"
+      - "Current diff and coverage artifacts"
+    constraints:
+      - "Do not push, open a PR, change branch protection, or mutate external state without approval."
+      - "Treat green tests and upload steps as claims, not proof."
+      - "Inspect for new exclusions, weak assertions, duplicate coverage paths, and denominator gaming."
+      - "Run every other Playwright invocation before the canonical final browser command."
+      - "Require port 8787 unused before and after: env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL CI=1 npx playwright test e2e/widget.spec.ts --project=chromium --workers=4 --retries=0"
+      - "After the canonical run, execute no later Playwright command; decode all 204 results, record report metadata/SHA-256, and recheck the hash after remaining gates."
+    expected_output:
+      - "Full gate results"
+      - "Vitest line/branch/function/statement baseline and delta by component"
+      - "Codecov-compatible hit/partial/miss interpretation"
+      - "Adversarial disproof evidence"
+      - "Recommendation for future informational and blocking thresholds"
+    receipt:
+      result: done
+      decision: not_complete
+      full_outcome_complete: false
+      rationale: "Final disproof proved the coverage, static, build, release, component, pinning, and fresh-main oracles, but browser acceptance is not currently clean. npm run test:e2e produced 296 passes, 2 skips, and 7 reproducible live/deployed-preview failures. The canonical local Chromium run then produced 203/204 passes with zero retries and one unexpected hover/resize persistence failure (saved top 697 changed to 693). This strongest realistic failure blocks completion and requires Judge scoping; no retry may be treated as proof."
+      commands:
+        - cmd: "git fetch origin main and commit/merge-base audit"
+          status: pass
+        - cmd: "npm test -- --coverage"
+          status: pass
+        - cmd: "npm run lint"
+          status: pass
+        - cmd: "npm run format:check"
+          status: pass
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "npm run build:widget"
+          status: pass
+        - cmd: "npm run test:e2e"
+          status: fail
+        - cmd: "npx playwright test --last-failed --workers=1 --retries=0 (diagnostic)"
+          status: fail
+        - cmd: "make check"
+          status: pass
+        - cmd: "port preflight; canonical CI-owned 204-case Chromium, four workers, zero retries; port postflight"
+          status: fail
+        - cmd: "coverage component/strict-state/diff/gaming audits"
+          status: pass
+        - cmd: "retained Playwright report decode/hash/port/fresh-main/board-health recheck"
+          status: pass
+      trusted_baseline:
+        commit: e0c5ece8edbbe5692cb5c540555fe6f3154130a7
+        origin_main: e0c5ece8edbbe5692cb5c540555fe6f3154130a7
+        test_files: 68
+        tests: 963
+        statements:
+          covered: 5748
+          total: 7837
+          pct: 73.34
+        branches:
+          covered: 3960
+          total: 5762
+          pct: 68.72
+        functions:
+          covered: 1034
+          total: 1348
+          pct: 76.7
+        lines:
+          covered: 5314
+          total: 7123
+          pct: 74.6
+      baseline_delta:
+        lines:
+          baseline: "4535/7060 64.23%"
+          current: "5314/7123 74.60%"
+          covered_delta: 779
+          denominator_delta: 63
+          percentage_points: 10.37
+        branches:
+          baseline: "3644/5736 63.52%"
+          current: "3960/5762 68.72%"
+          covered_delta: 316
+          denominator_delta: 26
+          percentage_points: 5.2
+        tests:
+          baseline: 895
+          current: 963
+          delta: 68
+        files:
+          baseline: 56
+          current: 68
+          delta: 12
+      component_delta:
+        widget:
+          baseline_lines: "1267/2799 45.27%"
+          current_lines: "1921/2853 67.33%"
+          covered_delta: 654
+          percentage_points: 22.06
+          baseline_branches: "910/1925 47.27%"
+          current_branches: "1178/1943 60.63%"
+          branch_covered_delta: 268
+          branch_percentage_points: 13.36
+        backend:
+          baseline_lines: "752/929 80.95%"
+          current_lines: "877/938 93.50%"
+          covered_delta: 125
+          percentage_points: 12.55
+          baseline_branches: "542/700 77.43%"
+          current_branches: "590/708 83.33%"
+          branch_covered_delta: 48
+          branch_percentage_points: 5.9
+        scripts:
+          baseline_lines: "2516/3332 75.51%"
+          current_lines: "2516/3332 75.51%"
+          covered_delta: 0
+          baseline_branches: "2192/3111 70.46%"
+          current_branches: "2192/3111 70.46%"
+          branch_covered_delta: 0
+      codecov_compatible_projection:
+        method: "LCOV DA plus branch-only source lines; DA-covered lines with any uncovered branch remain partial; partials are not hits. This is a local projection, not external Codecov processing proof."
+        total:
+          hit: 4920
+          partial: 802
+          miss: 1883
+          denominator: 7605
+          strict_pct: 64.69
+        widget:
+          hit: 1788
+          partial: 215
+          miss: 975
+          denominator: 2978
+          strict_pct: 60.04
+        backend:
+          hit: 805
+          partial: 107
+          miss: 61
+          denominator: 973
+          strict_pct: 82.73
+        scripts:
+          hit: 2327
+          partial: 480
+          miss: 847
+          denominator: 3654
+          strict_pct: 63.68
+        baseline_external: "4161 hit / 762 partial / 2608 miss / 7531 = 55.25%"
+      browser_disproof:
+        full_suite:
+          passed: 296
+          skipped: 2
+          failed: 7
+          diagnostic_serial_reproduction: "same 7 failed with one worker and zero retries"
+          classification: "deployed-preview/live project failures remain unresolved"
+        canonical_local:
+          total: 204
+          expected: 203
+          unexpected: 1
+          flaky: 0
+          skipped: 0
+          actual_workers: 4
+          retries: 0
+          failure: "hovered feedback button does not drift saved position during resize; expected saved top 697, received 693"
+          report_sha256: d46cd87c1f2e0f0f48245f849a90664b853a4c03beca079366b6734af76a0abf
+          report_bytes: 696359
+          mtime_epoch: 1786041254
+          port_8787_unused_after: true
+      adversarial_evidence:
+        - kind: fresh_main
+          detail: "HEAD, origin/main, and merge-base remain exact pinned commit; ahead/behind 0/0."
+        - kind: no_denominator_gaming
+          detail: "vitest.config.ts, playwright.config.ts, workflow, package manifests, and existing exclusions have no diff; no ignore annotations added."
+        - kind: risk_weighted_delta
+          detail: "All 779 newly covered native lines are product code: widget +654 and backend +125; scripts unchanged. Interaction tranche alone added 387 lines concentrated in four targeted modules."
+        - kind: assertion_density
+          detail: "Thirteen added/expanded direct suites contain 56 named tests and 276 expect calls, covering cryptographic, HTTP, lifecycle, cleanup, geometry, canvas, output, and disabled-state contracts."
+        - kind: strict_partials
+          detail: "codecov.yml explicitly enables JavaScript partials and sets LCOV partials_as_hits:false; official validator and executable structural contract pass."
+        - kind: component_partition
+          detail: "82 unique LCOV records exhaustively partition widget 46, backend 10, scripts 26, other/duplicates zero."
+        - kind: production_defects_closed
+          detail: "Concurrent first-upload 422 recovery/name collision and stalled-play timeout resource leak were first preserved as failing regressions, repaired narrowly, and independently verified."
+        - kind: supply_chain_and_events
+          detail: "All 70 actions remain full-SHA/Node24 compliant; OIDC remains isolated/fail-open; docs-only and merge_group contracts pass; no secret/app/permission/workflow changes."
+        - kind: browser_failure
+          detail: "Canonical local failure and seven reproducible live failures disprove current full browser acceptance despite earlier successful artifacts."
+      threshold_recommendation:
+        current: "Keep project auto/1%, patch 80%/0%, and all component/project/patch statuses informational."
+        future_blocking: "Consider promotion only after multiple representative product-PR and merge_group reports show stable denominators and public-fork attempts are safely observed. Promote project auto with 1% tolerance first; keep patch 80% separately evaluated. Do not use the 74.60% Vitest number as a Codecov strict threshold."
+        badge: "Defer until at least one product PR and merge_group produce stable component reports and public-fork behavior is observed; do not badge this unprocessed local configuration."
+      remaining_blockers:
+        - "Canonical local 204-case Chromium artifact is 203/204, not 204/204."
+        - "Full npm run test:e2e has seven reproducible live/deployed-preview failures."
+        - "Representative external Codecov processing remains unavailable, so statuses and threshold changes must remain informational/future work."
+      required_board_updates:
+        - "Record T013 done as a successful disproof with decision not_complete."
+        - "Activate T999 to classify browser failures and scope the smallest safe response."
+        - "Do not mark goal complete or remove the failed retained report."
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether the completed work satisfies the risk-weighted coverage oracle and the original owner outcome."
+    inputs:
+      - "All done task receipts"
+      - "T013 full verification and disproof evidence"
+      - "Current dirty diff"
+    constraints:
+      - "Read-only."
+      - "Reject completion if required Worker work is still queued or active."
+      - "Reject completion if percentage gains came from exclusions, partials-as-hits, assertion-light execution, script masking, or browser-test duplication."
+      - "Reject completion without direct cryptographic proof and targeted real-browser proof."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "Oracle mapping"
+      - "Missing evidence and exact next task if not complete"
+    receipt:
+      result: done
+      decision: not_complete
+      full_outcome_complete: false
+      rationale: "Completion rejected: canonical evidence is 203/204. Hover/resize is an intermittent pre-existing product defect. Five other failures are invalid local execution of deployment-only projects at a meta-refreshing root; two observe an unpinned external asset and are external-state drift. First make project selection fail closed without complete live inputs, preserving explicit CI live execution. Then repair trigger persistence and rerun zero-retry local/canonical gates. Retries, skips, or weakened assertions cannot establish completion."
+      evidence:
+        - kind: pinned_diff
+          detail: "HEAD/origin/main/merge-base exact pin; tranche does not modify widget index, E2E, Playwright, package, Makefile, or live workflows."
+        - kind: oracle_progress
+          detail: "74.60% lines/68.72% branches and all non-browser/static/security/reporting gates pass."
+        - kind: canonical_browser_failure
+          classification: "existing product defect"
+          detail: "Retained report 203/204; hover/resize persisted 693 instead of desired 697; timing-dependent resize reclamp/persist behavior."
+        - kind: live_failures
+          classification: "five existing harness defects plus two external-state drift cases"
+          detail: "Unset live inputs discovered deployment projects against local meta-refresh root and unpinned preview asset; not an admissible local oracle."
+        - kind: gate_interpretation
+          detail: "CI separates local projects from identity-pinned deployed live workflows; local npm test:e2e must fail closed to local projects when live inputs absent."
+      subgoal_contract: null
+      parallel_safety:
+        safe: false
+        rationale: "Harness then product packages serially share port/report state."
+      blocked_tasks:
+        - "Product repair waits for harness selection approval."
+        - "Final oracle waits for both repairs."
+      missing_evidence:
+        - "Behavior repair and repeated zero-retry proof."
+        - "Local-only zero-retry npm test:e2e."
+        - "Fresh canonical 204/204 retained artifact."
+        - "Post-repair final oracle/Judge."
+      required_board_updates:
+        - "Record not_complete."
+        - "Create serial T024-T029 continuation."
+        - "Do not retry invalid live run or mark complete."
+  - id: T024
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Make Playwright project selection fail closed: when LIVE_TARGET and PLAYWRIGHT_BASE_URL are absent, npm run test:e2e must discover the complete local Chromium/Radix suite but no deployed/live projects; explicit live selection must require complete live inputs and remain unchanged when present."
+    inputs:
+      - "T999 failure classification"
+      - "playwright.config.ts and CI/live workflows"
+    constraints:
+      - "No skips, retries, pass-with-no-tests behavior, renamed projects, workflow changes, or weakened assertions."
+      - "Preserve issue-canary isolation and every identity-pinned live path."
+    expected_output:
+      - "Fail-closed local/live discovery"
+      - "Executable policy proof"
+    allowed_files:
+      - "playwright.config.ts"
+      - "test/ci-workflow-contract.test.sh"
+    verify:
+      - "bash test/ci-workflow-contract.test.sh"
+      - "env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL npx playwright test --list --reporter=line"
+      - "env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL npx playwright test --project=chromium-live --list --reporter=line"
+      - "LIVE_TARGET=preview PLAYWRIGHT_BASE_URL=https://example.invalid npx playwright test --project=chromium-live --list --reporter=line"
+      - "LIVE_TARGET=preview PLAYWRIGHT_BASE_URL=https://example.invalid npx playwright test --project=chromium-live-radix --list --reporter=line"
+      - "npm run lint"
+      - "npm run format:check"
+      - "npm run typecheck"
+    stop_if:
+      - "Implementation adds skips, retries, pass-with-no-tests behavior, or weakens live assertions."
+      - "Any explicit CI live project is undiscoverable with complete live inputs."
+      - "Change alters project names, browser coverage, workflow commands, issue-canary isolation, or external services."
+      - "More files are required."
+    receipt:
+      result: done
+      changed_files:
+        - playwright.config.ts
+        - test/ci-workflow-contract.test.sh
+      commands:
+        - cmd: "bash test/ci-workflow-contract.test.sh"
+          status: pass
+        - cmd: "local no-input discovery"
+          status: pass
+        - cmd: "explicit live without inputs fails closed"
+          status: pass
+        - cmd: "complete-input chromium-live discovery"
+          status: pass
+        - cmd: "complete-input chromium-live-radix discovery"
+          status: pass
+        - cmd: "npm run lint"
+          status: pass
+        - cmd: "npm run format:check"
+          status: pass
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "prohibited workflow/package/E2E diff audit"
+          status: pass
+      summary: "Local no-input discovery lists 274 tests: 250 Chromium plus 8 each for Chromium/Firefox/WebKit Radix; no live or issue-canary project. Explicit chromium-live without inputs exits 1 with required input error, counted as contract proof. Complete representative inputs preserve chromium-live 20 tests/2 files and live-radix 2/1. All live projects fail closed; issue canary unchanged. All gates pass; project names, retries, assertions, workflows, and external behavior unchanged."
+      remaining_blockers: []
+      verification_attempts: 1
+      stopped_because: null
+  - id: T025
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit T024 as a test-oracle phase gate and approve only if local discovery excludes invalid live execution while every identity-pinned CI live path remains intact."
+    inputs:
+      - "T024 receipt/diff/output"
+      - "package/Makefile/CI/live workflow commands"
+    constraints:
+      - "Read-only."
+      - "Require fail-closed explicit live selection without inputs."
+    expected_output:
+      - "Harness selection verdict"
+      - "Exact T026 authorization or blocker"
+    receipt:
+      result: done
+      decision: rejected
+      full_outcome_complete: false
+      rationale: "Reject. Exact selectors and unqualified discovery work, but valid wildcard selectors can silently suppress matching live tests. Without inputs, chromium-* exits 0 running only chromium-radix while omitting 25 matching live tests; *-live and chromium-live* yield No tests found rather than required-input error. This is a false-green oracle. T026 blocked pending wildcard-aware repair."
+      evidence:
+        - kind: local_discovery
+          detail: "274 local tests across Chromium and three Radix projects; no live/issue-canary."
+        - kind: complete_input_discovery
+          detail: "305 tests across all nine ordinary projects with inputs."
+        - kind: strongest_failure
+          detail: "No-input chromium-* exits 0 with only 8 local Radix tests; complete inputs expose 33 including 25 live."
+        - kind: additional_wildcard_failure
+          detail: "*-live and chromium-live* fall through to No tests found."
+        - kind: issue_canary_isolation
+          detail: "Unqualified omits canary; exact canary finds one without live inputs."
+        - kind: unchanged_contracts
+          detail: "Names/retries/workers/package/workflows/E2E unchanged."
+      subgoal_contract: null
+      parallel_safety:
+        safe: false
+        rationale: "Repair guard before product work."
+      blocked_tasks:
+        - T026
+        - T027
+        - T028
+        - T029
+      missing_evidence:
+        - "Fail-loud every selector matching live project."
+        - "Wildcard regression contract."
+        - "Independent approval."
+      required_board_updates:
+        - "Record rejected."
+        - "Create T030/T031."
+        - "Keep T026 queued until T031."
+  - id: T030
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Repair live-project selection so every Playwright --project selector that matches any live project—including wildcard selectors and selectors also matching local projects—fails with required-input error unless both LIVE_TARGET and PLAYWRIGHT_BASE_URL are present. Preserve unqualified local discovery, exact live discovery with inputs, and exact-only issue-canary isolation."
+    inputs:
+      - "T025 wildcard false-green receipt"
+      - "Current T024 selection guard"
+    constraints:
+      - "No skips, retries, pass-zero, renamed projects, workflows, dependencies, or assertion changes."
+    expected_output:
+      - "Wildcard-aware fail-loud selector guard"
+      - "Executable exact/wildcard/partial-input regressions"
+    allowed_files:
+      - "playwright.config.ts"
+      - "test/ci-workflow-contract.test.sh"
+    verify:
+      - "bash test/ci-workflow-contract.test.sh"
+      - "env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL npm run test:e2e -- --list --reporter=line"
+      - "env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL npx playwright test --project=chromium-live --list --reporter=line"
+      - "env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL npx playwright test --project='chromium-*' --list --reporter=line"
+      - "env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL npx playwright test --project='*-live' --list --reporter=line"
+      - "env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL npx playwright test --project='*cross-browser-live' --list --reporter=line"
+      - "env -u LIVE_TARGET PLAYWRIGHT_BASE_URL=https://example.invalid npx playwright test --project=chromium-live --list --reporter=line"
+      - "env -u PLAYWRIGHT_BASE_URL LIVE_TARGET=preview npx playwright test --project=chromium-live --list --reporter=line"
+      - "LIVE_TARGET=preview PLAYWRIGHT_BASE_URL=https://example.invalid npx playwright test --list --reporter=line"
+      - "LIVE_TARGET=preview PLAYWRIGHT_BASE_URL=https://example.invalid npx playwright test --project='chromium-*' --list --reporter=line"
+      - "env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --list --reporter=line"
+      - "npm run lint"
+      - "npm run format:check"
+      - "npm run typecheck"
+      - "git diff --check"
+    stop_if:
+      - "Wildcard semantics cannot be established without guessing or dependency."
+      - "Any valid local-only selector is rejected."
+      - "Any complete-input live project/test disappears."
+      - "Implementation uses skips, retries, pass-zero, renamed projects, workflow changes, or outside files."
+    receipt:
+      result: done
+      changed_files:
+        - playwright.config.ts
+        - test/ci-workflow-contract.test.sh
+      commands:
+        - cmd: "bash test/ci-workflow-contract.test.sh"
+          status: pass
+        - cmd: "no-input unqualified discovery"
+          status: pass
+        - cmd: "no-input exact live fails required-input"
+          status: pass
+        - cmd: "no-input chromium-* fails required-input"
+          status: pass
+        - cmd: "no-input *-live fails required-input"
+          status: pass
+        - cmd: "no-input *cross-browser-live fails required-input"
+          status: pass
+        - cmd: "partial inputs fail required-input"
+          status: pass
+        - cmd: "complete-input unqualified discovery"
+          status: pass
+        - cmd: "complete-input chromium-* discovery"
+          status: pass
+        - cmd: "exact issue-canary discovery"
+          status: pass
+        - cmd: "npm run lint"
+          status: pass
+        - cmd: "npm run format:check"
+          status: pass
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "protected-scope diff audit"
+          status: pass
+      summary: "Implemented Playwright-compatible case-insensitive wildcard matching for explicit selectors. Any selector matching live requires both inputs, including mixed wildcards/partial inputs. No-input unqualified remains 274 local; complete inputs 305; chromium-* 33 across four projects; issue canary one. All contract/static/diff gates pass; no workflow/package/Makefile/E2E changes."
+      remaining_blockers: []
+      verification_attempts: 1
+      stopped_because: null
+  - id: T031
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Re-audit repaired project selection across exact, mixed wildcard, live-only wildcard, partial-input, complete-input, unqualified, and issue-canary paths before authorizing T026."
+    inputs:
+      - "T030 receipt/diff/output"
+      - "T025 rejection evidence"
+    constraints:
+      - "Read-only; line reporter only."
+      - "Reject any selector matching a live project that can silently omit it."
+    expected_output:
+      - "Wildcard guard verdict"
+      - "Explicit T026 authorization or blocker"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "Approve T030 and authorize T026. Independent discovery closes false-green paths: all exact/mixed/live-only/case-insensitive/partial-input selectors matching live fail required-input; local selectors pass; no-input unqualified 274 local; complete inputs 305; chromium-* 33; issue-canary exact-only. Names/retries/workers/package/Make/E2E/workflows match base; no skip/retry/pass-zero/external change."
+      evidence:
+        - kind: owned_diff
+          detail: "Only config and workflow contract; diff check passes."
+        - kind: wildcard_negative_matrix
+          detail: "chromium-*, *-live, *cross-browser-live, CHROMIUM-LIVE, firefox-* all fail required-input without inputs."
+        - kind: local_selector_safety
+          detail: "Exact/local wildcards preserve 250/8/8/8."
+        - kind: complete_input_matrix
+          detail: "305 across all ordinary projects; chromium-* 33."
+        - kind: issue_canary_isolation
+          detail: "Exact one; unqualified omitted."
+        - kind: pinned_contract
+          detail: "Names/retries/workers/fullyParallel/forbidOnly/trace unchanged; no passWithNoTests."
+        - kind: workflow_identity
+          detail: "All pinned live inputs and explicit workflows remain."
+      subgoal_contract: null
+      parallel_safety:
+        safe: false
+        rationale: "T026 exclusively owns browser report/port."
+      blocked_tasks:
+        - T027
+        - T028
+        - T029
+      missing_evidence:
+        - "Trigger invariant repair and repeated/full proof."
+        - T027/T028/T029.
+      required_board_updates:
+        - "Record approved."
+        - "Activate T026 with narrow package."
+  - id: T026
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Repair the pre-existing trigger-position defect so viewport clamping never replaces the user's persisted desired top with transient hover/resize geometry, while the rendered trigger remains in bounds and restores its desired position when space returns."
+    inputs:
+      - "T999 canonical failure"
+      - "T031 harness approval"
+      - "Current trigger persistence implementation and E2E contracts"
+    constraints:
+      - "No weakened test, arbitrary sleep, skip, retry dependence, or unrelated bootstrap refactor."
+      - "Preserve drag and keyboard persistence and visible viewport clamping."
+    expected_output:
+      - "Narrow desired-position/rendered-position invariant repair"
+      - "Repeated focused and complete local zero-retry proof"
+    allowed_files:
+      - "src/widget/index.ts"
+      - "e2e/widget.spec.ts"
+    verify:
+      - "bash test/ci-workflow-contract.test.sh"
+      - "npm run build:widget"
+      - "! lsof -nP -iTCP:8787 -sTCP:LISTEN"
+      - "env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL CI=1 npx playwright test e2e/widget.spec.ts --project=chromium --grep 'dragging the feedback button persists|feedback button position reclamps|hidden feedback button keeps saved position|hovered feedback button does not drift' --repeat-each=20 --workers=4 --retries=0 --reporter=line"
+      - "env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL CI=1 npm run test:e2e -- --workers=4 --retries=0"
+      - "! lsof -nP -iTCP:8787 -sTCP:LISTEN"
+      - "npm run lint"
+      - "npm run format:check"
+      - "npm run typecheck"
+    stop_if:
+      - "Test is weakened, delayed with arbitrary sleeps, skipped, or retry-dependent."
+      - "Drag/keyboard persistence changes, trigger can render out of viewport, or expanding viewport cannot restore desired position."
+      - "Repair requires unrelated bootstrap refactoring or files outside allowance."
+      - "Any local project fails with zero retries."
+      - "Approved local/live selection contract regresses."
+    receipt:
+      result: done
+      changed_files:
+        - src/widget/index.ts
+        - e2e/widget.spec.ts
+      commands:
+        - cmd: "bash test/ci-workflow-contract.test.sh"
+          status: pass
+        - cmd: "npm run build:widget"
+          status: pass
+        - cmd: "port preflight"
+          status: pass
+        - cmd: "focused four-case family repeat-each 20, 4 workers, zero retries"
+          status: pass
+        - cmd: "complete local npm test:e2e, 4 workers, zero retries"
+          status: pass
+        - cmd: "port postflight"
+          status: pass
+        - cmd: "npm run lint"
+          status: pass
+        - cmd: "npm run format:check"
+          status: pass
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "decode retained report"
+          status: pass
+        - cmd: "hash stability and scope audit"
+          status: pass
+      summary: "Before fix, preserved regression changed stored desired top 697 to transient clamped 307. Reclamping now renders from persisted desired top without overwriting it. Regression proves storage survives hovered shrink/restore, trigger stays within 360px viewport, restored rendering returns to saved top. Focused family 80/80; complete four-project local suite 274/274, zero retries. Retained report 274 expected, zero unexpected/flaky/skipped, four workers, correct projects, SHA256 d70630e17a82dbfab271483c5d1127451df34724bce9aa4d3d18002582bd76e5. Port clean; only allowed files changed; no sleeps/skips/retries weakening."
+      evidence:
+        - kind: before_fix_disproof
+          detail: "Focused regression failed with persisted desired top 697 changed to transient 307."
+        - kind: three_part_invariant
+          detail: "Stored desired top unchanged; rendered clamped in smaller viewport; restored rendering returns to desired top after hover removed."
+      remaining_blockers: []
+      verification_attempts: 1
+      stopped_because: null
+  - id: T027
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review T026 browser behavior and authorize final oracle only if the invariant, regression assertions, repeated proof, and complete local report are sound."
+    inputs:
+      - "T026 receipt/diff/report"
+      - "T999 defect classification"
+    constraints:
+      - "Read-only."
+      - "Reject retry, skip, flaky classification, timing padding, or assertion weakening."
+    expected_output:
+      - "Browser repair verdict"
+      - "Final-oracle authorization or blocker"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "Approve T026 and authorize T028. Two-file repair coherently separates desired persisted position from rendered clamping; drag/keyboard remain persistence writers, resize/show/reload render from stored desire. Regression strengthens storage, bounds, and restoration assertions. Retained report independently decodes 274 unique retry-0 local passes, correct projects, no skip/flaky/duplicate/live/canary, stable hash/port. Final T028 fresh oracle and canonical artifact remain."
+      evidence:
+        - kind: scope
+          detail: "Only index.ts and widget.spec.ts; diff check passes."
+        - kind: before_fix_disproof
+          detail: "Earlier 203/204 and removed save-on-reclamp source prove drift."
+        - kind: production_semantics
+          detail: "Reclamp reads stored desired top and renders without save."
+        - kind: drag_keyboard_semantics
+          detail: "Drag/keyboard persistence paths unchanged."
+        - kind: three_part_regression
+          detail: "Small viewport bounds, unchanged storage, restored render all asserted."
+        - kind: no_weakening
+          detail: "Viewport strengthened; no assertion removed/sleep/skip/retry."
+        - kind: retained_report
+          detail: "274 expected/274 passed, four workers, retry 0, correct 250/8/8/8 projects, hash d70630e17a82dbfab271483c5d1127451df34724bce9aa4d3d18002582bd76e5."
+        - kind: port
+          detail: "8787 unused."
+      subgoal_contract: null
+      parallel_safety:
+        safe: false
+        rationale: "T028 owns final port/report sequence."
+      blocked_tasks:
+        - T029
+      missing_evidence:
+        - "Fresh full oracle and canonical 204/204."
+        - "T029 mapping."
+      required_board_updates:
+        - "Record approved."
+        - "Activate T028; no Playwright after canonical command."
+  - id: T028
+    type: pm
+    assignee: PM
+    status: done
+    reasoning_hint: high
+    objective: "Rerun the complete commit-pinned oracle, actively disprove the combined tranche, and finish with a fresh canonical retained Chromium report."
+    inputs:
+      - "All receipts through T027"
+      - "Current coverage/diff/browser artifacts"
+    constraints:
+      - "No external deployment or state mutation."
+      - "Any live project without complete identity inputs is a blocker."
+      - "Canonical Chromium must be final Playwright invocation and retained/hash-checked."
+    expected_output:
+      - "Complete final oracle and disproof receipt"
+      - "Fresh component/strict coverage and browser artifact"
+    receipt:
+      result: done
+      decision: approved_for_final_judge
+      full_outcome_complete: false
+      rationale: "Complete post-repair oracle passes. Fresh-main pin remains exact. Unit, lint, format, type, build, release, security, pinning, CI scope/workflow, component, strict-partial, and diff/gaming audits pass. Local browser gate independently decoded to 274 unique retry-0 passes across exactly four approved projects. Canonical final Playwright invocation independently decoded to 204 unique retry-0 Chromium passes including the repaired hover/resize case, retained/hash-stable with clean port lifecycle. T029 may judge completion."
+      commands:
+        - cmd: "fresh-main fetch/pin/ahead-behind/diff audit"
+          status: pass
+        - cmd: "npm test -- --coverage"
+          status: pass
+        - cmd: "npm run lint"
+          status: pass
+        - cmd: "npm run format:check"
+          status: pass
+        - cmd: "npm run typecheck"
+          status: pass
+        - cmd: "npm run build:widget"
+          status: pass
+        - cmd: "make check"
+          status: pass
+        - cmd: "bash test/ci-workflow-contract.test.sh"
+          status: pass
+        - cmd: "coverage/component/strict-state/no-gaming audit"
+          status: pass
+        - cmd: "port preflight; local npm test:e2e 4 workers 0 retries; port postflight"
+          status: pass
+        - cmd: "decode intermediate 274-test report"
+          status: pass
+        - cmd: "port preflight; canonical 204 Chromium 4 workers 0 retries; port postflight"
+          status: pass
+        - cmd: "decode/hash retained canonical report and final read-only audit"
+          status: pass
+      verified_working_tree:
+        base_commit: fb7d2d974b2a66b3c799d2a3ee67ad6d7adc3438
+        origin_main: fb7d2d974b2a66b3c799d2a3ee67ad6d7adc3438
+        implementation_revision: enclosing_commit
+        provenance: "Metrics describe this working-tree delta over base_commit; once committed, the enclosing commit is the reproducible implementation revision. They are not attributed to the baseline commit."
+        post_rebase_verification: "Reproduced after rebasing onto base_commit: 68 files/965 unit tests, 275 local browser tests, and 205 canonical Chromium tests, all passing with browser retries disabled."
+        test_files: 68
+        tests: 965
+        statements: "5767/7837 73.58%"
+        branches: "3964/5766 68.74%"
+        functions: "1040/1348 77.15%"
+        lines: "5329/7123 74.81%"
+      baseline_delta:
+        lines: "4535/7060 64.23% -> 5329/7123 74.81%, +794 covered, +10.58pp"
+        branches: "3644/5736 63.52% -> 3964/5766 68.74%, +320 covered, +5.22pp"
+        tests: "895 -> 965, +70"
+        test_files: "56 -> 68, +12"
+      components:
+        widget:
+          lines: "1936/2853 67.86%"
+          branches: "1182/1947 60.70%"
+          baseline_lines: "1267/2799 45.27%"
+          baseline_branches: "910/1925 47.27%"
+        backend:
+          lines: "877/938 93.50%"
+          branches: "590/708 83.33%"
+          baseline_lines: "752/929 80.95%"
+          baseline_branches: "542/700 77.43%"
+        scripts:
+          lines: "2516/3332 75.51% unchanged"
+          branches: "2192/3111 70.46% unchanged"
+      strict_projection:
+        total: "4933 hit / 804 partial / 1869 miss / 7606 = 64.86% strict"
+        widget: "1801/217/961/2979 = 60.46%"
+        backend: "805/107/61/973 = 82.73%"
+        scripts: "2327/480/847/3654 = 63.68%"
+        note: "Local LCOV projection; not external Codecov processing. partials_as_hits remains false."
+      browser:
+        local:
+          total: 275
+          expected: 275
+          unexpected: 0
+          flaky: 0
+          skipped: 0
+          workers: 4
+          unique: 275
+          results: 275
+          retries:
+            - 0
+          projects:
+            chromium: 251
+            chromium-radix: 8
+            firefox-radix: 8
+            webkit-radix: 8
+        canonical:
+          total: 205
+          expected: 205
+          unexpected: 0
+          flaky: 0
+          skipped: 0
+          workers: 4
+          unique: 205
+          results: 205
+          retries:
+            - 0
+          project: chromium
+          file: widget.spec.ts
+          hover_regression: "present and passed"
+          active_drag_resize_regression: "present and passed"
+          sha256: 08761ae19cf38767cd17b0fd2d2d72181f67eaf9257cc211d663ceb20bd0696b
+          bytes: 696519
+          mtime_epoch: 1786135045
+          port_unused: true
+      adversarial_evidence:
+        - kind: no_gaming
+          detail: "No Vitest/package/workflow diff, no new exclusions/ignore directives/skips/retries/pass-zero/partials-as-hits, 82 unique exhaustive component paths."
+        - kind: risk_weighted
+          detail: "All native covered-line gain is product: widget +669 and backend +125; scripts unchanged."
+        - kind: defects_disproved_then_fixed
+          detail: "GitHub concurrent creation/collision, stalled capture cleanup, selector false-green, and trigger persistence drift each had preserved failing evidence before narrow repair."
+        - kind: assertion_quality
+          detail: "Direct cryptographic/HTTP/lifecycle/privacy/cleanup/geometry/canvas/output tests plus real browser pixel/pointer/Shadow DOM/mobile contracts."
+        - kind: scope
+          detail: "Every production/config change has paired tests and Judge receipts; protected workflow/dependency files unchanged."
+        - kind: artifact_retention
+          detail: "Canonical was final Playwright invocation; report decoded in memory and SHA256 unchanged after all read-only audits."
+      limitations:
+        - "External Codecov component processing across product PR/merge_group/public fork remains future informational evidence; no badge/blocking threshold now."
+        - "Deployment-only live projects were not run without complete identity inputs; pinned live workflows remain unchanged and explicitly guarded."
+      remaining_blockers: []
+      required_board_updates:
+        - "Record T028 done."
+        - "Activate T029 final Judge."
+        - "Do not run Playwright or overwrite retained artifact."
+  - id: T029
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Map the full original oracle to current receipts and verification, including repaired browser invariant and local/live separation, and decide completion."
+    inputs:
+      - "All receipts"
+      - "T028 final proof"
+      - "Current diff and artifacts"
+    constraints:
+      - "Read-only."
+      - "Reject any stale, skipped, retried, duplicated, partials-as-hits, assertion-weakened, or denominator-gamed evidence."
+      - "Reject completion while any required task remains active or queued."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "Final oracle mapping"
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      rationale: "Complete. Current artifacts validate the working-tree delta over pinned HEAD/origin, 68 files/965 tests, 74.81% lines and 68.74% branches, +794 covered lines/+320 branches. Components exhaust 82 unique LCOV records; strict projection keeps 804 partials out of hits. Direct risk contracts include pending video-frame callback timeout and abort cancellation. Post-review verification retained 205 retry-0 Chromium passes including hover/resize and active-drag/resize regressions, with the complete local matrix at 275/275. T028 records every gate passing. All non-final tasks terminal and prior blockers closed; no queued work."
+      evidence:
+        - kind: fresh_main
+          detail: "origin/main and merge-base exact fb7d2d974b2a66b3c799d2a3ee67ad6d7adc3438; the enclosing implementation revision is one commit ahead and zero behind."
+        - kind: terminal_board
+          detail: "All tasks terminal; prior blockers closed by later approved repairs."
+        - kind: full_gate_receipt
+          detail: "All unit/static/build/release/security/reporting/local/canonical gates pass."
+        - kind: native_coverage
+          detail: "5329/7123 lines 74.81%; 3964/5766 branches 68.74%; 5767/7837 statements; 1040/1348 functions."
+        - kind: baseline_delta
+          detail: "+794 covered lines, +320 branches; denominators grew 63/30."
+        - kind: component_partition
+          detail: "82 unique files: widget 46, backend 10, scripts 26; exhaustive."
+        - kind: no_script_masking
+          detail: "Scripts unchanged; all gain from widget/backend product."
+        - kind: strict_projection
+          detail: "4933 hit, 804 partial, 1869 miss, 7606 denominator, 64.86%; partials not hits."
+        - kind: strict_configuration
+          detail: "enable_partials true, partials_as_hits false, unit-only informational components."
+        - kind: no_gaming
+          detail: "No exclusion/package/workflow changes, ignores/skips/retries/pass-zero/duplicate coverage."
+        - kind: assertion_quality
+          detail: "Direct cryptographic/HTTP/lifecycle/privacy/cleanup/geometry/canvas/output contracts plus real browser proof."
+        - kind: browser_project_gate
+          detail: "275 local tests passed; variadic spaced and equals-form live selectors fail closed without inputs."
+        - kind: canonical_report
+          detail: "SHA256 08761ae19cf38767cd17b0fd2d2d72181f67eaf9257cc211d663ceb20bd0696b; 205 passes after rebase, four workers, retry 0, with hover/resize and active-drag/resize regressions passed."
+        - kind: limitations_not_blockers
+          detail: "External Codecov event processing remains informational; live deployment tests remain separate identity-pinned CI gates."
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks: []
+      missing_evidence: []
+      required_board_updates:
+        - "Record T029 complete/full_outcome true."
+        - "Mark goal complete/clear active."
+        - "No authorization to push/PR/deploy/promote thresholds/badge."
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: unknown
+    task: null
+    commands: []

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -185,6 +185,44 @@ test.describe('Widget Loading', () => {
       .toBeGreaterThanOrEqual(7);
   });
 
+  test('viewport resize preserves an active feedback button drag', async ({ page }) => {
+    await page.setViewportSize({ width: 900, height: 900 });
+    await page.goto('/test/');
+    await clearTriggerPositionStorage(page);
+    await page.reload();
+
+    const host = page.locator('#bugdrop-host');
+    const trigger = host.locator('css=.bd-trigger');
+    const handle = host.locator('css=.bd-trigger-drag-handle');
+    await expect(handle).toBeVisible({ timeout: 5000 });
+
+    await dragTriggerHandle(page, -160);
+    const repo = await getWidgetRepo(page);
+    const storageKey = `bugdrop_trigger_position_${repo}_bottom-right`;
+    const savedTop = Number(await page.evaluate(key => localStorage.getItem(key), storageKey));
+
+    const handleBox = await handle.boundingBox();
+    expect(handleBox).not.toBeNull();
+    const pointerX = handleBox!.x + handleBox!.width / 2;
+    const pointerY = handleBox!.y + handleBox!.height / 2;
+    await page.mouse.move(pointerX, pointerY);
+    await page.mouse.down();
+    await page.mouse.move(pointerX, pointerY + 80, { steps: 8 });
+
+    const activeDragTop = await trigger.evaluate(el => el.getBoundingClientRect().top);
+    expect(Math.abs(activeDragTop - savedTop)).toBeGreaterThan(40);
+
+    await page.evaluate(() => window.dispatchEvent(new Event('resize')));
+    await expect
+      .poll(() => trigger.evaluate(el => el.getBoundingClientRect().top))
+      .toBeCloseTo(activeDragTop, 0);
+
+    await page.mouse.up();
+    await expect
+      .poll(() => page.evaluate(key => Number(localStorage.getItem(key)), storageKey))
+      .toBeCloseTo(activeDragTop, 0);
+  });
+
   test('hidden feedback button keeps saved position across viewport resize', async ({ page }) => {
     await page.setViewportSize({ width: 900, height: 700 });
     await page.goto('/test/');
@@ -234,12 +272,35 @@ test.describe('Widget Loading', () => {
     expect(savedTop).not.toBeNull();
 
     await trigger.hover();
-    await page.setViewportSize({ width: 900, height: 860 });
+    await page.setViewportSize({ width: 900, height: 360 });
+
+    await expect
+      .poll(async () => {
+        return trigger.evaluate(el => {
+          const rect = el.getBoundingClientRect();
+          return rect.top >= 8 && window.innerHeight - rect.bottom >= 8;
+        });
+      })
+      .toBe(true);
+
+    const clampedBox = await trigger.boundingBox();
+    expect(clampedBox).not.toBeNull();
+    expect(clampedBox!.y).toBeGreaterThanOrEqual(8);
+    expect(clampedBox!.y + clampedBox!.height).toBeLessThanOrEqual(352);
+    await expect
+      .poll(() => page.evaluate(key => localStorage.getItem(key), storageKey))
+      .toBe(savedTop);
+
     await page.setViewportSize({ width: 900, height: 900 });
+    await page.mouse.move(10, 10);
 
     await expect
       .poll(() => page.evaluate(key => localStorage.getItem(key), storageKey))
       .toBe(savedTop);
+
+    await expect
+      .poll(() => trigger.evaluate(el => el.getBoundingClientRect().top))
+      .toBeCloseTo(Number(savedTop), 0);
   });
 
   test('missing local test config returns a javascript file', async ({ page }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,14 +2,50 @@ import { defineConfig, devices } from '@playwright/test';
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8787';
 const issueCanaryProject = 'chromium-issue-canary';
-const issueCanaryExplicitlySelected = process.argv.some((argument, index, arguments_) => {
-  return (
-    argument === `--project=${issueCanaryProject}` ||
-    (argument === '--project' && arguments_[index + 1] === issueCanaryProject)
-  );
-});
+const liveProjects = [
+  'chromium-live',
+  'chromium-live-radix',
+  'chromium-cross-browser-live',
+  'firefox-cross-browser-live',
+  'webkit-cross-browser-live',
+] as const;
+const explicitlySelectedProjects = new Set(
+  process.argv.flatMap((argument, index, arguments_) => {
+    if (!argument.startsWith('--project=') && argument !== '--project') return [];
+
+    const projectValues = arguments_.slice(index + 1);
+    const nextOptionIndex = projectValues.findIndex(project => project.startsWith('-'));
+    const followingProjects =
+      nextOptionIndex === -1 ? projectValues : projectValues.slice(0, nextOptionIndex);
+    return argument.startsWith('--project=')
+      ? [argument.slice('--project='.length), ...followingProjects]
+      : followingProjects;
+  })
+);
+const issueCanaryExplicitlySelected = explicitlySelectedProjects.has(issueCanaryProject);
+const liveProjectExplicitlySelected = [...explicitlySelectedProjects].some(selector =>
+  liveProjects.some(project => projectSelectorMatches(selector, project))
+);
+const liveInputsAvailable = Boolean(process.env.LIVE_TARGET && process.env.PLAYWRIGHT_BASE_URL);
 const issueCanaryTest = /.*\.issue-canary\.spec\.ts$/;
 const noTests = /$a/;
+
+function projectSelectorMatches(selector: string, project: string): boolean {
+  const pattern = selector
+    .toLocaleLowerCase()
+    .split('*')
+    .map(part => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('.*');
+  return new RegExp(`^${pattern}$`).test(project.toLocaleLowerCase());
+}
+
+if (liveProjectExplicitlySelected && !liveInputsAvailable) {
+  throw new Error('Live Playwright projects require both LIVE_TARGET and PLAYWRIGHT_BASE_URL.');
+}
+
+function liveTestMatch(pattern: RegExp): RegExp {
+  return liveInputsAvailable ? pattern : noTests;
+}
 
 export default defineConfig({
   testDir: './e2e',
@@ -49,7 +85,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
       },
-      testMatch: /.*\.live\.spec\.ts/,
+      testMatch: liveTestMatch(/.*\.live\.spec\.ts/),
       timeout: 60_000,
     },
     {
@@ -58,7 +94,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
       },
-      testMatch: /.*\.live-radix\.spec\.ts/,
+      testMatch: liveTestMatch(/.*\.live-radix\.spec\.ts/),
       timeout: 60_000,
     },
     {
@@ -67,7 +103,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
       },
-      testMatch: /.*\.cross-browser-live\.spec\.ts/,
+      testMatch: liveTestMatch(/.*\.cross-browser-live\.spec\.ts/),
       timeout: 60_000,
     },
     {
@@ -76,7 +112,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Firefox'],
       },
-      testMatch: /.*\.cross-browser-live\.spec\.ts/,
+      testMatch: liveTestMatch(/.*\.cross-browser-live\.spec\.ts/),
       timeout: 60_000,
     },
     {
@@ -85,7 +121,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Safari'],
       },
-      testMatch: /.*\.cross-browser-live\.spec\.ts/,
+      testMatch: liveTestMatch(/.*\.cross-browser-live\.spec\.ts/),
       timeout: 60_000,
     },
     {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -154,6 +154,9 @@ async function ensureScreenshotBranch(token: string, owner: string, repo: string
     { headers: headers(token) }
   );
   if (check.ok) return;
+  if (check.status !== 404) {
+    throw new Error(`Failed to check screenshot branch: ${check.status}`);
+  }
 
   // Get default branch SHA
   const repoRes = await fetch(`${GITHUB_API}/repos/${owner}/${repo}`, {
@@ -184,7 +187,23 @@ async function ensureScreenshotBranch(token: string, owner: string, repo: string
   });
   if (!createRes.ok) {
     const error = await createRes.text();
+    if (createRes.status === 422 && isExistingReferenceError(error)) {
+      const recheck = await fetch(
+        `${GITHUB_API}/repos/${owner}/${repo}/git/ref/heads/${SCREENSHOT_BRANCH}`,
+        { headers: headers(token) }
+      );
+      if (recheck.ok) return;
+    }
     throw new Error(`Failed to create screenshot branch: ${createRes.status} - ${error}`);
+  }
+}
+
+function isExistingReferenceError(body: string): boolean {
+  try {
+    const parsed = JSON.parse(body) as { message?: unknown };
+    return parsed.message === 'Reference already exists';
+  } catch {
+    return false;
   }
 }
 
@@ -205,9 +224,9 @@ export async function uploadScreenshotAsAsset(
   // Remove data URL prefix and extract the base64 content
   const content = base64DataUrl.replace(/^data:image\/\w+;base64,/, '');
 
-  // Generate unique filename with timestamp
+  // Retain the timestamp for traceability and add per-upload cryptographic entropy.
   const timestamp = Date.now();
-  const filename = `.bugdrop/screenshots/${timestamp}.png`;
+  const filename = `.bugdrop/screenshots/${timestamp}-${crypto.randomUUID()}.png`;
 
   return uploadBase64Asset(
     token,
@@ -226,7 +245,7 @@ export async function uploadAttachmentAsAsset(
   attachment: FeedbackAttachment
 ): Promise<string> {
   const timestamp = Date.now();
-  const filename = `.bugdrop/uploads/${timestamp}-${sanitizeAttachmentFilename(attachment.name)}`;
+  const filename = `.bugdrop/uploads/${timestamp}-${crypto.randomUUID()}-${sanitizeAttachmentFilename(attachment.name)}`;
   const content = attachment.dataUrl.replace(/^data:[^;]+;base64,/, '');
 
   return uploadBase64Asset(

--- a/src/widget/capture-timeout.ts
+++ b/src/widget/capture-timeout.ts
@@ -2,10 +2,20 @@ import { t } from './i18n';
 
 const CAPTURE_TIMEOUT_MS = 15_000;
 
-export function withCaptureTimeout<T>(capturePromise: Promise<T>): Promise<T> {
+export function withCaptureTimeout<T>(
+  capturePromise: Promise<T>,
+  onTimeout?: () => void
+): Promise<T> {
   let timer: ReturnType<typeof setTimeout>;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(t().captureTimeout)), CAPTURE_TIMEOUT_MS);
+    timer = setTimeout(() => {
+      try {
+        onTimeout?.();
+      } catch {
+        // Cancellation is best-effort; it must not replace the stable timeout result.
+      }
+      reject(new Error(t().captureTimeout));
+    }, CAPTURE_TIMEOUT_MS);
   });
 
   return Promise.race([capturePromise, timeoutPromise]).finally(() => clearTimeout(timer!));

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -607,11 +607,13 @@ function reclampVisibleTriggerPosition(trigger: HTMLElement, config: WidgetConfi
   const rect = trigger.getBoundingClientRect();
   if (rect.width === 0 || rect.height === 0) return;
 
-  const currentTop = parseFloat(trigger.style.top);
-  if (!Number.isFinite(currentTop)) return;
+  const renderedTop = parseFloat(trigger.style.top);
+  if (!Number.isFinite(renderedTop)) return;
 
-  const clampedTop = setTriggerTop(trigger, currentTop);
-  saveTriggerTop(config, clampedTop);
+  const desiredTop = trigger.classList.contains('bd-trigger--dragging')
+    ? renderedTop
+    : (getStoredTriggerTop(config) ?? renderedTop);
+  setTriggerTop(trigger, desiredTop);
 }
 
 function attachTriggerViewportClamp(trigger: HTMLElement, config: WidgetConfig): void {

--- a/src/widget/viewport-capture.ts
+++ b/src/widget/viewport-capture.ts
@@ -7,7 +7,13 @@ type DisplayMediaOptionsWithCurrentTab = DisplayMediaStreamOptions & {
 
 type VideoElementWithFrameCallback = HTMLVideoElement & {
   requestVideoFrameCallback?: (callback: () => void) => number;
+  cancelVideoFrameCallback?: (callbackId: number) => void;
 };
+
+interface CaptureResourceOwner {
+  attachStream: () => void;
+  cleanup: () => void;
+}
 
 declare global {
   interface Window {
@@ -32,22 +38,25 @@ function beginVisibleViewportCapture(): Promise<string> {
     preferCurrentTab: true,
   };
 
-  return withCaptureTimeout(
-    navigator.mediaDevices.getDisplayMedia(displayMediaOptions).then(stream => {
-      return captureVideoFrame(stream);
-    })
-  );
+  const controller = new AbortController();
+  const capturePromise = navigator.mediaDevices
+    .getDisplayMedia(displayMediaOptions)
+    .then(stream => captureVideoFrame(stream, controller.signal));
+
+  return withCaptureTimeout(capturePromise, () => controller.abort());
 }
 
-async function captureVideoFrame(stream: MediaStream): Promise<string> {
-  validateBrowserSurface(stream);
-
+async function captureVideoFrame(stream: MediaStream, signal: AbortSignal): Promise<string> {
   const video = document.createElement('video') as VideoElementWithFrameCallback;
   video.muted = true;
   video.playsInline = true;
+  const resources = createCaptureResourceOwner(stream, video, signal);
 
   try {
-    await waitForVideoFrame(video, stream);
+    validateBrowserSurface(stream);
+    throwIfAborted(signal);
+    await waitForVideoFrame(video, stream, signal, resources);
+    throwIfAborted(signal);
 
     const width = video.videoWidth || window.innerWidth;
     const height = video.videoHeight || window.innerHeight;
@@ -67,10 +76,7 @@ async function captureVideoFrame(stream: MediaStream): Promise<string> {
     ctx.drawImage(video, 0, 0, width, height);
     return canvas.toDataURL('image/png');
   } finally {
-    for (const track of stream.getTracks()) {
-      track.stop();
-    }
-    video.srcObject = null;
+    resources.cleanup();
   }
 }
 
@@ -78,27 +84,65 @@ function validateBrowserSurface(stream: MediaStream): void {
   const [track] = stream.getVideoTracks();
   const displaySurface = track?.getSettings().displaySurface;
   if (displaySurface && displaySurface !== 'browser') {
-    for (const streamTrack of stream.getTracks()) {
-      streamTrack.stop();
-    }
     throw new Error('Please choose the current browser tab for viewport capture');
   }
 }
 
+function createCaptureResourceOwner(
+  stream: MediaStream,
+  video: VideoElementWithFrameCallback,
+  signal: AbortSignal
+): CaptureResourceOwner {
+  let cleaned = false;
+  let streamAttached = false;
+  const cleanups: Array<() => void> = [];
+
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    for (const dispose of cleanups.splice(0)) dispose();
+    for (const track of stream.getTracks()) track.stop();
+    if (streamAttached) video.srcObject = null;
+  };
+  const onAbort = () => cleanup();
+  signal.addEventListener('abort', onAbort, { once: true });
+  cleanups.push(() => signal.removeEventListener('abort', onAbort));
+  if (signal.aborted) cleanup();
+
+  return {
+    attachStream: () => {
+      if (cleaned) return;
+      video.srcObject = stream;
+      streamAttached = true;
+    },
+    cleanup,
+  };
+}
+
 async function waitForVideoFrame(
   video: VideoElementWithFrameCallback,
-  stream: MediaStream
+  stream: MediaStream,
+  signal: AbortSignal,
+  resources: CaptureResourceOwner
 ): Promise<void> {
-  video.srcObject = stream;
-  await video.play().catch(() => {
-    // Some browsers expose the first frame after metadata without requiring play().
-  });
+  resources.attachStream();
+  throwIfAborted(signal);
+  let playPromise: Promise<void>;
+  try {
+    playPromise = video.play();
+  } catch {
+    playPromise = Promise.resolve();
+  }
+  await raceWithAbort(
+    playPromise.then(
+      () => undefined,
+      () => undefined
+    ),
+    signal
+  );
 
-  if (video.requestVideoFrameCallback) {
-    await Promise.race([
-      new Promise<void>(resolve => video.requestVideoFrameCallback?.(() => resolve())),
-      delay(250),
-    ]);
+  if (typeof video.requestVideoFrameCallback === 'function') {
+    await waitForVideoFrameCallback(video, signal);
     if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
       return;
     }
@@ -108,30 +152,77 @@ async function waitForVideoFrame(
     return;
   }
 
-  await Promise.race([
-    new Promise<void>((resolve, reject) => {
-      const onReady = () => {
-        cleanup();
-        resolve();
-      };
-      const onError = () => {
-        cleanup();
-        reject(new Error('Failed to load screen capture stream'));
-      };
-      const cleanup = () => {
-        video.removeEventListener('loadeddata', onReady);
-        video.removeEventListener('canplay', onReady);
-        video.removeEventListener('error', onError);
-      };
-
-      video.addEventListener('loadeddata', onReady);
-      video.addEventListener('canplay', onReady);
-      video.addEventListener('error', onError);
-    }),
-    delay(250),
-  ]);
+  await waitForVideoReadyEvent(video, signal);
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
+function raceWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(createAbortError());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener('abort', onAbort);
+      reject(createAbortError());
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      value => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      error => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+function waitForVideoFrameCallback(
+  video: VideoElementWithFrameCallback,
+  signal: AbortSignal
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let callbackId: number | undefined;
+    const timer = setTimeout(() => settle(resolve), 250);
+    const onAbort = () => settle(() => reject(createAbortError()));
+    const settle = (complete: () => void) => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      if (callbackId !== undefined) video.cancelVideoFrameCallback?.(callbackId);
+      callbackId = undefined;
+      complete();
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    callbackId = video.requestVideoFrameCallback?.(() => settle(resolve));
+    if (signal.aborted) onAbort();
+  });
+}
+
+function waitForVideoReadyEvent(video: HTMLVideoElement, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => settle(resolve), 250);
+    const onReady = () => settle(resolve);
+    const onError = () => settle(() => reject(new Error('Failed to load screen capture stream')));
+    const onAbort = () => settle(() => reject(createAbortError()));
+    const settle = (complete: () => void) => {
+      clearTimeout(timer);
+      video.removeEventListener('loadeddata', onReady);
+      video.removeEventListener('canplay', onReady);
+      video.removeEventListener('error', onError);
+      signal.removeEventListener('abort', onAbort);
+      complete();
+    };
+    video.addEventListener('loadeddata', onReady);
+    video.addEventListener('canplay', onReady);
+    video.addEventListener('error', onError);
+    signal.addEventListener('abort', onAbort, { once: true });
+    if (signal.aborted) onAbort();
+  });
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw createAbortError();
+}
+
+function createAbortError(): DOMException {
+  return new DOMException('Viewport capture aborted', 'AbortError');
 }

--- a/test/annotationFlow.test.ts
+++ b/test/annotationFlow.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const annotatorMocks = vi.hoisted(() => ({
+  createAnnotator: vi.fn(),
+  setTool: vi.fn(),
+  undo: vi.fn(),
+  getImageData: vi.fn(),
+  destroy: vi.fn(),
+}));
+
+vi.mock('../src/widget/annotator', () => ({
+  createAnnotator: annotatorMocks.createAnnotator,
+}));
+
+beforeEach(() => {
+  annotatorMocks.createAnnotator.mockReturnValue({
+    setTool: annotatorMocks.setTool,
+    undo: annotatorMocks.undo,
+    getImageData: annotatorMocks.getImageData,
+    destroy: annotatorMocks.destroy,
+  });
+  annotatorMocks.getImageData.mockReturnValue('annotated-image');
+  window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof matchMedia;
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.clearAllMocks();
+});
+
+async function openAnnotation(
+  redactionCount = 0,
+  opts?: Parameters<typeof import('../src/widget/annotation-flow').showAnnotationStep>[3]
+) {
+  const root = document.createElement('div');
+  document.body.append(root);
+  const { showAnnotationStep } = await import('../src/widget/annotation-flow');
+  const result = showAnnotationStep(root, 'data:image/png;base64,source', redactionCount, opts);
+  return { root, result };
+}
+
+describe('annotation flow', () => {
+  it('creates the annotator, switches active tools, and delegates undo', async () => {
+    const { root, result } = await openAnnotation();
+    expect(annotatorMocks.createAnnotator).toHaveBeenCalledWith(
+      root.querySelector('#annotation-canvas'),
+      'data:image/png;base64,source'
+    );
+
+    const arrow = root.querySelector<HTMLElement>('[data-tool="arrow"]')!;
+    arrow.click();
+    root.querySelector<HTMLElement>('[data-action="undo"]')?.click();
+
+    expect(annotatorMocks.setTool).toHaveBeenCalledTimes(1);
+    expect(annotatorMocks.setTool).toHaveBeenCalledWith('arrow');
+    expect(arrow.classList).toContain('active');
+    expect(root.querySelector('[data-tool="draw"]')?.classList).not.toContain('active');
+    expect(annotatorMocks.undo).toHaveBeenCalledTimes(1);
+    root.querySelector<HTMLElement>('.bd-close')?.click();
+    await expect(result).resolves.toBe('cancel');
+  });
+
+  it.each([
+    ['close', '.bd-close', 'cancel'],
+    ['retake', '[data-action="retake"]', 'retake'],
+  ] as const)(
+    '%s destroys once, removes the modal, and resolves %s',
+    async (_, selector, expected) => {
+      const { root, result } = await openAnnotation();
+      const button = root.querySelector<HTMLElement>(selector)!;
+      button.click();
+
+      await expect(result).resolves.toBe(expected);
+      expect(annotatorMocks.destroy).toHaveBeenCalledTimes(1);
+      expect(annotatorMocks.getImageData).not.toHaveBeenCalled();
+      expect(root.querySelector('.bd-overlay')).toBeNull();
+    }
+  );
+
+  it('gets the image before cleanup and resolves the annotation', async () => {
+    const order: string[] = [];
+    annotatorMocks.getImageData.mockImplementation(() => {
+      order.push('image');
+      return 'annotated-image';
+    });
+    annotatorMocks.destroy.mockImplementation(() => order.push('destroy'));
+    const { root, result } = await openAnnotation();
+
+    root.querySelector<HTMLElement>('[data-action="done"]')?.click();
+
+    await expect(result).resolves.toBe('annotated-image');
+    expect(order).toEqual(['image', 'destroy']);
+    expect(annotatorMocks.getImageData).toHaveBeenCalledTimes(1);
+    expect(annotatorMocks.destroy).toHaveBeenCalledTimes(1);
+    expect(root.querySelector('.bd-overlay')).toBeNull();
+  });
+
+  it('renders combined redaction guidance and a safe selected-element config link', async () => {
+    const { root, result } = await openAnnotation(2, {
+      redactionLimitations: true,
+      selectedElementCapture: true,
+    });
+
+    expect(root.textContent).toContain('2 private items were marked for redaction');
+    expect(root.textContent).toContain('does not inspect pixels inside embedded');
+    expect(root.textContent).toContain('Check that no sensitive information is visible');
+    const link = root.querySelector<HTMLAnchorElement>('.bd-selected-element-note a');
+    expect(link?.href).toBe('https://bugdrop.dev/docs/configuration#select-element-screenshots');
+    expect(link?.target).toBe('_blank');
+    expect(link?.rel).toBe('noopener noreferrer');
+    root.querySelector<HTMLElement>('.bd-close')?.click();
+    await result;
+  });
+
+  it('uses unavailable privacy guidance instead of count and limitation details', async () => {
+    const { root, result } = await openAnnotation(4, {
+      redactionUnavailable: true,
+      redactionLimitations: true,
+    });
+
+    expect(root.textContent).toContain('could not apply automatic private-field masks');
+    expect(root.textContent).not.toContain('4 private items');
+    expect(root.textContent).not.toContain('does not inspect pixels inside embedded');
+    root.querySelector<HTMLElement>('[data-action="retake"]')?.click();
+    await result;
+  });
+});

--- a/test/annotator.test.ts
+++ b/test/annotator.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAnnotator, type Tool } from '../src/widget/annotator';
+
+interface ContextMock {
+  beginPath: ReturnType<typeof vi.fn>;
+  closePath: ReturnType<typeof vi.fn>;
+  drawImage: ReturnType<typeof vi.fn>;
+  fill: ReturnType<typeof vi.fn>;
+  fillRect: ReturnType<typeof vi.fn>;
+  getImageData: ReturnType<typeof vi.fn>;
+  lineTo: ReturnType<typeof vi.fn>;
+  moveTo: ReturnType<typeof vi.fn>;
+  putImageData: ReturnType<typeof vi.fn>;
+  stroke: ReturnType<typeof vi.fn>;
+  strokeRect: ReturnType<typeof vi.fn>;
+  fillStyle: string;
+  lineCap: CanvasLineCap;
+  lineJoin: CanvasLineJoin;
+  lineWidth: number;
+  strokeStyle: string;
+}
+
+function mouse(type: string, x: number, y: number): MouseEvent {
+  return new MouseEvent(type, { bubbles: true, cancelable: true, clientX: x, clientY: y });
+}
+
+function drag(canvas: HTMLCanvasElement, from: [number, number], to: [number, number]): void {
+  canvas.dispatchEvent(mouse('mousedown', ...from));
+  canvas.dispatchEvent(mouse('mousemove', ...to));
+  window.dispatchEvent(mouse('mouseup', ...to));
+}
+
+describe('createAnnotator', () => {
+  let OriginalImage: typeof Image;
+  let context: ContextMock;
+  let snapshotNumber: number;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="container"></div>';
+    snapshotNumber = 0;
+    context = {
+      beginPath: vi.fn(),
+      closePath: vi.fn(),
+      drawImage: vi.fn(),
+      fill: vi.fn(),
+      fillRect: vi.fn(),
+      getImageData: vi.fn(() => ({ marker: ++snapshotNumber }) as unknown as ImageData),
+      lineTo: vi.fn(),
+      moveTo: vi.fn(),
+      putImageData: vi.fn(),
+      stroke: vi.fn(),
+      strokeRect: vi.fn(),
+      fillStyle: '',
+      lineCap: 'butt',
+      lineJoin: 'miter',
+      lineWidth: 1,
+      strokeStyle: '',
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      context as unknown as CanvasRenderingContext2D
+    );
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(
+      'data:image/png;base64,annotated'
+    );
+    vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      left: 10,
+      top: 20,
+      width: 200,
+      height: 100,
+      right: 210,
+      bottom: 120,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    });
+
+    OriginalImage = window.Image;
+    (window as unknown as { Image: unknown }).Image = class FakeImage {
+      onload: (() => void) | null = null;
+      width = 400;
+      height = 200;
+      set src(_value: string) {
+        queueMicrotask(() => this.onload?.());
+      }
+    };
+  });
+
+  afterEach(() => {
+    (window as unknown as { Image: unknown }).Image = OriginalImage;
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  async function setup() {
+    const container = document.querySelector<HTMLElement>('#container')!;
+    const annotator = createAnnotator(container, 'data:image/png;base64,source');
+    await Promise.resolve();
+    return { annotator, canvas: container.querySelector('canvas')! };
+  }
+
+  it('scales pointer coordinates to canvas pixels and clamps output bounds', async () => {
+    const { annotator, canvas } = await setup();
+    drag(canvas, [60, 45], [260, 150]);
+
+    expect(context.moveTo).toHaveBeenCalledWith(100, 50);
+    expect(context.lineTo).toHaveBeenCalledWith(400, 200);
+    expect(context.lineWidth).toBe(11);
+    expect(context.strokeStyle).toBe('#ff0000');
+    expect(annotator.getImageData()).toBe('data:image/png;base64,annotated');
+  });
+
+  it('emits durable canvas output for every annotation tool', async () => {
+    const { annotator, canvas } = await setup();
+    const useTool = (tool: Tool) => {
+      annotator.setTool(tool);
+      drag(canvas, [30, 40], [90, 80]);
+    };
+
+    useTool('draw');
+    useTool('arrow');
+    expect(context.fill).toHaveBeenCalled();
+    useTool('rect');
+    expect(context.strokeRect).toHaveBeenCalledWith(40, 40, 120, 80);
+    useTool('redact');
+    expect(context.fillRect).toHaveBeenCalledWith(39, 39, 122, 82);
+    expect(context.getImageData).toHaveBeenCalledTimes(5);
+  });
+
+  it('undoes mixed completed annotations in order', async () => {
+    const { annotator, canvas } = await setup();
+    drag(canvas, [30, 40], [90, 80]);
+    annotator.setTool('arrow');
+    drag(canvas, [40, 45], [100, 85]);
+    annotator.setTool('rect');
+    drag(canvas, [50, 50], [110, 90]);
+
+    context.putImageData.mockClear();
+    annotator.undo();
+    annotator.undo();
+    annotator.undo();
+    annotator.undo();
+
+    expect(
+      context.putImageData.mock.calls.map(([state]) => (state as { marker: number }).marker)
+    ).toEqual([3, 2, 1]);
+  });
+
+  it('cancels unfinished drafts and destroys idempotently', async () => {
+    const removeWindowListener = vi.spyOn(window, 'removeEventListener');
+    const { annotator, canvas } = await setup();
+    annotator.setTool('rect');
+    canvas.dispatchEvent(mouse('mousedown', 30, 40));
+    canvas.dispatchEvent(mouse('mousemove', 90, 80));
+
+    context.putImageData.mockClear();
+    annotator.setTool('arrow');
+    expect(context.putImageData).toHaveBeenCalledTimes(1);
+    expect(context.getImageData).toHaveBeenCalledTimes(1);
+
+    annotator.destroy();
+    expect(() => annotator.destroy()).not.toThrow();
+    expect(canvas.isConnected).toBe(false);
+    expect(removeWindowListener).toHaveBeenCalledWith('mouseup', expect.any(Function));
+  });
+});

--- a/test/areaPicker.test.ts
+++ b/test/areaPicker.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAreaPicker } from '../src/widget/area-picker';
+
+function pointer(type: string, x: number, y: number, pointerId = 1, isPrimary = true): Event {
+  const event = new MouseEvent(type, { bubbles: true, cancelable: true, clientX: x, clientY: y });
+  Object.defineProperties(event, {
+    pointerId: { value: pointerId },
+    isPrimary: { value: isPrimary },
+    pointerType: { value: 'touch' },
+  });
+  return event;
+}
+
+async function startPicker(options?: { coarse?: boolean; redactionsAvailable?: boolean }) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn(
+      () =>
+        ({
+          matches: options?.coarse ?? false,
+        }) as MediaQueryList
+    ),
+  });
+  const result = createAreaPicker(undefined, {
+    redactionsAvailable: options?.redactionsAvailable,
+  });
+  await vi.advanceTimersByTimeAsync(50);
+  return { result };
+}
+
+describe('createAreaPicker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '';
+    Object.defineProperty(window, 'scrollX', { configurable: true, value: 30 });
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 40 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('rejects undersized reverse drags before translating page coordinates', async () => {
+    const { result } = await startPicker();
+    const overlay = document.querySelector('#bugdrop-area-picker-overlay')!;
+
+    overlay.dispatchEvent(pointer('pointerdown', 50, 60));
+    document.dispatchEvent(pointer('pointermove', 56, 90));
+    document.dispatchEvent(pointer('pointerup', 56, 90));
+    expect(
+      document.querySelector<HTMLElement>('#bugdrop-area-picker-selection')!.style.display
+    ).toBe('none');
+
+    overlay.dispatchEvent(pointer('pointerdown', 100, 120));
+    document.dispatchEvent(pointer('pointermove', 20, 30));
+    const selection = document.querySelector<HTMLElement>('#bugdrop-area-picker-selection')!;
+    expect([
+      selection.style.left,
+      selection.style.top,
+      selection.style.width,
+      selection.style.height,
+    ]).toEqual(['20px', '30px', '80px', '90px']);
+    document.dispatchEvent(pointer('pointerup', 20, 30));
+
+    expect(await result).toEqual(expect.objectContaining({ x: 50, y: 70, width: 80, height: 90 }));
+    expect(document.querySelector('#bugdrop-area-picker-overlay')).toBeNull();
+  });
+
+  it('shows coarse-pointer cancellation with redaction-aware guidance', async () => {
+    const { result } = await startPicker({ coarse: true, redactionsAvailable: true });
+    const cancel = document.querySelector<HTMLButtonElement>('#bugdrop-area-picker-cancel');
+    expect(cancel).not.toBeNull();
+    expect(document.querySelector('#bugdrop-area-picker-tooltip')?.textContent).toContain(
+      'Marked private fields may be masked if included'
+    );
+
+    cancel!.click();
+    expect(await result).toBeNull();
+    expect(document.querySelector('#bugdrop-area-picker-tooltip')).toBeNull();
+  });
+
+  it('cancels and removes every listener after pointer cleanup', async () => {
+    const documentRemove = vi.spyOn(document, 'removeEventListener');
+    const { result } = await startPicker();
+    const overlay = document.querySelector('#bugdrop-area-picker-overlay')!;
+    overlay.dispatchEvent(pointer('pointerdown', 10, 10, 7));
+    document.dispatchEvent(pointer('pointermove', 30, 35, 7));
+    document.dispatchEvent(pointer('pointercancel', 30, 35, 7));
+
+    const selection = document.querySelector<HTMLElement>('#bugdrop-area-picker-selection')!;
+    expect(selection.style.display).toBe('none');
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(await result).toBeNull();
+    expect(documentRemove.mock.calls.map(([type]) => type)).toEqual(
+      expect.arrayContaining(['pointermove', 'pointerup', 'pointercancel', 'keydown'])
+    );
+  });
+});

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -6,6 +6,7 @@ repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 ci_workflow="$repo_root/.github/workflows/ci.yml"
 coverage_config="$repo_root/vitest.config.ts"
 codecov_config="$repo_root/codecov.yml"
+playwright_config="$repo_root/playwright.config.ts"
 live_workflow="$repo_root/.github/workflows/live-tests.yml"
 canary_spec="$repo_root/e2e/widget.issue-canary.spec.ts"
 canary_engine="$repo_root/e2e/widget.issue-canary.ts"
@@ -118,8 +119,142 @@ require_literal "$codecov_config" 'target: 80%'
 require_literal "$codecov_config" "- 'src/**'"
 require_literal "$codecov_config" 'comment: false'
 require_literal "$codecov_config" 'annotations: false'
-[[ $(grep -Fc 'informational: true' "$codecov_config") -eq 2 ]] ||
-  fail 'project and patch Codecov statuses must both remain informational'
+[[ $(grep -Fc 'informational: true' "$codecov_config") -eq 3 ]] ||
+  fail 'project, patch, and component Codecov statuses must remain informational'
+
+if ! node --input-type=module - "$codecov_config" <<'NODE'
+import fs from 'node:fs';
+import YAML from 'yaml';
+
+const configPath = process.argv[2];
+const config = YAML.parse(fs.readFileSync(configPath, 'utf8'));
+const expectedComponents = [
+  {
+    component_id: 'widget',
+    name: 'Widget',
+    paths: ['src/widget/**'],
+  },
+  {
+    component_id: 'backend',
+    name: 'Backend',
+    paths: [
+      'src/index.ts',
+      'src/defaults.ts',
+      'src/types.ts',
+      'src/lib/**',
+      'src/middleware/**',
+      'src/routes/**',
+    ],
+  },
+  {
+    component_id: 'scripts',
+    name: 'Scripts',
+    paths: ['scripts/**'],
+  },
+];
+const expectedStatus = [
+  {
+    type: 'project',
+    target: 'auto',
+    threshold: '1%',
+    informational: true,
+  },
+];
+
+function assertExact(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${label}: ${JSON.stringify(actual)}`);
+  }
+}
+
+assertExact(config.parsers?.javascript, { enable_partials: true }, 'javascript parser');
+assertExact(config.parsers?.lcov, { partials_as_hits: false }, 'lcov parser');
+assertExact(
+  config.component_management?.default_rules,
+  { flag_regexes: ['^unit$'], statuses: expectedStatus },
+  'component defaults'
+);
+assertExact(
+  config.component_management?.individual_components,
+  expectedComponents,
+  'individual components'
+);
+NODE
+then
+  fail 'Codecov component configuration does not match the unit-only contract'
+fi
+
+require_literal "$playwright_config" "'chromium-live'"
+require_literal "$playwright_config" "'chromium-live-radix'"
+require_literal "$playwright_config" "'chromium-cross-browser-live'"
+require_literal "$playwright_config" "'firefox-cross-browser-live'"
+require_literal "$playwright_config" "'webkit-cross-browser-live'"
+
+local_discovery=$(env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL \
+  npx playwright test --list --reporter=line 2>&1) ||
+  fail 'local Playwright discovery failed without live inputs'
+grep -Fq '[chromium]' <<< "$local_discovery" || fail 'local Chromium project was not discovered'
+for excluded_project in \
+  chromium-live \
+  chromium-live-radix \
+  chromium-cross-browser-live \
+  firefox-cross-browser-live \
+  webkit-cross-browser-live \
+  chromium-issue-canary; do
+  if grep -Fq "[$excluded_project]" <<< "$local_discovery"; then
+    fail "unqualified Playwright discovery included protected project: $excluded_project"
+  fi
+done
+
+for live_project in \
+  chromium-live \
+  chromium-live-radix \
+  chromium-cross-browser-live \
+  firefox-cross-browser-live \
+  webkit-cross-browser-live; do
+  live_discovery=$(LIVE_TARGET=preview PLAYWRIGHT_BASE_URL=https://example.invalid \
+    npx playwright test --project="$live_project" --list --reporter=line 2>&1) ||
+    fail "complete-input Playwright discovery failed: $live_project"
+  grep -Fq "[$live_project]" <<< "$live_discovery" ||
+    fail "complete-input Playwright discovery omitted project: $live_project"
+done
+
+require_live_input_failure() {
+  local selector=$1
+  local output
+  if output=$(env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL \
+    npx playwright test --project="$selector" --list --reporter=line 2>&1); then
+    fail "Playwright selector silently omitted live tests without inputs: $selector"
+  fi
+  grep -Fq 'Live Playwright projects require both LIVE_TARGET and PLAYWRIGHT_BASE_URL.' \
+    <<< "$output" || fail "Playwright selector did not report missing live inputs: $selector"
+}
+
+for selector in chromium-live 'chromium-*' '*-live' '*cross-browser-live'; do
+  require_live_input_failure "$selector"
+done
+
+variadic_output=$(env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL \
+  npx playwright test --project chromium chromium-live --list --reporter=line 2>&1) &&
+  fail 'variadic Playwright project selection silently omitted live tests without inputs'
+grep -Fq 'Live Playwright projects require both LIVE_TARGET and PLAYWRIGHT_BASE_URL.' \
+  <<< "$variadic_output" || fail 'variadic Playwright project selection bypassed the live-input guard'
+
+variadic_equals_output=$(env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL \
+  npx playwright test --project=chromium chromium-live --list --reporter=line 2>&1) &&
+  fail 'equals-form variadic Playwright selection silently omitted live tests without inputs'
+grep -Fq 'Live Playwright projects require both LIVE_TARGET and PLAYWRIGHT_BASE_URL.' \
+  <<< "$variadic_equals_output" || fail 'equals-form variadic selection bypassed the live-input guard'
+
+for partial_input in \
+  'LIVE_TARGET=preview' \
+  'PLAYWRIGHT_BASE_URL=https://example.invalid'; do
+  output=$(env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL $partial_input \
+    npx playwright test --project=chromium-live --list --reporter=line 2>&1) &&
+    fail "partial live input silently passed project discovery: $partial_input"
+  grep -Fq 'Live Playwright projects require both LIVE_TARGET and PLAYWRIGHT_BASE_URL.' \
+    <<< "$output" || fail "partial live input did not report the missing pair: $partial_input"
+done
 
 e2e_block=$(job_block "$ci_workflow" e2e)
 if grep -Eq '^    if:' <<< "$e2e_block"; then

--- a/test/consoleLogs.test.ts
+++ b/test/consoleLogs.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalConsole = {
+  log: console.log,
+  info: console.info,
+  warn: console.warn,
+  error: console.error,
+};
+
+async function loadCapture() {
+  vi.resetModules();
+  const module = await import('../src/widget/console-logs');
+  module.startConsoleLogCapture();
+  return module;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-08-06T12:34:56.000Z'));
+  console.log = vi.fn();
+  console.info = vi.fn();
+  console.warn = vi.fn();
+  console.error = vi.fn();
+});
+
+afterEach(() => {
+  console.log = originalConsole.log;
+  console.info = originalConsole.info;
+  console.warn = originalConsole.warn;
+  console.error = originalConsole.error;
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe('console log capture', () => {
+  it('starts idempotently, preserves console behavior, and timestamps each level', async () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+    const delegatedLog = vi.mocked(console.log);
+    const capture = await loadCapture();
+    const wrappedLog = console.log;
+
+    capture.startConsoleLogCapture();
+    console.log('hello', 7);
+    console.info('info');
+    console.warn('warn');
+    console.error('error');
+
+    expect(console.log).toBe(wrappedLog);
+    expect(delegatedLog).toHaveBeenCalledWith('hello', 7);
+    expect(addEventListener.mock.calls.filter(([type]) => type === 'error')).toHaveLength(1);
+    expect(
+      addEventListener.mock.calls.filter(([type]) => type === 'unhandledrejection')
+    ).toHaveLength(1);
+    expect(capture.getConsoleLogSnapshot()).toMatchObject([
+      { level: 'log', message: 'hello 7', timestamp: '2026-08-06T12:34:56.000Z' },
+      { level: 'info', message: 'info' },
+      { level: 'warn', message: 'warn' },
+      { level: 'error', message: 'error' },
+    ]);
+  });
+
+  it('redacts secrets after hostile-value serialization failures', async () => {
+    const capture = await loadCapture();
+    const circular: Record<string, unknown> = { password: 'plain-secret' };
+    circular.self = circular;
+    const hostile = {
+      toJSON() {
+        throw new Error('serialization failed');
+      },
+      toString() {
+        return 'token=abcdefghijklmnopqrstuvwxyz123456';
+      },
+    };
+
+    console.log(circular, hostile, 42n);
+    window.dispatchEvent(
+      new PromiseRejectionEvent('unhandledrejection', {
+        promise: Promise.resolve(),
+        reason: hostile,
+      })
+    );
+
+    const messages = capture.getConsoleLogSnapshot().map(entry => entry.message);
+    expect(messages).toEqual([
+      '[object Object] token=[redacted] 42',
+      'Unhandled promise rejection: token=[redacted]',
+    ]);
+    expect(messages.join(' ')).not.toContain('abcdefghijklmnopqrstuvwxyz123456');
+  });
+
+  it('captures error metadata, applies fallbacks, and truncates after redaction', async () => {
+    const capture = await loadCapture();
+
+    window.dispatchEvent(
+      new ErrorEvent('error', {
+        message: `authorization=Bearer ${'a'.repeat(1100)}`,
+        filename: 'https://example.test/app.js',
+        lineno: 12,
+        colno: 34,
+      })
+    );
+    window.dispatchEvent(new ErrorEvent('error'));
+
+    expect(capture.getConsoleLogSnapshot()).toMatchObject([
+      {
+        level: 'error',
+        message: 'authorization=Bearer [redacted]',
+        sourceUrl: 'https://example.test/app.js',
+        lineNumber: 12,
+        columnNumber: 34,
+      },
+      { level: 'error', message: 'Unhandled error' },
+    ]);
+    console.log('visible '.repeat(200));
+    expect(capture.getConsoleLogSnapshot().at(-1)?.message).toHaveLength(1000);
+  });
+
+  it('keeps only 50 entries and returns immutable snapshots', async () => {
+    const capture = await loadCapture();
+    for (let index = 0; index < 55; index += 1) console.log(`entry-${index}`);
+
+    const first = capture.getConsoleLogSnapshot();
+    expect(first).toHaveLength(50);
+    expect(first[0].message).toBe('entry-5');
+    first[0].message = 'mutated';
+    first.push({ level: 'error', message: 'injected', timestamp: 'never' });
+
+    const second = capture.getConsoleLogSnapshot();
+    expect(second).toHaveLength(50);
+    expect(second[0].message).toBe('entry-5');
+  });
+});

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -1,0 +1,434 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../src/types';
+
+const { mockGenerateGitHubAppJWT } = vi.hoisted(() => ({
+  mockGenerateGitHubAppJWT: vi.fn(),
+}));
+
+vi.mock('../src/lib/jwt', () => ({ generateGitHubAppJWT: mockGenerateGitHubAppJWT }));
+
+import {
+  GitHubLabelError,
+  createIssue,
+  getInstallationToken,
+  isRepoPublic,
+  uploadAttachmentAsAsset,
+  uploadScreenshotAsAsset,
+} from '../src/lib/github';
+
+const API_ROOT = 'https://api.github.com/repos/acme/widgets';
+const TOKEN = 'installation-token';
+const JWT = 'app-jwt';
+const API_HEADERS = {
+  Authorization: `Bearer ${TOKEN}`,
+  Accept: 'application/vnd.github+json',
+  'Content-Type': 'application/json',
+  'User-Agent': 'BugDrop/1.0',
+  'X-GitHub-Api-Version': '2022-11-28',
+};
+
+interface ExpectedRequest {
+  url: string | RegExp;
+  method?: string;
+  token?: string;
+  body?: unknown;
+  response: Response;
+}
+
+function expectRequests(requests: ExpectedRequest[]): ReturnType<typeof vi.fn<typeof fetch>> {
+  let index = 0;
+  const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+    const request = requests[index++];
+    const url = typeof input === 'string' ? input : input.url;
+    if (!request) throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`);
+
+    if (typeof request.url === 'string') expect(url).toBe(request.url);
+    else expect(url).toMatch(request.url);
+    expect(init?.method ?? 'GET').toBe(request.method ?? 'GET');
+    expect(init?.headers).toEqual({
+      ...API_HEADERS,
+      Authorization: `Bearer ${request.token ?? TOKEN}`,
+    });
+    if ('body' in request) expect(JSON.parse(String(init?.body))).toEqual(request.body);
+    else expect(init?.body).toBeUndefined();
+    return request.response;
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function branchSetupRequests(createResponse = new Response(null, { status: 201 })) {
+  return [
+    {
+      url: `${API_ROOT}/git/ref/heads/bugdrop-screenshots`,
+      response: new Response(null, { status: 404 }),
+    },
+    { url: API_ROOT, response: Response.json({ default_branch: 'main' }) },
+    {
+      url: `${API_ROOT}/git/ref/heads/main`,
+      response: Response.json({ object: { sha: 'base-sha' } }),
+    },
+    {
+      url: `${API_ROOT}/git/refs`,
+      method: 'POST',
+      body: { ref: 'refs/heads/bugdrop-screenshots', sha: 'base-sha' },
+      response: createResponse,
+    },
+  ];
+}
+
+describe('GitHub API boundary', () => {
+  beforeEach(() => {
+    mockGenerateGitHubAppJWT.mockReset().mockResolvedValue(JWT);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>(async input => {
+        const url = typeof input === 'string' ? input : input.url;
+        throw new Error(`Unexpected request: ${url}`);
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('gets the installation and token with exact requests and fails each stage closed', async () => {
+    const env = { GITHUB_APP_ID: '42', GITHUB_PRIVATE_KEY: 'private-key' } as Env;
+    let fetchMock = expectRequests([
+      {
+        url: `${API_ROOT}/installation`,
+        token: JWT,
+        response: Response.json({ id: 123 }),
+      },
+      {
+        url: 'https://api.github.com/app/installations/123/access_tokens',
+        method: 'POST',
+        token: JWT,
+        response: Response.json({ token: TOKEN }),
+      },
+    ]);
+    await expect(getInstallationToken(env, 'acme', 'widgets')).resolves.toBe(TOKEN);
+    expect(mockGenerateGitHubAppJWT).toHaveBeenNthCalledWith(1, '42', 'private-key');
+    expect(mockGenerateGitHubAppJWT).toHaveBeenNthCalledWith(2, '42', 'private-key');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    fetchMock = expectRequests([
+      {
+        url: `${API_ROOT}/installation`,
+        token: JWT,
+        response: new Response('missing', { status: 404 }),
+      },
+    ]);
+    await expect(getInstallationToken(env, 'acme', 'widgets')).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    expectRequests([
+      { url: `${API_ROOT}/installation`, token: JWT, response: Response.json({ id: 123 }) },
+      {
+        url: 'https://api.github.com/app/installations/123/access_tokens',
+        method: 'POST',
+        token: JWT,
+        response: new Response('denied', { status: 403 }),
+      },
+    ]);
+    await expect(getInstallationToken(env, 'acme', 'widgets')).resolves.toBeNull();
+    await expect(getInstallationToken({} as Env, 'acme', 'widgets')).resolves.toBeNull();
+  });
+
+  it('creates issues and classifies only structured label validation failures', async () => {
+    const issue = { number: 7, html_url: 'https://github.com/acme/widgets/issues/7' };
+    let fetchMock = expectRequests([
+      {
+        url: `${API_ROOT}/issues`,
+        method: 'POST',
+        body: { title: 'Title', body: 'Body', labels: ['feedback', 'urgent'] },
+        response: Response.json(issue),
+      },
+    ]);
+    await expect(
+      createIssue(TOKEN, 'acme', 'widgets', 'Title', 'Body', ['feedback', 'urgent'])
+    ).resolves.toEqual(issue);
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    fetchMock = expectRequests([
+      {
+        url: `${API_ROOT}/issues`,
+        method: 'POST',
+        body: { title: 'Title', body: 'Body', labels: ['bad'] },
+        response: Response.json({ errors: [{ field: 'labels' }] }, { status: 422 }),
+      },
+    ]);
+    const labelError = await createIssue(TOKEN, 'acme', 'widgets', 'Title', 'Body', ['bad']).catch(
+      (error: unknown) => error
+    );
+    expect(labelError).toBeInstanceOf(GitHubLabelError);
+    expect(labelError).toMatchObject({ status: 422 });
+
+    for (const body of ['{"errors":[{"field":"title"}]}', 'labels are invalid']) {
+      expectRequests([
+        {
+          url: `${API_ROOT}/issues`,
+          method: 'POST',
+          body: { title: 'Title', body: 'Body', labels: ['bad'] },
+          response: new Response(body, { status: 422 }),
+        },
+      ]);
+      await expect(createIssue(TOKEN, 'acme', 'widgets', 'Title', 'Body', ['bad'])).rejects.toThrow(
+        `Failed to create issue: 422 - ${body}`
+      );
+    }
+  });
+
+  it('reports repository visibility and fails closed on HTTP or transport errors', async () => {
+    let fetchMock = expectRequests([
+      { url: API_ROOT, response: Response.json({ private: false }) },
+    ]);
+    await expect(isRepoPublic(TOKEN, 'acme', 'widgets')).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    fetchMock = expectRequests([{ url: API_ROOT, response: Response.json({ private: true }) }]);
+    await expect(isRepoPublic(TOKEN, 'acme', 'widgets')).resolves.toBe(false);
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    expectRequests([{ url: API_ROOT, response: new Response('denied', { status: 403 }) }]);
+    await expect(isRepoPublic(TOKEN, 'acme', 'widgets')).resolves.toBe(false);
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>().mockRejectedValue(new Error('offline')));
+    await expect(isRepoPublic(TOKEN, 'acme', 'widgets')).resolves.toBe(false);
+  });
+
+  it('fails closed when the observed URL, method, authorization header, API version, or body is mutated', async () => {
+    const fetchMock = expectRequests([
+      {
+        url: `${API_ROOT}/issues`,
+        method: 'POST',
+        body: { title: 'Exact title', body: 'Exact body', labels: ['feedback'] },
+        response: Response.json({ number: 9, html_url: 'https://github.com/issue/9' }),
+      },
+    ]);
+    await createIssue(TOKEN, 'acme', 'widgets', 'Exact title', 'Exact body');
+    expect(fetchMock).toHaveBeenCalledWith(`${API_ROOT}/issues`, {
+      method: 'POST',
+      headers: API_HEADERS,
+      body: JSON.stringify({ title: 'Exact title', body: 'Exact body', labels: ['feedback'] }),
+    });
+  });
+});
+
+describe('GitHub asset persistence', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>(async input => {
+        const url = typeof input === 'string' ? input : input.url;
+        throw new Error(`Unexpected request: ${url}`);
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('recovers only from the exact already-existing-ref race after confirming the branch', async () => {
+    let branchChecks = 0;
+    let branchCreates = 0;
+    const uploadedUrls: string[] = [];
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url;
+      expect(init?.headers).toEqual(API_HEADERS);
+      if (url === `${API_ROOT}/git/ref/heads/bugdrop-screenshots`) {
+        expect(init?.method).toBeUndefined();
+        branchChecks += 1;
+        return branchChecks <= 2
+          ? new Response(null, { status: 404 })
+          : Response.json({ ref: 'refs/heads/bugdrop-screenshots' });
+      }
+      if (url === API_ROOT) {
+        expect(init?.method).toBeUndefined();
+        return Response.json({ default_branch: 'main' });
+      }
+      if (url === `${API_ROOT}/git/ref/heads/main`) {
+        expect(init?.method).toBeUndefined();
+        return Response.json({ object: { sha: 'base-sha' } });
+      }
+      if (url === `${API_ROOT}/git/refs`) {
+        expect(init?.method).toBe('POST');
+        expect(JSON.parse(String(init?.body))).toEqual({
+          ref: 'refs/heads/bugdrop-screenshots',
+          sha: 'base-sha',
+        });
+        branchCreates += 1;
+        return branchCreates === 1
+          ? new Response(null, { status: 201 })
+          : Response.json({ message: 'Reference already exists' }, { status: 422 });
+      }
+      if (url.startsWith(`${API_ROOT}/contents/.bugdrop/screenshots/`)) {
+        expect(init?.method).toBe('PUT');
+        uploadedUrls.push(url);
+        return Response.json({
+          content: { html_url: `https://github.com/blob/${uploadedUrls.length}` },
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const results = await Promise.all([
+      uploadScreenshotAsAsset(TOKEN, 'acme', 'widgets', 'data:image/png;base64,AAA='),
+      uploadScreenshotAsAsset(TOKEN, 'acme', 'widgets', 'data:image/png;base64,BBB='),
+    ]);
+
+    expect(results).toEqual([
+      'https://github.com/blob/1?raw=true',
+      'https://github.com/blob/2?raw=true',
+    ]);
+    expect(branchChecks).toBe(3);
+    expect(branchCreates).toBe(2);
+    expect(new Set(uploadedUrls).size).toBe(2);
+  });
+
+  it('rejects unrelated or malformed 422 responses and failed branch rechecks', async () => {
+    const cases = [
+      { body: '{"message":"Validation Failed"}', recheck: false },
+      { body: '{"message":"Reference already exists today"}', recheck: false },
+      { body: 'not-json', recheck: false },
+      { body: '{"message":"Reference already exists"}', recheck: true },
+    ];
+
+    for (const testCase of cases) {
+      const requests: ExpectedRequest[] = branchSetupRequests(
+        new Response(testCase.body, { status: 422 })
+      );
+      if (testCase.recheck) {
+        requests.push({
+          url: `${API_ROOT}/git/ref/heads/bugdrop-screenshots`,
+          response: new Response('still missing', { status: 404 }),
+        });
+      }
+      expectRequests(requests);
+      await expect(
+        uploadScreenshotAsAsset(TOKEN, 'acme', 'widgets', 'data:image/png;base64,AAA=')
+      ).rejects.toThrow(`Failed to create screenshot branch: 422 - ${testCase.body}`);
+    }
+  });
+
+  it('fails closed when the initial screenshot branch lookup is not 404', async () => {
+    const fetchMock = expectRequests([
+      {
+        url: `${API_ROOT}/git/ref/heads/bugdrop-screenshots`,
+        response: new Response('forbidden', { status: 403 }),
+      },
+    ]);
+    await expect(
+      uploadScreenshotAsAsset(TOKEN, 'acme', 'widgets', 'data:image/png;base64,AAA=')
+    ).rejects.toThrow('Failed to check screenshot branch: 403');
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('uses distinct screenshot and attachment paths in the same millisecond', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_725_000_000_000);
+    const uploadedUrls: string[] = [];
+    const uploadedBodies: Array<{ message: string; content: string; branch: string }> = [];
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url;
+      expect(init?.headers).toEqual(API_HEADERS);
+      if (url === `${API_ROOT}/git/ref/heads/bugdrop-screenshots`) {
+        expect(init?.method).toBeUndefined();
+        return Response.json({ ref: 'refs/heads/bugdrop-screenshots' });
+      }
+      if (url.startsWith(`${API_ROOT}/contents/`)) {
+        expect(init?.method).toBe('PUT');
+        uploadedUrls.push(url);
+        uploadedBodies.push(JSON.parse(String(init?.body)) as (typeof uploadedBodies)[number]);
+        return Response.json({
+          content: { html_url: `https://github.com/blob/${uploadedUrls.length}` },
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const results = await Promise.all([
+      uploadScreenshotAsAsset(TOKEN, 'acme', 'widgets', 'data:image/png;base64,AAA='),
+      uploadScreenshotAsAsset(TOKEN, 'acme', 'widgets', 'data:image/png;base64,BBB='),
+      uploadAttachmentAsAsset(TOKEN, 'acme', 'widgets', {
+        name: ' ../../bad name?.txt ',
+        type: 'text/plain',
+        size: 3,
+        dataUrl: 'data:text/plain;base64,Q0ND',
+      }),
+      uploadAttachmentAsAsset(TOKEN, 'acme', 'widgets', {
+        name: '///',
+        type: 'text/plain',
+        size: 3,
+        dataUrl: 'data:text/plain;base64,RERE',
+      }),
+    ]);
+
+    expect(results).toEqual([
+      'https://github.com/blob/1?raw=true',
+      'https://github.com/blob/2?raw=true',
+      'https://github.com/blob/3?raw=true',
+      'https://github.com/blob/4?raw=true',
+    ]);
+    expect(new Set(uploadedUrls).size).toBe(4);
+    expect(uploadedUrls[0]).toMatch(/\/screenshots\/1725000000000-[0-9a-f-]{36}\.png$/);
+    expect(uploadedUrls[1]).toMatch(/\/screenshots\/1725000000000-[0-9a-f-]{36}\.png$/);
+    expect(uploadedUrls[2]).toMatch(
+      /\/uploads\/1725000000000-[0-9a-f-]{36}-\.\.-\.\.-bad-name-\.txt$/
+    );
+    expect(uploadedUrls[3]).toMatch(/\/uploads\/1725000000000-[0-9a-f-]{36}-upload$/);
+    expect(uploadedBodies.map(body => body.content)).toEqual(['AAA=', 'BBB=', 'Q0ND', 'RERE']);
+    expect(uploadedBodies.every(body => body.branch === 'bugdrop-screenshots')).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(8);
+  });
+
+  it('reports exact setup and upload failures', async () => {
+    for (const { requests, message } of [
+      {
+        requests: [
+          branchSetupRequests()[0],
+          { url: API_ROOT, response: new Response('denied', { status: 403 }) },
+        ],
+        message: 'Failed to get repo info: 403',
+      },
+      {
+        requests: [
+          ...branchSetupRequests().slice(0, 2),
+          {
+            url: `${API_ROOT}/git/ref/heads/main`,
+            response: new Response('missing', { status: 404 }),
+          },
+        ],
+        message: 'Failed to get default branch ref: 404',
+      },
+      {
+        requests: [
+          {
+            url: `${API_ROOT}/git/ref/heads/bugdrop-screenshots`,
+            response: Response.json({ ref: 'existing' }),
+          },
+          {
+            url: /^https:\/\/api\.github\.com\/repos\/acme\/widgets\/contents\//,
+            method: 'PUT',
+            body: {
+              message: expect.stringMatching(/^Add BugDrop screenshot \d+$/),
+              content: 'AAA=',
+              branch: 'bugdrop-screenshots',
+            },
+            response: new Response('conflict', { status: 409 }),
+          },
+        ],
+        message: 'Failed to upload screenshot: 409 - conflict',
+      },
+    ] as Array<{ requests: ExpectedRequest[]; message: string }>) {
+      expectRequests(requests);
+      await expect(
+        uploadScreenshotAsAsset(TOKEN, 'acme', 'widgets', 'data:image/png;base64,AAA=')
+      ).rejects.toThrow(message);
+    }
+  });
+});

--- a/test/jwt.test.ts
+++ b/test/jwt.test.ts
@@ -1,0 +1,98 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { generateGitHubAppJWT } from '../src/lib/jwt';
+
+const FIXED_TIME = new Date('2026-08-06T12:34:56.000Z');
+
+let pkcs8PrivateKey: string;
+let pkcs1PrivateKey: string;
+let publicKey: CryptoKey;
+
+function decodeBase64Url(value: string): Uint8Array {
+  const base64 = value
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+    .padEnd(Math.ceil(value.length / 4) * 4, '=');
+  return Uint8Array.from(atob(base64), character => character.charCodeAt(0));
+}
+
+function decodeJson(value: string): unknown {
+  return JSON.parse(new TextDecoder().decode(decodeBase64Url(value)));
+}
+
+beforeAll(async () => {
+  const pair = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  pkcs8PrivateKey = pair.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+  pkcs1PrivateKey = pair.privateKey.export({ type: 'pkcs1', format: 'pem' }).toString();
+  const spki = pair.publicKey.export({ type: 'spki', format: 'der' });
+  publicKey = await crypto.subtle.importKey(
+    'spki',
+    spki,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['verify']
+  );
+});
+
+describe('generateGitHubAppJWT', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('cryptographically verifies RS256 and rejects altered signing input', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(FIXED_TIME.getTime());
+    const token = await generateGitHubAppJWT('123456', pkcs8PrivateKey);
+    const [header, payload, signature] = token.split('.');
+    const signingInput = `${header}.${payload}`;
+
+    expect(decodeJson(header)).toEqual({ alg: 'RS256', typ: 'JWT' });
+    expect(decodeJson(payload)).toEqual({
+      iat: Math.floor(FIXED_TIME.getTime() / 1000) - 60,
+      exp: Math.floor(FIXED_TIME.getTime() / 1000) + 600,
+      iss: '123456',
+    });
+    await expect(
+      crypto.subtle.verify(
+        { name: 'RSASSA-PKCS1-v1_5' },
+        publicKey,
+        decodeBase64Url(signature),
+        new TextEncoder().encode(signingInput)
+      )
+    ).resolves.toBe(true);
+    await expect(
+      crypto.subtle.verify(
+        { name: 'RSASSA-PKCS1-v1_5' },
+        publicKey,
+        decodeBase64Url(signature),
+        new TextEncoder().encode(`${header}.${payload.slice(0, -1)}A`)
+      )
+    ).resolves.toBe(false);
+  });
+
+  it('converts PKCS#1 private keys and produces a verifiable signature', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(FIXED_TIME.getTime());
+    const token = await generateGitHubAppJWT('654321', pkcs1PrivateKey);
+    const [header, payload, signature] = token.split('.');
+
+    expect(decodeJson(payload)).toMatchObject({ iss: '654321' });
+    await expect(
+      crypto.subtle.verify(
+        { name: 'RSASSA-PKCS1-v1_5' },
+        publicKey,
+        decodeBase64Url(signature),
+        new TextEncoder().encode(`${header}.${payload}`)
+      )
+    ).resolves.toBe(true);
+  });
+
+  it.each([
+    ['malformed PKCS#8', '-----BEGIN PRIVATE KEY-----\nnot-base64!\n-----END PRIVATE KEY-----'],
+    [
+      'malformed PKCS#1',
+      '-----BEGIN RSA PRIVATE KEY-----\nnot-base64!\n-----END RSA PRIVATE KEY-----',
+    ],
+    ['empty key', ''],
+  ])('rejects %s input', async (_name, privateKey) => {
+    await expect(generateGitHubAppJWT('123456', privateKey)).rejects.toThrow();
+  });
+});

--- a/test/picker.test.ts
+++ b/test/picker.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createElementPicker } from '../src/widget/picker';
+
+function pointer(type: string, x: number, y: number, pointerId = 1, isPrimary = true): Event {
+  const event = new MouseEvent(type, { bubbles: true, cancelable: true, clientX: x, clientY: y });
+  Object.defineProperties(event, {
+    pointerId: { value: pointerId },
+    isPrimary: { value: isPrimary },
+    pointerType: { value: 'touch' },
+  });
+  return event;
+}
+
+async function startPicker(coarse = false) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn(() => ({ matches: coarse }) as MediaQueryList),
+  });
+  const result = createElementPicker();
+  await vi.advanceTimersByTimeAsync(50);
+  return { result };
+}
+
+describe('createElementPicker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = `
+      <button id="target"><span id="nested">Pick me</span></button>
+      <div id="bugdrop-owned" data-bugdrop-owned><span id="owned-child"></span></div>
+    `;
+    Object.defineProperty(document, 'elementsFromPoint', {
+      configurable: true,
+      value: vi.fn(() => [
+        document.querySelector('#bugdrop-element-picker-overlay')!,
+        document.querySelector('#owned-child')!,
+        document.querySelector('#nested')!,
+      ]),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('suppresses the selecting click while resolving the nearest clickable target', async () => {
+    const pageClick = vi.fn();
+    document.querySelector('#target')!.addEventListener('click', pageClick);
+    const { result } = await startPicker();
+    const overlay = document.querySelector('#bugdrop-element-picker-overlay')!;
+
+    overlay.dispatchEvent(pointer('pointerdown', 20, 30));
+    overlay.dispatchEvent(pointer('pointerup', 20, 30));
+    const selected = await result;
+    expect(selected?.id).toBe('target');
+
+    const syntheticClick = new MouseEvent('click', { bubbles: true, cancelable: true });
+    document.querySelector('#target')!.dispatchEvent(syntheticClick);
+    expect(syntheticClick.defaultPrevented).toBe(true);
+    expect(pageClick).not.toHaveBeenCalled();
+  });
+
+  it('cancels and removes every listener on Escape', async () => {
+    const documentRemove = vi.spyOn(document, 'removeEventListener');
+    const windowRemove = vi.spyOn(window, 'removeEventListener');
+    const { result } = await startPicker();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(await result).toBeNull();
+    expect(document.querySelector('#bugdrop-element-picker-overlay')).toBeNull();
+    expect(document.body.style.cursor).toBe('');
+    expect(documentRemove.mock.calls.map(([type]) => type)).toEqual(
+      expect.arrayContaining(['mousemove', 'click', 'keydown'])
+    );
+    expect(windowRemove.mock.calls.map(([type]) => type)).toEqual(
+      expect.arrayContaining(['pointerdown', 'pointermove', 'pointerup', 'pointercancel'])
+    );
+  });
+
+  it('normalizes touch and coarse-pointer input and supports inline cancel', async () => {
+    const { result } = await startPicker(true);
+    const cancel = document.querySelector<HTMLButtonElement>('#bugdrop-element-picker-cancel');
+    expect(cancel).not.toBeNull();
+    cancel!.click();
+    expect(await result).toBeNull();
+  });
+
+  it('ignores secondary pointers and resets a canceled primary pointer', async () => {
+    const { result } = await startPicker();
+    const overlay = document.querySelector('#bugdrop-element-picker-overlay')!;
+    overlay.dispatchEvent(pointer('pointerdown', 10, 10, 1, false));
+    overlay.dispatchEvent(pointer('pointerdown', 10, 10, 2));
+    overlay.dispatchEvent(pointer('pointercancel', 10, 10, 3));
+    overlay.dispatchEvent(pointer('pointercancel', 10, 10, 2));
+    overlay.dispatchEvent(pointer('pointerdown', 20, 20, 4));
+    overlay.dispatchEvent(pointer('pointerup', 20, 20, 4));
+    expect((await result)?.id).toBe('target');
+  });
+});

--- a/test/pickerTarget.test.ts
+++ b/test/pickerTarget.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { getSelectionTarget } from '../src/widget/picker-target';
+
+describe('getSelectionTarget', () => {
+  it('resolves nested SVG and clickable ancestors', () => {
+    document.body.innerHTML = `
+      <button id="action"><span><svg><g><path id="svg-child"></path></g></svg></span></button>
+      <a id="link" href="/issues"><strong id="link-child">Issue</strong></a>
+    `;
+
+    expect(getSelectionTarget(document.querySelector('#svg-child')!)).toBe(
+      document.querySelector('#action')
+    );
+    expect(getSelectionTarget(document.querySelector('#link-child')!)).toBe(
+      document.querySelector('#link')
+    );
+  });
+
+  it('recognizes enabled controls, interactive roles, summary, and nonnegative tabindex', () => {
+    document.body.innerHTML = `
+      <div id="role" role="unknown BUTTON"><span id="role-child"></span></div>
+      <div id="focusable" tabindex="0"><span id="focus-child"></span></div>
+      <details><summary id="summary"><span id="summary-child"></span></summary></details>
+      <input id="input"><span id="plain"></span>
+    `;
+
+    expect(getSelectionTarget(document.querySelector('#role-child')!)).toBe(
+      document.querySelector('#role')
+    );
+    expect(getSelectionTarget(document.querySelector('#focus-child')!)).toBe(
+      document.querySelector('#focusable')
+    );
+    expect(getSelectionTarget(document.querySelector('#summary-child')!)).toBe(
+      document.querySelector('#summary')
+    );
+    expect(getSelectionTarget(document.querySelector('#input')!)).toBe(
+      document.querySelector('#input')
+    );
+    expect(getSelectionTarget(document.querySelector('#plain')!)).toBe(
+      document.querySelector('#plain')
+    );
+  });
+
+  it('does not promote disabled or aria-disabled ancestors', () => {
+    document.body.innerHTML = `
+      <button id="disabled" disabled><span id="disabled-child"></span></button>
+      <div id="aria-disabled" role="button" aria-disabled="true">
+        <span id="aria-child"></span>
+      </div>
+      <a id="no-href"><span id="anchor-child"></span></a>
+    `;
+
+    expect(getSelectionTarget(document.querySelector('#disabled-child')!).id).toBe(
+      'disabled-child'
+    );
+    expect(getSelectionTarget(document.querySelector('#aria-child')!).id).toBe('aria-child');
+    expect(getSelectionTarget(document.querySelector('#anchor-child')!).id).toBe('anchor-child');
+  });
+});

--- a/test/screenshotOptions.test.ts
+++ b/test/screenshotOptions.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const screenshotMocks = vi.hoisted(() => ({
+  beginViewportCapture: vi.fn<() => Promise<string>>(),
+  canCaptureViewportNatively: vi.fn(),
+  getRedactionCount: vi.fn(),
+  isFullPageDisabled: vi.fn(),
+}));
+
+vi.mock('../src/widget/screenshot', () => screenshotMocks);
+
+async function choose(action: string, opts?: { allowSkip?: boolean }) {
+  const root = document.createElement('div');
+  document.body.append(root);
+  const { showScreenshotOptions } = await import('../src/widget/screenshot-options');
+  const result = showScreenshotOptions(root, opts);
+  const button = root.querySelector<HTMLElement>(`[data-action="${action}"]`);
+  expect(button).not.toBeNull();
+  button?.click();
+  return { choice: await result, root };
+}
+
+beforeEach(() => {
+  screenshotMocks.isFullPageDisabled.mockReturnValue(false);
+  screenshotMocks.canCaptureViewportNatively.mockReturnValue(false);
+  screenshotMocks.getRedactionCount.mockReturnValue(0);
+  screenshotMocks.beginViewportCapture.mockResolvedValue('viewport-image');
+  window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof matchMedia;
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.clearAllMocks();
+});
+
+describe('screenshot options', () => {
+  it.each([
+    ['capture', 'capture'],
+    ['area', 'area'],
+    ['element', 'element'],
+    ['skip', 'skip'],
+  ] as const)('resolves %s and removes its modal', async (action, kind) => {
+    const { choice, root } = await choose(action);
+    expect(choice).toEqual({ kind });
+    expect(root.querySelector('.bd-overlay')).toBeNull();
+  });
+
+  it('cancels from close and omits skip when screenshots are required', async () => {
+    const root = document.createElement('div');
+    document.body.append(root);
+    const { showScreenshotOptions } = await import('../src/widget/screenshot-options');
+    const result = showScreenshotOptions(root, { allowSkip: false });
+
+    expect(root.querySelector('[data-action="skip"]')).toBeNull();
+    root.querySelector<HTMLElement>('.bd-close')?.click();
+    await expect(result).resolves.toEqual({ kind: 'cancel' });
+    expect(root.querySelector('.bd-overlay')).toBeNull();
+  });
+
+  it('shows only element fallback and escaped privacy guidance on complex pages', async () => {
+    screenshotMocks.isFullPageDisabled.mockReturnValue(true);
+    screenshotMocks.getRedactionCount.mockReturnValue(3);
+    const root = document.createElement('div');
+    document.body.append(root);
+    const { showScreenshotOptions } = await import('../src/widget/screenshot-options');
+    const result = showScreenshotOptions(root);
+
+    expect(root.textContent).toContain('Select a specific element instead.');
+    expect(root.textContent).toContain('marked some fields for redaction');
+    expect(root.querySelector('[data-action="capture"]')).toBeNull();
+    expect(root.querySelector('[data-action="viewport"]')).toBeNull();
+    expect(root.querySelector('[data-action="area"]')).toBeNull();
+    root.querySelector<HTMLElement>('[data-action="element"]')?.click();
+    await expect(result).resolves.toEqual({ kind: 'element' });
+  });
+
+  it('starts viewport capture inside the click and returns the same delayed promise', async () => {
+    screenshotMocks.isFullPageDisabled.mockReturnValue(true);
+    screenshotMocks.canCaptureViewportNatively.mockReturnValue(true);
+    let resolveCapture!: (value: string) => void;
+    const capture = new Promise<string>(resolve => {
+      resolveCapture = resolve;
+    });
+    screenshotMocks.beginViewportCapture.mockReturnValue(capture);
+    const root = document.createElement('div');
+    document.body.append(root);
+    const { showScreenshotOptions } = await import('../src/widget/screenshot-options');
+    const result = showScreenshotOptions(root);
+
+    expect(root.textContent).toContain('cannot apply automatic private-field masks');
+    root.querySelector<HTMLElement>('[data-action="viewport"]')?.click();
+    expect(screenshotMocks.beginViewportCapture).toHaveBeenCalledTimes(1);
+    const choice = await result;
+    expect(choice).toEqual({ kind: 'viewport', capture });
+    resolveCapture('delayed-image');
+    if (choice.kind === 'viewport') await expect(choice.capture).resolves.toBe('delayed-image');
+  });
+
+  it('handles an immediate viewport rejection without changing the returned failure', async () => {
+    screenshotMocks.isFullPageDisabled.mockReturnValue(true);
+    screenshotMocks.canCaptureViewportNatively.mockReturnValue(true);
+    const failure = Promise.reject(new Error('capture denied'));
+    screenshotMocks.beginViewportCapture.mockReturnValue(failure);
+
+    const { choice } = await choose('viewport');
+    expect(screenshotMocks.beginViewportCapture).toHaveBeenCalledTimes(1);
+    if (choice.kind !== 'viewport') throw new Error('Expected viewport choice');
+    await expect(choice.capture).rejects.toThrow('capture denied');
+  });
+});

--- a/test/variantForm.test.ts
+++ b/test/variantForm.test.ts
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVariantForm } from '../src/widget/variants/form';
+import type { SubmissionResult, VariantConfig } from '../src/widget/variants/public-types';
+
+const config: VariantConfig = {
+  id: 'question',
+  presentation: { kind: 'modal' },
+  content: { title: 'Ask a question', cancelLabel: 'Cancel' },
+  fields: [{ id: 'response', type: 'longText', label: 'Response', required: true }],
+  issue: { title: 'Question: {{response}}' },
+};
+
+const result: SubmissionResult = {
+  issueNumber: 12,
+  issueUrl: 'https://github.com/owner/repo/issues/12',
+  isPublic: true,
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function submit(form: HTMLFormElement): void {
+  form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }));
+}
+
+describe('variant form lifecycle', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    vi.spyOn(globalThis.crypto, 'randomUUID')
+      .mockReturnValueOnce('00000000-0000-4000-8000-000000000001')
+      .mockReturnValueOnce('00000000-0000-4000-8000-000000000002')
+      .mockReturnValue('00000000-0000-4000-8000-000000000003');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('suppresses duplicate submissions while busy and exposes one successful transition', async () => {
+    const pending = deferred<SubmissionResult>();
+    const onSubmitted = vi.fn();
+    const onCancel = vi.fn();
+    const submitRequest = vi.fn().mockReturnValue(pending.promise);
+    const controller = createVariantForm({
+      config,
+      instanceId: 'form-1',
+      context: { account_id: 'acct-1' },
+      initialAnswers: { response: '  Help  ' },
+      submit: submitRequest,
+      cancel: { label: 'Not now', onCancel },
+      onSubmitted,
+    });
+    document.body.appendChild(controller.element);
+    const form = controller.element.querySelector('form')!;
+
+    submit(form);
+    submit(form);
+    expect(submitRequest).toHaveBeenCalledTimes(1);
+    expect(submitRequest).toHaveBeenCalledWith(
+      { response: 'Help' },
+      {
+        context: { account_id: 'acct-1' },
+        submissionId: 'submission-00000000-0000-4000-8000-000000000001',
+      }
+    );
+    expect(form.getAttribute('aria-busy')).toBe('true');
+    expect(controller.element.querySelector<HTMLButtonElement>('.bdv-submit')?.disabled).toBe(true);
+    expect(controller.element.querySelector<HTMLButtonElement>('.bdv-cancel')?.disabled).toBe(true);
+    expect(controller.element.querySelector('textarea')?.disabled).toBe(true);
+
+    pending.resolve(result);
+    await pending.promise;
+    await Promise.resolve();
+    expect(form.hidden).toBe(true);
+    expect(controller.element.querySelector<HTMLElement>('.bdv-success')?.hidden).toBe(false);
+    expect(controller.element.querySelector<HTMLAnchorElement>('.bdv-success-link')?.href).toBe(
+      result.issueUrl
+    );
+    expect(onSubmitted).toHaveBeenCalledOnce();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failure, permits retry with the same id, and reset restores initial state with a new id', async () => {
+    const submitRequest = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Temporary outage'))
+      .mockResolvedValue(result);
+    const controller = createVariantForm({
+      config,
+      instanceId: 'form-2',
+      initialAnswers: { response: 'Initial answer' },
+      submit: submitRequest,
+    });
+    document.body.appendChild(controller.element);
+    const form = controller.element.querySelector('form')!;
+    const textarea = controller.element.querySelector<HTMLTextAreaElement>('textarea')!;
+
+    textarea.value = 'First attempt';
+    submit(form);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(controller.element.querySelector('.bdv-status')?.textContent).toBe('Temporary outage');
+    expect(controller.element.querySelector('.bdv-status')?.getAttribute('data-kind')).toBe(
+      'error'
+    );
+    expect(textarea.disabled).toBe(false);
+
+    textarea.value = 'Second attempt';
+    submit(form);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(submitRequest).toHaveBeenCalledTimes(2);
+    expect(submitRequest.mock.calls[0]?.[1]).toEqual(submitRequest.mock.calls[1]?.[1]);
+
+    controller.reset();
+    expect(form.hidden).toBe(false);
+    expect(controller.element.querySelector<HTMLElement>('.bdv-success')?.hidden).toBe(true);
+    expect(
+      controller.element.querySelector<HTMLAnchorElement>('.bdv-success-link')?.hasAttribute('href')
+    ).toBe(false);
+    expect(textarea.value).toBe('Initial answer');
+
+    textarea.value = 'After reset';
+    submit(form);
+    await Promise.resolve();
+    expect(submitRequest.mock.calls[2]?.[1]?.submissionId).toBe(
+      'submission-00000000-0000-4000-8000-000000000002'
+    );
+  });
+
+  it('cancels only while active and disposal removes submit, cancel, and keyboard listeners', async () => {
+    const pending = deferred<SubmissionResult>();
+    const submitRequest = vi.fn().mockReturnValue(pending.promise);
+    const onCancel = vi.fn();
+    const onSubmitted = vi.fn();
+    const controller = createVariantForm({
+      config,
+      instanceId: 'form-3',
+      initialAnswers: { response: 'Answer' },
+      submit: submitRequest,
+      cancel: { label: 'Cancel', onCancel },
+      onSubmitted,
+    });
+    document.body.appendChild(controller.element);
+    const form = controller.element.querySelector('form')!;
+    const cancel = controller.element.querySelector<HTMLButtonElement>('.bdv-cancel')!;
+    const textarea = controller.element.querySelector<HTMLTextAreaElement>('textarea')!;
+
+    cancel.click();
+    expect(onCancel).toHaveBeenCalledOnce();
+    submit(form);
+    controller.dispose();
+    controller.dispose();
+    cancel.disabled = false;
+    cancel.click();
+    submit(form);
+    const enter = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    textarea.dispatchEvent(enter);
+    expect(enter.defaultPrevented).toBe(false);
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(submitRequest).toHaveBeenCalledOnce();
+
+    pending.resolve(result);
+    await pending.promise;
+    await Promise.resolve();
+    expect(onSubmitted).not.toHaveBeenCalled();
+    expect(controller.element.querySelector<HTMLElement>('.bdv-success')?.hidden).toBe(true);
+  });
+
+  it('keeps reset inert while busy or after disposal', () => {
+    const pending = deferred<SubmissionResult>();
+    const controller = createVariantForm({
+      config,
+      instanceId: 'form-4',
+      initialAnswers: { response: 'Initial' },
+      submit: () => pending.promise,
+    });
+    document.body.appendChild(controller.element);
+    const form = controller.element.querySelector('form')!;
+    const textarea = controller.element.querySelector<HTMLTextAreaElement>('textarea')!;
+    textarea.value = 'Busy value';
+    submit(form);
+    controller.reset();
+    expect(textarea.value).toBe('Busy value');
+
+    controller.dispose();
+    textarea.value = 'Disposed value';
+    controller.reset();
+    expect(textarea.value).toBe('Disposed value');
+  });
+});

--- a/test/variantManager.test.ts
+++ b/test/variantManager.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createVariantManager } from '../src/widget/variants/manager';
 import type { VariantConfig } from '../src/widget/variants/public-types';
 
@@ -25,6 +25,16 @@ const modalConfig: VariantConfig = {
 describe('rendered variant manager', () => {
   beforeEach(() => {
     document.body.replaceChildren();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('Unexpected network request');
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('keeps registration lazy and mounts one owned isolated child', () => {
@@ -143,5 +153,26 @@ describe('rendered variant manager', () => {
     expect(document.querySelectorAll('[data-bugdrop-owned]')).toHaveLength(1);
     expect(document.body.style.overflow).toBe('hidden');
     second.close();
+  });
+
+  it('cancels through the rendered control and disposes stale form listeners', async () => {
+    const manager = createVariantManager({ repo: 'owner/repo', apiUrl: '/api' });
+    const opened = manager
+      .register(modalConfig)
+      .open({ initialAnswers: { response: 'Never submitted' } });
+    const host = document.querySelector<HTMLElement>('[data-bugdrop-owned]')!;
+    const shadow = host.shadowRoot;
+    if (!shadow) throw new Error('Expected the rendered modal shadow root');
+    const form = shadow.querySelector<HTMLFormElement>('form')!;
+    const cancel = shadow.querySelector<HTMLButtonElement>('.bdv-cancel')!;
+
+    cancel.click();
+    await expect(opened.result).resolves.toEqual({ status: 'closed' });
+    expect(document.querySelector('[data-bugdrop-owned]')).toBeNull();
+
+    cancel.click();
+    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/test/variantSubmission.test.ts
+++ b/test/variantSubmission.test.ts
@@ -1,0 +1,242 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { submitVariant } from '../src/widget/variants/submission';
+import type { VariantConfig } from '../src/widget/variants/public-types';
+
+const config: VariantConfig = {
+  id: 'export-review',
+  presentation: { kind: 'inline' },
+  content: { title: 'Review the export' },
+  fields: [{ id: 'rating', type: 'rating', label: 'Rating', required: true, scale: 5 }],
+  issue: {
+    classification: 'feedback',
+    title: 'Export review: {{rating}}/5',
+    sections: [{ heading: 'Rating', field: 'rating', format: 'stars' }],
+  },
+};
+
+const transport = {
+  repo: 'Owner/Repo',
+  apiUrl: 'https://api.example.test/v1',
+};
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, json: vi.fn().mockResolvedValue(body) } as unknown as Response;
+}
+
+describe('variant submission transport', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-03T04:05:06.789Z'));
+    window.history.replaceState({}, '', '/account/export?token=secret-query#private-fragment');
+    Object.defineProperties(window, {
+      innerWidth: { configurable: true, value: 1440 },
+      innerHeight: { configurable: true, value: 900 },
+      devicePixelRatio: { configurable: true, value: 2 },
+    });
+    Object.defineProperties(navigator, {
+      userAgent: {
+        configurable: true,
+        value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) Chrome/126.0.0.0 Safari/537.36',
+      },
+      language: { configurable: true, value: 'en-GB' },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('Unexpected network request');
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('sends the exact URL, method, headers, authentication, payload, and redacted metadata', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        issueNumber: 37,
+        issueUrl: 'https://github.com/owner/repo/issues/37',
+        isPublic: true,
+        labelMappingWarnings: ['fallback label used'],
+      })
+    );
+    const tokenProvider = vi.fn().mockResolvedValue('private-token');
+
+    await expect(
+      submitVariant(
+        { ...transport, authTokenProvider: tokenProvider },
+        config,
+        { rating: 4 },
+        { context: { export_id: 'exp-42' }, submissionId: 'submission-fixed' }
+      )
+    ).resolves.toEqual({
+      issueNumber: 37,
+      issueUrl: 'https://github.com/owner/repo/issues/37',
+      isPublic: true,
+      labelMappingWarnings: ['fallback label used'],
+    });
+
+    expect(tokenProvider).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.example.test/v1/feedback');
+    expect(init).toEqual({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer private-token',
+      },
+      body: expect.any(String),
+    });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      repo: 'Owner/Repo',
+      variantId: 'export-review',
+      submissionId: 'submission-fixed',
+      issue: {
+        title: 'Export review: 4/5',
+        classification: 'feedback',
+        sections: [{ heading: 'Rating', value: '★★★★☆ (4/5)', format: 'text' }],
+      },
+      metadata: {
+        url: 'http://localhost:3000/account/export',
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) Chrome/126.0.0.0 Safari/537.36',
+        viewport: { width: 1440, height: 900 },
+        timestamp: '2026-02-03T04:05:06.789Z',
+        browser: { name: 'Chrome', version: '126.0.0.0' },
+        os: { name: 'macOS', version: '14.5' },
+        devicePixelRatio: 2,
+        language: 'en-GB',
+      },
+    });
+    expect(String(init?.body)).not.toContain('secret-query');
+    expect(String(init?.body)).not.toContain('private-fragment');
+  });
+
+  it('uses a secure random UUID and preserves an already-prefixed bearer token', async () => {
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(
+      '123e4567-e89b-42d3-a456-426614174000'
+    );
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        issueNumber: 8,
+        issueUrl: 'https://github.com/owner/repo/issues/8',
+        isPublic: false,
+      })
+    );
+
+    await submitVariant(
+      { ...transport, authTokenProvider: () => 'Bearer existing-token' },
+      config,
+      { rating: 5 }
+    );
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(init?.headers).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer existing-token',
+    });
+    expect(JSON.parse(String(init?.body)).submissionId).toBe(
+      '123e4567-e89b-42d3-a456-426614174000'
+    );
+  });
+
+  it('falls back to cryptographic random bytes when randomUUID is unavailable', async () => {
+    const getRandomValues = vi.fn((bytes: Uint8Array) => {
+      bytes.set(Array.from({ length: 16 }, (_, index) => index));
+      return bytes;
+    });
+    vi.stubGlobal('crypto', { getRandomValues });
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        issueNumber: 9,
+        issueUrl: 'https://github.com/owner/repo/issues/9',
+        isPublic: true,
+      })
+    );
+
+    await submitVariant(transport, config, { rating: 3 });
+
+    expect(getRandomValues).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(JSON.parse(String(init?.body)).submissionId).toBe('000102030405060708090a0b0c0d0e0f');
+  });
+
+  it('fails before transport when no secure identifier source exists', async () => {
+    vi.stubGlobal('crypto', {});
+
+    await expect(submitVariant(transport, config, { rating: 3 })).rejects.toThrow(
+      'cryptographically secure random generator'
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      {
+        success: true,
+        issueNumber: 0,
+        issueUrl: 'https://github.com/owner/repo/issues/0',
+        isPublic: true,
+      },
+    ],
+    [
+      {
+        success: true,
+        issueNumber: 7,
+        issueUrl: 'https://evil.test/owner/repo/issues/7',
+        isPublic: true,
+      },
+    ],
+    [
+      {
+        success: true,
+        issueNumber: 7,
+        issueUrl: 'https://github.com/owner/repo/issues/7?token=x',
+        isPublic: true,
+      },
+    ],
+    [
+      {
+        success: true,
+        issueNumber: 7,
+        issueUrl: 'https://github.com/owner/repo/issues/7',
+        isPublic: 'yes',
+      },
+    ],
+  ])('rejects malformed successful Issue responses: %j', async malformed => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse(malformed));
+
+    await expect(
+      submitVariant(transport, config, { rating: 2 }, { submissionId: 'fixed' })
+    ).rejects.toThrow('invalid Issue result');
+  });
+
+  it('surfaces explicit server failures and rejects invalid JSON', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({ success: false, error: 'Access denied' }, false)
+    );
+    await expect(
+      submitVariant(transport, config, { rating: 2 }, { submissionId: 'server-failure' })
+    ).rejects.toThrow('Access denied');
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected token')),
+    } as unknown as Response);
+    await expect(
+      submitVariant(transport, config, { rating: 2 }, { submissionId: 'bad-json' })
+    ).rejects.toThrow('Unexpected token');
+  });
+});

--- a/test/viewportCapture.test.ts
+++ b/test/viewportCapture.test.ts
@@ -1,0 +1,334 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface StreamHarness {
+  stream: MediaStream;
+  stop: ReturnType<typeof vi.fn>;
+}
+
+function makeStream(displaySurface: DisplayCaptureSurfaceType = 'browser'): StreamHarness {
+  const stop = vi.fn();
+  const videoTrack = {
+    stop,
+    getSettings: () => ({ displaySurface }),
+  } as unknown as MediaStreamTrack;
+  return {
+    stop,
+    stream: {
+      getVideoTracks: () => [videoTrack],
+      getTracks: () => [videoTrack],
+    } as unknown as MediaStream,
+  };
+}
+
+function installDisplayMedia(result: Promise<MediaStream>) {
+  const getDisplayMedia = vi.fn(() => result);
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getDisplayMedia },
+  });
+  return getDisplayMedia;
+}
+
+function installVideo(opts: {
+  readyState?: number;
+  width?: number;
+  height?: number;
+  play?: () => Promise<void>;
+  requestFrame?: (callback: () => void) => number;
+  cancelFrame?: (callbackId: number) => void;
+}) {
+  const realCreateElement = document.createElement.bind(document);
+  const video = realCreateElement('video');
+  Object.defineProperties(video, {
+    readyState: { configurable: true, get: () => opts.readyState ?? 4 },
+    videoWidth: { configurable: true, get: () => opts.width ?? 640 },
+    videoHeight: { configurable: true, get: () => opts.height ?? 480 },
+  });
+  video.play = vi.fn(opts.play ?? (() => Promise.resolve()));
+  if (opts.requestFrame) {
+    Object.assign(video, {
+      requestVideoFrameCallback: vi.fn(opts.requestFrame),
+      cancelVideoFrameCallback: vi.fn(opts.cancelFrame ?? (() => undefined)),
+    });
+  }
+  const drawImage = vi.fn();
+  const canvas = realCreateElement('canvas');
+  vi.spyOn(canvas, 'getContext').mockReturnValue({
+    drawImage,
+  } as unknown as CanvasRenderingContext2D);
+  vi.spyOn(canvas, 'toDataURL').mockReturnValue('data:image/png;base64,frame');
+  vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+    if (tagName === 'video') return video;
+    if (tagName === 'canvas') return canvas;
+    return realCreateElement(tagName);
+  });
+  return { video, canvas, drawImage };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  delete window.__bugdropMockViewportCapture;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  delete window.__bugdropMockViewportCapture;
+});
+
+describe('viewport capture', () => {
+  it('runs cancellation only on timeout and preserves the timeout error if cancellation throws', async () => {
+    vi.useFakeTimers();
+    const { withCaptureTimeout } = await import('../src/widget/capture-timeout');
+    const afterSuccess = vi.fn();
+
+    await expect(withCaptureTimeout(Promise.resolve('captured'), afterSuccess)).resolves.toBe(
+      'captured'
+    );
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(afterSuccess).not.toHaveBeenCalled();
+
+    const onTimeout = vi.fn(() => {
+      throw new Error('cancellation failed');
+    });
+    const result = withCaptureTimeout(new Promise(() => undefined), onTimeout);
+    const rejection = expect(result).rejects.toThrow('Screenshot capture timed out');
+    await vi.advanceTimersByTimeAsync(15_000);
+    await rejection;
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the deterministic override and restores owned-root privacy after rejection', async () => {
+    const host = document.createElement('div');
+    host.id = 'bugdrop-host';
+    host.style.visibility = 'visible';
+    document.body.append(host);
+    const capture = vi.fn(async () => {
+      expect(host.style.getPropertyValue('visibility')).toBe('hidden');
+      throw new Error('override failed');
+    });
+    window.__bugdropMockViewportCapture = capture;
+    const { beginViewportCapture } = await import('../src/widget/viewport-capture');
+
+    await expect(beginViewportCapture()).rejects.toThrow('override failed');
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(host.style.getPropertyValue('visibility')).toBe('visible');
+  });
+
+  it('rejects unavailable, denied, and wrong-surface capture while restoring state', async () => {
+    const { beginViewportCapture } = await import('../src/widget/viewport-capture');
+    Object.defineProperty(navigator, 'mediaDevices', { configurable: true, value: undefined });
+    await expect(beginViewportCapture()).rejects.toThrow('Screen Capture API is not available');
+
+    installDisplayMedia(Promise.reject(new Error('permission denied')));
+    await expect(beginViewportCapture()).rejects.toThrow('permission denied');
+
+    const wrongSurface = makeStream('monitor');
+    installDisplayMedia(Promise.resolve(wrongSurface.stream));
+    await expect(beginViewportCapture()).rejects.toThrow(
+      'Please choose the current browser tab for viewport capture'
+    );
+    expect(wrongSurface.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('requests current-tab capture and accepts a delayed loadeddata event', async () => {
+    let readyState = 0;
+    const harness = makeStream();
+    const getDisplayMedia = installDisplayMedia(Promise.resolve(harness.stream));
+    const { video, canvas, drawImage } = installVideo({
+      get readyState() {
+        return readyState;
+      },
+    });
+    const addEventListener = vi.spyOn(video, 'addEventListener');
+    const removeEventListener = vi.spyOn(video, 'removeEventListener');
+    const { beginViewportCapture } = await import('../src/widget/viewport-capture');
+
+    const result = beginViewportCapture();
+    await vi.waitFor(() =>
+      expect(addEventListener).toHaveBeenCalledWith('loadeddata', expect.any(Function))
+    );
+    readyState = 4;
+    video.dispatchEvent(new Event('loadeddata'));
+
+    await expect(result).resolves.toBe('data:image/png;base64,frame');
+    expect(getDisplayMedia).toHaveBeenCalledWith({
+      video: { displaySurface: 'browser' },
+      audio: false,
+      preferCurrentTab: true,
+    });
+    expect(drawImage).toHaveBeenCalledWith(video, 0, 0, 640, 480);
+    expect(canvas.width).toBe(640);
+    expect(canvas.height).toBe(480);
+    expect(harness.stop).toHaveBeenCalledTimes(1);
+    expect(video.srcObject).toBeNull();
+    for (const type of ['loadeddata', 'canplay', 'error']) {
+      expect(
+        removeEventListener.mock.calls.filter(([eventType]) => eventType === type)
+      ).toHaveLength(1);
+    }
+  });
+
+  it('cleans tracks and srcObject exactly once when stalled playback times out', async () => {
+    vi.useFakeTimers();
+    const harness = makeStream();
+    installDisplayMedia(Promise.resolve(harness.stream));
+    const setSrcObject = vi.fn();
+    const { video, drawImage } = installVideo({ play: () => new Promise(() => undefined) });
+    Object.defineProperty(video, 'srcObject', {
+      configurable: true,
+      get: () => null,
+      set: setSrcObject,
+    });
+    const { beginViewportCapture } = await import('../src/widget/viewport-capture');
+
+    const result = beginViewportCapture();
+    const rejection = expect(result).rejects.toThrow('Screenshot capture timed out');
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    await rejection;
+    expect(harness.stop).toHaveBeenCalledTimes(1);
+    expect(setSrcObject).toHaveBeenNthCalledWith(1, harness.stream);
+    expect(setSrcObject).toHaveBeenNthCalledWith(2, null);
+    expect(setSrcObject).toHaveBeenCalledTimes(2);
+    expect(drawImage).not.toHaveBeenCalled();
+  });
+
+  it('cancels a pending video frame callback when its readiness wait expires', async () => {
+    vi.useFakeTimers();
+    const harness = makeStream();
+    const cancelFrame = vi.fn();
+    const requestFrame = vi.fn(() => 41);
+    installDisplayMedia(Promise.resolve(harness.stream));
+    const { video, drawImage } = installVideo({
+      readyState: 4,
+      requestFrame,
+      cancelFrame,
+    });
+    const { beginViewportCapture } = await import('../src/widget/viewport-capture');
+
+    const result = beginViewportCapture();
+    await vi.waitFor(() => expect(requestFrame).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(result).resolves.toBe('data:image/png;base64,frame');
+    expect(cancelFrame).toHaveBeenCalledOnce();
+    expect(cancelFrame).toHaveBeenCalledWith(41);
+    expect(drawImage).toHaveBeenCalledWith(video, 0, 0, 640, 480);
+    expect(harness.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels a pending video frame callback when capture is aborted', async () => {
+    const harness = makeStream();
+    const cancelFrame = vi.fn();
+    const requestFrame = vi.fn(() => 42);
+    let abortCapture!: () => void;
+    vi.resetModules();
+    vi.doMock('../src/widget/capture-timeout', () => ({
+      withCaptureTimeout: <T>(promise: Promise<T>, onTimeout: () => void) => {
+        abortCapture = onTimeout;
+        return promise;
+      },
+    }));
+    installDisplayMedia(Promise.resolve(harness.stream));
+    installVideo({ readyState: 0, requestFrame, cancelFrame });
+
+    try {
+      const { beginViewportCapture } = await import('../src/widget/viewport-capture');
+      const result = beginViewportCapture();
+      await vi.waitFor(() => expect(requestFrame).toHaveBeenCalledTimes(1));
+      abortCapture();
+
+      await expect(result).rejects.toMatchObject({ name: 'AbortError' });
+      expect(cancelFrame).toHaveBeenCalledOnce();
+      expect(cancelFrame).toHaveBeenCalledWith(42);
+      expect(harness.stop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.doUnmock('../src/widget/capture-timeout');
+      vi.resetModules();
+    }
+  });
+
+  it('observes late playback resolution and rejection without double cleanup', async () => {
+    for (const outcome of ['resolution', 'rejection'] as const) {
+      vi.useFakeTimers();
+      const harness = makeStream();
+      const play = deferred<void>();
+      installDisplayMedia(Promise.resolve(harness.stream));
+      const { video, drawImage } = installVideo({ play: () => play.promise });
+      const setSrcObject = vi.fn();
+      Object.defineProperty(video, 'srcObject', {
+        configurable: true,
+        get: () => null,
+        set: setSrcObject,
+      });
+      const { beginViewportCapture } = await import('../src/widget/viewport-capture');
+
+      const result = beginViewportCapture();
+      const rejection = expect(result).rejects.toThrow('Screenshot capture timed out');
+      await vi.advanceTimersByTimeAsync(15_000);
+      await rejection;
+      if (outcome === 'resolution') play.resolve();
+      else play.reject(new Error('late playback failure'));
+      await vi.runAllTimersAsync();
+
+      expect(harness.stop).toHaveBeenCalledTimes(1);
+      expect(setSrcObject).toHaveBeenCalledTimes(2);
+      expect(drawImage).not.toHaveBeenCalled();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('stops a stream that arrives after timeout without playing or drawing', async () => {
+    vi.useFakeTimers();
+    const acquisition = deferred<MediaStream>();
+    const harness = makeStream();
+    installDisplayMedia(acquisition.promise);
+    const { video, drawImage } = installVideo({ readyState: 4 });
+    const { beginViewportCapture } = await import('../src/widget/viewport-capture');
+
+    const result = beginViewportCapture();
+    const rejection = expect(result).rejects.toThrow('Screenshot capture timed out');
+    await vi.advanceTimersByTimeAsync(15_000);
+    await rejection;
+    acquisition.resolve(harness.stream);
+    await vi.runAllTimersAsync();
+
+    expect(harness.stop).toHaveBeenCalledTimes(1);
+    expect(video.play).not.toHaveBeenCalled();
+    expect(drawImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing frames and canvas contexts while stopping each track once', async () => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 0 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 0 });
+    const noFrame = makeStream();
+    installDisplayMedia(Promise.resolve(noFrame.stream));
+    installVideo({ readyState: 4, width: 0, height: 0 });
+    const { beginViewportCapture } = await import('../src/widget/viewport-capture');
+    await expect(beginViewportCapture()).rejects.toThrow(
+      'Screen capture stream did not provide a video frame'
+    );
+    expect(noFrame.stop).toHaveBeenCalledTimes(1);
+
+    vi.restoreAllMocks();
+    const noContext = makeStream();
+    installDisplayMedia(Promise.resolve(noContext.stream));
+    const { canvas } = installVideo({ readyState: 4 });
+    vi.mocked(canvas.getContext).mockReturnValue(null);
+    await expect(beginViewportCapture()).rejects.toThrow('Failed to get canvas context');
+    expect(noContext.stop).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- add direct, network-free coverage for GitHub authentication and persistence, variant submission, console privacy, viewport capture, picker, area-picker, annotation, and screenshot-option boundaries
- harden GitHub asset upload races, viewport capture cancellation, trigger resize persistence, and fail-closed Playwright live-project selection
- add informational, unit-only Codecov components for widget, backend, and scripts while preserving strict partial-line treatment
- retain the GoalBuddy implementation and verification record

## Verification

- `npm test -- --coverage` — 68 files, 965 tests; 74.81% lines and 68.74% branches
- `make check`
- `bash test/ci-workflow-contract.test.sh`
- local Playwright matrix — 275/275, zero retries
- canonical Chromium widget suite — 205/205, zero retries
- pre-push typecheck

## Rollout

Codecov project, patch, and component statuses remain informational. Browser coverage is not uploaded, comments and annotations remain disabled, and no badge or branch-protection change is included.