### PR TITLE
docs: expose public service status

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ the live page after testing to restore its original widget and `fetch` implement
 ## Documentation
 
 - [Full Documentation](https://bugdrop.dev/docs)
+- [Service Status](https://bugdrop.dev/status)
 - [Built with BugDrop Showcase](https://bugdrop.dev/showcase)
 - [GitHub Marketplace](https://github.com/marketplace/bugdrop-in-app-feedback-to-github-issues)
 - [Configuration](https://bugdrop.dev/docs/configuration)
@@ -163,8 +164,10 @@ the complete path from the browser to Cloudflare, the GitHub App, and the result
 
 This coverage has grown from pre-merge preview validation into scheduled production verification.
 We will keep turning new failure modes and operational lessons into repeatable checks, with public
-workflow history as evidence. Inspect the [merge-queue checks](https://github.com/mean-weasel/bugdrop/actions/workflows/ci.yml)
-and [production heartbeat](https://github.com/mean-weasel/bugdrop/actions/workflows/production-heartbeat.yml),
+workflow history as evidence. View the current component health and incident history on the
+[public service status page](https://bugdrop.dev/status). Inspect the
+[merge-queue checks](https://github.com/mean-weasel/bugdrop/actions/workflows/ci.yml) and
+[production heartbeat](https://github.com/mean-weasel/bugdrop/actions/workflows/production-heartbeat.yml),
 or read the detailed [preview canary](docs/merge-queue-issue-canary.md) and
 [production heartbeat](docs/production-heartbeat.md) designs.
 


### PR DESCRIPTION
## Summary

- add the public service-status page to the README documentation links
- connect the reliability overview to current component health and incident history
- retain the existing Status links already live in the website navigation and footer

## Verification

- `npm run format:check -- README.md`
- pre-push TypeScript checks
- `git diff --check`
- confirmed `https://bugdrop.dev/status` returns HTTP 200
- confirmed the live homepage renders two `/status` links (navigation and footer)
- PR review toolkit: no high-confidence issues found

## Burden of proof

The strongest realistic failure mode was directing users to a missing page or failing to cover the requested website placement. The live status endpoint returned HTTP 200, and the rendered homepage contains two status links, confirming that the navigation and footer placements are already deployed.