### PR TITLE
test: clear non-production CodeQL findings

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - test/fixtures/legacy-compat/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           languages: javascript-typescript
           build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Analyze with CodeQL
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/e2e/live-console-errors.ts
+++ b/e2e/live-console-errors.ts
@@ -1,0 +1,16 @@
+const URL_PATTERN = /https?:\/\/[^\s"'<>]+/g;
+
+function referencesGoogleFontsHost(message: string): boolean {
+  return (message.match(URL_PATTERN) ?? []).some(
+    candidate => URL.canParse(candidate) && new URL(candidate).hostname === 'fonts.gstatic.com'
+  );
+}
+
+export function isExpectedLiveConsoleError(message: string): boolean {
+  return (
+    message.includes('Missing data-repo') ||
+    referencesGoogleFontsHost(message) ||
+    message.includes('CORS') ||
+    message.includes('net::ERR_FAILED')
+  );
+}

--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -5,6 +5,7 @@ import {
   test,
   waitForPreviewWidgetResponse,
 } from './live-preview-widget';
+import { isExpectedLiveConsoleError } from './live-console-errors';
 
 /**
  * Live E2E tests for BugDrop widget on a real cross-origin deployment.
@@ -336,13 +337,7 @@ test.describe('Widget Loading (Live)', () => {
     await expect(button).toBeVisible({ timeout: 10_000 });
 
     // No unexpected console errors (filter out CORS font errors and known benign messages)
-    const unexpectedErrors = errors.filter(
-      e =>
-        !e.includes('Missing data-repo') &&
-        !e.includes('fonts.gstatic.com') &&
-        !e.includes('CORS') &&
-        !e.includes('net::ERR_FAILED')
-    );
+    const unexpectedErrors = errors.filter(error => !isExpectedLiveConsoleError(error));
     expect(unexpectedErrors).toHaveLength(0);
   });
 

--- a/scripts/check-security-analysis-workflows.mjs
+++ b/scripts/check-security-analysis-workflows.mjs
@@ -65,6 +65,7 @@ checkEqual(
 checkEqual('codeql.yml: init configuration', codeqlInit?.with, {
   languages: 'javascript-typescript',
   'build-mode': 'none',
+  'config-file': './.github/codeql/codeql-config.yml',
 });
 checkEqual(
   'codeql.yml: analyze action',
@@ -73,6 +74,11 @@ checkEqual(
 );
 checkEqual('codeql.yml: analyze configuration', codeqlAnalyze?.with, {
   category: '/language:javascript-typescript',
+});
+
+const codeqlConfig = await readWorkflow('../codeql/codeql-config.yml');
+checkEqual('codeql-config.yml: configuration', codeqlConfig, {
+  'paths-ignore': ['test/fixtures/legacy-compat/**'],
 });
 
 const dependencyReview = await readWorkflow('dependency-review.yml');

--- a/test/liveConsoleErrors.test.ts
+++ b/test/liveConsoleErrors.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { isExpectedLiveConsoleError } from '../e2e/live-console-errors';
+
+describe('live console error filtering', () => {
+  it.each([
+    ['missing repository configuration', 'Missing data-repo attribute'],
+    ['Google Fonts resource warning', 'Font https://fonts.gstatic.com/s/font.woff2 returned 403'],
+    ['generic CORS failure', 'CORS blocked a cross-origin resource'],
+    ['failed font request', 'GET https://fonts.gstatic.com/s/font.woff2 net::ERR_FAILED'],
+  ])('accepts the known %s error', (_name, message) => {
+    expect(isExpectedLiveConsoleError(message)).toBe(true);
+  });
+
+  it.each([
+    ['hostname suffix', 'GET https://fonts.gstatic.com.attacker.test/payload.js failed'],
+    ['credentials', 'GET https://fonts.gstatic.com@attacker.test/payload.js failed'],
+    ['subdomain', 'GET https://cdn.fonts.gstatic.com/font.woff2 failed'],
+    ['query parameter', 'GET https://attacker.test/?next=https://fonts.gstatic.com failed'],
+    ['plain-text mention', 'Unexpected script from fonts.gstatic.com executed'],
+  ])('does not hide an unrelated error containing a %s', (_name, message) => {
+    expect(isExpectedLiveConsoleError(message)).toBe(false);
+  });
+});

--- a/test/security-analysis-workflows.test.sh
+++ b/test/security-analysis-workflows.test.sh
@@ -10,10 +10,11 @@ trap 'rm -rf "$fixture_root"' EXIT
 make_fixture() {
   local name=$1
   local directory="$fixture_root/$name"
-  mkdir -p "$directory"
-  cp "$repo_root/.github/workflows/codeql.yml" "$directory/"
-  cp "$repo_root/.github/workflows/dependency-review.yml" "$directory/"
-  printf '%s\n' "$directory"
+  mkdir -p "$directory/workflows" "$directory/codeql"
+  cp "$repo_root/.github/workflows/codeql.yml" "$directory/workflows/"
+  cp "$repo_root/.github/workflows/dependency-review.yml" "$directory/workflows/"
+  cp "$repo_root/.github/codeql/codeql-config.yml" "$directory/codeql/"
+  printf '%s\n' "$directory/workflows"
 }
 
 expect_failure() {
@@ -42,6 +43,16 @@ expect_failure "$wrong_language" 'codeql.yml: init configuration'
 missing_upload=$(make_fixture missing-upload)
 perl -0pi -e "s/      security-events: write\n//" "$missing_upload/codeql.yml"
 expect_failure "$missing_upload" 'codeql.yml: analyze permissions'
+
+missing_codeql_config=$(make_fixture missing-codeql-config)
+perl -0pi -e "s/          config-file: \.\/\.github\/codeql\/codeql-config\.yml\n//" \
+  "$missing_codeql_config/codeql.yml"
+expect_failure "$missing_codeql_config" 'codeql.yml: init configuration'
+
+broad_codeql_exclusion=$(make_fixture broad-codeql-exclusion)
+perl -0pi -e 's#test/fixtures/legacy-compat/\*\*#test/fixtures/**#' \
+  "$fixture_root/broad-codeql-exclusion/codeql/codeql-config.yml"
+expect_failure "$broad_codeql_exclusion" 'codeql-config.yml: configuration'
 
 disabled_codeql_job=$(make_fixture disabled-codeql-job)
 perl -0pi -e 's/(  analyze:\n)/$1    if: false\n/' "$disabled_codeql_job/codeql.yml"


### PR DESCRIPTION
## Summary

- replace the incomplete Google Fonts substring filter with exact parsed-host matching
- exclude only frozen legacy compatibility fixtures from JavaScript CodeQL analysis
- lock both behaviors with adversarial unit and workflow mutation tests

## Why the exclusion is narrow

The remaining DOM XSS result is in an immutable historical widget fixture used for compatibility testing. Editing it would invalidate the fixture. The CodeQL config excludes only `test/fixtures/legacy-compat/**`; a repository guard rejects broader exclusions.

## Validation

- `make check`
- `npm test` — 70 files, 990 tests
- `npx vitest run test/liveConsoleErrors.test.ts` — 9 tests
- `bash test/security-analysis-workflows.test.sh`
- `actionlint .github/workflows/codeql.yml`
- independent correctness, tests, contracts, and simplification reviews: no findings

The first full test attempt had three 5-second timeouts in `retention-integration.test.ts`; that file passed 8/8 in isolation and the repeated full suite passed 990/990.