### PR TITLE
chore: enforce least-privilege workflow tokens

### DIFF
--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -5,10 +5,14 @@ on:
     paths:
       - 'benchmarks/**'
 
+permissions: {}
+
 jobs:
   lint:
     name: Lint Benchmarks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, synchronize, reopened]
   merge_group:
 
+permissions: {}
+
 jobs:
   # Fast checks run first
   check:
@@ -205,6 +207,8 @@ jobs:
     name: E2E Tests (Shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
     needs: check
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -275,6 +279,8 @@ jobs:
     name: Radix Cross-Browser E2E (${{ matrix.browser }})
     runs-on: ubuntu-latest
     needs: check
+    permissions:
+      contents: read
     if: needs.check.outputs.full_ci != 'false'
     strategy:
       fail-fast: false
@@ -335,6 +341,8 @@ jobs:
     timeout-minutes: 45
     needs: [check, test, e2e, radix-e2e]
     if: github.event_name == 'merge_group'
+    permissions:
+      contents: read
     concurrency:
       group: bugdrop-shared-preview
       cancel-in-progress: false

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -77,6 +77,8 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+permissions: {}
+
 concurrency:
   group: ${{ github.event_name == 'schedule' && 'bugdrop-shared-preview' || format('bugdrop-live-{0}-{1}', github.workflow, github.run_id) }}
   cancel-in-progress: false
@@ -87,6 +89,8 @@ jobs:
     name: Live E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     env:
       LIVE_TARGET: ${{ github.event_name == 'schedule' && 'preview' || inputs.target || 'preview' }}
       PLAYWRIGHT_BASE_URL: ${{ inputs.target == 'production' && 'https://bugdrop-widget-test.vercel.app' || 'https://bugdrop-widget-test-git-preview-jermwatts-projects.vercel.app' }}

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -6,9 +6,13 @@ on:
     paths:
       - 'docs/website/**'
 
+permissions: {}
+
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout bugdrop
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build build-widget build-all deploy test test-release test-release-workflow test-static-assets release-plan-help test-watch test-e2e test-e2e-ui test-e2e-shard test-radix-e2e test-live-radix test-live-cross-browser lint lint-fix format format-check typecheck knip audit check-actions-node24 check-ci-scope check-ci-workflow check-production-heartbeat-workflow check-release-workflow check ci clean install install-playwright help
+.PHONY: dev build build-widget build-all deploy test test-release test-release-workflow test-static-assets release-plan-help test-watch test-e2e test-e2e-ui test-e2e-shard test-radix-e2e test-live-radix test-live-cross-browser lint lint-fix format format-check typecheck knip audit check-actions-node24 check-workflow-permissions check-ci-scope check-ci-workflow check-production-heartbeat-workflow check-release-workflow check ci clean install install-playwright help
 
 # Development
 dev:
@@ -99,6 +99,10 @@ check-actions-node24:
 	npm run check:actions-node24
 	bash test/github-actions-pinning.test.sh
 
+check-workflow-permissions:
+	npm run check:workflow-permissions
+	bash test/workflow-permissions.test.sh
+
 check-ci-scope:
 	bash test/ci-scope.test.sh
 
@@ -112,7 +116,7 @@ check-release-workflow:
 	bash test/release-workflow-contract.test.sh
 
 # Combined Commands
-check: test-release lint format-check typecheck knip audit check-actions-node24 check-ci-scope check-ci-workflow check-production-heartbeat-workflow check-release-workflow
+check: test-release lint format-check typecheck knip audit check-actions-node24 check-workflow-permissions check-ci-scope check-ci-workflow check-production-heartbeat-workflow check-release-workflow
 	@echo "✓ All checks passed"
 
 ci: check test build-all test-e2e

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "check:actions-node24": "node scripts/check-github-actions.mjs",
+    "check:workflow-permissions": "node scripts/check-workflow-permissions.mjs",
     "validate": "npm run lint && npm run format:check && npm run typecheck && npm run test",
     "prepare": "husky"
   },

