### PR TITLE
fix: recover split tag publication failures

### DIFF
--- a/scripts/release/github-publication-adapter.mjs
+++ b/scripts/release/github-publication-adapter.mjs
@@ -106,6 +106,14 @@ export function createGithubPublicationAdapter({
   };
   const request = async (method, path, options = {}) => {
     const url = endpoint(options.base ?? apiUrl, path);
+    const evidence = status => ({
+      method,
+      path: url.pathname,
+      phase: options.phase,
+      status,
+    });
+    const observed = (data, status) =>
+      options.phase ? { data, evidence: evidence(status) } : data;
     try {
       return await withRequestDeadline(async signal => {
         const response = await fetchImpl(url, {
@@ -130,28 +138,33 @@ export function createGithubPublicationAdapter({
         if (options.missing && response.status === 404) return null;
         if (!(options.expected ?? [200, 201]).includes(response.status)) {
           fail('GITHUB_REQUEST_FAILED', 'GitHub request failed', {
-            method,
-            path: url.pathname,
-            status: response.status,
+            ...evidence(response.status),
           });
         }
-        if (response.status === 204) return null;
-        let value;
+        if (response.status === 204) return observed(null, response.status);
         try {
-          value = await response.json();
-        } catch {
-          fail('INVALID_RESPONSE', `${url.pathname} did not return JSON`);
-        }
-        if (options.array) {
-          if (!Array.isArray(value)) {
-            fail('INVALID_RESPONSE', `${url.pathname} response is invalid`);
+          let value;
+          try {
+            value = await response.json();
+          } catch {
+            fail('INVALID_RESPONSE', `${url.pathname} did not return JSON`);
           }
-          return {
-            data: value,
-            hasNext: /<[^>]+>;\s*rel="next"/.test(response.headers.get('link') ?? ''),
-          };
+          if (options.array) {
+            if (!Array.isArray(value)) {
+              fail('INVALID_RESPONSE', `${url.pathname} response is invalid`);
+            }
+            return {
+              data: value,
+              hasNext: /<[^>]+>;\s*rel="next"/.test(response.headers.get('link') ?? ''),
+            };
+          }
+          return observed(record(value, url.pathname), response.status);
+        } catch (error) {
+          if (error instanceof GithubPublicationAdapterError && options.phase) {
+            error.details = { ...error.details, ...evidence(response.status) };
+          }
+          throw error;
         }
-        return record(value, url.pathname);
       });
     } catch (error) {
       if (error instanceof GithubPublicationAdapterError) throw error;
@@ -160,7 +173,7 @@ export function createGithubPublicationAdapter({
         error instanceof RequestDeadlineError
           ? 'GitHub request timed out'
           : 'GitHub request failed',
-        { method, path: url.pathname, status: null }
+        { ...evidence(null) }
       );
     }
   };
@@ -368,12 +381,56 @@ export function createGithubPublicationAdapter({
       const targetSha = match(action.targetSha, SHA, 'targetSha');
       const created = await request('POST', `/repos/${repository}/git/tags`, {
         body: { tag, message: String(action.annotation ?? ''), object: targetSha, type: 'commit' },
+        phase: 'create-annotated-tag-object',
       });
-      const objectSha = match(created.sha, SHA, 'tag object SHA');
-      await request('POST', `/repos/${repository}/git/refs`, {
-        body: { ref: `refs/tags/${tag}`, sha: objectSha },
-      });
-      return { objectSha };
+      let objectSha;
+      try {
+        if (!SHA.test(created.data.sha ?? '')) {
+          fail('INVALID_RESPONSE', 'created tag object identity is invalid', created.evidence);
+        }
+        objectSha = created.data.sha;
+      } catch (error) {
+        if (error instanceof GithubPublicationAdapterError) {
+          error.details = {
+            ...error.details,
+            phaseEvidence: [created.evidence],
+            validationPhase: 'validate-annotated-tag-object-response',
+          };
+        }
+        throw error;
+      }
+      let createdRef;
+      try {
+        createdRef = await request('POST', `/repos/${repository}/git/refs`, {
+          body: { ref: `refs/tags/${tag}`, sha: objectSha },
+          phase: 'create-annotated-tag-ref',
+        });
+        if (
+          createdRef.data.ref !== `refs/tags/${tag}` ||
+          createdRef.data.object?.type !== 'tag' ||
+          createdRef.data.object?.sha !== objectSha
+        ) {
+          fail('INVALID_RESPONSE', 'created tag ref identity is invalid', createdRef.evidence);
+        }
+      } catch (error) {
+        if (error instanceof GithubPublicationAdapterError) {
+          error.details = {
+            ...error.details,
+            objectSha,
+            phaseEvidence: [
+              created.evidence,
+              {
+                method: error.details.method,
+                path: error.details.path,
+                phase: error.details.phase,
+                status: error.details.status,
+              },
+            ],
+          };
+        }
+        throw error;
+      }
+      return { objectSha, phaseEvidence: [created.evidence, createdRef.evidence] };
     },
     async createDraft(action) {
       const created = await request('POST', `/repos/${repository}/releases`, {

--- a/scripts/release/publication.mjs
+++ b/scripts/release/publication.mjs
@@ -18,6 +18,8 @@ const RECOVERY = Object.freeze({
 });
 const CONVERGENCE_INSPECTIONS = 6;
 const CONVERGENCE_INTERVAL_MS = 2000;
+const TAG_OBJECT_PHASE = 'create-annotated-tag-object';
+const TAG_REF_PHASE = 'create-annotated-tag-ref';
 export class PublicationError extends Error {
   constructor(code, message, details = {}) {
     super(`${code}: ${message}`);
@@ -141,6 +143,7 @@ export function validatePublicationBundle(input) {
     name: `BugDrop ${finalPlan.tag.slice(1)}`,
     planIdentity: finalPlan.planIdentity,
     protocol: finalPlan.protocol,
+    repository: finalPlan.repository,
     requiredAssets: required,
     ...(finalPlan.staticPackageIdentity
       ? { staticPackageIdentity: finalPlan.staticPackageIdentity }
@@ -313,6 +316,36 @@ function publicAction(action) {
   const { bytes: _bytes, body: _body, marker: _marker, ...safe } = action;
   return safe;
 }
+function publicPhaseEvidence(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter(
+      item =>
+        item?.constructor === Object &&
+        item.method === 'POST' &&
+        typeof item.path === 'string' &&
+        typeof item.phase === 'string' &&
+        (item.status === null || Number.isSafeInteger(item.status))
+    )
+    .map(({ method, path, phase, status }) => ({ method, path, phase, status }));
+}
+function preservedTagObjectResult(expected, action, error) {
+  if (action.kind !== 'create-tag' || error?.details?.phase !== TAG_REF_PHASE) return null;
+  const objectSha = error.details.objectSha;
+  const evidence = publicPhaseEvidence(error.details.phaseEvidence);
+  const [objectPhase, refPhase] = evidence;
+  const basePath = `/repos/${expected.repository}/git`;
+  const exactEvidence =
+    evidence.length === 2 &&
+    objectPhase?.phase === TAG_OBJECT_PHASE &&
+    objectPhase.path === `${basePath}/tags` &&
+    objectPhase.status === 201 &&
+    refPhase?.phase === TAG_REF_PHASE &&
+    refPhase.path === `${basePath}/refs`;
+  return SHA_PATTERN.test(objectSha ?? '') && exactEvidence
+    ? { objectSha, phaseEvidence: evidence }
+    : null;
+}
 async function mutate(adapter, action) {
   if (action.kind === 'create-tag') return adapter.createAnnotatedTag(action);
   if (action.kind === 'create-draft') return adapter.createDraft(action);
@@ -388,17 +421,32 @@ export async function executePublication({
     attemptedActions.add(key);
     let mutationError;
     let mutationResult;
+    let phaseEvidence = [];
     try {
       mutationResult = await mutate(adapter, action);
+      phaseEvidence = publicPhaseEvidence(mutationResult?.phaseEvidence);
       mutated = true;
       history.push({
         action: publicAction(action),
         result: 'applied',
+        ...(phaseEvidence.length ? { phaseEvidence } : {}),
+        ...(mutationResult?.objectSha ? { objectSha: mutationResult.objectSha } : {}),
         ...(mutationResult?.releaseId ? { releaseId: mutationResult.releaseId } : {}),
       });
       if (action.kind === 'create-draft') ownedReleaseId = mutationResult?.releaseId ?? null;
     } catch (error) {
       mutationError = error instanceof Error ? error.message : String(error);
+      phaseEvidence = publicPhaseEvidence(
+        error?.details?.phaseEvidence ?? (error?.details ? [error.details] : [])
+      );
+      const preserved = preservedTagObjectResult(expected, action, error);
+      if (preserved) mutationResult = preserved;
+      history.push({
+        action: publicAction(action),
+        result: 'phase-failed',
+        ...(preserved?.objectSha ? { objectSha: preserved.objectSha } : {}),
+        ...(phaseEvidence.length ? { phaseEvidence } : {}),
+      });
     }
     let converged = false;
     for (let inspection = 0; inspection < convergenceInspections; inspection += 1) {
@@ -421,7 +469,12 @@ export async function executePublication({
     }
     if (mutationError) {
       mutated = true;
-      history.push({ action: publicAction(action), result: 'confirmed-after-lost-response' });
+      history.push({
+        action: publicAction(action),
+        result: 'confirmed-after-lost-response',
+        ...(mutationResult?.objectSha ? { objectSha: mutationResult.objectSha } : {}),
+        ...(phaseEvidence.length ? { phaseEvidence } : {}),
+      });
     }
     if (state.status === 'exact-published') {
       return {

--- a/scripts/release/publication.mjs
+++ b/scripts/release/publication.mjs
@@ -341,7 +341,8 @@ function preservedTagObjectResult(expected, action, error) {
     objectPhase.path === `${basePath}/tags` &&
     objectPhase.status === 201 &&
     refPhase?.phase === TAG_REF_PHASE &&
-    refPhase.path === `${basePath}/refs`;
+    refPhase.path === `${basePath}/refs` &&
+    (refPhase.status === null || refPhase.status === 201);
   return SHA_PATTERN.test(objectSha ?? '') && exactEvidence
     ? { objectSha, phaseEvidence: evidence }
     : null;

--- a/test/release/github-publication-adapter.test.ts
+++ b/test/release/github-publication-adapter.test.ts
@@ -492,7 +492,13 @@ describe('GitHub publication mutations', () => {
       });
       return url.pathname.endsWith('/git/tags')
         ? response({ sha: TAG_OBJECT_SHA }, 201)
-        : response({ ref: 'refs/tags/v1.2.3' }, 201);
+        : response(
+            {
+              ref: 'refs/tags/v1.2.3',
+              object: { type: 'tag', sha: TAG_OBJECT_SHA },
+            },
+            201
+          );
     });
     await expect(
       adapter(fetchImpl).createAnnotatedTag({
@@ -500,7 +506,23 @@ describe('GitHub publication mutations', () => {
         targetSha: SHA,
         annotation: 'exact annotation',
       })
-    ).resolves.toEqual({ objectSha: TAG_OBJECT_SHA });
+    ).resolves.toEqual({
+      objectSha: TAG_OBJECT_SHA,
+      phaseEvidence: [
+        {
+          method: 'POST',
+          path: '/repos/mean-weasel/bugdrop/git/tags',
+          phase: 'create-annotated-tag-object',
+          status: 201,
+        },
+        {
+          method: 'POST',
+          path: '/repos/mean-weasel/bugdrop/git/refs',
+          phase: 'create-annotated-tag-ref',
+          status: 201,
+        },
+      ],
+    });
     expect(calls).toEqual([
       {
         method: 'POST',
@@ -513,6 +535,187 @@ describe('GitHub publication mutations', () => {
         body: { ref: 'refs/tags/v1.2.3', sha: TAG_OBJECT_SHA },
       },
     ]);
+  });
+
+  it('preserves the exact tag-object SHA and both phase observations when tag-ref creation fails', async () => {
+    const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      return url.pathname.endsWith('/git/tags')
+        ? response({ sha: TAG_OBJECT_SHA }, 201)
+        : response({ message: 'ref response lost' }, 503);
+    });
+
+    await expect(
+      adapter(fetchImpl).createAnnotatedTag({
+        tag: 'v1.2.3',
+        targetSha: SHA,
+        annotation: 'exact annotation',
+      })
+    ).rejects.toMatchObject({
+      code: 'GITHUB_REQUEST_FAILED',
+      details: {
+        method: 'POST',
+        objectSha: TAG_OBJECT_SHA,
+        path: '/repos/mean-weasel/bugdrop/git/refs',
+        phase: 'create-annotated-tag-ref',
+        status: 503,
+        phaseEvidence: [
+          {
+            method: 'POST',
+            path: '/repos/mean-weasel/bugdrop/git/tags',
+            phase: 'create-annotated-tag-object',
+            status: 201,
+          },
+          {
+            method: 'POST',
+            path: '/repos/mean-weasel/bugdrop/git/refs',
+            phase: 'create-annotated-tag-ref',
+            status: 503,
+          },
+        ],
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves exact phase evidence and object SHA when a successful tag-ref response is truncated', async () => {
+    const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      return url.pathname.endsWith('/git/tags')
+        ? response({ sha: TAG_OBJECT_SHA }, 201)
+        : new Response('{"truncated"', { status: 201 });
+    });
+
+    await expect(
+      adapter(fetchImpl).createAnnotatedTag({
+        tag: 'v1.2.3',
+        targetSha: SHA,
+        annotation: 'exact annotation',
+      })
+    ).rejects.toMatchObject({
+      code: 'INVALID_RESPONSE',
+      details: {
+        method: 'POST',
+        objectSha: TAG_OBJECT_SHA,
+        path: '/repos/mean-weasel/bugdrop/git/refs',
+        phase: 'create-annotated-tag-ref',
+        status: 201,
+        phaseEvidence: [
+          {
+            method: 'POST',
+            path: '/repos/mean-weasel/bugdrop/git/tags',
+            phase: 'create-annotated-tag-object',
+            status: 201,
+          },
+          {
+            method: 'POST',
+            path: '/repos/mean-weasel/bugdrop/git/refs',
+            phase: 'create-annotated-tag-ref',
+            status: 201,
+          },
+        ],
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('retains phase evidence for a malformed successful tag-object response shape', async () => {
+    const fetchImpl = vi.fn(async () => response([], 201));
+
+    await expect(
+      adapter(fetchImpl).createAnnotatedTag({
+        tag: 'v1.2.3',
+        targetSha: SHA,
+        annotation: 'exact annotation',
+      })
+    ).rejects.toMatchObject({
+      code: 'INVALID_RESPONSE',
+      details: {
+        method: 'POST',
+        path: '/repos/mean-weasel/bugdrop/git/tags',
+        phase: 'create-annotated-tag-object',
+        status: 201,
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('retains request and validation phases when the tag-object SHA shape is invalid', async () => {
+    const fetchImpl = vi.fn(async () => response({ sha: 'not-a-sha' }, 201));
+
+    await expect(
+      adapter(fetchImpl).createAnnotatedTag({
+        tag: 'v1.2.3',
+        targetSha: SHA,
+        annotation: 'exact annotation',
+      })
+    ).rejects.toMatchObject({
+      code: 'INVALID_RESPONSE',
+      details: {
+        method: 'POST',
+        path: '/repos/mean-weasel/bugdrop/git/tags',
+        phase: 'create-annotated-tag-object',
+        status: 201,
+        validationPhase: 'validate-annotated-tag-object-response',
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('preserves exact ref-phase evidence and object SHA for a mismatched successful ref body', async () => {
+    const fetchImpl = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      return url.pathname.endsWith('/git/tags')
+        ? response({ sha: TAG_OBJECT_SHA }, 201)
+        : response(
+            {
+              ref: 'refs/tags/v9.9.9',
+              object: { type: 'tag', sha: '9'.repeat(40) },
+            },
+            201
+          );
+    });
+
+    await expect(
+      adapter(fetchImpl).createAnnotatedTag({
+        tag: 'v1.2.3',
+        targetSha: SHA,
+        annotation: 'exact annotation',
+      })
+    ).rejects.toMatchObject({
+      code: 'INVALID_RESPONSE',
+      details: {
+        method: 'POST',
+        objectSha: TAG_OBJECT_SHA,
+        path: '/repos/mean-weasel/bugdrop/git/refs',
+        phase: 'create-annotated-tag-ref',
+        status: 201,
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('identifies a lost tag-object response without inventing a tag-object SHA', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('response lost');
+    });
+
+    await expect(
+      adapter(fetchImpl).createAnnotatedTag({
+        tag: 'v1.2.3',
+        targetSha: SHA,
+        annotation: 'exact annotation',
+      })
+    ).rejects.toMatchObject({
+      code: 'GITHUB_REQUEST_FAILED',
+      details: {
+        method: 'POST',
+        path: '/repos/mean-weasel/bugdrop/git/tags',
+        phase: 'create-annotated-tag-object',
+        status: null,
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
   it('creates a draft, uploads exact bytes, then publishes', async () => {

--- a/test/release/live-release.test.ts
+++ b/test/release/live-release.test.ts
@@ -188,6 +188,31 @@ describe('live release production orchestration', () => {
     });
   });
 
+  it('does not treat an exact annotated tag without its Release as published', async () => {
+    const bundle = workflowBundle();
+    const publication = validatePublicationBundle(bundle);
+    const adapter = {
+      inspect: vi.fn(async () => ({
+        complete: true,
+        tagRef: { objectSha: 'c'.repeat(40) },
+        tagObject: {
+          annotation: publication.tagAnnotation,
+          kind: 'annotated',
+          objectSha: 'c'.repeat(40),
+          targetSha: publication.targetSha,
+          targetType: 'commit',
+        },
+        releases: [],
+      })),
+    };
+
+    await expect(inspectPublication({ bundle, adapter })).resolves.toMatchObject({
+      status: 'partial-resumable',
+      nextAction: { kind: 'create-draft', tag: publication.tag },
+      planIdentity: bundle.finalPlan.planIdentity,
+    });
+  });
+
   it('reconciles a lost deploy response only after source and asset live proof', async () => {
     const cloudflare = client();
     const baseline = await captureBaseline({

--- a/test/release/publication.test.ts
+++ b/test/release/publication.test.ts
@@ -537,6 +537,53 @@ describe('complete publication and exact retry', () => {
     expect(adapter.log).not.toContain('create-draft');
   });
 
+  it('does not reconcile a definitively rejected tag-ref request', async () => {
+    const bundle = publicationBundle();
+    const expected = validatePublicationBundle(bundle);
+    const adapter = new FakeGitHubPublicationAdapter();
+    const objectSha = '7'.repeat(40);
+    adapter.createAnnotatedTag = async () => {
+      adapter.log.push('create-tag');
+      throw tagPhaseError({ objectSha, phase: 'create-annotated-tag-ref', status: 422 });
+    };
+    const inspect = adapter.inspect.bind(adapter);
+    let inspections = 0;
+    adapter.inspect = async () => {
+      inspections += 1;
+      if (inspections === 1) return inspect();
+      adapter.log.push('inspect');
+      return {
+        complete: true,
+        tagRef: { objectSha },
+        tagObject: {
+          kind: 'annotated',
+          objectSha,
+          targetType: 'commit',
+          targetSha: bundle.finalPlan.targetSha,
+          annotation: expected.tagAnnotation,
+        },
+        releases: [],
+      };
+    };
+
+    const result = await executePublication({ adapter, bundle, convergenceIntervalMs: 0 });
+    expect(result).toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining('mutation-outcome-unobserved:create-tag'),
+      history: [
+        expect.objectContaining({
+          result: 'phase-failed',
+          phaseEvidence: expect.arrayContaining([
+            expect.objectContaining({ phase: 'create-annotated-tag-ref', status: 422 }),
+          ]),
+        }),
+      ],
+    });
+    expect(result.history[0]).not.toHaveProperty('objectSha');
+    expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.log).not.toContain('create-draft');
+  });
+
   it('does not adopt a delayed foreign ref after preserving a different tag-object SHA', async () => {
     const bundle = publicationBundle();
     const expected = validatePublicationBundle(bundle);

--- a/test/release/publication.test.ts
+++ b/test/release/publication.test.ts
@@ -24,6 +24,56 @@ import {
 } from '../fixtures/release/publication/fake-github';
 
 class FakeGitHubPublicationAdapter extends BaseFakeGitHubPublicationAdapter {
+  override async createAnnotatedTag(input: Record<string, unknown>) {
+    try {
+      const result = await super.createAnnotatedTag(input);
+      return {
+        ...result,
+        phaseEvidence: [
+          {
+            method: 'POST',
+            path: '/repos/mean-weasel/bugdrop/git/tags',
+            phase: 'create-annotated-tag-object',
+            status: 201,
+          },
+          {
+            method: 'POST',
+            path: '/repos/mean-weasel/bugdrop/git/refs',
+            phase: 'create-annotated-tag-ref',
+            status: 201,
+          },
+        ],
+      };
+    } catch (error) {
+      if (error instanceof Error && this.state.tagRef && this.state.tagObject) {
+        Object.assign(error, {
+          details: {
+            method: 'POST',
+            objectSha: this.state.tagRef.objectSha,
+            path: '/repos/mean-weasel/bugdrop/git/refs',
+            phase: 'create-annotated-tag-ref',
+            status: null,
+            phaseEvidence: [
+              {
+                method: 'POST',
+                path: '/repos/mean-weasel/bugdrop/git/tags',
+                phase: 'create-annotated-tag-object',
+                status: 201,
+              },
+              {
+                method: 'POST',
+                path: '/repos/mean-weasel/bugdrop/git/refs',
+                phase: 'create-annotated-tag-ref',
+                status: null,
+              },
+            ],
+          },
+        });
+      }
+      throw error;
+    }
+  }
+
   override async createDraft(input: Record<string, unknown>) {
     try {
       return await super.createDraft(input);
@@ -43,6 +93,44 @@ const conflictCases = JSON.parse(
 
 function sha256(bytes: Buffer) {
   return createHash('sha256').update(bytes).digest('hex');
+}
+
+function tagPhaseError({
+  objectSha,
+  phase,
+  status = null,
+}: {
+  objectSha?: string;
+  phase: 'create-annotated-tag-object' | 'create-annotated-tag-ref';
+  status?: number | null;
+}) {
+  const error = new Error(`lost ${phase} response`);
+  const objectEvidence = {
+    method: 'POST',
+    path: '/repos/mean-weasel/bugdrop/git/tags',
+    phase: 'create-annotated-tag-object',
+    status: phase === 'create-annotated-tag-object' ? status : 201,
+  };
+  const currentEvidence =
+    phase === 'create-annotated-tag-object'
+      ? objectEvidence
+      : {
+          method: 'POST',
+          path: '/repos/mean-weasel/bugdrop/git/refs',
+          phase,
+          status,
+        };
+  Object.assign(error, {
+    details: {
+      ...currentEvidence,
+      ...(objectSha ? { objectSha } : {}),
+      phaseEvidence:
+        phase === 'create-annotated-tag-object'
+          ? [objectEvidence]
+          : [objectEvidence, currentEvidence],
+    },
+  });
+  return error;
 }
 
 function publicationBundle(verificationResult: 'passed' | 'failed' = 'passed') {
@@ -231,25 +319,48 @@ describe('complete publication and exact retry', () => {
     }
   );
 
-  it.each(['create-tag', 'create-draft'] as const)(
-    'fails closed after an applied %s response is lost without claiming ownership',
-    async point => {
-      const bundle = publicationBundle();
-      const adapter = new FakeGitHubPublicationAdapter({ loseAfter: [point] });
+  it('reconciles an applied create-tag after its tag-ref response is lost', async () => {
+    const bundle = publicationBundle();
+    const adapter = new FakeGitHubPublicationAdapter({ loseAfter: ['create-tag'] });
 
-      await expect(
-        executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
-      ).resolves.toMatchObject({
-        status: 'unknown-critical',
-        reason: expect.stringContaining(`mutation-outcome-unobserved:${point}`),
-      });
-      expect(adapter.log.filter(item => item.startsWith(point))).toHaveLength(1);
-      if (point === 'create-tag') expect(adapter.log).not.toContain('create-draft');
-      if (point === 'create-draft') {
-        expect(adapter.log.some(item => item.startsWith('upload-asset'))).toBe(false);
-      }
-    }
-  );
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
+      status: 'published',
+      history: expect.arrayContaining([
+        expect.objectContaining({
+          action: expect.objectContaining({ kind: 'create-tag' }),
+          objectSha: '7'.repeat(40),
+          result: 'confirmed-after-lost-response',
+          phaseEvidence: expect.arrayContaining([
+            expect.objectContaining({
+              method: 'POST',
+              path: '/repos/mean-weasel/bugdrop/git/refs',
+              phase: 'create-annotated-tag-ref',
+              status: null,
+            }),
+          ]),
+        }),
+      ]),
+    });
+    expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.applied.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(1);
+  });
+
+  it('fails closed after an applied create-draft response is lost without claiming ownership', async () => {
+    const bundle = publicationBundle();
+    const adapter = new FakeGitHubPublicationAdapter({ loseAfter: ['create-draft'] });
+
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining('mutation-outcome-unobserved:create-draft'),
+    });
+    expect(adapter.log.filter(item => item.startsWith('create-draft'))).toHaveLength(1);
+    expect(adapter.log.some(item => item.startsWith('upload-asset'))).toBe(false);
+  });
 
   it('never adopts a foreign exact tag after the create-tag request failed before application', async () => {
     const bundle = publicationBundle();
@@ -283,6 +394,234 @@ describe('complete publication and exact retry', () => {
     expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
     expect(adapter.applied.filter(item => item === 'create-tag')).toHaveLength(0);
     expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(0);
+  });
+
+  it('fails closed on a lost tag-object response even if an exact-looking foreign ref appears', async () => {
+    const bundle = publicationBundle();
+    const expected = validatePublicationBundle(bundle);
+    const adapter = new FakeGitHubPublicationAdapter();
+    adapter.createAnnotatedTag = async () => {
+      adapter.log.push('create-tag');
+      throw tagPhaseError({ phase: 'create-annotated-tag-object' });
+    };
+    const inspect = adapter.inspect.bind(adapter);
+    let inspections = 0;
+    adapter.inspect = async () => {
+      inspections += 1;
+      if (inspections === 1) return inspect();
+      return {
+        complete: true,
+        tagRef: { objectSha: '7'.repeat(40) },
+        tagObject: {
+          kind: 'annotated',
+          objectSha: '7'.repeat(40),
+          targetType: 'commit',
+          targetSha: bundle.finalPlan.targetSha,
+          annotation: expected.tagAnnotation,
+        },
+        releases: [],
+      };
+    };
+
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining('mutation-outcome-unobserved:create-tag'),
+      history: [
+        expect.objectContaining({
+          result: 'phase-failed',
+          phaseEvidence: [
+            expect.objectContaining({
+              method: 'POST',
+              path: '/repos/mean-weasel/bugdrop/git/tags',
+              phase: 'create-annotated-tag-object',
+              status: null,
+            }),
+          ],
+        }),
+      ],
+    });
+    expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.log).not.toContain('create-draft');
+  });
+
+  it('reconciles a malformed-201 tag-ref response only when the delayed ref has the preserved object SHA', async () => {
+    const bundle = publicationBundle();
+    const expected = validatePublicationBundle(bundle);
+    const adapter = new FakeGitHubPublicationAdapter();
+    const objectSha = '7'.repeat(40);
+    const absent = clonePublicationState(adapter.state);
+    const exact = {
+      complete: true,
+      tagRef: { objectSha },
+      tagObject: {
+        kind: 'annotated',
+        objectSha,
+        targetType: 'commit',
+        targetSha: bundle.finalPlan.targetSha,
+        annotation: expected.tagAnnotation,
+      },
+      releases: [],
+    };
+    adapter.createAnnotatedTag = async () => {
+      adapter.log.push('create-tag');
+      throw tagPhaseError({ objectSha, phase: 'create-annotated-tag-ref', status: 201 });
+    };
+    const inspect = adapter.inspect.bind(adapter);
+    let inspections = 0;
+    adapter.inspect = async () => {
+      inspections += 1;
+      if (inspections === 1) return inspect();
+      if (inspections < 4) {
+        adapter.log.push('inspect');
+        return clonePublicationState(absent);
+      }
+      if (!adapter.state.tagRef) adapter.state = clonePublicationState(exact);
+      return inspect();
+    };
+
+    await expect(
+      executePublication({
+        adapter,
+        bundle,
+        convergenceIntervalMs: 0,
+        sleep: async () => {},
+      })
+    ).resolves.toMatchObject({
+      status: 'published',
+      history: expect.arrayContaining([
+        expect.objectContaining({
+          objectSha,
+          result: 'confirmed-after-lost-response',
+          phaseEvidence: expect.arrayContaining([
+            expect.objectContaining({
+              method: 'POST',
+              path: '/repos/mean-weasel/bugdrop/git/refs',
+              phase: 'create-annotated-tag-ref',
+              status: 201,
+            }),
+          ]),
+        }),
+      ]),
+    });
+    expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(1);
+  });
+
+  it('leaves a malformed-201 tag-ref response unknown-critical when the ref remains absent', async () => {
+    const bundle = publicationBundle();
+    const adapter = new FakeGitHubPublicationAdapter();
+    const objectSha = '7'.repeat(40);
+    adapter.createAnnotatedTag = async () => {
+      adapter.log.push('create-tag');
+      throw tagPhaseError({ objectSha, phase: 'create-annotated-tag-ref', status: 201 });
+    };
+
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining('mutation-outcome-unobserved:create-tag'),
+      history: [
+        expect.objectContaining({
+          objectSha,
+          result: 'phase-failed',
+          phaseEvidence: expect.arrayContaining([
+            expect.objectContaining({ phase: 'create-annotated-tag-ref', status: 201 }),
+          ]),
+        }),
+      ],
+    });
+    expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.log).not.toContain('create-draft');
+  });
+
+  it('does not adopt a delayed foreign ref after preserving a different tag-object SHA', async () => {
+    const bundle = publicationBundle();
+    const expected = validatePublicationBundle(bundle);
+    const adapter = new FakeGitHubPublicationAdapter();
+    const preservedObjectSha = '7'.repeat(40);
+    const foreignObjectSha = '8'.repeat(40);
+    adapter.createAnnotatedTag = async () => {
+      adapter.log.push('create-tag');
+      throw tagPhaseError({
+        objectSha: preservedObjectSha,
+        phase: 'create-annotated-tag-ref',
+        status: 201,
+      });
+    };
+    const inspect = adapter.inspect.bind(adapter);
+    let inspections = 0;
+    adapter.inspect = async () => {
+      inspections += 1;
+      if (inspections === 1) return inspect();
+      adapter.log.push('inspect');
+      return {
+        complete: true,
+        tagRef: { objectSha: foreignObjectSha },
+        tagObject: {
+          kind: 'annotated',
+          objectSha: foreignObjectSha,
+          targetType: 'commit',
+          targetSha: bundle.finalPlan.targetSha,
+          annotation: expected.tagAnnotation,
+        },
+        releases: [],
+      };
+    };
+
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining('mutation-outcome-unobserved:create-tag'),
+    });
+    expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.log).not.toContain('create-draft');
+  });
+
+  it('does not trust preserved tag identity when phase evidence names a foreign repository path', async () => {
+    const bundle = publicationBundle();
+    const expected = validatePublicationBundle(bundle);
+    const adapter = new FakeGitHubPublicationAdapter();
+    const objectSha = '7'.repeat(40);
+    adapter.createAnnotatedTag = async () => {
+      adapter.log.push('create-tag');
+      const error = tagPhaseError({ objectSha, phase: 'create-annotated-tag-ref' }) as Error & {
+        details: { phaseEvidence: Array<{ path: string }> };
+      };
+      error.details.phaseEvidence[0].path = '/repos/mean-weasel/foreign/git/tags';
+      throw error;
+    };
+    const inspect = adapter.inspect.bind(adapter);
+    let inspections = 0;
+    adapter.inspect = async () => {
+      inspections += 1;
+      if (inspections === 1) return inspect();
+      adapter.log.push('inspect');
+      return {
+        complete: true,
+        tagRef: { objectSha },
+        tagObject: {
+          kind: 'annotated',
+          objectSha,
+          targetType: 'commit',
+          targetSha: bundle.finalPlan.targetSha,
+          annotation: expected.tagAnnotation,
+        },
+        releases: [],
+      };
+    };
+
+    await expect(
+      executePublication({ adapter, bundle, convergenceIntervalMs: 0 })
+    ).resolves.toMatchObject({
+      status: 'unknown-critical',
+      reason: expect.stringContaining('mutation-outcome-unobserved:create-tag'),
+    });
+    expect(adapter.log.filter(item => item === 'create-tag')).toHaveLength(1);
+    expect(adapter.log).not.toContain('create-draft');
   });
 
   it('rejects a wrong-name Release and never adopts it after create-draft ownership is lost', async () => {


### PR DESCRIPTION
## Summary

- split annotated tag-object creation from tag-ref creation and preserve phase-specific evidence
- reconcile a lost or malformed tag-ref response only when the authenticated ref converges to the exact preserved tag-object SHA
- fail closed on absent, foreign, spoofed, or mismatched tag state
- add focused adapter, publication, and live-release regression coverage

## Incident context

T089-L1 deployed the v1.55.2 candidate successfully, but GitHub publication returned an unobserved create-tag outcome. Production rollback was verified and the release gate was restored disabled. The previous controller could not distinguish tag-object success from tag-ref failure. This patch repairs that recovery boundary; it does not dispatch or publish a release.

## Verification

- 108 focused release tests passed
- 6 adversarial truncated, malformed-201, and foreign-tag probes passed
- changed files passed ESLint and git diff checks
- independent correctness, test, silent-failure, and contract reviews found no high-confidence defects
- full release suite: 405/417 passed in the dependency-free review worktree; all 12 remaining failures require esbuild, which is intentionally absent there and unrelated to this diff

## Safety

No production, Cloudflare, Release, tag, workflow, environment, or branch-protection state is changed by this PR.