### PR TITLE
chore: add CodeQL and dependency review

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '23 4 * * 2'
+
+permissions: {}
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - name: Analyze with CodeQL
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,29 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    name: Review dependency changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate
+          fail-on-scopes: runtime, development, unknown
+          license-check: false
+          show-openssf-scorecard: false
+          show-patched-versions: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build build-widget build-all deploy test test-release test-release-workflow test-static-assets release-plan-help test-watch test-e2e test-e2e-ui test-e2e-shard test-radix-e2e test-live-radix test-live-cross-browser lint lint-fix format format-check typecheck knip audit check-actions-node24 check-workflow-permissions check-ci-scope check-ci-workflow check-production-heartbeat-workflow check-release-workflow check ci clean install install-playwright help
+.PHONY: dev build build-widget build-all deploy test test-release test-release-workflow test-static-assets release-plan-help test-watch test-e2e test-e2e-ui test-e2e-shard test-radix-e2e test-live-radix test-live-cross-browser lint lint-fix format format-check typecheck knip audit check-actions-node24 check-workflow-permissions check-security-analysis-workflows check-ci-scope check-ci-workflow check-production-heartbeat-workflow check-release-workflow check ci clean install install-playwright help
 
 # Development
 dev:
@@ -103,6 +103,10 @@ check-workflow-permissions:
 	npm run check:workflow-permissions
 	bash test/workflow-permissions.test.sh
 
+check-security-analysis-workflows:
+	npm run check:security-analysis-workflows
+	bash test/security-analysis-workflows.test.sh
+
 check-ci-scope:
 	bash test/ci-scope.test.sh
 
@@ -116,7 +120,7 @@ check-release-workflow:
 	bash test/release-workflow-contract.test.sh
 
 # Combined Commands
-check: test-release lint format-check typecheck knip audit check-actions-node24 check-workflow-permissions check-ci-scope check-ci-workflow check-production-heartbeat-workflow check-release-workflow
+check: test-release lint format-check typecheck knip audit check-actions-node24 check-workflow-permissions check-security-analysis-workflows check-ci-scope check-ci-workflow check-production-heartbeat-workflow check-release-workflow
 	@echo "✓ All checks passed"
 
 ci: check test build-all test-e2e

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "check:actions-node24": "node scripts/check-github-actions.mjs",
+    "check:security-analysis-workflows": "node scripts/check-security-analysis-workflows.mjs",
     "check:workflow-permissions": "node scripts/check-workflow-permissions.mjs",
     "validate": "npm run lint && npm run format:check && npm run typecheck && npm run test",
     "prepare": "husky"

