### PR TITLE
feat: add composable feedback variants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test-radix-e2e:
 		echo "Usage: make test-radix-e2e BROWSER=chromium|firefox|webkit"; \
 		exit 1; \
 	fi
-	npx playwright test e2e/widget.radix.spec.ts --project=$(BROWSER)-radix --workers=1
+	npx playwright test e2e/widget.radix.spec.ts e2e/variant-modal.radix.spec.ts e2e/variant-accessibility.radix.spec.ts --project=$(BROWSER)-radix --workers=1 --retries=0
 
 test-live-radix:
 	@if [ -z "$(LIVE_TARGET)" ] || [ -z "$(PLAYWRIGHT_BASE_URL)" ]; then \

--- a/docs/website/javascript-api.mdx
+++ b/docs/website/javascript-api.mdx
@@ -177,9 +177,81 @@ mountedReview.reset();
 mountedReview.unmount();
 ```
 
-The inline renderer provides accessible short-text, long-text, and rating controls. Choosing a star
-changes only local form state; it never submits. A GitHub Issue is created only after the explicit
-Submit button succeeds.
+The inline renderer provides accessible short-text, long-text, rating, and single-choice controls.
+Choosing an option changes only local form state; it never submits. A GitHub Issue is created only
+after the explicit Submit button succeeds.
+
+For example, an inline poll keeps stable answer values separate from its visible labels and optional
+descriptions. `radio`, `cards`, and `buttons` displays all retain native radio keyboard semantics:
+
+```js
+const poll = window.BugDrop.registerVariant({
+  id: 'next-integration-poll',
+  presentation: { kind: 'inline' },
+  content: { title: 'What should we build next?', submitLabel: 'Vote' },
+  fields: [
+    {
+      id: 'choice',
+      type: 'singleChoice',
+      label: 'Choose one',
+      required: true,
+      display: 'cards',
+      options: [
+        { value: 'onedrive', label: 'OneDrive' },
+        { value: 'box', label: 'Box' },
+        { value: 'other', label: 'Something else' },
+      ],
+    },
+    { id: 'detail', type: 'longText', label: 'Optional detail', maxLength: 500 },
+  ],
+  issue: {
+    classification: 'feature',
+    title: 'Integration vote — {{choice}}',
+    sections: [
+      { heading: 'Choice', field: 'choice', format: 'choice' },
+      { heading: 'Detail', field: 'detail', omitWhenEmpty: true },
+    ],
+  },
+});
+
+const mountedPoll = poll.mount(document.querySelector('#poll-slot'));
+```
+
+The title template receives the stable configured value (for example, `onedrive`), while the
+`choice` section renders its display label (`OneDrive`). Configured labels and descriptions are
+inserted as text. Resetting a successful mounted poll restores its initial answers and creates a new
+submission identity; `unmount()` disposes only that instance.
+
+Compact suggestions do not need a special renderer or field. Compose the existing short- and
+long-text controllers in the modal presentation:
+
+```js
+const suggestion = window.BugDrop.registerVariant({
+  id: 'compact-suggestion',
+  presentation: { kind: 'modal', size: 'default' },
+  content: { title: 'Share an idea', submitLabel: 'Submit idea' },
+  fields: [
+    { id: 'summary', type: 'shortText', label: 'Idea', required: true, maxLength: 120 },
+    { id: 'detail', type: 'longText', label: 'How would this help?', maxLength: 2000 },
+  ],
+  issue: {
+    classification: 'feature',
+    title: '[Idea] {{summary}}',
+    sections: [
+      { heading: 'Idea', field: 'summary' },
+      { heading: 'Why it would help', field: 'detail', omitWhenEmpty: true },
+    ],
+  },
+});
+
+suggestion.open();
+```
+
+Every built-in controller follows the same internal controller contract for values, errors,
+disabled state, focus, reset, and disposal. Contributors extending the built-in field union add a
+controller and its shared conformance fixture; the browser still emits generic Issue sections, so
+the Worker formatter does not gain a field-specific branch. A public renderer registration API is
+not part of this contract.
 
 For a host-owned CTA, register a modal variant and call its handle instead of the legacy
 `BugDrop.open()` method:
@@ -222,10 +294,17 @@ as `submitted`, `closed`, or `busy`. A variant requested while the legacy wizard
 `busy`. Opening the legacy wizard while a variant modal is active closes the variant first. The
 legacy `BugDrop.close()` method remains legacy-scoped.
 
-BugDrop's merge-queue preview checks render both this CTA modal and the inline star review from the
-exact deployed widget bytes. They assert each normalized draft without creating Issues, followed by
-one zero-retry rendered CTA canary that creates, independently verifies, closes, and sweeps one real
-GitHub Issue through the existing GitHub App.
+BugDrop's merge-queue preview checks render the star review, CTA question, poll, and compact
+suggestion from the exact deployed widget bytes. Each UX intercepts and asserts its normalized draft
+without creating an Issue. A separate zero-retry representative canary then creates, independently
+verifies, closes, and sweeps exactly one real GitHub Issue through the shared Worker and GitHub App
+path; browser and UX coverage never multiply that destructive canary.
+
+For component cleanup, keep the returned mounted or opened handle. Call `unmount()` for inline
+instances and `close()` for an open modal. Both are safe to call repeatedly and dispose only their
+own host, controller state, and listeners. `reset()` restores the supplied initial answers and, after
+a successful submission, starts a new submission identity without affecting another mounted
+instance or the legacy widget.
 
 If your application owns the UI, the same immutable handle also supports headless submission:
 

--- a/e2e/variant-accessibility.radix.spec.ts
+++ b/e2e/variant-accessibility.radix.spec.ts
@@ -54,6 +54,134 @@ test('rating keyboard behavior requires explicit Submit', async ({ page }) => {
   expect(submissionCount).toBe(1);
 });
 
+test('single-choice keyboard behavior requires explicit Submit', async ({ page }) => {
+  let submissionCount = 0;
+  await page.route('**/feedback', route => {
+    if (route.request().method() !== 'POST') return route.continue();
+    submissionCount += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        issueNumber: 302,
+        issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/302',
+        isPublic: false,
+      }),
+    });
+  });
+  await page.goto('/test/');
+  await expect
+    .poll(() => page.evaluate(() => typeof window.BugDrop?.registerVariant))
+    .toBe('function');
+  await page.evaluate(() => {
+    const slot = document.createElement('div');
+    slot.id = 'cross-browser-poll-slot';
+    document.body.appendChild(slot);
+    window
+      .BugDrop!.registerVariant({
+        id: 'cross-browser-poll',
+        presentation: { kind: 'inline' },
+        content: { title: 'Choose an integration', submitLabel: 'Submit vote' },
+        fields: [
+          {
+            id: 'choice',
+            type: 'singleChoice',
+            label: 'Integration',
+            required: true,
+            display: 'buttons',
+            options: [
+              { value: 'onedrive', label: 'OneDrive' },
+              { value: 'box', label: 'Box' },
+              { value: 'other', label: 'Something else' },
+            ],
+          },
+        ],
+        issue: { title: 'Integration vote {{choice}}' },
+      })
+      .mount(slot);
+  });
+
+  const host = page.locator('#cross-browser-poll-slot > [data-bugdrop-owned]');
+  const choices = host.getByRole('radiogroup', { name: 'Integration' });
+  const submit = host.getByRole('button', { name: 'Submit vote' });
+  await submit.click();
+  await expect(choices).toHaveAttribute('aria-invalid', 'true');
+  const oneDrive = choices.getByRole('radio', { name: 'OneDrive' });
+  await expect(oneDrive).toBeFocused();
+  await oneDrive.press('ArrowRight');
+  const box = choices.getByRole('radio', { name: 'Box' });
+  await expect(box).toBeFocused();
+  await expect(box).toBeChecked();
+  await box.press('Enter');
+  await box.press('Space');
+  expect(submissionCount).toBe(0);
+  await submit.click();
+  await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+  expect(submissionCount).toBe(1);
+});
+
+test('compact suggestion validates and submits explicitly across browser engines', async ({
+  page,
+}) => {
+  let submissionCount = 0;
+  await page.route('**/feedback', route => {
+    if (route.request().method() !== 'POST') return route.continue();
+    submissionCount += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        issueNumber: 303,
+        issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/303',
+        isPublic: false,
+      }),
+    });
+  });
+  await page.goto('/test/');
+  await expect
+    .poll(() => page.evaluate(() => typeof window.BugDrop?.registerVariant))
+    .toBe('function');
+  await page.evaluate(() => {
+    window
+      .BugDrop!.registerVariant({
+        id: 'cross-browser-compact-suggestion',
+        presentation: { kind: 'modal', size: 'default' },
+        content: { title: 'Share an idea', submitLabel: 'Submit idea' },
+        fields: [
+          { id: 'summary', type: 'shortText', label: 'Idea', required: true, maxLength: 120 },
+          { id: 'detail', type: 'longText', label: 'How would this help?', maxLength: 2_000 },
+        ],
+        issue: {
+          title: '[Idea] {{summary}}',
+          sections: [
+            { heading: 'Idea', field: 'summary' },
+            { heading: 'Why it would help', field: 'detail', omitWhenEmpty: true },
+          ],
+        },
+      })
+      .open();
+  });
+
+  const host = page.locator('body > [data-bugdrop-owned]');
+  const summary = host.getByRole('textbox', { name: 'Idea' });
+  const submit = host.getByRole('button', { name: 'Submit idea' });
+  await submit.click();
+  await expect(summary).toHaveAttribute('aria-invalid', 'true');
+  await expect(summary).toBeFocused();
+  expect(submissionCount).toBe(0);
+  await summary.fill('Keyboard-friendly compact form');
+  await summary.press('Enter');
+  expect(submissionCount).toBe(0);
+  expect(
+    await submit.evaluate(element => element.getBoundingClientRect().height)
+  ).toBeGreaterThanOrEqual(44);
+  await submit.click();
+  await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+  expect(submissionCount).toBe(1);
+});
+
 test('modal focus is contained and Escape restores the host page', async ({ page }) => {
   await page.goto('/test/');
   await expect

--- a/e2e/variant-inline.spec.ts
+++ b/e2e/variant-inline.spec.ts
@@ -222,4 +222,119 @@ test.describe('rendered inline variants', () => {
       'true'
     );
   });
+
+  test('submits an exact single-choice poll draft only through explicit Submit and resets identity', async ({
+    page,
+  }) => {
+    const submissions: Array<Record<string, unknown>> = [];
+    await page.route('**/api/feedback', route => {
+      submissions.push(route.request().postDataJSON() as Record<string, unknown>);
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          issueNumber: 106,
+          issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/106',
+          isPublic: false,
+        }),
+      });
+    });
+    await page.goto('/test/');
+    await page.locator('#bugdrop-host').locator('css=.bd-trigger').waitFor();
+    await page.evaluate(() => {
+      const slot = document.createElement('div');
+      slot.id = 'poll-slot';
+      document.body.appendChild(slot);
+      const mounted = window
+        .BugDrop!.registerVariant({
+          id: 'next-integration-poll',
+          presentation: { kind: 'inline' },
+          content: { title: 'What should we build next?', submitLabel: 'Vote' },
+          fields: [
+            {
+              id: 'choice',
+              type: 'singleChoice',
+              label: 'Choose one',
+              required: true,
+              display: 'cards',
+              options: [
+                {
+                  value: 'onedrive-stable',
+                  label: '<OneDrive>',
+                  description: 'Microsoft storage',
+                },
+                { value: 'box-stable', label: 'Box', description: 'Secure content cloud' },
+              ],
+            },
+            { id: 'detail', type: 'longText', label: 'Optional detail', maxLength: 500 },
+          ],
+          issue: {
+            classification: 'feature',
+            title: 'Integration vote — {{choice}}',
+            sections: [
+              { heading: 'Choice', field: 'choice', format: 'choice' },
+              { heading: 'Detail', field: 'detail', omitWhenEmpty: true },
+            ],
+          },
+        })
+        .mount(slot);
+      (window as Window & { __poll?: { reset(): void; unmount(): void } }).__poll = mounted;
+    });
+
+    const host = page.locator('#poll-slot > [data-bugdrop-owned]');
+    const group = host.getByRole('radiogroup', { name: 'Choose one' });
+    const submit = host.getByRole('button', { name: 'Vote' });
+    await submit.click();
+    await expect(group).toHaveAttribute('aria-invalid', 'true');
+    const oneDrive = group.getByRole('radio', { name: '<OneDrive> Microsoft storage' });
+    await expect(oneDrive).toBeFocused();
+    expect(submissions).toHaveLength(0);
+    await oneDrive.click();
+    expect(submissions).toHaveLength(0);
+    await expect(host.locator('img')).toHaveCount(0);
+    expect(
+      await oneDrive.evaluate(element => element.closest('label')!.getBoundingClientRect().height)
+    ).toBeGreaterThanOrEqual(44);
+    await host.getByRole('textbox', { name: 'Optional detail' }).fill('  Please add sync.  ');
+    expect(submissions).toHaveLength(0);
+    await submit.click();
+    await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0]).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      variantId: 'next-integration-poll',
+      issue: {
+        title: 'Integration vote — onedrive-stable',
+        classification: 'feature',
+        sections: [
+          { heading: 'Choice', value: '<OneDrive>', format: 'text' },
+          { heading: 'Detail', value: 'Please add sync.', format: 'text' },
+        ],
+      },
+    });
+
+    await page.evaluate(() => (window as Window & { __poll?: { reset(): void } }).__poll?.reset());
+    await expect(oneDrive).not.toBeChecked();
+    await expect(host.getByRole('textbox', { name: 'Optional detail' })).toHaveValue('');
+    const box = group.getByRole('radio', { name: 'Box Secure content cloud' });
+    await box.click();
+    expect(submissions).toHaveLength(1);
+    await submit.click();
+    expect(submissions).toHaveLength(2);
+    expect(submissions[1]).toMatchObject({
+      issue: {
+        title: 'Integration vote — box-stable',
+        sections: [{ heading: 'Choice', value: 'Box', format: 'text' }],
+      },
+    });
+    expect(submissions[1]?.submissionId).not.toBe(submissions[0]?.submissionId);
+
+    await page.evaluate(() =>
+      (window as Window & { __poll?: { unmount(): void } }).__poll?.unmount()
+    );
+    await expect(host).toHaveCount(0);
+  });
 });

--- a/e2e/variant-modal.spec.ts
+++ b/e2e/variant-modal.spec.ts
@@ -49,7 +49,98 @@ async function registerProviderQuestion(page: Page) {
   });
 }
 
+async function openCompactSuggestion(page: Page) {
+  await page.evaluate(() => {
+    window
+      .BugDrop!.registerVariant({
+        id: 'compact-suggestion',
+        presentation: { kind: 'modal', size: 'default' },
+        content: { title: 'Share an idea', submitLabel: 'Submit idea' },
+        fields: [
+          {
+            id: 'summary',
+            type: 'shortText',
+            label: 'Idea',
+            required: true,
+            maxLength: 120,
+          },
+          {
+            id: 'detail',
+            type: 'longText',
+            label: 'How would this help?',
+            maxLength: 2_000,
+          },
+        ],
+        issue: {
+          classification: 'feature',
+          title: '[Idea] {{summary}}',
+          sections: [
+            { heading: 'Idea', field: 'summary' },
+            { heading: 'Why it would help', field: 'detail', omitWhenEmpty: true },
+          ],
+        },
+      })
+      .open();
+  });
+}
+
 test.describe('rendered CTA modal variant', () => {
+  test('composes the compact suggestion and intercepts its exact draft', async ({ page }) => {
+    const submissions: Array<Record<string, unknown>> = [];
+    await page.route('**/api/feedback', route => {
+      submissions.push(route.request().postDataJSON() as Record<string, unknown>);
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          issueNumber: 205,
+          issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/205',
+          isPublic: false,
+        }),
+      });
+    });
+    await ready(page);
+    await openCompactSuggestion(page);
+
+    const host = page.locator('body > [data-bugdrop-owned]');
+    await expect(host.getByRole('dialog', { name: 'Share an idea' })).toBeVisible();
+    const summary = host.getByRole('textbox', { name: 'Idea' });
+    await host.getByRole('button', { name: 'Submit idea' }).click();
+    await expect(summary).toHaveAttribute('aria-invalid', 'true');
+    await expect(summary).toBeFocused();
+    expect(submissions).toHaveLength(0);
+
+    await summary.fill('  Add keyboard shortcuts  ');
+    await summary.press('Enter');
+    expect(submissions).toHaveLength(0);
+    await host
+      .getByRole('textbox', { name: 'How would this help?' })
+      .fill('  They would speed up repeated triage.  ');
+    await host.getByRole('button', { name: 'Submit idea' }).click();
+    await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0]).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      repo: 'mean-weasel/bugdrop-widget-test',
+      variantId: 'compact-suggestion',
+      issue: {
+        title: '[Idea] Add keyboard shortcuts',
+        classification: 'feature',
+        sections: [
+          { heading: 'Idea', value: 'Add keyboard shortcuts', format: 'text' },
+          {
+            heading: 'Why it would help',
+            value: 'They would speed up repeated triage.',
+            format: 'text',
+          },
+        ],
+      },
+    });
+  });
+
   test('creates the exact draft only after explicit Submit and settles submitted', async ({
     page,
   }) => {

--- a/e2e/variant.live.spec.ts
+++ b/e2e/variant.live.spec.ts
@@ -162,4 +162,124 @@ test.describe('rendered variants on the deployed widget', () => {
       },
     });
   });
+
+  test('renders and submits the exact inline poll draft from pinned bytes', async ({ page }) => {
+    const submissions = await interceptOneSubmission(page);
+    await loadExactWidget(page);
+    await page.evaluate(() => {
+      const slot = document.createElement('div');
+      slot.id = 'live-poll-slot';
+      document.body.appendChild(slot);
+      window
+        .BugDrop!.registerVariant({
+          id: 'live-next-integration-poll',
+          presentation: { kind: 'inline' },
+          content: { title: 'What should we build next?', submitLabel: 'Vote' },
+          fields: [
+            {
+              id: 'choice',
+              type: 'singleChoice',
+              label: 'Choose one',
+              required: true,
+              display: 'cards',
+              options: [
+                { value: 'onedrive', label: 'OneDrive' },
+                { value: 'box', label: 'Box' },
+              ],
+            },
+            { id: 'detail', type: 'longText', label: 'Optional detail', maxLength: 500 },
+          ],
+          issue: {
+            classification: 'feature',
+            title: 'Integration vote — {{choice}}',
+            sections: [
+              { heading: 'Choice', field: 'choice', format: 'choice' },
+              { heading: 'Detail', field: 'detail', omitWhenEmpty: true },
+            ],
+          },
+        })
+        .mount(slot);
+    });
+
+    const host = page.locator('#live-poll-slot > [data-bugdrop-owned]');
+    await host.getByRole('radio', { name: 'OneDrive' }).click();
+    await host.getByRole('textbox', { name: 'Optional detail' }).fill('Exact preview poll');
+    expect(submissions).toHaveLength(0);
+    await host.getByRole('button', { name: 'Vote' }).click();
+    await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0].postDataJSON()).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      variantId: 'live-next-integration-poll',
+      issue: {
+        title: 'Integration vote — onedrive',
+        classification: 'feature',
+        sections: [
+          { heading: 'Choice', value: 'OneDrive', format: 'text' },
+          { heading: 'Detail', value: 'Exact preview poll', format: 'text' },
+        ],
+      },
+    });
+  });
+
+  test('opens and submits the exact compact-suggestion draft from pinned bytes', async ({
+    page,
+  }) => {
+    const submissions = await interceptOneSubmission(page);
+    await loadExactWidget(page);
+    await page.evaluate(() => {
+      window
+        .BugDrop!.registerVariant({
+          id: 'live-compact-suggestion',
+          presentation: { kind: 'modal', size: 'default' },
+          content: { title: 'Share an idea', submitLabel: 'Submit idea' },
+          fields: [
+            { id: 'summary', type: 'shortText', label: 'Idea', required: true, maxLength: 120 },
+            {
+              id: 'detail',
+              type: 'longText',
+              label: 'How would this help?',
+              maxLength: 2_000,
+            },
+          ],
+          issue: {
+            classification: 'feature',
+            title: '[Idea] {{summary}}',
+            sections: [
+              { heading: 'Idea', field: 'summary' },
+              { heading: 'Why it would help', field: 'detail', omitWhenEmpty: true },
+            ],
+          },
+        })
+        .open();
+    });
+
+    const host = page.locator('body > [data-bugdrop-owned]');
+    await host.getByRole('textbox', { name: 'Idea' }).fill('Pinned preview suggestion');
+    await host
+      .getByRole('textbox', { name: 'How would this help?' })
+      .fill('It proves the existing primitives compose.');
+    expect(submissions).toHaveLength(0);
+    await host.getByRole('button', { name: 'Submit idea' }).click();
+    await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0].postDataJSON()).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      variantId: 'live-compact-suggestion',
+      issue: {
+        title: '[Idea] Pinned preview suggestion',
+        classification: 'feature',
+        sections: [
+          { heading: 'Idea', value: 'Pinned preview suggestion', format: 'text' },
+          {
+            heading: 'Why it would help',
+            value: 'It proves the existing primitives compose.',
+            format: 'text',
+          },
+        ],
+      },
+    });
+  });
 });

--- a/e2e/widget.cross-browser-live.spec.ts
+++ b/e2e/widget.cross-browser-live.spec.ts
@@ -132,6 +132,76 @@ test.describe('Cross-Browser Live Preview Smoke', () => {
     expect(payloads[0].screenshot).toBeNull();
   });
 
+  test('submits a compact suggestion from the exact preview widget without a real Issue', async ({
+    page,
+  }) => {
+    const responsePromise = expectedWidgetOrigin
+      ? waitForPreviewWidgetResponse(page, expectedWidgetOrigin)
+      : undefined;
+    const payloads: Array<Record<string, unknown>> = [];
+    await page.route('**/feedback', route => {
+      if (route.request().method() !== 'POST') return route.continue();
+      payloads.push(route.request().postDataJSON() as Record<string, unknown>);
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          issueNumber: 2,
+          issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/2',
+          isPublic: false,
+        }),
+      });
+    });
+    await page.goto(venuePath);
+    await expect
+      .poll(() => page.evaluate(() => typeof window.BugDrop?.registerVariant))
+      .toBe('function');
+    if (responsePromise && expectedWidgetSha256) {
+      await assertExactPreviewWidgetResponse(await responsePromise, expectedWidgetSha256);
+    }
+    await page.evaluate(() => {
+      window
+        .BugDrop!.registerVariant({
+          id: 'cross-browser-live-compact-suggestion',
+          presentation: { kind: 'modal', size: 'default' },
+          content: { title: 'Share an idea', submitLabel: 'Submit idea' },
+          fields: [
+            { id: 'summary', type: 'shortText', label: 'Idea', required: true, maxLength: 120 },
+            { id: 'detail', type: 'longText', label: 'How would this help?', maxLength: 2_000 },
+          ],
+          issue: {
+            classification: 'feature',
+            title: '[Idea] {{summary}}',
+            sections: [
+              { heading: 'Idea', field: 'summary' },
+              { heading: 'Why it would help', field: 'detail', omitWhenEmpty: true },
+            ],
+          },
+        })
+        .open();
+    });
+
+    const variantHost = page.locator('body > [data-bugdrop-owned]');
+    await variantHost.getByRole('textbox', { name: 'Idea' }).fill('Cross-browser preview idea');
+    expect(payloads).toHaveLength(0);
+    await variantHost.getByRole('button', { name: 'Submit idea' }).click();
+    await expect(
+      variantHost.getByRole('heading', { name: 'Thanks for your feedback!' })
+    ).toBeVisible();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      variantId: 'cross-browser-live-compact-suggestion',
+      issue: {
+        title: '[Idea] Cross-browser preview idea',
+        classification: 'feature',
+        sections: [{ heading: 'Idea', value: 'Cross-browser preview idea', format: 'text' }],
+      },
+    });
+  });
+
   test('handles complex-page screenshot options without starting expensive capture', async ({
     browserName,
     page,

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -2830,6 +2830,152 @@ test.describe('JavaScript API', () => {
     }
   });
 
+  test('simultaneous inline variants isolate answers, submission IDs, reset, disposal, and legacy state', async ({
+    page,
+  }) => {
+    const submitted: Record<string, unknown>[] = [];
+    await page.route('**/api/check**', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"installed":true}' })
+    );
+    await page.route('**/api/feedback', route => {
+      submitted.push(route.request().postDataJSON() as Record<string, unknown>);
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          issueNumber: 92,
+          issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/92',
+          isPublic: false,
+        }),
+      });
+    });
+    await page.goto('/test/');
+    const legacyHost = page.locator('#bugdrop-host');
+    await legacyHost.locator('css=.bd-trigger').waitFor();
+
+    const identities = await page.evaluate(() => {
+      const firstSlot = document.createElement('div');
+      firstSlot.id = 'simultaneous-first';
+      const secondSlot = document.createElement('div');
+      secondSlot.id = 'simultaneous-second';
+      document.body.append(firstSlot, secondSlot);
+      const handle = window.BugDrop!.registerVariant({
+        id: 'simultaneous-inline-poll',
+        presentation: { kind: 'inline' },
+        content: { title: 'Pick a provider', submitLabel: 'Submit vote' },
+        fields: [
+          {
+            id: 'choice',
+            type: 'singleChoice',
+            label: 'Provider',
+            required: true,
+            options: [
+              { value: 'one', label: 'One' },
+              { value: 'two', label: 'Two' },
+            ],
+          },
+          { id: 'detail', type: 'shortText', label: 'Detail' },
+        ],
+        issue: {
+          title: 'Provider {{choice}}',
+          sections: [
+            { heading: 'Choice', field: 'choice', format: 'choice' },
+            { heading: 'Detail', field: 'detail', omitWhenEmpty: true },
+          ],
+        },
+      });
+      const first = handle.mount(firstSlot, { initialAnswers: { choice: 'one' } });
+      const second = handle.mount(secondSlot, { initialAnswers: { choice: 'two' } });
+      const firstHost = firstSlot.querySelector<HTMLElement>('[data-bugdrop-owned]')!;
+      const secondHost = secondSlot.querySelector<HTMLElement>('[data-bugdrop-owned]')!;
+      const firstName =
+        firstHost.shadowRoot!.querySelector<HTMLInputElement>('input[type="radio"]')!.name;
+      const secondName =
+        secondHost.shadowRoot!.querySelector<HTMLInputElement>('input[type="radio"]')!.name;
+      (
+        window as Window & {
+          __simultaneous?: {
+            first: { reset(): void; unmount(): void };
+            second: { unmount(): void };
+          };
+        }
+      ).__simultaneous = { first, second };
+      return { firstName, secondName, firstId: first.instanceId, secondId: second.instanceId };
+    });
+
+    expect(identities.firstId).not.toBe(identities.secondId);
+    expect(identities.firstName).not.toBe(identities.secondName);
+    const first = page.locator('#simultaneous-first > [data-bugdrop-owned]');
+    const second = page.locator('#simultaneous-second > [data-bugdrop-owned]');
+    await first.getByRole('textbox', { name: 'Detail' }).fill('First answer');
+    await second.getByRole('textbox', { name: 'Detail' }).fill('Second answer');
+    await first.getByRole('button', { name: 'Submit vote' }).click();
+    await second.getByRole('button', { name: 'Submit vote' }).click();
+    await expect(first.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+    await expect(second.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+    expect(submitted).toHaveLength(2);
+    expect(submitted[0]).toMatchObject({
+      issue: {
+        title: 'Provider one',
+        sections: [
+          { heading: 'Choice', value: 'One', format: 'text' },
+          { heading: 'Detail', value: 'First answer', format: 'text' },
+        ],
+      },
+    });
+    expect(submitted[1]).toMatchObject({
+      issue: {
+        title: 'Provider two',
+        sections: [
+          { heading: 'Choice', value: 'Two', format: 'text' },
+          { heading: 'Detail', value: 'Second answer', format: 'text' },
+        ],
+      },
+    });
+    expect(submitted[0]?.submissionId).not.toBe(submitted[1]?.submissionId);
+
+    await page.evaluate(() =>
+      (
+        window as Window & {
+          __simultaneous?: { first: { reset(): void } };
+        }
+      ).__simultaneous?.first.reset()
+    );
+    await expect(first.getByRole('radio', { name: 'One' })).toBeChecked();
+    await expect(first.getByRole('textbox', { name: 'Detail' })).toHaveValue('');
+    await expect(second.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+    await first.getByRole('button', { name: 'Submit vote' }).click();
+    expect(submitted).toHaveLength(3);
+    expect(submitted[2]?.submissionId).not.toBe(submitted[0]?.submissionId);
+
+    await page.evaluate(() =>
+      (
+        window as Window & {
+          __simultaneous?: { first: { unmount(): void } };
+        }
+      ).__simultaneous?.first.unmount()
+    );
+    await expect(first).toHaveCount(0);
+    await expect(second).toHaveCount(1);
+
+    await page.evaluate(() => window.BugDrop!.open());
+    await expect(legacyHost.locator('css=.bd-modal')).toBeVisible();
+    await expect(second).toHaveCount(1);
+    await page.evaluate(() => window.BugDrop!.close());
+    await expect(legacyHost.locator('css=.bd-modal')).not.toBeVisible();
+    await page.evaluate(() =>
+      (
+        window as Window & {
+          __simultaneous?: { second: { unmount(): void } };
+        }
+      ).__simultaneous?.second.unmount()
+    );
+    await expect(second).toHaveCount(0);
+    await expect(page.locator('[data-bugdrop-owned]')).toHaveCount(0);
+    await expect(legacyHost.locator('css=.bd-trigger')).toBeVisible();
+  });
+
   test('rejects failed and noncanonical structured submission responses', async ({ page }) => {
     await page.route('**/api/feedback', route => {
       const payload = route.request().postDataJSON() as { submissionId?: string };

--- a/src/widget/variants/fields/index.ts
+++ b/src/widget/variants/fields/index.ts
@@ -2,11 +2,12 @@ import type { VariantField } from '../public-types';
 import { createLongTextController } from './long-text';
 import { createRatingController } from './rating';
 import { createShortTextController } from './short-text';
+import { createSingleChoiceController } from './single-choice';
 import type { FieldController } from './types';
 
 export function createFieldController(field: VariantField, instanceId: string): FieldController {
   if (field.type === 'shortText') return createShortTextController(field, instanceId);
   if (field.type === 'longText') return createLongTextController(field, instanceId);
   if (field.type === 'rating') return createRatingController(field, instanceId);
-  throw new Error('BugDrop single-choice rendering is not available in Phase 2');
+  return createSingleChoiceController(field, instanceId);
 }

--- a/src/widget/variants/fields/single-choice.ts
+++ b/src/widget/variants/fields/single-choice.ts
@@ -1,0 +1,52 @@
+import type { SingleChoiceField } from '../public-types';
+import { createFieldScaffold } from './shared';
+import type { FieldController } from './types';
+
+export function createSingleChoiceController(
+  field: SingleChoiceField,
+  instanceId: string
+): FieldController {
+  const scaffold = createFieldScaffold(field, instanceId);
+  const group = document.createElement('div');
+  group.className = `choice ${field.display ?? ''}`;
+  group.setAttribute('role', 'radiogroup');
+  group.setAttribute('aria-labelledby', scaffold.labelId);
+  group.setAttribute('aria-required', String(field.required ?? false));
+  if (scaffold.describedBy) group.setAttribute('aria-describedby', scaffold.describedBy);
+
+  const inputs = field.options.map(option => {
+    const label = document.createElement('label');
+    const input = document.createElement('input');
+    input.type = 'radio';
+    input.name = scaffold.controlId;
+    input.value = option.value;
+    label.append(input, option.label);
+    if (option.description) {
+      const description = document.createElement('span');
+      description.className = 'bdv-help';
+      description.textContent = option.description;
+      label.appendChild(description);
+    }
+    group.appendChild(label);
+    return input;
+  });
+  scaffold.wrapper.insertBefore(group, scaffold.wrapper.querySelector('.bdv-error'));
+  const selected = () => group.querySelector<HTMLInputElement>(':checked');
+
+  return {
+    field,
+    element: scaffold.wrapper,
+    getValue: () => selected()?.value ?? '',
+    setValue(value) {
+      for (const input of inputs) input.checked = input.value === value;
+    },
+    setError: message => scaffold.setError(group, message),
+    setDisabled(disabled) {
+      for (const input of inputs) input.disabled = disabled;
+    },
+    focus() {
+      (selected() ?? inputs[0])?.focus();
+    },
+    dispose() {},
+  };
+}

--- a/src/widget/variants/styles.ts
+++ b/src/widget/variants/styles.ts
@@ -55,7 +55,7 @@ const VARIANT_CSS = `
   *, *::before, *::after { box-sizing: border-box; }
 
   .bdv-root {
-    --bdv-bg: #ffffff;
+    --bdv-bg: #fff;
     --bdv-bg-muted: #f8fafc;
     --bdv-text: #0f172a;
     --bdv-text-muted: #64748b;
@@ -87,7 +87,7 @@ const VARIANT_CSS = `
     background: var(--bdv-bg);
     color: var(--bdv-text);
     padding: 24px;
-    box-shadow: 0 8px 28px rgb(15 23 42 / 10%);
+    box-shadow: 0 8px 28px #0f172a1a;
   }
 
   .bdv-root[data-density="compact"] .bdv-surface { padding: 16px; }
@@ -105,8 +105,8 @@ const VARIANT_CSS = `
   .bdv-field { min-width: 0; }
   .bdv-label { display: block; margin-bottom: 6px; font-weight: 650; }
   .bdv-required { color: var(--bdv-danger); }
-  .bdv-help { margin: -2px 0 7px; color: var(--bdv-text-muted); font-size: 0.875rem; }
-  .bdv-error { margin-top: 6px; color: var(--bdv-danger); font-size: 0.875rem; }
+  .bdv-help { margin: -2px 0 7px; color: var(--bdv-text-muted); font-size: .875rem; }
+  .bdv-error { margin-top: 6px; color: var(--bdv-danger); font-size: .875rem; }
 
   .bdv-input {
     width: 100%;
@@ -121,6 +121,7 @@ const VARIANT_CSS = `
   textarea.bdv-input { min-height: 108px; resize: vertical; }
   .bdv-input:focus-visible,
   .bdv-rating-option:focus-visible,
+  .choice > label:has(:focus-visible),
   .bdv-submit:focus-visible,
   .bdv-cancel:focus-visible,
   .bdv-close:focus-visible,
@@ -145,14 +146,34 @@ const VARIANT_CSS = `
   }
   .bdv-rating-option:hover,
   .bdv-rating-option--active { color: var(--bdv-accent); border-color: var(--bdv-accent); }
-  .bdv-rating-option:disabled { cursor: wait; opacity: 0.65; }
+  .bdv-rating-option:disabled { cursor: wait; opacity: .65; }
   .bdv-rating-labels {
     display: flex;
     justify-content: space-between;
     margin-top: 5px;
     color: var(--bdv-text-muted);
-    font-size: 0.8rem;
+    font-size: .8rem;
   }
+
+  .choice { display: grid; gap: 8px; }
+  .choice > label {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    min-height: 44px;
+    align-items: center;
+    gap: 0 10px;
+    border: 1px solid transparent;
+    border-radius: 9px;
+    cursor: pointer;
+    padding: 9px 10px;
+    font-weight: 650;
+  }
+  .choice > label:has(:checked) { border-color: var(--bdv-accent); }
+  .cards > *, .buttons > * { background: var(--bdv-bg-muted); border-color: var(--bdv-border); }
+  .buttons { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
+  .choice input { grid-row: span 2; width: 20px; height: 20px; accent-color: var(--bdv-accent); }
+  .choice .bdv-help { margin: 0; font-weight: 400; }
+  .choice :disabled ~ * { opacity: .65; }
 
   .bdv-actions { display: flex; align-items: center; gap: 12px; margin-top: 20px; }
   .bdv-submit {
@@ -160,7 +181,7 @@ const VARIANT_CSS = `
     border: 0;
     border-radius: 9px;
     background: var(--bdv-accent);
-    color: #ffffff;
+    color: #fff;
     cursor: pointer;
     padding: 10px 18px;
     font: inherit;
@@ -177,7 +198,7 @@ const VARIANT_CSS = `
     font: inherit;
     font-weight: 650;
   }
-  .bdv-cancel:disabled { cursor: wait; opacity: 0.65; }
+  .bdv-cancel:disabled { cursor: wait; opacity: .65; }
   .bdv-overlay {
     display: grid;
     min-height: 100%;
@@ -185,7 +206,7 @@ const VARIANT_CSS = `
     overflow: auto;
     padding: max(20px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right))
       max(20px, env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left));
-    background: rgb(15 23 42 / 56%);
+    background: #0f172a8f;
   }
   .bdv-root[data-presentation="modal"] { height: 100%; }
   .bdv-root[data-presentation="modal"] .bdv-surface { max-width: 560px; }
@@ -210,7 +231,7 @@ const VARIANT_CSS = `
   }
   .bdv-close:hover { background: var(--bdv-bg-muted); color: var(--bdv-text); }
   .bdv-root[data-presentation="modal"] .bdv-header { padding-right: 36px; }
-  .bdv-submit:disabled { cursor: wait; opacity: 0.65; }
+  .bdv-submit:disabled { cursor: wait; opacity: .65; }
   .bdv-status { min-height: 1.5em; margin: 12px 0 0; color: var(--bdv-text-muted); }
   .bdv-status[data-kind="error"] { color: var(--bdv-danger); }
   .bdv-success { outline: none; }

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -13,9 +13,12 @@ canary_engine="$repo_root/e2e/widget.issue-canary.ts"
 live_spec="$repo_root/e2e/widget.live.spec.ts"
 variant_live_spec="$repo_root/e2e/variant.live.spec.ts"
 variant_accessibility_spec="$repo_root/e2e/variant-accessibility.radix.spec.ts"
+variant_conformance_spec="$repo_root/test/variantFieldConformance.test.ts"
+variant_inline_spec="$repo_root/e2e/widget.spec.ts"
 live_radix_spec="$repo_root/e2e/widget.live-radix.spec.ts"
 cross_browser_live_spec="$repo_root/e2e/widget.cross-browser-live.spec.ts"
 exact_widget_fixture="$repo_root/e2e/live-preview-widget.ts"
+makefile="$repo_root/Makefile"
 
 fail() {
   echo "CI workflow contract failed: $*" >&2
@@ -428,10 +431,22 @@ require_literal "$variant_live_spec" "from './live-preview-widget'"
 require_literal "$variant_live_spec" "page.route('**/feedback'"
 require_literal "$variant_live_spec" 'renders and submits the exact inline star-review draft'
 require_literal "$variant_live_spec" 'opens and submits the exact CTA text-modal draft'
+require_literal "$variant_live_spec" 'renders and submits the exact inline poll draft from pinned bytes'
+require_literal "$variant_live_spec" 'opens and submits the exact compact-suggestion draft from pinned bytes'
 require_literal "$variant_live_spec" 'assertExactPreviewWidgetResponse'
 require_literal "$variant_accessibility_spec" 'rating keyboard behavior requires explicit Submit'
+require_literal "$variant_accessibility_spec" 'single-choice keyboard behavior requires explicit Submit'
+require_literal "$variant_accessibility_spec" 'compact suggestion validates and submits explicitly across browser engines'
 require_literal "$variant_accessibility_spec" 'modal focus is contained and Escape restores the host page'
 require_literal "$variant_accessibility_spec" "expect(submissionCount).toBe(0)"
+require_literal "$variant_conformance_spec" 'built-in field-controller conformance'
+require_literal "$variant_conformance_spec" 'short text'
+require_literal "$variant_conformance_spec" 'long text'
+require_literal "$variant_conformance_spec" 'rating'
+require_literal "$variant_conformance_spec" 'single choice'
+require_literal "$variant_inline_spec" 'simultaneous inline variants isolate answers, submission IDs, reset, disposal, and legacy state'
+require_literal "$cross_browser_live_spec" 'submits a compact suggestion from the exact preview widget without a real Issue'
+require_literal "$makefile" 'npx playwright test e2e/widget.radix.spec.ts e2e/variant-modal.radix.spec.ts e2e/variant-accessibility.radix.spec.ts --project=$(BROWSER)-radix --workers=1 --retries=0'
 for live_browser_spec in "$live_spec" "$live_radix_spec" "$cross_browser_live_spec"; do
   require_literal "$live_browser_spec" "from './live-preview-widget'"
 done

--- a/test/structuredFeedback.test.ts
+++ b/test/structuredFeedback.test.ts
@@ -132,6 +132,30 @@ describe('structured feedback Worker contract', () => {
     expect(mockGetInstallationToken).toHaveBeenCalledOnce();
   });
 
+  it('formats a hypothetical contributor field as generic sections without a Worker branch', async () => {
+    const payload = structuredClone(validPayload);
+    payload.variantId = 'contributor-priority-matrix';
+    payload.issue = {
+      title: 'Contributor extension proof',
+      classification: 'feature',
+      sections: [
+        { heading: 'Matrix selection', value: 'high-impact / low-effort', format: 'text' },
+        { heading: 'Contributor rationale', value: 'Ship the generic contract.', format: 'quote' },
+        { heading: 'Machine value', value: 'priority:p1', format: 'code' },
+      ],
+    };
+
+    const response = await submit(payload);
+    const body = mockCreateIssue.mock.calls[0][4] as string;
+
+    expect(response.status).toBe(200);
+    expect(mockCreateIssue).toHaveBeenCalledOnce();
+    expect(body).toContain('## Matrix selection\n\nhigh-impact / low-effort');
+    expect(body).toContain('## Contributor rationale\n\n> Ship the generic contract.');
+    expect(body).toContain('## Machine value\n\n```\npriority:p1\n```');
+    expect(body).toContain('<!-- bugdrop-submission: submission-1234 -->');
+  });
+
   it('shares the existing auth-token boundary before GitHub access', async () => {
     const protectedEnv = {
       ...env,

--- a/test/variantConfig.test.ts
+++ b/test/variantConfig.test.ts
@@ -34,6 +34,27 @@ describe('variant config validation', () => {
     expect(Object.isFrozen(frozen.fields[0])).toBe(true);
   });
 
+  it('accepts bounded choices while keeping stable values separate from display copy', () => {
+    const choiceConfig: VariantConfig = {
+      ...config(),
+      fields: [
+        {
+          id: 'choice',
+          type: 'singleChoice',
+          label: 'Choose one',
+          display: 'cards',
+          options: [
+            { value: 'onedrive', label: '<OneDrive>', description: 'Best for <Office>' },
+            { value: 'box', label: 'Box' },
+          ],
+        },
+      ],
+      issue: { title: 'Vote {{choice}}' },
+    };
+
+    expect(validateAndFreezeVariantConfig(choiceConfig).fields[0]).toEqual(choiceConfig.fields[0]);
+  });
+
   it.each([
     ['reserved id', { ...config(), id: 'legacy' }],
     ['invalid id', { ...config(), id: 'Export Review' }],
@@ -88,6 +109,23 @@ describe('variant config validation', () => {
               { value: 'b', label: 'B' },
             ],
             display: 'select',
+          },
+        ],
+      },
+    ],
+    [
+      'duplicate choice value',
+      {
+        ...config(),
+        fields: [
+          {
+            id: 'choice',
+            type: 'singleChoice',
+            label: 'Choice',
+            options: [
+              { value: 'same', label: 'A' },
+              { value: 'same', label: 'B' },
+            ],
           },
         ],
       },

--- a/test/variantFieldConformance.test.ts
+++ b/test/variantFieldConformance.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { normalizeVariantAnswers } from '../src/widget/variants/answer-validation';
+import { createFieldController } from '../src/widget/variants/fields';
+import type { VariantField } from '../src/widget/variants/public-types';
+
+interface ConformanceFixture {
+  name: string;
+  field: VariantField;
+  value: string | number;
+  normalized: string | number;
+  controlSelector: string;
+  accessibilitySelector: string;
+}
+
+const fixtures: ConformanceFixture[] = [
+  {
+    name: 'short text',
+    field: {
+      id: 'summary',
+      type: 'shortText',
+      label: 'Summary',
+      helpText: 'Keep it brief',
+      required: true,
+      maxLength: 120,
+    },
+    value: '  A compact idea  ',
+    normalized: 'A compact idea',
+    controlSelector: 'input',
+    accessibilitySelector: 'input',
+  },
+  {
+    name: 'long text',
+    field: {
+      id: 'detail',
+      type: 'longText',
+      label: 'Detail',
+      helpText: 'Add context',
+      required: true,
+      maxLength: 2_000,
+    },
+    value: '  More contributor context  ',
+    normalized: 'More contributor context',
+    controlSelector: 'textarea',
+    accessibilitySelector: 'textarea',
+  },
+  {
+    name: 'rating',
+    field: {
+      id: 'rating',
+      type: 'rating',
+      label: 'Rating',
+      helpText: 'Choose a score',
+      required: true,
+      scale: 5,
+    },
+    value: 4,
+    normalized: 4,
+    controlSelector: '[role="radio"][aria-label="4 stars"]',
+    accessibilitySelector: '[role="radiogroup"]',
+  },
+  {
+    name: 'single choice',
+    field: {
+      id: 'choice',
+      type: 'singleChoice',
+      label: 'Choice',
+      helpText: 'Choose one',
+      required: true,
+      options: [
+        { value: 'one', label: 'One' },
+        { value: 'two', label: 'Two' },
+      ],
+    },
+    value: 'two',
+    normalized: 'two',
+    controlSelector: 'input[value="two"]',
+    accessibilitySelector: '[role="radiogroup"]',
+  },
+];
+
+describe('built-in field-controller conformance', () => {
+  beforeEach(() => document.body.replaceChildren());
+
+  it.each(fixtures)(
+    '$name satisfies the shared render, value, validation, focus, disabled, reset, and disposal contract',
+    ({ field, value, normalized, controlSelector, accessibilitySelector }) => {
+      const controller = createFieldController(field, `conformance-${field.id}`);
+      document.body.appendChild(controller.element);
+      const control = controller.element.querySelector<HTMLElement>(controlSelector);
+      const accessibilityTarget =
+        controller.element.querySelector<HTMLElement>(accessibilitySelector);
+      const error = controller.element.querySelector<HTMLElement>('.bdv-error');
+
+      expect(controller.field).toBe(field);
+      expect(controller.element.dataset.bugdropField).toBe(field.id);
+      expect(controller.element.textContent).toContain(field.label);
+      expect(control).not.toBeNull();
+      expect(accessibilityTarget?.getAttribute('aria-describedby')).toContain(`${field.id}-help`);
+
+      controller.setValue(value);
+      expect(controller.getValue()).toBe(value);
+      expect(normalizeVariantAnswers([field], { [field.id]: controller.getValue() })).toEqual({
+        [field.id]: normalized,
+      });
+
+      controller.setError('Conformance error');
+      expect(error).toMatchObject({ hidden: false, textContent: 'Conformance error' });
+      expect(
+        accessibilityTarget?.getAttribute('aria-invalid') === 'true'
+          ? accessibilityTarget.getAttribute('aria-describedby')
+          : null
+      ).toContain(`${field.id}-error`);
+      controller.setError(null);
+      expect(error).toMatchObject({ hidden: true, textContent: '' });
+
+      controller.setDisabled(true);
+      expect(
+        Array.from(
+          controller.element.querySelectorAll<HTMLInputElement | HTMLButtonElement>(
+            'input, textarea, button'
+          )
+        ).every(element => element.disabled)
+      ).toBe(true);
+      controller.setDisabled(false);
+      controller.focus();
+      expect(controller.element.contains(document.activeElement)).toBe(true);
+
+      controller.setValue('');
+      expect(controller.getValue()).toBe('');
+      controller.dispose();
+      controller.dispose();
+      expect(controller.element.isConnected).toBe(true);
+    }
+  );
+
+  it('keeps generated controller identities isolated across simultaneous instances', () => {
+    const field = fixtures[3]!.field;
+    const first = createFieldController(field, 'first-instance');
+    const second = createFieldController(field, 'second-instance');
+    document.body.append(first.element, second.element);
+
+    const firstNames = Array.from(first.element.querySelectorAll<HTMLInputElement>('input')).map(
+      input => input.name
+    );
+    const secondNames = Array.from(second.element.querySelectorAll<HTMLInputElement>('input')).map(
+      input => input.name
+    );
+    expect(new Set(firstNames)).toEqual(new Set(['first-instance-choice']));
+    expect(new Set(secondNames)).toEqual(new Set(['second-instance-choice']));
+    expect(firstNames[0]).not.toBe(secondNames[0]);
+  });
+});

--- a/test/variantFields.test.ts
+++ b/test/variantFields.test.ts
@@ -89,4 +89,50 @@ describe('rendered variant field controllers', () => {
     expect(rating.getValue()).toBe('');
     rating.dispose();
   });
+
+  it.each(['radio', 'cards', 'buttons'] as const)(
+    'renders %s choices with native radio semantics and stable values',
+    display => {
+      const choice = createFieldController(
+        {
+          id: 'provider',
+          type: 'singleChoice',
+          label: 'Provider',
+          helpText: 'Choose one',
+          required: true,
+          display,
+          options: [
+            { value: 'stable-gcp', label: '<Google Cloud>', description: '<Fast & global>' },
+            { value: 'stable-azure', label: 'Microsoft Azure' },
+          ],
+        },
+        `instance-${display}`
+      );
+      document.body.appendChild(choice.element);
+      const group = choice.element.querySelector<HTMLElement>('[role="radiogroup"]');
+      const inputs = Array.from(choice.element.querySelectorAll<HTMLInputElement>('input'));
+
+      expect(group?.classList.contains(display)).toBe(true);
+      expect(inputs).toHaveLength(2);
+      expect(inputs.every(input => input.type === 'radio')).toBe(true);
+      const optionCopy = group?.querySelector('label');
+      expect(optionCopy?.childNodes[1]?.textContent).toBe('<Google Cloud>');
+      expect(optionCopy?.querySelector('.bdv-help')?.textContent).toBe('<Fast & global>');
+      expect(choice.element.querySelector('img')).toBeNull();
+
+      inputs[1]?.click();
+      expect(choice.getValue()).toBe('stable-azure');
+      choice.setValue('stable-gcp');
+      expect(inputs[0]?.checked).toBe(true);
+      choice.setValue('unknown');
+      expect(choice.getValue()).toBe('');
+      choice.setError('Choose an option');
+      expect(group?.getAttribute('aria-invalid')).toBe('true');
+      choice.focus();
+      expect(document.activeElement).toBe(inputs[0]);
+      choice.setDisabled(true);
+      expect(inputs.every(input => input.disabled)).toBe(true);
+      choice.dispose();
+    }
+  );
 });

--- a/test/variantIssueDraft.test.ts
+++ b/test/variantIssueDraft.test.ts
@@ -32,6 +32,35 @@ const config: VariantConfig = {
   },
 };
 
+const compactSuggestionConfig: VariantConfig = {
+  id: 'compact-suggestion',
+  presentation: { kind: 'modal', size: 'default' },
+  content: { title: 'Share an idea', submitLabel: 'Submit idea' },
+  fields: [
+    {
+      id: 'summary',
+      type: 'shortText',
+      label: 'Idea',
+      required: true,
+      maxLength: 120,
+    },
+    {
+      id: 'detail',
+      type: 'longText',
+      label: 'How would this help?',
+      maxLength: 2_000,
+    },
+  ],
+  issue: {
+    classification: 'feature',
+    title: '[Idea] {{summary}}',
+    sections: [
+      { heading: 'Idea', field: 'summary' },
+      { heading: 'Why it would help', field: 'detail', omitWhenEmpty: true },
+    ],
+  },
+};
+
 describe('variant Issue draft compilation', () => {
   it('normalizes fields into the field-agnostic Worker draft', () => {
     expect(
@@ -45,6 +74,15 @@ describe('variant Issue draft compilation', () => {
         { heading: 'Surface', value: 'settings', format: 'code' },
       ],
     });
+  });
+
+  it('uses stable choice values in titles and display labels only in choice sections', () => {
+    const draft = compileIssueDraft(config, { rating: 5, choice: 'azure', detail: '' });
+
+    expect(draft.title).toBe('Vote — azure —');
+    expect(draft.sections.find(section => section.heading === 'Choice')?.value).toBe(
+      'Microsoft Azure'
+    );
   });
 
   it('validates required, choice, rating, unknown-answer, and context boundaries', () => {
@@ -103,5 +141,32 @@ describe('variant Issue draft compilation', () => {
     });
 
     expect(draft.title).toHaveLength(256);
+  });
+
+  it('composes the exact compact-suggestion draft from existing text primitives', () => {
+    expect(
+      compileIssueDraft(compactSuggestionConfig, {
+        summary: '  Add keyboard shortcuts  ',
+        detail: '  They would speed up repeated triage.  ',
+      })
+    ).toEqual({
+      title: '[Idea] Add keyboard shortcuts',
+      classification: 'feature',
+      sections: [
+        { heading: 'Idea', value: 'Add keyboard shortcuts', format: 'text' },
+        {
+          heading: 'Why it would help',
+          value: 'They would speed up repeated triage.',
+          format: 'text',
+        },
+      ],
+    });
+
+    expect(
+      compileIssueDraft(compactSuggestionConfig, {
+        summary: 'Keep the form small',
+        detail: '   ',
+      }).sections
+    ).toEqual([{ heading: 'Idea', value: 'Keep the form small', format: 'text' }]);
   });
 });

--- a/test/variantManager.test.ts
+++ b/test/variantManager.test.ts
@@ -22,6 +22,25 @@ const modalConfig: VariantConfig = {
   issue: { title: 'Provider {{response}}' },
 };
 
+const pollConfig: VariantConfig = {
+  id: 'integration-poll',
+  presentation: { kind: 'inline' },
+  content: { title: 'Pick one' },
+  fields: [
+    {
+      id: 'choice',
+      type: 'singleChoice',
+      label: 'Choice',
+      required: true,
+      options: [
+        { value: 'one', label: 'One' },
+        { value: 'two', label: 'Two' },
+      ],
+    },
+  ],
+  issue: { title: 'Choice {{choice}}' },
+};
+
 describe('rendered variant manager', () => {
   beforeEach(() => {
     document.body.replaceChildren();
@@ -90,6 +109,29 @@ describe('rendered variant manager', () => {
         ?.shadowRoot?.querySelector('[aria-checked="true"]')
         ?.getAttribute('aria-label')
     ).toBe('5 stars');
+  });
+
+  it('restores and disposes single-choice controller state through the mounted handle', () => {
+    const manager = createVariantManager({ repo: 'owner/repo', apiUrl: '/api' });
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const mounted = manager
+      .register(pollConfig)
+      .mount(target, { initialAnswers: { choice: 'two' } });
+    const host = target.querySelector<HTMLElement>('[data-bugdrop-owned]');
+    const radios = Array.from(
+      host?.shadowRoot?.querySelectorAll<HTMLInputElement>('input[type="radio"]') ?? []
+    );
+
+    expect(radios[1]?.checked).toBe(true);
+    radios[0]?.click();
+    expect(radios[0]?.checked).toBe(true);
+    mounted.reset();
+    expect(radios[1]?.checked).toBe(true);
+    mounted.unmount();
+    mounted.reset();
+    mounted.unmount();
+    expect(target.childElementCount).toBe(0);
   });
 
   it('rejects modal mount and unknown initial answers without leaking a host', () => {

--- a/test/variantPublicTypes.test.ts
+++ b/test/variantPublicTypes.test.ts
@@ -10,11 +10,30 @@ import type {
   VariantHandle,
 } from '../src/widget/public-api';
 
+const compactSuggestion = {
+  id: 'compact-suggestion',
+  presentation: { kind: 'modal', size: 'default' },
+  content: { title: 'Share an idea', submitLabel: 'Submit idea' },
+  fields: [
+    { id: 'summary', type: 'shortText', label: 'Idea', required: true, maxLength: 120 },
+    { id: 'detail', type: 'longText', label: 'How would this help?', maxLength: 2_000 },
+  ],
+  issue: {
+    classification: 'feature',
+    title: '[Idea] {{summary}}',
+    sections: [
+      { heading: 'Idea', field: 'summary' },
+      { heading: 'Why it would help', field: 'detail', omitWhenEmpty: true },
+    ],
+  },
+} satisfies VariantConfig;
+
 describe('published variant API declarations', () => {
   it('type-checks registration and headless submission without runtime imports', () => {
     expectTypeOf<BugDropPublicAPI['registerVariant']>().parameter(0).toMatchTypeOf<VariantConfig>();
     expectTypeOf<ReturnType<BugDropPublicAPI['registerVariant']>>().toEqualTypeOf<VariantHandle>();
     expectTypeOf<ReturnType<VariantHandle['submit']>>().toEqualTypeOf<Promise<SubmissionResult>>();
+    expect(compactSuggestion.id).toBe('compact-suggestion');
     expect(true).toBe(true);
   });
 
@@ -41,7 +60,7 @@ describe('published variant API declarations', () => {
           "import type { VariantHandle } from 'bugdrop/widget';",
           "import type { SubmissionResult } from 'bugdrop/widget.js';",
           'declare const api: BugDropPublicAPI;',
-          'declare const config: VariantConfig;',
+          `const config = ${JSON.stringify(compactSuggestion)} satisfies VariantConfig;`,
           'const handle: VariantHandle = api.registerVariant(config);',
           'const result: Promise<SubmissionResult> = handle.submit({});',
           'void result;',


### PR DESCRIPTION
## Summary

- add an accessible single-choice field with radio, card, and button layouts
- ship reusable inline poll and compact suggestion compositions through the existing GitHub-native structured submission path
- add shared field conformance, multi-instance isolation, reset/disposal, exact-draft, and contributor documentation coverage
- preserve the legacy widget and Phase 2 APIs while retaining one representative real-Issue canary per merge group

## Verification

- npm run validate (72 files, 1,021 tests)
- make check (19 release files, 418 tests; lint, format, typecheck, audit, and workflow contracts)
- widget gzip: 52,589 <= 52,597 bytes
- legacy compatibility fixtures: v1.1.0 and v1.53.1
- 8 local inline/modal UX tests with zero retries
- 2 focused multi-instance/legacy isolation tests with zero retries
- 30 Chromium/Firefox/WebKit Radix and accessibility tests with zero retries
- 4 pinned-byte rendered variant tests with intercepted submissions
- 12 pinned-byte cross-browser live-smoke tests with intercepted submissions

## Merge-tip proof

The merge queue preview job verifies exact deployed widget bytes and Worker identity, exercises every retained/new UX, then runs one screenshot-free real-Issue canary through the existing GitHub App. The verifier independently checks the Issue, closes it, and proves no matching Issues remain open.