### PR TITLE
fix: harden manual release recovery

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -668,6 +668,7 @@ jobs:
     name: Publish exact authenticated GitHub Release
     needs: [guard-and-plan, verify-candidate, approval-baseline, deploy-candidate, live-e2e]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: production
     permissions:
       contents: write
@@ -856,9 +857,29 @@ jobs:
           echo "status=$status" >> "$GITHUB_OUTPUT"
           jq -r '"### Finalization — \(.status)\n\nRollback attempted: `\(.rollbackAttempted)`"' finalization.json >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Require verified stable or restored production
+      - name: Preserve finalization evidence
+        if: ${{ always() }}
+        shell: bash
         run: |
-          status='${{ steps.finalize.outputs.status }}'
+          if ! jq -e 'type == "object" and (.status | type == "string")' finalization.json >/dev/null 2>&1; then
+            jq -n --arg planIdentity '${{ needs.verify-candidate.outputs.plan_identity }}' \
+              '{protocol: "bugdrop.live-release/v1", status: "manual-recovery-required", reason: "finalizer-did-not-produce-valid-evidence", rollbackAttempted: false, planIdentity: $planIdentity}' \
+              > finalization.json
+          fi
+
+      - name: Upload authoritative finalization outcome
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-finalization-${{ needs.verify-candidate.outputs.plan_key }}-${{ github.run_attempt }}
+          path: finalization.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Require verified stable or restored production
+        if: ${{ always() }}
+        run: |
+          status=$(jq -er '.status' finalization.json)
           test "$status" = 'published-stable' || \
             test "$status" = 'baseline-restored' || \
             test "$status" = 'rollback-verified' || \

--- a/scripts/release/github-publication-adapter.mjs
+++ b/scripts/release/github-publication-adapter.mjs
@@ -9,7 +9,9 @@ const RELEASE_ID = /^[1-9]\d*$/;
 const TOKEN = /^[A-Za-z0-9_.-]{16,4096}$/;
 const RELEASES_PER_PAGE = 100;
 const MAX_RELEASE_PAGES = 100;