--- a/scripts/check-github-actions.mjs
+++ b/scripts/check-github-actions.mjs
@@ -11,8 +11,11 @@ const minimumMajor = new Map([
   ['actions/cache/save', 5],
   ['actions/checkout', 5],
   ['actions/download-artifact', 5],
+  ['actions/dependency-review-action', 5],
   ['actions/setup-node', 5],
   ['actions/upload-artifact', 5],
+  ['github/codeql-action/analyze', 4],
+  ['github/codeql-action/init', 4],
 ]);
 
 const approvedReleases = new Map([
@@ -31,7 +34,10 @@ const approvedReleases = new Map([
   ['actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4', 'v5.0.0'],
   ['actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a', 'v7.0.1'],
   ['actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f', 'v7.0.0'],
+  ['actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294', 'v5.0.0'],
   ['codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f', 'v7.0.0'],
+  ['github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3', 'v4.37.6'],
+  ['github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3', 'v4.37.6'],
 ]);
 
 const failures = [];

--- a/scripts/check-security-analysis-workflows.mjs
+++ b/scripts/check-security-analysis-workflows.mjs
@@ -1,0 +1,124 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
+import { parse } from 'yaml';
+
+const workflowRoot = resolve(process.argv[2] ?? '.github/workflows');
+const failures = [];
+
+const checkEqual = (location, actual, expected) => {
+  if (!isDeepStrictEqual(actual, expected)) {
+    failures.push(`${location}: expected ${JSON.stringify(expected)}`);
+  }
+};
+
+const checkBlocking = (location, node) => {
+  for (const key of ['if', 'continue-on-error']) {
+    if (node && Object.hasOwn(node, key)) {
+      failures.push(`${location}: must not define ${key}`);
+    }
+  }
+};
+
+const readWorkflow = async file => {
+  try {
+    return parse(await readFile(resolve(workflowRoot, file), 'utf8'));
+  } catch (error) {
+    failures.push(`${file}: ${error.message}`);
+    return {};
+  }
+};
+
+const codeql = await readWorkflow('codeql.yml');
+checkEqual('codeql.yml: triggers', codeql.on, {
+  push: { branches: ['main'] },
+  pull_request: { branches: ['main'] },
+  schedule: [{ cron: '23 4 * * 2' }],
+});
+checkEqual('codeql.yml: top-level permissions', codeql.permissions, {});
+checkEqual('codeql.yml: analyze permissions', codeql.jobs?.analyze?.permissions, {
+  contents: 'read',
+  'security-events': 'write',
+});
+checkBlocking('codeql.yml: analyze job', codeql.jobs?.analyze);
+
+const codeqlSteps = codeql.jobs?.analyze?.steps ?? [];
+const codeqlCheckout = codeqlSteps.find(step => step.name === 'Checkout repository');
+const codeqlInit = codeqlSteps.find(step => step.name === 'Initialize CodeQL');
+const codeqlAnalyze = codeqlSteps.find(step => step.name === 'Analyze with CodeQL');
+checkBlocking('codeql.yml: checkout step', codeqlCheckout);
+checkBlocking('codeql.yml: init step', codeqlInit);
+checkBlocking('codeql.yml: analyze step', codeqlAnalyze);
+checkEqual(
+  'codeql.yml: checkout action',
+  codeqlCheckout?.uses,
+  'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
+);
+checkEqual('codeql.yml: checkout configuration', codeqlCheckout?.with, {
+  'persist-credentials': false,
+});
+checkEqual(
+  'codeql.yml: init action',
+  codeqlInit?.uses,
+  'github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3'
+);
+checkEqual('codeql.yml: init configuration', codeqlInit?.with, {
+  languages: 'javascript-typescript',
+  'build-mode': 'none',
+});
+checkEqual(
+  'codeql.yml: analyze action',
+  codeqlAnalyze?.uses,
+  'github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3'
+);
+checkEqual('codeql.yml: analyze configuration', codeqlAnalyze?.with, {
+  category: '/language:javascript-typescript',
+});
+
+const dependencyReview = await readWorkflow('dependency-review.yml');
+checkEqual('dependency-review.yml: triggers', dependencyReview.on, {
+  pull_request: { branches: ['main'] },
+});
+checkEqual('dependency-review.yml: top-level permissions', dependencyReview.permissions, {});
+checkEqual(
+  'dependency-review.yml: job permissions',
+  dependencyReview.jobs?.['dependency-review']?.permissions,
+  { contents: 'read' }
+);
+checkBlocking(
+  'dependency-review.yml: dependency-review job',
+  dependencyReview.jobs?.['dependency-review']
+);
+
+const dependencySteps = dependencyReview.jobs?.['dependency-review']?.steps ?? [];
+const dependencyCheckout = dependencySteps.find(step => step.name === 'Checkout repository');
+const dependencyScan = dependencySteps.find(step => step.name === 'Review dependency changes');
+checkBlocking('dependency-review.yml: checkout step', dependencyCheckout);
+checkBlocking('dependency-review.yml: review step', dependencyScan);
+checkEqual(
+  'dependency-review.yml: checkout action',
+  dependencyCheckout?.uses,
+  'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
+);
+checkEqual('dependency-review.yml: checkout configuration', dependencyCheckout?.with, {
+  'persist-credentials': false,
+});
+checkEqual(
+  'dependency-review.yml: review action',
+  dependencyScan?.uses,
+  'actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294'
+);
+checkEqual('dependency-review.yml: review configuration', dependencyScan?.with, {
+  'fail-on-severity': 'moderate',
+  'fail-on-scopes': 'runtime, development, unknown',
+  'license-check': false,
+  'show-openssf-scorecard': false,
+  'show-patched-versions': true,
+});
+
+if (failures.length > 0) {
+  console.error(failures.join('\n'));
+  process.exit(1);
+}
+
+console.log('CodeQL and dependency-review workflow contracts passed');

--- a/scripts/check-workflow-permissions.mjs
+++ b/scripts/check-workflow-permissions.mjs
@@ -8,6 +8,8 @@ const expectedTopLevel = new Map([
   ['benchmark-ci.yml', {}],
   ['ci.yml', {}],
   ['cloudflare-capability.yml', { contents: 'read' }],
+  ['codeql.yml', {}],
+  ['dependency-review.yml', {}],
   ['deploy.yml', { contents: 'read' }],
   ['discord-release.yml', { contents: 'read' }],
   ['live-tests.yml', {}],
@@ -24,12 +26,15 @@ const denyByDefaultJobs = new Map([
   ['ci.yml:live-preview-tests', {}],
   ['ci.yml:radix-e2e', { contents: 'read' }],
   ['ci.yml:test', { contents: 'read' }],
+  ['codeql.yml:analyze', { contents: 'read', 'security-events': 'write' }],
+  ['dependency-review.yml:dependency-review', { contents: 'read' }],
   ['live-tests.yml:live-tests', { contents: 'read' }],
   ['sync-docs.yml:sync', { contents: 'read' }],
 ]);
 
 const allowedWrites = new Set([
   'ci.yml:coverage:id-token',
+  'codeql.yml:analyze:security-events',
   'deploy.yml:publish-release:contents',
   'production-heartbeat.yml:incident:issues',
 ]);

--- a/test/security-analysis-workflows.test.sh
+++ b/test/security-analysis-workflows.test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+checker="$repo_root/scripts/check-security-analysis-workflows.mjs"
+fixture_root=$(mktemp -d /tmp/bugdrop-security-analysis-test.XXXXXX)
+trap 'rm -rf "$fixture_root"' EXIT
+
+make_fixture() {
+  local name=$1
+  local directory="$fixture_root/$name"
+  mkdir -p "$directory"
+  cp "$repo_root/.github/workflows/codeql.yml" "$directory/"
+  cp "$repo_root/.github/workflows/dependency-review.yml" "$directory/"
+  printf '%s\n' "$directory"
+}
+
+expect_failure() {
+  local directory=$1
+  local expected=$2
+  if node "$checker" "$directory" > "$fixture_root/output" 2>&1; then
+    echo "Security workflow checker unexpectedly accepted an unsafe fixture" >&2
+    exit 1
+  fi
+  grep -Fq "$expected" "$fixture_root/output" || {
+    cat "$fixture_root/output" >&2
+    exit 1
+  }
+}
+
+node "$checker" "$repo_root/.github/workflows" > /dev/null
+
+missing_schedule=$(make_fixture missing-schedule)
+perl -0pi -e "s/  schedule:\n    - cron: '23 4 \* \* 2'\n//" "$missing_schedule/codeql.yml"
+expect_failure "$missing_schedule" 'codeql.yml: triggers'
+
+wrong_language=$(make_fixture wrong-language)
+perl -0pi -e 's/languages: javascript-typescript/languages: actions/' "$wrong_language/codeql.yml"
+expect_failure "$wrong_language" 'codeql.yml: init configuration'
+
+missing_upload=$(make_fixture missing-upload)
+perl -0pi -e "s/      security-events: write\n//" "$missing_upload/codeql.yml"
+expect_failure "$missing_upload" 'codeql.yml: analyze permissions'
+
+disabled_codeql_job=$(make_fixture disabled-codeql-job)
+perl -0pi -e 's/(  analyze:\n)/$1    if: false\n/' "$disabled_codeql_job/codeql.yml"
+expect_failure "$disabled_codeql_job" 'codeql.yml: analyze job: must not define if'
+
+disabled_codeql_step=$(make_fixture disabled-codeql-step)
+perl -0pi -e 's/(      - name: Analyze with CodeQL\n)/$1        if: false\n/' \
+  "$disabled_codeql_step/codeql.yml"
+expect_failure "$disabled_codeql_step" 'codeql.yml: analyze step: must not define if'
+
+warn_only=$(make_fixture warn-only)
+perl -0pi -e 's/(          fail-on-severity: moderate\n)/$1          warn-only: true\n/' \
+  "$warn_only/dependency-review.yml"
+expect_failure "$warn_only" 'dependency-review.yml: review configuration'
+
+runtime_only=$(make_fixture runtime-only)
+perl -0pi -e 's/fail-on-scopes: runtime, development, unknown/fail-on-scopes: runtime/' \
+  "$runtime_only/dependency-review.yml"
+expect_failure "$runtime_only" 'dependency-review.yml: review configuration'
+
+nonblocking_dependency_job=$(make_fixture nonblocking-dependency-job)
+perl -0pi -e 's/(  dependency-review:\n)/$1    continue-on-error: true\n/' \
+  "$nonblocking_dependency_job/dependency-review.yml"
+expect_failure "$nonblocking_dependency_job" \
+  'dependency-review.yml: dependency-review job: must not define continue-on-error'
+
+nonblocking_dependency_step=$(make_fixture nonblocking-dependency-step)
+perl -0pi -e 's/(      - name: Review dependency changes\n)/$1        continue-on-error: true\n/' \
+  "$nonblocking_dependency_step/dependency-review.yml"
+expect_failure "$nonblocking_dependency_step" \
+  'dependency-review.yml: review step: must not define continue-on-error'
+
+echo 'Security analysis workflow mutation checks passed'


### PR DESCRIPTION
## Summary

- add pinned CodeQL analysis for JavaScript/TypeScript on pull requests, main pushes, and a weekly schedule
- add pinned dependency review that blocks moderate-or-higher vulnerabilities across runtime, development, and unknown scopes
- enforce least-privilege token permissions and fail-closed workflow contracts
- extend action pinning and workflow permission policies for both workflows

## Validation

- make check
- npm test (68 files, 965 tests)
- actionlint on both new workflows
- local OpenSSF Scorecard v5.5.0: Pinned-Dependencies 10, SAST 10, Token-Permissions 10
- required PR review toolkit perspectives rerun after fixing a confirmed job/step bypass

## Operational notes

- no repository settings were changed
- license enforcement is intentionally disabled until BugDrop adopts an explicit dependency license policy
- actual CodeQL upload/analyzed-source evidence and dependency-review API behavior will be inspected in this PR before merge
- a deliberately vulnerable test PR remains a separate, explicitly authorized proof step