--- a/scripts/check-workflow-permissions.mjs
+++ b/scripts/check-workflow-permissions.mjs
@@ -1,0 +1,123 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { parse } from 'yaml';
+
+const workflowRoot = resolve(process.argv[2] ?? '.github/workflows');
+
+const expectedTopLevel = new Map([
+  ['benchmark-ci.yml', {}],
+  ['ci.yml', {}],
+  ['cloudflare-capability.yml', { contents: 'read' }],
+  ['deploy.yml', { contents: 'read' }],
+  ['discord-release.yml', { contents: 'read' }],
+  ['live-tests.yml', {}],
+  ['production-heartbeat.yml', { contents: 'read' }],
+  ['sync-docs.yml', {}],
+]);
+
+const denyByDefaultJobs = new Map([
+  ['benchmark-ci.yml:lint', { contents: 'read' }],
+  ['ci.yml:check', { checks: 'read', contents: 'read' }],
+  ['ci.yml:coverage', { contents: 'read', 'id-token': 'write' }],
+  ['ci.yml:deploy-preview', { contents: 'read' }],
+  ['ci.yml:e2e', { contents: 'read' }],
+  ['ci.yml:live-preview-tests', {}],
+  ['ci.yml:radix-e2e', { contents: 'read' }],
+  ['ci.yml:test', { contents: 'read' }],
+  ['live-tests.yml:live-tests', { contents: 'read' }],
+  ['sync-docs.yml:sync', { contents: 'read' }],
+]);
+
+const allowedWrites = new Set([
+  'ci.yml:coverage:id-token',
+  'deploy.yml:publish-release:contents',
+  'production-heartbeat.yml:incident:issues',
+]);
+
+const failures = [];
+const observedWrites = new Set();
+const observedJobs = new Set();
+const workflowFiles = (await readdir(workflowRoot)).filter(file => /\.ya?ml$/.test(file)).sort();
+
+const normalized = permissions =>
+  JSON.stringify(
+    Object.fromEntries(
+      Object.entries(permissions).sort(([left], [right]) => left.localeCompare(right))
+    )
+  );
+const isPermissionMap = permissions =>
+  typeof permissions === 'object' && permissions !== null && !Array.isArray(permissions);
+
+for (const file of workflowFiles) {
+  const workflow = parse(await readFile(resolve(workflowRoot, file), 'utf8'));
+  const expectedPermissions = expectedTopLevel.get(file);
+
+  if (!expectedPermissions) {
+    failures.push(`${file}: add this workflow to the explicit top-level permission policy`);
+    continue;
+  }
+  if (!Object.hasOwn(workflow, 'permissions')) {
+    failures.push(`${file}: top-level permissions must be explicitly declared`);
+  } else if (!isPermissionMap(workflow.permissions)) {
+    failures.push(`${file}: top-level permissions must be an explicit permission map`);
+  } else if (normalized(workflow.permissions) !== normalized(expectedPermissions)) {
+    failures.push(`${file}: top-level permissions must be ${JSON.stringify(expectedPermissions)}`);
+  }
+
+  for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+    const jobKey = `${file}:${jobName}`;
+    observedJobs.add(jobKey);
+    const expectedJobPermissions = denyByDefaultJobs.get(jobKey);
+    const actualJobPermissions = Object.hasOwn(job, 'permissions')
+      ? job.permissions
+      : workflow.permissions;
+
+    if (!isPermissionMap(actualJobPermissions)) {
+      failures.push(`${jobKey}: permissions must be an explicit permission map`);
+      continue;
+    }
+
+    if (
+      expectedJobPermissions &&
+      normalized(actualJobPermissions) !== normalized(expectedJobPermissions)
+    ) {
+      failures.push(
+        `${jobKey}: effective permissions must be ${JSON.stringify(expectedJobPermissions)}`
+      );
+    }
+
+    for (const [scope, access] of Object.entries(actualJobPermissions)) {
+      if (access !== 'write') continue;
+      const writeKey = `${jobKey}:${scope}`;
+      observedWrites.add(writeKey);
+      if (!allowedWrites.has(writeKey)) {
+        failures.push(`${jobKey}: ${scope}: write is not an approved grant`);
+      }
+    }
+
+    if (typeof job.uses === 'string' && job.uses.startsWith('./')) {
+      if (actualJobPermissions.contents !== 'read') {
+        failures.push(`${jobKey}: local reusable workflow calls require contents: read`);
+      }
+    }
+  }
+}
+
+for (const file of expectedTopLevel.keys()) {
+  if (!workflowFiles.includes(file)) failures.push(`${file}: expected workflow is missing`);
+}
+for (const jobKey of denyByDefaultJobs.keys()) {
+  if (!observedJobs.has(jobKey)) failures.push(`${jobKey}: expected job is missing`);
+}
+for (const writeKey of allowedWrites) {
+  if (!observedWrites.has(writeKey)) failures.push(`${writeKey}: approved write grant is missing`);
+}
+
+if (failures.length > 0) {
+  console.error(failures.join('\n'));
+  process.exit(1);
+}
+
+console.log(
+  `${workflowFiles.length} workflows have explicit boundaries and ${observedWrites.size} approved write grants`
+);