-const ASSET_TIMEOUT_MS = 30_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+class RequestDeadlineError extends Error {}
 
 export class GithubPublicationAdapterError extends Error {
   constructor(code, message, details = {}) {
@@ -58,6 +60,7 @@ export function createGithubPublicationAdapter({
   apiUrl = 'https://api.github.com',
   fetchImpl = fetch,
   repository,
+  requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
   token,
   uploadsUrl = 'https://uploads.github.com',
 }) {
@@ -66,6 +69,13 @@ export function createGithubPublicationAdapter({
     repository.split('/').some(part => part.startsWith('.') || part.includes('..'))
   ) {
     fail('INVALID_INPUT', 'repository is invalid');
+  }
+  if (
+    !Number.isSafeInteger(requestTimeoutMs) ||
+    requestTimeoutMs < 1 ||
+    requestTimeoutMs > 60_000
+  ) {
+    fail('INVALID_INPUT', 'requestTimeoutMs is invalid');
   }
   if (!TOKEN.test(token ?? '')) fail('TOKEN_REQUIRED', 'token is required');
   const apiOrigin = new URL(apiUrl).origin;
@@ -79,57 +89,79 @@ export function createGithubPublicationAdapter({
     authorization: `Bearer ${token}`,
     'x-github-api-version': API_VERSION,
   });
+  const withRequestDeadline = async operation => {
+    const controller = new AbortController();
+    let timer;
+    const timeout = new Promise((_, reject) => {
+      timer = setTimeout(() => {
+        reject(new RequestDeadlineError('GitHub request deadline expired'));
+        controller.abort();
+      }, requestTimeoutMs);
+    });
+    try {
+      return await Promise.race([operation(controller.signal), timeout]);
+    } finally {
+      clearTimeout(timer);
+    }
+  };
   const request = async (method, path, options = {}) => {
     const url = endpoint(options.base ?? apiUrl, path);
-    let response;
     try {
-      response = await fetchImpl(url, {
-        method,
-        redirect: 'error',
-        headers: {
-          ...headers('application/vnd.github+json'),
+      return await withRequestDeadline(async signal => {
+        const response = await fetchImpl(url, {
+          method,
+          redirect: 'error',
+          signal,
+          headers: {
+            ...headers('application/vnd.github+json'),
+            ...(options.body === undefined
+              ? {}
+              : { 'content-type': options.contentType ?? 'application/json' }),
+          },
           ...(options.body === undefined
             ? {}
-            : { 'content-type': options.contentType ?? 'application/json' }),
-        },
-        ...(options.body === undefined
-          ? {}
-          : {
-              body:
-                options.contentType === 'application/octet-stream'
-                  ? options.body
-                  : JSON.stringify(options.body),
-            }),
+            : {
+                body:
+                  options.contentType === 'application/octet-stream'
+                    ? options.body
+                    : JSON.stringify(options.body),
+              }),
+        });
+        if (options.missing && response.status === 404) return null;
+        if (!(options.expected ?? [200, 201]).includes(response.status)) {
+          fail('GITHUB_REQUEST_FAILED', 'GitHub request failed', {
+            method,
+            path: url.pathname,
+            status: response.status,
+          });
+        }
+        if (response.status === 204) return null;
+        let value;
+        try {
+          value = await response.json();
+        } catch {
+          fail('INVALID_RESPONSE', `${url.pathname} did not return JSON`);
+        }
+        if (options.array) {
+          if (!Array.isArray(value)) {
+            fail('INVALID_RESPONSE', `${url.pathname} response is invalid`);
+          }
+          return {
+            data: value,
+            hasNext: /<[^>]+>;\s*rel="next"/.test(response.headers.get('link') ?? ''),
+          };
+        }
+        return record(value, url.pathname);
       });
-    } catch {
-      fail('GITHUB_REQUEST_FAILED', 'GitHub request failed', {
-        method,
-        path: url.pathname,
-        status: null,
-      });
-    }
-    if (options.missing && response.status === 404) return null;
-    if (!(options.expected ?? [200, 201]).includes(response.status)) {
-      fail('GITHUB_REQUEST_FAILED', 'GitHub request failed', {
-        method,
-        path: url.pathname,
-        status: response.status,
-      });
-    }
-    if (response.status === 204) return null;
-    try {
-      const value = await response.json();
-      if (options.array) {
-        if (!Array.isArray(value)) fail('INVALID_RESPONSE', `${url.pathname} response is invalid`);
-        return {
-          data: value,
-          hasNext: /<[^>]+>;\s*rel="next"/.test(response.headers.get('link') ?? ''),
-        };
-      }
-      return record(value, url.pathname);
     } catch (error) {
       if (error instanceof GithubPublicationAdapterError) throw error;
-      fail('INVALID_RESPONSE', `${url.pathname} did not return JSON`);
+      fail(
+        error instanceof RequestDeadlineError ? 'GITHUB_REQUEST_TIMEOUT' : 'GITHUB_REQUEST_FAILED',
+        error instanceof RequestDeadlineError
+          ? 'GitHub request timed out'
+          : 'GitHub request failed',
+        { method, path: url.pathname, status: null }
+      );
     }
   };
   const requestBytes = async (assetUrl, expectedSize, assetId) => {
@@ -139,61 +171,69 @@ export function createGithubPublicationAdapter({
       url.pathname !== `/repos/${repository}/releases/assets/${assetId}`
     )
       fail('UNSAFE_ENDPOINT', 'asset API URL is untrusted');
-    let response;
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), ASSET_TIMEOUT_MS);
     try {
-      response = await fetchImpl(url, {
-        headers: headers('application/octet-stream'),
-        redirect: 'manual',
-        signal: controller.signal,
-      });
-      if ([301, 302, 303, 307, 308].includes(response.status)) {
-        let location;
-        try {
-          location = new URL(response.headers.get('location'));
-        } catch {
-          fail('UNSAFE_ENDPOINT', 'asset redirect is malformed');
-        }
-        if (
-          location.protocol !== 'https:' ||
-          location.username ||
-          location.password ||
-          !storageOrigins.has(location.origin)
-        )
-          fail('UNSAFE_ENDPOINT', 'asset redirect is untrusted');
-        response = await fetchImpl(location, {
-          headers: { accept: 'application/octet-stream' },
-          redirect: 'error',
-          signal: controller.signal,
+      return await withRequestDeadline(async signal => {
+        let response = await fetchImpl(url, {
+          headers: headers('application/octet-stream'),
+          redirect: 'manual',
+          signal,
         });
-      }
-      if (!response.ok)
-        fail('GITHUB_REQUEST_FAILED', 'GitHub asset request failed', { status: response.status });
-      const declared = response.headers.get('content-length');
-      if (declared !== null && Number(declared) !== expectedSize)
-        fail('INVALID_RESPONSE', 'asset Content-Length differs from GitHub metadata');
-      if (!response.body) fail('INVALID_RESPONSE', 'asset body is unavailable');
-      const chunks = [];
-      let total = 0;
-      const reader = response.body.getReader();
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        total += value.byteLength;
-        if (total > MAX_WIDGET_BYTES || total > expectedSize) {
-          await reader.cancel();
-          fail('INVALID_RESPONSE', 'asset exceeds its authenticated byte bound');
+        if ([301, 302, 303, 307, 308].includes(response.status)) {
+          let location;
+          try {
+            location = new URL(response.headers.get('location'));
+          } catch {
+            fail('UNSAFE_ENDPOINT', 'asset redirect is malformed');
+          }
+          if (
+            location.protocol !== 'https:' ||
+            location.username ||
+            location.password ||
+            !storageOrigins.has(location.origin)
+          ) {
+            fail('UNSAFE_ENDPOINT', 'asset redirect is untrusted');
+          }
+          response = await fetchImpl(location, {
+            headers: { accept: 'application/octet-stream' },
+            redirect: 'error',
+            signal,
+          });
         }
-        chunks.push(Buffer.from(value));
-      }
-      if (total !== expectedSize) fail('INVALID_RESPONSE', 'asset response is truncated');
-      return Buffer.concat(chunks, total);
+        if (!response.ok) {
+          fail('GITHUB_REQUEST_FAILED', 'GitHub asset request failed', {
+            status: response.status,
+          });
+        }
+        const declared = response.headers.get('content-length');
+        if (declared !== null && Number(declared) !== expectedSize) {
+          fail('INVALID_RESPONSE', 'asset Content-Length differs from GitHub metadata');
+        }
+        if (!response.body) fail('INVALID_RESPONSE', 'asset body is unavailable');
+        const chunks = [];
+        let total = 0;
+        const reader = response.body.getReader();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          total += value.byteLength;
+          if (total > MAX_WIDGET_BYTES || total > expectedSize) {
+            await reader.cancel();
+            fail('INVALID_RESPONSE', 'asset exceeds its authenticated byte bound');
+          }
+          chunks.push(Buffer.from(value));
+        }
+        if (total !== expectedSize) fail('INVALID_RESPONSE', 'asset response is truncated');
+        return Buffer.concat(chunks, total);
+      });
     } catch (error) {
       if (error instanceof GithubPublicationAdapterError) throw error;
-      fail('GITHUB_REQUEST_FAILED', 'GitHub asset request failed or timed out', { status: null });
-    } finally {
-      clearTimeout(timer);
+      fail(
+        error instanceof RequestDeadlineError ? 'GITHUB_REQUEST_TIMEOUT' : 'GITHUB_REQUEST_FAILED',
+        error instanceof RequestDeadlineError
+          ? 'GitHub asset request timed out'
+          : 'GitHub asset request failed',
+        { status: null }
+      );
     }
   };
   const inspectTag = async tag => {
@@ -254,6 +294,7 @@ export function createGithubPublicationAdapter({
       body: String(release.body ?? ''),
       draft: release.draft === true,
       id: String(release.id),
+      name: String(release.name ?? ''),
       prerelease: release.prerelease === true,
       published: release.draft === false && release.published_at !== null,
       tag,

--- a/scripts/release/live-release.mjs
+++ b/scripts/release/live-release.mjs
@@ -217,6 +217,20 @@ async function inspectAfterMutation({
   throw lastError;
 }
 
+function requireInspectionOptions(attempts, intervalMs, sleep) {
+  if (
+    !Number.isSafeInteger(attempts) ||
+    attempts < 1 ||
+    attempts > 100 ||
+    !Number.isSafeInteger(intervalMs) ||
+    intervalMs < 0 ||
+    intervalMs > 60000 ||
+    (sleep !== undefined && typeof sleep !== 'function')
+  ) {
+    fail('INVALID_LIVE_RELEASE_INPUT', 'post-mutation inspection retry options are invalid');
+  }
+}
+
 export async function captureBaseline({ client, expected, observe = collectBaselineIdentity }) {
   const current = await inspectAuthoritative(client, expected.origin, observe);
   return {
@@ -249,17 +263,7 @@ export async function deployCandidate({
   sleep,
   verify = value => pollLiveVerification({ expected: value }),
 }) {
-  if (
-    !Number.isSafeInteger(inspectionAttempts) ||
-    inspectionAttempts < 1 ||
-    inspectionAttempts > 100 ||
-    !Number.isSafeInteger(inspectionIntervalMs) ||
-    inspectionIntervalMs < 0 ||
-    inspectionIntervalMs > 60000 ||
-    (sleep !== undefined && typeof sleep !== 'function')
-  ) {
-    fail('INVALID_LIVE_RELEASE_INPUT', 'post-deploy inspection retry options are invalid');
-  }
+  requireInspectionOptions(inspectionAttempts, inspectionIntervalMs, sleep);
   requireAuthorization(authorization, expected);
   if (
     baseline?.status !== 'baseline-captured' ||
@@ -367,15 +371,43 @@ function rollbackProof(baseline, current) {
   });
 }
 
+async function pollRollbackVerification({
+  baseline,
+  client,
+  origin,
+  observe,
+  maxAttempts,
+  intervalMs,
+  sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds)),
+}) {
+  let lastProof = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const current = await inspectAuthoritative(client, origin, observe);
+      lastProof = rollbackProof(baseline, current);
+      if (lastProof.status === 'verified') return lastProof;
+    } catch {
+      lastProof = null;
+      // A later cache-resistant read may converge to the authoritative rollback.
+    }
+    if (attempt < maxAttempts) await sleep(intervalMs);
+  }
+  return lastProof;
+}
+
 export async function finalizeRelease({
   baseline,
   client,
   deployment,
   expected,
   publication,
+  inspectionAttempts = 12,
+  inspectionIntervalMs = 5000,
   observe = collectBaselineIdentity,
+  sleep,
   verify = value => pollLiveVerification({ expected: value }),
 }) {
+  requireInspectionOptions(inspectionAttempts, inspectionIntervalMs, sleep);
   if (deployment?.mutationAttempted !== true) {
     return { protocol: PROTOCOL, status: 'no-mutation', rollbackAttempted: false };
   }
@@ -438,10 +470,16 @@ export async function finalizeRelease({
     baseline.deployment.versionId,
     `restore baseline ${expected.planIdentity.slice(7, 19)}`
   );
-  let restored;
-  try {
-    restored = await inspectAuthoritative(client, expected.origin, observe);
-  } catch {
+  const proof = await pollRollbackVerification({
+    baseline,
+    client,
+    origin: expected.origin,
+    observe,
+    maxAttempts: inspectionAttempts,
+    intervalMs: inspectionIntervalMs,
+    ...(sleep ? { sleep } : {}),
+  });
+  if (!proof) {
     return {
       protocol: PROTOCOL,
       status: 'manual-recovery-required',
@@ -450,7 +488,6 @@ export async function finalizeRelease({
       commandStatus: command.status,
     };
   }
-  const proof = rollbackProof(baseline, restored);
   return proof.status === 'verified'
     ? {
         protocol: PROTOCOL,

--- a/scripts/release/publication.mjs
+++ b/scripts/release/publication.mjs
@@ -16,7 +16,8 @@ const RECOVERY = Object.freeze({
   preservePublicationState: true,
   production: 'restore-prior-baseline',
 });
-const CONVERGENCE_INSPECTIONS = 4;
+const CONVERGENCE_INSPECTIONS = 6;
+const CONVERGENCE_INTERVAL_MS = 2000;
 export class PublicationError extends Error {
   constructor(code, message, details = {}) {
     super(`${code}: ${message}`);
@@ -154,6 +155,7 @@ const unknown = reason => ({ status: 'unknown-critical', reason });
 function releaseState(expected, release) {
   if (
     release.targetSha !== expected.targetSha ||
+    release.name !== expected.name ||
     release.prerelease !== false ||
     !same(release.marker, expected.marker) ||
     release.body !== expected.body ||
@@ -260,11 +262,21 @@ function actionKey(action) {
   if (action.kind === 'publish-draft') return `${action.kind}:${action.releaseId}`;
   return action.kind;
 }
+function observedReleaseId(observation) {
+  const releases = observation?.releases;
+  return Array.isArray(releases) && releases.length === 1 ? releases[0]?.id : null;
+}
 function isForwardState(expected, action, state, mutationResult, observation) {
+  const releaseId = observedReleaseId(observation);
   if (state.status === 'exact-published') {
-    const releaseId = observation?.releases?.[0]?.id;
     if (action.kind === 'create-tag') return false;
-    if (action.kind === 'create-draft') return mutationResult?.releaseId === releaseId;
+    if (action.kind === 'create-draft') {
+      return (
+        Boolean(releaseId) &&
+        Boolean(mutationResult?.releaseId) &&
+        mutationResult.releaseId === releaseId
+      );
+    }
     return action.releaseId === releaseId;
   }
   if (state.status !== 'partial-resumable') return false;
@@ -272,13 +284,17 @@ function isForwardState(expected, action, state, mutationResult, observation) {
   if (action.kind === 'create-tag') {
     return (
       next.kind === 'create-draft' &&
-      mutationResult?.objectSha === observation?.tagRef?.objectSha &&
+      Boolean(mutationResult?.objectSha) &&
+      mutationResult.objectSha === observation?.tagRef?.objectSha &&
       observation?.releases?.length === 0
     );
   }
   if (action.kind === 'create-draft') {
     return (
-      mutationResult?.releaseId === next.releaseId &&
+      Boolean(releaseId) &&
+      Boolean(mutationResult?.releaseId) &&
+      mutationResult.releaseId === releaseId &&
+      releaseId === next.releaseId &&
       (next.kind === 'upload-asset' || next.kind === 'publish-draft')
     );
   }
@@ -314,7 +330,24 @@ function stopped(expected, state, details = {}) {
     ...(state.nextAction ? { nextAction: publicAction(state.nextAction) } : {}),
   };
 }
-export async function executePublication({ adapter, bundle }) {
+export async function executePublication({
+  adapter,
+  bundle,
+  convergenceInspections = CONVERGENCE_INSPECTIONS,
+  convergenceIntervalMs = CONVERGENCE_INTERVAL_MS,
+  sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds)),
+}) {
+  if (
+    !Number.isSafeInteger(convergenceInspections) ||
+    convergenceInspections < 1 ||
+    convergenceInspections > 20 ||
+    !Number.isSafeInteger(convergenceIntervalMs) ||
+    convergenceIntervalMs < 0 ||
+    convergenceIntervalMs > 10000 ||
+    typeof sleep !== 'function'
+  ) {
+    fail('INVALID_CONVERGENCE_OPTIONS', 'publication convergence options are invalid');
+  }
   const expected = validatePublicationBundle(bundle);
   const history = [];
   const attemptedActions = new Set();
@@ -368,15 +401,17 @@ export async function executePublication({ adapter, bundle }) {
       mutationError = error instanceof Error ? error.message : String(error);
     }
     let converged = false;
-    for (let inspection = 0; inspection < CONVERGENCE_INSPECTIONS; inspection += 1) {
+    for (let inspection = 0; inspection < convergenceInspections; inspection += 1) {
       ({ observation, state } = await inspect(ownedReleaseId));
       if (state.status === 'conflict') {
         return stopped(expected, state, { history, ...(mutationError ? { mutationError } : {}) });
       }
       if (isForwardState(expected, action, state, mutationResult, observation)) {
+        if (action.kind === 'create-draft') ownedReleaseId = observedReleaseId(observation);
         converged = true;
         break;
       }
+      if (inspection + 1 < convergenceInspections) await sleep(convergenceIntervalMs);
     }
     if (!converged) {
       return stopped(expected, unknown(`mutation-outcome-unobserved:${key}`), {

--- a/scripts/release/verify-live.mjs
+++ b/scripts/release/verify-live.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
 
 import { canonicalHash } from './canonical-json.mjs';
@@ -209,12 +209,19 @@ export function verifyLiveSnapshot(input, snapshot) {
   };
 }
 const sha256 = bytes => createHash('sha256').update(bytes).digest('hex');
-async function fetchOk(url, fetchImpl, timeoutMs, overallSignal) {
+async function fetchOk(url, fetchImpl, timeoutMs, overallSignal, cacheToken) {
   const requestSignal = AbortSignal.timeout(timeoutMs);
   const signal = overallSignal ? AbortSignal.any([requestSignal, overallSignal]) : requestSignal;
   let response;
   try {
-    response = await fetchImpl(url, { redirect: 'error', signal });
+    const requestUrl = new URL(url);
+    requestUrl.searchParams.set('__bugdrop_observation', cacheToken);
+    response = await fetchImpl(requestUrl, {
+      cache: 'no-store',
+      headers: { 'cache-control': 'no-cache', pragma: 'no-cache' },
+      redirect: 'error',
+      signal,
+    });
   } catch (error) {
     if (requestSignal.aborted && !overallSignal?.aborted) {
       fail('LIVE_FETCH_TIMEOUT', `${url} exceeded ${timeoutMs}ms`);
@@ -264,6 +271,7 @@ async function collectSnapshot(
   signal
 ) {
   const budget = { used: 0 };
+  const cacheToken = randomUUID();
   const deadline = totalTimeoutMs === null ? null : Date.now() + totalTimeoutMs;
   const requestTimeout = () => {
     if (deadline === null) return timeoutMs;
@@ -275,7 +283,7 @@ async function collectSnapshot(
   };
   const healthUrl = `${origin}/api/health`;
   const healthBytes = await readBoundedBytes(
-    await fetchOk(healthUrl, fetchImpl, requestTimeout(), signal),
+    await fetchOk(healthUrl, fetchImpl, requestTimeout(), signal, cacheToken),
     healthUrl,
     MAX_HEALTH_BYTES,
     budget
@@ -293,7 +301,7 @@ async function collectSnapshot(
   for (let index = 0; index < queue.length; index += 1) {
     const filename = queue[index];
     const url = `${origin}/${filename}`;
-    const response = await fetchOk(url, fetchImpl, requestTimeout(), signal);
+    const response = await fetchOk(url, fetchImpl, requestTimeout(), signal, cacheToken);
     const payload = await readBoundedBytes(
       response,
       url,

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -335,6 +335,7 @@ publish_block=$(job_block publish-release)
 for literal in \
   'needs: [guard-and-plan, verify-candidate, approval-baseline, deploy-candidate, live-e2e]' \
   'environment: production' \
+  'timeout-minutes: 15' \
   'contents: write' \
   'node controller/scripts/release/live-release.mjs publish' \
   'BUGDROP_GITHUB_TOKEN: ${{ github.token }}'; do
@@ -370,10 +371,20 @@ for literal in \
   '--arg candidateAssets "$GITHUB_WORKSPACE/candidate/.release-static-package"' \
   '--arg bundlePath "$GITHUB_WORKSPACE/release-state/state2-bundle.json"' \
   'node controller/scripts/release/live-release.mjs finalize' \
+  'Preserve finalization evidence' \
+  'Upload authoritative finalization outcome' \
+  'name: release-finalization-${{ needs.verify-candidate.outputs.plan_key }}-${{ github.run_attempt }}' \
+  'path: finalization.json' \
+  'if-no-files-found: error' \
   'Require verified stable or restored production' \
   'test "$status" = '\''no-mutation'\'''; do
   grep -Fq -- "$literal" <<< "$final_block" || fail "finalizer lacks: $literal"
 done
+
+upload_line=$(grep -n 'name: Upload authoritative finalization outcome' <<< "$final_block" | cut -d: -f1)
+assert_line=$(grep -n 'name: Require verified stable or restored production' <<< "$final_block" | cut -d: -f1)
+[[ -n "$upload_line" && -n "$assert_line" && "$upload_line" -lt "$assert_line" ]] ||
+  fail 'finalization evidence must upload before the terminal assertion'
 
 [[ $(grep -Fc "if: \${{ needs.deploy-candidate.result != 'skipped' }}" <<< "$final_block") -eq 7 ]] ||
   fail 'skipped deployment must bypass all recovery setup and artifact downloads'

--- a/test/release/github-publication-adapter.test.ts
+++ b/test/release/github-publication-adapter.test.ts
@@ -15,15 +15,18 @@ function response(value: unknown, status = 200, headers?: HeadersInit) {
   return new Response(value === null ? null : JSON.stringify(value), { status, headers });
 }
 
-function adapter(fetchImpl: typeof fetch) {
+function adapter(fetchImpl: typeof fetch, requestTimeoutMs = 30_000) {
   return createGithubPublicationAdapter({
     apiUrl: API,
     uploadsUrl: UPLOADS,
     fetchImpl,
     repository: 'mean-weasel/bugdrop',
+    requestTimeoutMs,
     token: TOKEN,
   });
 }
+
+type PublicationAdapter = ReturnType<typeof createGithubPublicationAdapter>;
 
 describe('GitHub publication inspection', () => {
   it('hydrates one annotated tag, marker, and exact asset bytes', async () => {
@@ -42,6 +45,7 @@ describe('GitHub publication inspection', () => {
           {
             id: 123,
             tag_name: 'v1.2.3',
+            name: 'BugDrop 1.2.3',
             body: `notes\n\n${bodyMarker}`,
             draft: false,
             prerelease: false,
@@ -86,6 +90,7 @@ describe('GitHub publication inspection', () => {
           draft: false,
           id: '123',
           marker,
+          name: 'BugDrop 1.2.3',
           prerelease: false,
           published: true,
           tag: 'v1.2.3',
@@ -418,6 +423,64 @@ describe('GitHub publication inspection', () => {
 });
 
 describe('GitHub publication mutations', () => {
+  it('aborts a never-resolving inspection within its explicit request deadline', async () => {
+    let requestSignal: AbortSignal | null = null;
+    const fetchImpl = vi.fn((_input: URL | RequestInfo, init?: RequestInit) => {
+      requestSignal = init?.signal ?? null;
+      return new Promise<Response>(() => {});
+    });
+
+    await expect(adapter(fetchImpl as typeof fetch, 5).inspect('v1.2.3')).rejects.toMatchObject({
+      code: 'GITHUB_REQUEST_TIMEOUT',
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
+  it.each([
+    [
+      'create-tag',
+      (client: PublicationAdapter) =>
+        client.createAnnotatedTag({
+          tag: 'v1.2.3',
+          targetSha: SHA,
+          annotation: 'exact annotation',
+        }),
+    ],
+    [
+      'create-draft',
+      (client: PublicationAdapter) =>
+        client.createDraft({
+          tag: 'v1.2.3',
+          targetSha: SHA,
+          name: 'BugDrop 1.2.3',
+          body: 'notes',
+        }),
+    ],
+    [
+      'upload-asset',
+      (client: PublicationAdapter) =>
+        client.uploadAsset({
+          releaseId: '123',
+          name: 'widget.js',
+          bytes: Buffer.from('asset'),
+        }),
+    ],
+    ['publish-draft', (client: PublicationAdapter) => client.publishDraft({ releaseId: '123' })],
+  ] as const)('aborts a never-resolving %s request without retrying it', async (_name, mutate) => {
+    let requestSignal: AbortSignal | null = null;
+    const fetchImpl = vi.fn((_input: URL | RequestInfo, init?: RequestInit) => {
+      requestSignal = init?.signal ?? null;
+      return new Promise<Response>(() => {});
+    });
+
+    await expect(mutate(adapter(fetchImpl as typeof fetch, 5))).rejects.toMatchObject({
+      code: 'GITHUB_REQUEST_TIMEOUT',
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
   it('creates an annotated tag object and exact ref', async () => {
     const calls: Array<{ body: unknown; method: string; path: string }> = [];
     const fetchImpl = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
@@ -541,6 +604,15 @@ describe('GitHub publication mutations', () => {
         }),
     ],
     ['bad tag', () => adapter(fetch).inspect('main')],
+    [
+      'bad request timeout',
+      () =>
+        createGithubPublicationAdapter({
+          repository: 'owner/repo',
+          requestTimeoutMs: 0,
+          token: TOKEN,
+        }),
+    ],
     ['bad release id', () => adapter(fetch).publishDraft({ releaseId: '../1' })],
     [
       'bad asset name',

--- a/test/release/live-release.test.ts
+++ b/test/release/live-release.test.ts
@@ -173,6 +173,7 @@ describe('live release production orchestration', () => {
             draft: false,
             id: '123',
             marker: publication.marker,
+            name: publication.name,
             prerelease: false,
             published: true,
             tag: publication.tag,
@@ -313,6 +314,99 @@ describe('live release production orchestration', () => {
       'version-baseline',
       expect.stringContaining('restore baseline')
     );
+  });
+
+  it('polls read-only after rollback until the authoritative baseline is visible', async () => {
+    const cloudflare = client();
+    const baseline = await captureBaseline({
+      client: cloudflare,
+      expected,
+      observe: cloudflare.observe,
+    });
+    const deployment = await deployCandidate({
+      authorization,
+      baseline,
+      client: cloudflare,
+      expected,
+      observe: cloudflare.observe,
+      verify: async () => ({ status: 'verified', targetSha: SHA }),
+    });
+    let postRollbackReads = 0;
+    const observe = vi.fn(async () => {
+      if (cloudflare.rollback.mock.calls.length && postRollbackReads++ === 0) {
+        return {
+          ...state('baseline', null).live,
+          assetIdentity: state('candidate', SHA).live.assetIdentity,
+        };
+      }
+      return cloudflare.observe();
+    });
+    const sleep = vi.fn(async () => {});
+
+    await expect(
+      finalizeRelease({
+        baseline,
+        client: cloudflare,
+        deployment,
+        expected,
+        publication: { status: 'unknown-critical' },
+        inspectionAttempts: 2,
+        inspectionIntervalMs: 1,
+        observe,
+        sleep,
+        verify: async () => ({ status: 'verified', targetSha: SHA }),
+      })
+    ).resolves.toMatchObject({ status: 'rollback-verified', rollbackAttempted: true });
+    expect(cloudflare.rollback).toHaveBeenCalledOnce();
+    expect(sleep).toHaveBeenCalledOnce();
+  });
+
+  it('reports terminal rollback inspection unavailability instead of a stale mismatch', async () => {
+    const cloudflare = client();
+    const baseline = await captureBaseline({
+      client: cloudflare,
+      expected,
+      observe: cloudflare.observe,
+    });
+    const deployment = await deployCandidate({
+      authorization,
+      baseline,
+      client: cloudflare,
+      expected,
+      observe: cloudflare.observe,
+      verify: async () => ({ status: 'verified', targetSha: SHA }),
+    });
+    let postRollbackReads = 0;
+    const observe = vi.fn(async () => {
+      if (!cloudflare.rollback.mock.calls.length) return cloudflare.observe();
+      postRollbackReads += 1;
+      if (postRollbackReads === 1) {
+        return {
+          ...state('baseline', null).live,
+          assetIdentity: state('candidate', SHA).live.assetIdentity,
+        };
+      }
+      throw new Error('authoritative inspection unavailable');
+    });
+
+    await expect(
+      finalizeRelease({
+        baseline,
+        client: cloudflare,
+        deployment,
+        expected,
+        publication: { status: 'unknown-critical' },
+        inspectionAttempts: 2,
+        inspectionIntervalMs: 0,
+        observe,
+        sleep: async () => {},
+        verify: async () => ({ status: 'verified', targetSha: SHA }),
+      })
+    ).resolves.toMatchObject({
+      status: 'manual-recovery-required',
+      reason: 'rollback-inspection-unavailable',
+      rollbackAttempted: true,
+    });
   });
 
   it('never rolls back an unexpected active state', async () => {

--- a/test/release/publication.test.ts
+++ b/test/release/publication.test.ts
@@ -20,8 +20,18 @@ import {
 } from '../../scripts/release/publication.mjs';
 import {
   clonePublicationState,
-  FakeGitHubPublicationAdapter,
+  FakeGitHubPublicationAdapter as BaseFakeGitHubPublicationAdapter,
 } from '../fixtures/release/publication/fake-github';
+
+class FakeGitHubPublicationAdapter extends BaseFakeGitHubPublicationAdapter {
+  override async createDraft(input: Record<string, unknown>) {
+    try {
+      return await super.createDraft(input);
+    } finally {
+      Object.assign(this.state.releases?.[0] ?? {}, { name: input.name });
+    }
+  }
+}
 
 const SHA = { target: 'a'.repeat(40), controller: 'b'.repeat(40), main: 'c'.repeat(40) };
 const conflictCases = JSON.parse(
@@ -195,7 +205,9 @@ describe('complete publication and exact retry', () => {
   it('turns an exact rerun into an authenticated no-op', async () => {
     const { adapter, bundle } = await publishedAdapter();
     const before = [...adapter.applied];
-    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
       status: 'already-published',
       planIdentity: bundle.finalPlan.planIdentity,
     });
@@ -220,13 +232,16 @@ describe('complete publication and exact retry', () => {
   );
 
   it.each(['create-tag', 'create-draft'] as const)(
-    'fails closed after an applied %s response is lost without claiming fresh ownership',
+    'fails closed after an applied %s response is lost without claiming ownership',
     async point => {
       const bundle = publicationBundle();
       const adapter = new FakeGitHubPublicationAdapter({ loseAfter: [point] });
-      await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+
+      await expect(
+        executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+      ).resolves.toMatchObject({
         status: 'unknown-critical',
-        reason: expect.stringContaining('mutation-outcome-unobserved'),
+        reason: expect.stringContaining(`mutation-outcome-unobserved:${point}`),
       });
       expect(adapter.log.filter(item => item.startsWith(point))).toHaveLength(1);
       if (point === 'create-tag') expect(adapter.log).not.toContain('create-draft');
@@ -236,26 +251,7 @@ describe('complete publication and exact retry', () => {
     }
   );
 
-  it('fails closed when a lost tag response is followed by the correct tag becoming visible', async () => {
-    const bundle = publicationBundle();
-    const adapter = delayMutationVisibility(
-      new FakeGitHubPublicationAdapter({ loseAfter: ['create-tag'] }),
-      'create-tag',
-      2
-    );
-
-    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
-      status: 'unknown-critical',
-      reason: expect.stringContaining('mutation-outcome-unobserved:create-tag'),
-    });
-    expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
-    expect(adapter.applied.filter(item => item === 'create-tag')).toHaveLength(1);
-    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(0);
-    expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(0);
-    expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
-  });
-
-  it('fails closed when an unapplied lost tag is followed by a matching tag observation', async () => {
+  it('never adopts a foreign exact tag after the create-tag request failed before application', async () => {
     const bundle = publicationBundle();
     const expected = validatePublicationBundle(bundle);
     const adapter = new FakeGitHubPublicationAdapter({ loseBefore: ['create-tag'] });
@@ -264,7 +260,6 @@ describe('complete publication and exact retry', () => {
     adapter.inspect = async () => {
       inspections += 1;
       if (inspections === 1) return inspect();
-      adapter.log.push('inspect');
       return {
         complete: true,
         tagRef: { objectSha: '7'.repeat(40) },
@@ -279,14 +274,105 @@ describe('complete publication and exact retry', () => {
       };
     };
 
-    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
       status: 'unknown-critical',
       reason: expect.stringContaining('mutation-outcome-unobserved:create-tag'),
     });
     expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
     expect(adapter.applied.filter(item => item === 'create-tag')).toHaveLength(0);
     expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(0);
-    expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(0);
+  });
+
+  it('rejects a wrong-name Release and never adopts it after create-draft ownership is lost', async () => {
+    const bundle = publicationBundle();
+    const adapter = new FakeGitHubPublicationAdapter({ loseBefore: ['create-draft'] });
+    const createDraft = adapter.createDraft.bind(adapter);
+    adapter.createDraft = async input => {
+      try {
+        return await createDraft(input);
+      } catch (error) {
+        adapter.state.releases = [
+          {
+            ...(new FakeGitHubPublicationAdapter().state.releases?.[0] ?? {}),
+            id: '999',
+            tag: input.tag as string,
+            targetSha: input.targetSha as string,
+            draft: true,
+            published: false,
+            prerelease: false,
+            marker: input.marker as Record<string, unknown>,
+            body: input.body as string,
+            bodyMarker: input.bodyMarker as string,
+            assets: [],
+            name: 'Not the planned Release',
+          } as never,
+        ];
+        throw error;
+      }
+    };
+
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({ status: 'conflict', reason: 'release-identity-mismatch' });
+    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(1);
+    expect(adapter.applied.filter(item => item === 'create-draft')).toHaveLength(0);
+    expect(adapter.log.some(item => item.startsWith('upload-asset'))).toBe(false);
+  });
+
+  it('never adopts a concurrent exact-published Release without a create-draft result ID', async () => {
+    const bundle = publicationBundle();
+    const foreign = new FakeGitHubPublicationAdapter();
+    await expect(
+      executePublication({ adapter: foreign, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({ status: 'published' });
+    const adapter = new FakeGitHubPublicationAdapter({ loseBefore: ['create-draft'] });
+    const createDraft = adapter.createDraft.bind(adapter);
+    adapter.createDraft = async input => {
+      try {
+        return await createDraft(input);
+      } catch (error) {
+        adapter.state.releases = clonePublicationState(foreign.state.releases);
+        throw error;
+      }
+    };
+
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining('mutation-outcome-unobserved:create-draft'),
+    });
+    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(1);
+    expect(adapter.applied.filter(item => item === 'create-draft')).toHaveLength(0);
+    expect(adapter.log.some(item => item.startsWith('upload-asset'))).toBe(false);
+    expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
+  });
+
+  it('accepts exact-published convergence only with the returned create-draft Release ID', async () => {
+    const bundle = publicationBundle();
+    const adapter = queueMutationInspections(
+      new FakeGitHubPublicationAdapter(),
+      'create-draft',
+      (_before, after) => {
+        const published = clonePublicationState(after);
+        published.releases![0].assets = Object.entries(bundle.assets).map(([name, bytes]) => ({
+          name,
+          bytes: Buffer.from(bytes),
+        }));
+        published.releases![0].draft = false;
+        published.releases![0].published = true;
+        return [published];
+      }
+    );
+
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({ status: 'published' });
+    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(1);
+    expect(adapter.applied.filter(item => item === 'create-draft')).toHaveLength(1);
+    expect(adapter.log.some(item => item.startsWith('upload-asset'))).toBe(false);
     expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
   });
 
@@ -302,7 +388,9 @@ describe('complete publication and exact retry', () => {
       }
     );
 
-    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
       status: 'conflict',
       reason: 'tag-identity-mismatch',
     });
@@ -318,7 +406,9 @@ describe('complete publication and exact retry', () => {
     async point => {
       const bundle = publicationBundle();
       const adapter = delayMutationVisibility(new FakeGitHubPublicationAdapter(), point, 2);
-      await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      await expect(
+        executePublication({ adapter, bundle, sleep: async () => {} })
+      ).resolves.toMatchObject({
         status: 'published',
       });
       expect(adapter.applied.filter(item => item.startsWith(point))).toHaveLength(
@@ -339,7 +429,9 @@ describe('complete publication and exact retry', () => {
         point,
         2
       );
-      await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      await expect(
+        executePublication({ adapter, bundle, sleep: async () => {} })
+      ).resolves.toMatchObject({
         status: 'published',
       });
       expect(adapter.applied.filter(item => item.startsWith(point))).toHaveLength(
@@ -357,7 +449,9 @@ describe('complete publication and exact retry', () => {
         point,
         Number.POSITIVE_INFINITY
       );
-      await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      await expect(
+        executePublication({ adapter, bundle, sleep: async () => {} })
+      ).resolves.toMatchObject({
         status: 'unknown-critical',
         reason: expect.stringContaining('mutation-outcome-unobserved'),
         recovery: { automaticGitHubCleanup: false },
@@ -380,11 +474,13 @@ describe('complete publication and exact retry', () => {
       (_before, after) => {
         const mismatch = clonePublicationState(after);
         mismatch.releases![0].id = '456';
-        return Array.from({ length: 4 }, () => clonePublicationState(mismatch));
+        return Array.from({ length: 6 }, () => clonePublicationState(mismatch));
       }
     );
 
-    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
       status: 'unknown-critical',
       reason: expect.stringContaining('mutation-outcome-unobserved:create-draft'),
     });
@@ -408,7 +504,9 @@ describe('complete publication and exact retry', () => {
       }
     );
 
-    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
       status: 'conflict',
       reason: 'duplicate-release',
     });
@@ -474,11 +572,13 @@ describe('complete publication and exact retry', () => {
       (_before, after) => {
         const tagOnly = clonePublicationState(after);
         tagOnly.releases = [];
-        return Array.from({ length: 4 }, () => clonePublicationState(tagOnly));
+        return Array.from({ length: 6 }, () => clonePublicationState(tagOnly));
       }
     );
 
-    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
       status: 'unknown-critical',
       reason: expect.stringContaining('mutation-outcome-unobserved:publish-draft'),
     });
@@ -505,11 +605,13 @@ describe('complete publication and exact retry', () => {
         regressive.releases![0].assets = regressive.releases![0].assets.filter(
           asset => asset.name !== earlier
         );
-        return Array.from({ length: 4 }, () => clonePublicationState(regressive));
+        return Array.from({ length: 6 }, () => clonePublicationState(regressive));
       }
     );
 
-    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
       status: 'unknown-critical',
       reason: expect.stringContaining(`mutation-outcome-unobserved:upload-asset:123:${current}`),
     });
@@ -524,10 +626,12 @@ describe('complete publication and exact retry', () => {
     const adapter = queueMutationInspections(
       new FakeGitHubPublicationAdapter(),
       'create-draft',
-      before => Array.from({ length: 4 }, () => clonePublicationState(before))
+      before => Array.from({ length: 6 }, () => clonePublicationState(before))
     );
 
-    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
       status: 'unknown-critical',
       reason: expect.stringContaining('mutation-outcome-unobserved:create-draft'),
     });
@@ -543,7 +647,9 @@ describe('complete publication and exact retry', () => {
     async point => {
       const bundle = publicationBundle();
       const adapter = new FakeGitHubPublicationAdapter({ loseBefore: [point] });
-      await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+      await expect(
+        executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+      ).resolves.toMatchObject({
         status: 'unknown-critical',
         reason: expect.stringContaining('mutation-outcome-unobserved'),
         recovery: { production: 'restore-prior-baseline', automaticGitHubCleanup: false },
@@ -568,7 +674,9 @@ describe('complete publication and exact retry', () => {
       ]
     );
 
-    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
       status: 'published',
     });
     expect(adapter.applied.filter(item => item === 'create-draft')).toHaveLength(1);
@@ -579,15 +687,15 @@ describe('complete publication and exact retry', () => {
     const adapter = queueMutationInspections(
       new FakeGitHubPublicationAdapter(),
       'create-draft',
-      before => [
-        new Error('transient inspection failure'),
-        clonePublicationState(before),
-        new Error('transient inspection failure'),
-        clonePublicationState(before),
-      ]
+      before =>
+        Array.from({ length: 6 }, (_, index) =>
+          index % 2 ? clonePublicationState(before) : new Error('transient inspection failure')
+        )
     );
 
-    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
       status: 'unknown-critical',
       reason: expect.stringContaining('mutation-outcome-unobserved'),
     });
@@ -688,7 +796,9 @@ describe('conflicts, unknown state, and bundle authentication', () => {
   it('fails closed when state becomes unreadable after a successful mutation', async () => {
     const bundle = publicationBundle();
     const adapter = new FakeGitHubPublicationAdapter({ failInspectAfterApplied: true });
-    await expect(executePublication({ adapter, bundle })).resolves.toMatchObject({
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
       status: 'unknown-critical',
       recovery: { automaticGitHubCleanup: false },
     });

--- a/test/release/verify-live.test.ts
+++ b/test/release/verify-live.test.ts
@@ -123,6 +123,32 @@ describe('explicit live verification', () => {
 });
 
 describe('polling and scheduled observation', () => {
+  it('uses cache-resistant requests and a fresh observation token for each snapshot', async () => {
+    const requests: { url: URL; init?: RequestInit }[] = [];
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      requests.push({ url, init });
+      if (url.pathname === '/api/health') {
+        return Response.json({ status: 'ok', environment: 'production', buildSha: SHA });
+      }
+      if (url.pathname === '/widget.js') return new Response('widget');
+      if (url.pathname === '/versions.json') return Response.json({ current: '1.56.0' });
+      throw new Error(`unexpected request ${url.pathname}`);
+    });
+
+    await collectRecoveryIdentity(expected().origin, fetchImpl as typeof fetch);
+    await collectRecoveryIdentity(expected().origin, fetchImpl as typeof fetch);
+
+    const tokens = requests.map(item => item.url.searchParams.get('__bugdrop_observation'));
+    expect(new Set(tokens.slice(0, 3)).size).toBe(1);
+    expect(new Set(tokens.slice(3, 6)).size).toBe(1);
+    expect(tokens[0]).not.toBe(tokens[3]);
+    for (const { init } of requests) {
+      expect(init).toMatchObject({ cache: 'no-store' });
+      expect(init?.headers).toMatchObject({ 'cache-control': 'no-cache', pragma: 'no-cache' });
+    }
+  });
+
   it('retries a mismatch and succeeds only on the exact snapshot', async () => {
     const wrong = snapshot();
     wrong.health.buildSha = '0'.repeat(40);


### PR DESCRIPTION
## Incident context

The authorized N+1 release deployed and verified the candidate, but GitHub publication created one exact annotated tag plus duplicate empty draft Releases before stopping. The protected finalizer restored the prior production baseline and ended manual-recovery-required.

## Fix

- Bound every GitHub inspection and mutation request without retrying mutations.
- Require exact tag and Release ownership, planned Release naming, and authenticated post-mutation convergence.
- Use cache-resistant rollback polling and preserve terminal inspection unavailability.
- Guarantee finalizer execution/evidence ordering and attempt-unique finalization artifacts.

## Verification

- 405 release tests passed, including adversarial ownership and rollback regressions.
- 976 full tests passed with lint, formatting, and TypeScript checks.
- Release workflow contract, Actions Node 24 pinning, and both permission checks passed.
- Audited ten-file patch SHA-256: `23e700f26678da092c3f9292213fa7aeb5d01730b92cb4d4122a92fbcb20031c`.

## Production safety

No production or release mutation was performed while preparing this PR. No workflow was dispatched or rerun, and no production, tag, Release, gate, or deployment state was changed.