### PR TITLE
feat: report successful production heartbeats

### DIFF
--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -351,3 +351,15 @@ jobs:
             echo "Production heartbeat failed: heartbeat_job=$HEARTBEAT_JOB heartbeat_ok=$HEARTBEAT_OK summarize=$SUMMARIZE_OUTCOME artifact_prepare=$ARTIFACT_PREPARE_OUTCOME artifact=$ARTIFACT_OUTCOME incident=$INCIDENT_JOB" >&2
             exit 1
           fi
+
+      - name: Check in successful production heartbeat
+        continue-on-error: true
+        env:
+          MONITOR_HEARTBEAT_SECRET: ${{ secrets.MONITOR_HEARTBEAT_SECRET }}
+        run: |
+          curl --fail --silent --show-error --max-time 10 \
+            --retry 2 --retry-all-errors \
+            --request POST \
+            --header "Authorization: Bearer $MONITOR_HEARTBEAT_SECRET" \
+            --header "X-BugDrop-Heartbeat-Id: ${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
+            https://bugdrop.dev/api/monitor/heartbeat

--- a/test/production-heartbeat-workflow-contract.test.sh
+++ b/test/production-heartbeat-workflow-contract.test.sh
@@ -80,7 +80,8 @@ for step in \
   'Summarize heartbeat stages' \
   'Upload heartbeat diagnostics' \
   'Reconcile one stable incident Issue' \
-  'Fail closed on every required outcome'; do
+  'Fail closed on every required outcome' \
+  'Check in successful production heartbeat'; do
   require "name: $step"
 done
 require 'if: always() && steps.identity.outcome'
@@ -134,6 +135,22 @@ require '[ "$SUMMARIZE_OUTCOME" != success ]'
 require '[ "$ARTIFACT_PREPARE_OUTCOME" = success ]'
 require '[ "$ARTIFACT_PREPARE_OUTCOME" != success ]'
 
+checkin_block=$(awk '
+  /name: Check in successful production heartbeat/ { capture = 1 }
+  capture { print }
+' "$workflow")
+for required in \
+  'continue-on-error: true' \
+  'MONITOR_HEARTBEAT_SECRET: ${{ secrets.MONITOR_HEARTBEAT_SECRET }}' \
+  'curl --fail --silent --show-error --max-time 10' \
+  '--retry 2 --retry-all-errors' \
+  '--request POST' \
+  '--header "Authorization: Bearer $MONITOR_HEARTBEAT_SECRET"' \
+  '--header "X-BugDrop-Heartbeat-Id: ${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"' \
+  'https://bugdrop.dev/api/monitor/heartbeat'; do
+  grep -Fq -- "$required" <<< "$checkin_block" || fail "check-in step missing: $required"
+done
+
 summary_move_line=$(grep -n 'mv "$diagnostics_tmp" "$diagnostics_path"' "$workflow" | cut -d: -f1)
 summary_output_line=$(grep -n 'echo "heartbeat_ok=$heartbeat_ok" >> "$GITHUB_OUTPUT"' "$workflow" | cut -d: -f1)
 (( summary_move_line < summary_output_line )) ||
@@ -144,5 +161,10 @@ sweep_line=$(grep -n 'name: Final production-prefix sweep' "$workflow" | cut -d:
 controlled_line=$(grep -n 'name: Controlled post-cleanup failure' "$workflow" | cut -d: -f1)
 (( cleanup_line < sweep_line && sweep_line < controlled_line )) ||
   fail 'controlled failure must occur only after both cleanup passes'
+
+conclusion_line=$(grep -n 'name: Fail closed on every required outcome' "$workflow" | cut -d: -f1)
+checkin_line=$(grep -n 'name: Check in successful production heartbeat' "$workflow" | cut -d: -f1)
+(( conclusion_line < checkin_line )) ||
+  fail 'dead-man check-in must run only after the authoritative fail-closed conclusion'
 
 echo 'Production heartbeat workflow contract checks passed'


### PR DESCRIPTION
## Summary

- check in with the BugDrop public status service only after every authoritative production heartbeat outcome succeeds
- keep status-service transport failures non-blocking so monitoring cannot turn a healthy E2E run red
- extend the workflow contract test to pin the request, secret, retry, idempotency, and ordering contract

## Activation

- `MONITOR_HEARTBEAT_SECRET` is already configured as a repository Actions secret
- the production status endpoint is deployed and accepting authenticated check-ins

## Verification

- `bash test/production-heartbeat-workflow-contract.test.sh`
- `actionlint -ignore SC2129 .github/workflows/production-heartbeat.yml`
- `npm run lint -- --quiet`
- `npm test -- --run` (71 files, 1,007 tests)
- pre-push TypeScript checks
- PR review toolkit: correctness, tests, silent-failures, and contracts found no candidates