### PR TITLE
docs: align vulnerability reporting guidance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,41 @@
 # Security Policy
 
+## Supported Versions
+
+Security fixes are provided for the latest stable release and the current hosted service. Fixes
+normally land on `main` and are included in the next stable release. Older releases and
+version-pinned assets are not guaranteed to receive backports, so self-hosters should upgrade to the
+latest stable release before requesting a fix for an older version.
+
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability, please report it responsibly:
+Please report suspected vulnerabilities privately through one of these channels:
 
-1. **Do not** open a public GitHub issue
-2. **Email** security concerns to: neonwatty@gmail.com or jeremy@mean-weasel.com
-3. **Include**:
-   - Description of the vulnerability
-   - Steps to reproduce
-   - Potential impact
+1. **Preferred:** [GitHub private vulnerability reporting](https://github.com/mean-weasel/bugdrop/security/advisories/new)
+2. **Email fallback:** [neonwatty@gmail.com](mailto:neonwatty@gmail.com) or
+   [jeremy@mean-weasel.com](mailto:jeremy@mean-weasel.com)
 
-## Response Timeline
+Ordinary email is not end-to-end encrypted. Use GitHub private vulnerability reporting for reports
+that contain sensitive details, credentials, or unpublished exploit material. Do not open a public
+GitHub issue. If the preferred channel is unavailable, use either email fallback rather than
+disclosing the issue publicly.
 
-- **Acknowledgment**: Within 48 hours
-- **Initial assessment**: Within 7 days
-- **Fix timeline**: Depends on severity, typically 30-90 days
+Include, when available:
+
+- A description of the vulnerability and its potential impact
+- The affected release, hosted URL, or commit
+- Reproduction steps or a minimal proof of concept
+- Relevant configuration and environmental details, with secrets removed
+- Whether you plan to publish the report and any requested disclosure timeline
+
+## Response Targets
+
+- **Acknowledgment:** Within 48 hours
+- **Initial assessment:** Within 7 days
+- **Remediation:** Typically 30-90 days, depending on severity and complexity
+
+These are best-effort targets rather than guarantees. The maintainers will share material status or
+timeline changes through the private reporting channel.
 
 ## Scope
 
@@ -23,9 +43,21 @@ This policy covers:
 
 - The Cloudflare Worker (`src/`)
 - The client widget (`src/widget/`)
+- Release artifacts published by this repository
 - The hosted instance at `bugdrop.neonwatty.workers.dev`
+- Dependency vulnerabilities that are reachable through or materially affect BugDrop
 
-## Out of Scope
+Self-hosted deployment configuration is controlled by the instance owner. Reports about an upstream
+dependency with no BugDrop-specific impact should go to that upstream project, but reports showing
+that BugDrop is affected are in scope here.
 
-- Self-hosted instances (contact the instance owner)
-- Third-party dependencies (report to the upstream project)
+## Triage and Coordinated Disclosure
+
+The BugDrop repository maintainers own intake and triage. They will validate the report, assess
+severity using reachability and user impact, and prioritize critical and high-severity issues. When a
+dependency is involved, the maintainers will determine BugDrop's exposure, coordinate with the
+upstream project when appropriate, and update affected BugDrop releases or guidance.
+
+Please allow time for investigation and remediation before public disclosure. The maintainers will
+coordinate a disclosure date with the reporter, publish a GitHub security advisory or CVE when
+appropriate, and credit reporters who request attribution and consent to being named.

--- a/docs/website/security.mdx
+++ b/docs/website/security.mdx
@@ -230,10 +230,23 @@ If installation status is also sensitive, set `AUTH_TOKEN_REQUIRED_FOR_CHECK = "
 
 ## Reporting Security Issues
 
-If you discover a security vulnerability in BugDrop, please report it responsibly:
+If you discover a security vulnerability in BugDrop, report it privately:
 
 - **Do not** create a public GitHub Issue for security vulnerabilities
-- Contact the maintainers directly through GitHub's private vulnerability reporting feature on the [BugDrop repository](https://github.com/mean-weasel/bugdrop)
+- **Preferred:** use [GitHub private vulnerability reporting](https://github.com/mean-weasel/bugdrop/security/advisories/new)
+- **Email fallback:** [neonwatty@gmail.com](mailto:neonwatty@gmail.com) or [jeremy@mean-weasel.com](mailto:jeremy@mean-weasel.com)
+
+Ordinary email is not end-to-end encrypted. Use GitHub private vulnerability reporting for sensitive
+details, credentials, or unpublished exploit material. If GitHub reporting is unavailable, use either
+email fallback rather than disclosing the issue publicly.
+
+BugDrop provides security fixes for the latest stable release and current hosted service. The
+maintainers target acknowledgment within 48 hours and an initial assessment within 7 days, but these
+are best-effort targets rather than guarantees. Reports about dependencies are in scope when the
+dependency is reachable through or materially affects BugDrop.
+
+See the canonical [BugDrop security policy](https://github.com/mean-weasel/bugdrop/security/policy)
+for supported-version, scope, triage, and coordinated-disclosure details.
 
 ## Next Steps
 

--- a/test/securityPolicy.test.ts
+++ b/test/securityPolicy.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const repositoryPolicy = readFileSync(new URL('../SECURITY.md', import.meta.url), 'utf8');
+const websitePolicy = readFileSync(
+  new URL('../docs/website/security.mdx', import.meta.url),
+  'utf8'
+);
+
+const privateReportUrl = 'https://github.com/mean-weasel/bugdrop/security/advisories/new';
+const fallbackEmails = ['mailto:neonwatty@gmail.com', 'mailto:jeremy@mean-weasel.com'];
+
+describe('security reporting policy', () => {
+  it.each([
+    ['repository policy', repositoryPolicy],
+    ['website policy', websitePolicy],
+  ])('publishes the same private reporting channels in the %s', (_name, policy) => {
+    expect(policy).toContain(privateReportUrl);
+    for (const email of fallbackEmails) {
+      expect(policy).toContain(email);
+    }
+  });
+
+  it('defines the maintained versions and intake process', () => {
+    expect(repositoryPolicy).toContain('## Supported Versions');
+    expect(repositoryPolicy).toContain('latest stable release');
+    expect(repositoryPolicy).toContain('not end-to-end encrypted');
+    expect(repositoryPolicy).toContain('## Triage and Coordinated Disclosure');
+    expect(repositoryPolicy).toContain('dependency');
+  });
+
+  it('points website readers to the canonical repository policy', () => {
+    expect(websitePolicy).toContain('https://github.com/mean-weasel/bugdrop/security/policy');
+  });
+});


### PR DESCRIPTION
## Summary

- make enabled GitHub private vulnerability reporting the preferred intake channel while preserving both email fallbacks
- document latest-stable support, best-effort response targets, dependency handling, and coordinated disclosure
- clarify that ordinary email is not end-to-end encrypted
- add a regression test that keeps repository and website reporting channels aligned

## Current setting evidence

- private vulnerability reporting is enabled
- Dependabot alerts and security updates are enabled with zero open alerts
- secret scanning, push protection, non-provider patterns, and validity checks are enabled with zero open alerts

## Validation

- `make check`
- `npm test` — 71 files, 994 tests
- `npx vitest run test/securityPolicy.test.ts` — 4 tests
- `git diff --check`
- independent correctness, tests, documentation, and simplification reviews: no findings

The native Codex baseline review could not run because its command-execution host was unavailable; the required focused reviews completed successfully.