--- a/test/workflow-permissions.test.sh
+++ b/test/workflow-permissions.test.sh
@@ -28,7 +28,7 @@ expect_failure() {
   }
 }
 
-node "$checker" > /dev/null
+node "$checker" "$repo_root/.github/workflows" > /dev/null
 
 missing_top=$(make_fixture missing-top)
 perl -0pi -e 's/\npermissions: \{\}\n/\n/' "$missing_top/benchmark-ci.yml"

--- a/test/workflow-permissions.test.sh
+++ b/test/workflow-permissions.test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+checker="$repo_root/scripts/check-workflow-permissions.mjs"
+fixture_root=$(mktemp -d /tmp/bugdrop-workflow-permissions-test.XXXXXX)
+trap 'rm -rf "$fixture_root"' EXIT
+
+make_fixture() {
+  local name=$1
+  local directory="$fixture_root/$name"
+  mkdir -p "$directory"
+  cp "$repo_root"/.github/workflows/*.yml "$directory/"
+  printf '%s\n' "$directory"
+}
+
+expect_failure() {
+  local directory=$1
+  local expected=$2
+  if node "$checker" "$directory" > "$fixture_root/output" 2>&1; then
+    echo "Permission checker unexpectedly accepted an unsafe fixture" >&2
+    exit 1
+  fi
+  grep -Fq "$expected" "$fixture_root/output" || {
+    cat "$fixture_root/output" >&2
+    exit 1
+  }
+}
+
+node "$checker" > /dev/null
+
+missing_top=$(make_fixture missing-top)
+perl -0pi -e 's/\npermissions: \{\}\n/\n/' "$missing_top/benchmark-ci.yml"
+expect_failure "$missing_top" 'benchmark-ci.yml: top-level permissions must be explicitly declared'
+
+null_top=$(make_fixture null-top)
+perl -0pi -e 's/permissions: \{\}/permissions: null/' "$null_top/benchmark-ci.yml"
+expect_failure "$null_top" \
+  'benchmark-ci.yml: top-level permissions must be an explicit permission map'
+
+null_job=$(make_fixture null-job)
+perl -0pi -e 's/(  live-preview-tests:\n)/$1    permissions: null\n/' \
+  "$null_job/ci.yml"
+expect_failure "$null_job" \
+  'ci.yml:live-preview-tests: permissions must be an explicit permission map'
+
+unexpected_write=$(make_fixture unexpected-write)
+perl -0pi -e 's/(    permissions:\n      contents: read\n)/$1      issues: write\n/' \
+  "$unexpected_write/benchmark-ci.yml"
+expect_failure "$unexpected_write" 'benchmark-ci.yml:lint: issues: write is not an approved grant'
+
+broad_job=$(make_fixture broad-job)
+perl -0pi -e 's/(  prove:\n)/$1    permissions: write-all\n/' \
+  "$broad_job/cloudflare-capability.yml"
+expect_failure "$broad_job" \
+  'cloudflare-capability.yml:prove: permissions must be an explicit permission map'
+
+missing_job_boundary=$(make_fixture missing-job-boundary)
+perl -0pi -e 's/(  e2e:\n(?:.*\n){0,4}?    needs: check\n)    permissions:\n      contents: read\n/$1/' \
+  "$missing_job_boundary/ci.yml"
+expect_failure "$missing_job_boundary" \
+  'ci.yml:e2e: effective permissions must be {"contents":"read"}'
+
+echo 'Workflow permission policy checks passed'


### PR DESCRIPTION
## Summary

- deny GitHub token access by default in benchmark, CI, live-test, and docs-sync workflows
- grant `contents: read` only to jobs that check out or invoke repository code
- preserve the three reviewed write grants for Codecov OIDC, release publishing, and heartbeat incidents
- add a fail-closed workflow permission policy check and mutation-based regression suite

## Validation

- `make check`
- `npm test` (68 files, 965 tests)
- local OpenSSF Scorecard v5.5.0 `Token-Permissions`: 10/10
- `git diff --check`

## Security review

Focused correctness, contracts, test, and simplification reviews completed. One confirmed explicit-null schema bypass was fixed and regression-tested. No repository settings or external publishing configuration were changed.