### PR TITLE
feat: add verifiable release attestations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -664,9 +664,97 @@ jobs:
     secrets:
       VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
+  attest-release:
+    name: Attest exact immutable Release subjects
+    if: ${{ needs.approval-baseline.outputs.proceed == 'true' }}
+    needs: [guard-and-plan, verify-candidate, approval-baseline, deploy-candidate, live-e2e]
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    outputs:
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+    steps:
+      - name: Checkout immutable controller
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.guard-and-plan.outputs.controller_sha }}
+          path: controller
+          persist-credentials: false
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: '22'
+
+      - name: Install immutable controller without lifecycle scripts
+        run: npm --prefix controller ci --ignore-scripts
+
+      - name: Download exact approved State 2 artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          artifact-ids: ${{ needs.verify-candidate.outputs.artifact_id }}
+          path: approved
+
+      - name: Materialize exactly six authenticated subjects without rebuilding
+        shell: bash
+        run: |
+          jq -n \
+            --arg bundlePath "$GITHUB_WORKSPACE/approved/state2-bundle.json" \
+            --arg outputDir "$RUNNER_TEMP/release-subjects" \
+            '{$bundlePath, $outputDir}' > attestation-stage-input.json
+          node controller/scripts/release/attestation.mjs stage attestation-stage-input.json \
+            > attestation-subjects.json
+          test "$(jq -er '.subjects | length' attestation-subjects.json)" = '6'
+          jq -r '.subjects[] | "\(.digest.sha256)  \(.name)"' attestation-subjects.json \
+            > "$RUNNER_TEMP/attestation-subjects.sha256"
+
+      - name: Create hosted provenance for the exact subjects
+        id: attest
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        with:
+          subject-checksums: ${{ runner.temp }}/attestation-subjects.sha256
+
+      - name: Authenticate portable evidence under pinned identity policy
+        shell: bash
+        env:
+          BUGDROP_GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          install -d attestation-evidence
+          cp '${{ steps.attest.outputs.bundle-path }}' \
+            attestation-evidence/attestation.intoto.jsonl
+          jq -n \
+            --arg bundlePath "$GITHUB_WORKSPACE/approved/state2-bundle.json" \
+            --arg attestationPath "$GITHUB_WORKSPACE/attestation-evidence/attestation.intoto.jsonl" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg controllerSha '${{ needs.guard-and-plan.outputs.controller_sha }}' \
+            '{$bundlePath, $attestationPath, $repository, $controllerSha}' \
+            > attestation-verify-input.json
+          node controller/scripts/release/attestation.mjs verify attestation-verify-input.json \
+            > attestation-evidence/attestation-verification.json
+          test "$(jq -er '.status' attestation-evidence/attestation-verification.json)" = 'verified'
+
+      - name: Upload exact portable attestation evidence
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-attestation-${{ needs.verify-candidate.outputs.plan_key }}
+          path: attestation-evidence/
+          if-no-files-found: error
+          retention-days: 30
+
   publish-release:
     name: Publish exact authenticated GitHub Release
-    needs: [guard-and-plan, verify-candidate, approval-baseline, deploy-candidate, live-e2e]
+    needs:
+      [
+        guard-and-plan,
+        verify-candidate,
+        approval-baseline,
+        deploy-candidate,
+        live-e2e,
+        attest-release,
+      ]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: production
@@ -690,10 +778,10 @@ jobs:
       - name: Install immutable controller without lifecycle scripts
         run: npm --prefix controller ci --ignore-scripts
 
-      - name: Download exact State 2 and approved authorization
+      - name: Download exact State 2, authorization, and attestation evidence
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
-          artifact-ids: ${{ needs.verify-candidate.outputs.artifact_id }},${{ needs.approval-baseline.outputs.artifact_id }}
+          artifact-ids: ${{ needs.verify-candidate.outputs.artifact_id }},${{ needs.approval-baseline.outputs.artifact_id }},${{ needs.attest-release.outputs.artifact_id }}
           path: release-state
           merge-multiple: true
 
@@ -706,8 +794,11 @@ jobs:
           jq -n \
             --arg bundlePath "$GITHUB_WORKSPACE/release-state/state2-bundle.json" \
             --arg authorizationPath "$GITHUB_WORKSPACE/release-state/authorization.json" \
+            --arg attestationPath "$GITHUB_WORKSPACE/release-state/attestation.intoto.jsonl" \
+            --arg controllerSha '${{ needs.guard-and-plan.outputs.controller_sha }}' \
             --arg repository "$GITHUB_REPOSITORY" \
-            '{$bundlePath, $authorizationPath, $repository}' > publication-input.json
+            '{$bundlePath, $authorizationPath, $attestationPath, $controllerSha, $repository}' \
+            > publication-input.json
           node controller/scripts/release/live-release.mjs publish publication-input.json > publication.json
           status=$(jq -er '.status' publication.json)
           if [ "$status" = 'published' ]; then
@@ -754,6 +845,7 @@ jobs:
         approval-baseline,
         deploy-candidate,
         live-e2e,
+        attest-release,
         publish-release,
         notify,
       ]
@@ -805,6 +897,13 @@ jobs:
           name: release-deployment-${{ needs.verify-candidate.outputs.plan_key }}
           path: release-state
 
+      - name: Download exact attestation evidence when created
+        if: ${{ needs.deploy-candidate.result != 'skipped' && needs.attest-release.result == 'success' }}
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          artifact-ids: ${{ needs.attest-release.outputs.artifact_id }}
+          path: release-state
+
       - name: Stage exact static package below candidate trust root
         if: ${{ needs.deploy-candidate.result != 'skipped' }}
         run: |
@@ -849,8 +948,11 @@ jobs:
             --arg baselinePath "$GITHUB_WORKSPACE/release-state/baseline.json" \
             --arg deploymentPath "$GITHUB_WORKSPACE/release-state/deployment.json" \
             --arg bundlePath "$GITHUB_WORKSPACE/release-state/state2-bundle.json" \
+            --arg controllerSha '${{ needs.guard-and-plan.outputs.controller_sha }}' \
             --arg repository "$GITHUB_REPOSITORY" \
-            '{$controllerRoot, $candidateRoot, $controllerConfig, $controllerLock, $candidateEntrypoint, $candidateAssets, $targetSha, $expectedPath, $baselinePath, $deploymentPath, $bundlePath, $repository}' \
+            --arg attestationPath "$GITHUB_WORKSPACE/release-state/attestation.intoto.jsonl" \
+            --argjson hasAttestation "$(test -s release-state/attestation.intoto.jsonl && echo true || echo false)" \
+            '{$controllerRoot, $candidateRoot, $controllerConfig, $controllerLock, $candidateEntrypoint, $candidateAssets, $targetSha, $expectedPath, $baselinePath, $deploymentPath, $bundlePath, $controllerSha, $repository} + (if $hasAttestation then {$attestationPath} else {} end)' \
             > finalize-input.json
           node controller/scripts/release/live-release.mjs finalize finalize-input.json > finalization.json
           status=$(jq -er '.status' finalization.json)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -158,6 +158,7 @@ available 14-day workflow artifacts:
 - `request-plan-<request-key>` and `release-plan-<plan-key>`
 - `release-baseline-<plan-key>`
 - `release-deployment-<plan-key>`
+- `release-attestation-<plan-key>` (30-day portable bundle and verification receipt)
 - `release-publication-<plan-key>`
 - finalization status and GitHub job summary
 
@@ -165,6 +166,71 @@ For a completed live release, also record the GitHub Release URL and asset check
 version/build identity, production live-test result, `versions.json` digest, exact widget digest, and
 notification outcome. For recovery, retain raw artifacts and record every observation separately from
 every command attempted.
+
+## Release provenance
+
+A live release publishes seven assets. Six immutable content assets are provenance subjects: the
+exact-version widget, `versions.json`, `request-plan.json`, `release-content.json`,
+`final-release-plan.json`, and `checksums.sha256`. `attestation.intoto.jsonl` is the seventh,
+evidence-only asset. It is intentionally outside the checksum and subject sets so the signed bundle
+never refers to itself. Mutable Cloudflare aliases, retained historical files, rebuilt output, and
+Actions artifact ZIPs are never attested.
+
+After protected approval and successful production tests, the isolated `attest-release` job
+materializes those six files directly from the exact State 2 artifact, creates one GitHub-hosted SLSA
+provenance statement, verifies the portable bundle, and uploads it under an exact artifact ID. The
+job has only `contents: read`, `id-token: write`, and `attestations: write`. The later publication job
+has `contents: write` but no OIDC or attestation authority, downloads that exact artifact ID, repeats
+verification, and publishes the same bytes. Dry runs and authenticated completed-plan no-ops cannot
+reach the attestation job.
+
+To verify a downloaded release, first run `sha256sum -c checksums.sha256`. Read the immutable
+controller SHA from `request-plan.json` at `.source.controllerSha`. While still online, acquire the
+current trusted roots and preserve their checksum with the downloaded Release evidence:
+
+```bash
+gh attestation trusted-root > trusted_root.jsonl
+sha256sum trusted_root.jsonl > trusted_root.jsonl.sha256
+```
+
+Obtain the trusted root through a separately trusted online channel when the Release download itself
+is under investigation. After preserving it, verify each of the six subjects online:
+
+```bash
+gh attestation verify <subject> \
+  --repo mean-weasel/bugdrop \
+  --signer-workflow mean-weasel/bugdrop/.github/workflows/deploy.yml \
+  --signer-digest <controller-sha> \
+  --source-digest <controller-sha> \
+  --source-ref refs/heads/main \
+  --cert-oidc-issuer https://token.actions.githubusercontent.com \
+  --deny-self-hosted-runners
+
+```
+
+For genuinely offline verification, disconnect the verifier from the network, check the preserved
+trusted-root checksum, and verify the portable bundle without an API lookup:
+
+```bash
+sha256sum -c trusted_root.jsonl.sha256
+gh attestation verify <subject> \
+  --bundle attestation.intoto.jsonl \
+  --custom-trusted-root trusted_root.jsonl \
+  --repo mean-weasel/bugdrop \
+  --signer-workflow mean-weasel/bugdrop/.github/workflows/deploy.yml \
+  --signer-digest <controller-sha> \
+  --source-digest <controller-sha> \
+  --source-ref refs/heads/main \
+  --cert-oidc-issuer https://token.actions.githubusercontent.com \
+  --deny-self-hosted-runners
+```
+
+Verification must return one unambiguous SLSA statement whose subject set is exactly those six
+files. A missing bundle, missing or extra subject, identity-policy mismatch, unexpected eighth
+Release asset, or one-byte change stops publication. If attestation fails after deployment,
+publication remains skipped and finalization reinspects GitHub before restoring the captured
+production baseline. Never delete, replace, or hand-repair a partial Release; preserve its evidence
+and use the reviewed reset-and-replay procedure.
 
 ## Retention
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -263,10 +263,12 @@ assert_exact_attestation offline-verification.json
 Either procedure fails for zero or multiple matching attestations, missing or extra subjects,
 name/digest disagreement, an unverified or changed local subject byte, an identity-policy mismatch,
 or an invalid signature. A missing bundle, unexpected eighth Release asset, or one-byte change stops
-publication. If attestation fails after deployment,
-publication remains skipped and finalization reinspects GitHub before restoring the captured
-production baseline. Never delete, replace, or hand-repair a partial Release; preserve its evidence
-and use the reviewed reset-and-replay procedure.
+publication. After the attestation rollout boundary, missing evidence or verifier failure becomes a
+preinspection publication conflict: GitHub is not inspected because its publication evidence has not
+been authenticated. Finalization still inspects the active Cloudflare candidate and restores and
+verifies the captured production baseline. GitHub is re-inspected only when attestation authentication
+succeeds and the publication-inspection path actually runs. Never delete, replace, or hand-repair a
+partial Release; preserve its evidence and use the reviewed reset-and-replay procedure.
 
 ## Retention
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -184,50 +184,86 @@ has `contents: write` but no OIDC or attestation authority, downloads that exact
 verification, and publishes the same bytes. Dry runs and authenticated completed-plan no-ops cannot
 reach the attestation job.
 
-To verify a downloaded release, first run `sha256sum -c checksums.sha256`. Read the immutable
-controller SHA from `request-plan.json` at `.source.controllerSha`. While still online, acquire the
-current trusted roots and preserve their checksum with the downloaded Release evidence:
+Run the following from a directory containing the seven downloaded Release assets. It hashes every
+local subject byte (including `checksums.sha256` itself), verifies the checksum manifest, applies the
+complete identity policy, requires exactly one matching signed statement, and compares its exact six
+name/digest pairs with the local files:
 
 ```bash
+set -euo pipefail
+
+controller_sha=$(jq -er '.source.controllerSha | select(test("^[0-9a-f]{40}$"))' request-plan.json)
+tag=$(jq -er '.tag | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))' final-release-plan.json)
+widget="widget.${tag}.js"
+subjects=(
+  checksums.sha256
+  final-release-plan.json
+  release-content.json
+  request-plan.json
+  versions.json
+  "$widget"
+)
+for subject in "${subjects[@]}"; do test -f "$subject"; done
+sha256sum -c checksums.sha256
+LC_ALL=C sha256sum -- "${subjects[@]}" | LC_ALL=C sort -k2 > local-subjects.sha256
+
+identity_policy=(
+  --repo mean-weasel/bugdrop
+  --signer-workflow mean-weasel/bugdrop/.github/workflows/deploy.yml
+  --signer-digest "$controller_sha"
+  --source-digest "$controller_sha"
+  --source-ref refs/heads/main
+  --cert-oidc-issuer https://token.actions.githubusercontent.com
+  --deny-self-hosted-runners
+)
+
+assert_exact_attestation() {
+  local result=$1
+  jq -e '
+    type == "array" and length == 1 and
+    .[0].verificationResult.statement._type == "https://in-toto.io/Statement/v1" and
+    .[0].verificationResult.statement.predicateType == "https://slsa.dev/provenance/v1" and
+    (.[0].verificationResult.statement.subject | type == "array" and length == 6) and
+    all(.[0].verificationResult.statement.subject[];
+      (.name | type == "string") and
+      (.digest | type == "object" and keys == ["sha256"]) and
+      (.digest.sha256 | test("^[0-9a-f]{64}$")))
+  ' "$result" >/dev/null
+  jq -r '.[0].verificationResult.statement.subject[] |
+    "\(.digest.sha256)  \(.name)"' "$result" |
+    LC_ALL=C sort -k2 > "${result}.subjects.sha256"
+  diff -u local-subjects.sha256 "${result}.subjects.sha256"
+}
+
+gh attestation verify "$widget" "${identity_policy[@]}" --format json > online-verification.json
+assert_exact_attestation online-verification.json
+
+# Still online: acquire current roots, then preserve these files through a trusted channel.
 gh attestation trusted-root > trusted_root.jsonl
 sha256sum trusted_root.jsonl > trusted_root.jsonl.sha256
 ```
 
 Obtain the trusted root through a separately trusted online channel when the Release download itself
-is under investigation. After preserving it, verify each of the six subjects online:
-
-```bash
-gh attestation verify <subject> \
-  --repo mean-weasel/bugdrop \
-  --signer-workflow mean-weasel/bugdrop/.github/workflows/deploy.yml \
-  --signer-digest <controller-sha> \
-  --source-digest <controller-sha> \
-  --source-ref refs/heads/main \
-  --cert-oidc-issuer https://token.actions.githubusercontent.com \
-  --deny-self-hosted-runners
-
-```
-
-For genuinely offline verification, disconnect the verifier from the network, check the preserved
-trusted-root checksum, and verify the portable bundle without an API lookup:
+is under investigation. For genuinely offline verification, preserve the Release assets,
+`local-subjects.sha256`, the function and identity variables from above, and the trusted-root files;
+disconnect the verifier from the network; then run:
 
 ```bash
 sha256sum -c trusted_root.jsonl.sha256
-gh attestation verify <subject> \
+LC_ALL=C sha256sum -- "${subjects[@]}" | LC_ALL=C sort -k2 |
+  diff -u local-subjects.sha256 -
+gh attestation verify "$widget" \
   --bundle attestation.intoto.jsonl \
   --custom-trusted-root trusted_root.jsonl \
-  --repo mean-weasel/bugdrop \
-  --signer-workflow mean-weasel/bugdrop/.github/workflows/deploy.yml \
-  --signer-digest <controller-sha> \
-  --source-digest <controller-sha> \
-  --source-ref refs/heads/main \
-  --cert-oidc-issuer https://token.actions.githubusercontent.com \
-  --deny-self-hosted-runners
+  "${identity_policy[@]}" \
+  --format json > offline-verification.json
+assert_exact_attestation offline-verification.json
 ```
 
-Verification must return one unambiguous SLSA statement whose subject set is exactly those six
-files. A missing bundle, missing or extra subject, identity-policy mismatch, unexpected eighth
-Release asset, or one-byte change stops publication. If attestation fails after deployment,
+Either procedure fails for zero or multiple matching attestations, missing or extra subjects,
+name/digest disagreement, an unverified or changed local subject byte, an identity-policy mismatch,
+or an invalid signature. A missing bundle, unexpected eighth Release asset, or one-byte change stops
+publication. If attestation fails after deployment,
 publication remains skipped and finalization reinspects GitHub before restoring the captured
 production baseline. Never delete, replace, or hand-repair a partial Release; preserve its evidence
 and use the reviewed reset-and-replay procedure.

--- a/scripts/check-github-actions.mjs
+++ b/scripts/check-github-actions.mjs
@@ -6,6 +6,7 @@ const workflowRoot = resolve(process.argv[2] ?? '.github/workflows');
 const workflowFiles = (await readdir(workflowRoot)).filter(file => /\.ya?ml$/.test(file)).sort();
 
 const minimumMajor = new Map([
+  ['actions/attest', 4],
   ['actions/cache', 5],
   ['actions/cache/restore', 5],
   ['actions/cache/save', 5],
@@ -19,6 +20,7 @@ const minimumMajor = new Map([
 ]);
 
 const approvedReleases = new Map([
+  ['actions/attest@a1948c3f048ba23858d222213b7c278aabede763', 'v4.1.1'],
   ['actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9', 'v6.1.0'],
   ['actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9', 'v6.1.0'],
   ['actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25', 'v5.1.0'],

--- a/scripts/check-workflow-permissions.mjs
+++ b/scripts/check-workflow-permissions.mjs
@@ -28,6 +28,7 @@ const denyByDefaultJobs = new Map([
   ['ci.yml:test', { contents: 'read' }],
   ['codeql.yml:analyze', { contents: 'read', 'security-events': 'write' }],
   ['dependency-review.yml:dependency-review', { contents: 'read' }],
+  ['deploy.yml:attest-release', { attestations: 'write', contents: 'read', 'id-token': 'write' }],
   ['live-tests.yml:live-tests', { contents: 'read' }],
   ['sync-docs.yml:sync', { contents: 'read' }],
 ]);
@@ -36,6 +37,8 @@ const allowedWrites = new Set([
   'ci.yml:coverage:id-token',
   'codeql.yml:analyze:security-events',
   'deploy.yml:publish-release:contents',
+  'deploy.yml:attest-release:attestations',
+  'deploy.yml:attest-release:id-token',
   'production-heartbeat.yml:incident:issues',
 ]);
 

--- a/scripts/release/attestation.mjs
+++ b/scripts/release/attestation.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { execFile as execFileCallback } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+import { canonicalize, compareUtf8 } from './canonical-json.mjs';
+import { validatePublicationBundle } from './publication.mjs';
+
+export const ATTESTATION_ASSET = 'attestation.intoto.jsonl';
+export const SLSA_PROVENANCE = 'https://slsa.dev/provenance/v1';
+const SHA = /^[0-9a-f]{40}$/;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const SOURCE_REF = 'refs/heads/main';
+const OIDC_ISSUER = 'https://token.actions.githubusercontent.com';
+const execFile = promisify(execFileCallback);
+const sha256 = bytes => createHash('sha256').update(bytes).digest('hex');
+
+export class AttestationError extends Error {
+  constructor(code, message) {
+    super(`${code}: ${message}`);
+    Object.assign(this, { code, name: 'AttestationError' });
+  }
+}
+
+function fail(code, message) {
+  throw new AttestationError(code, message);
+}
+
+function bytes(value, field) {
+  if (!Buffer.isBuffer(value)) fail('INVALID_ATTESTATION_INPUT', `${field} must be bytes`);
+  return value;
+}
+
+export function attestationPolicy({ repository, controllerSha }) {
+  if (!REPOSITORY.test(repository ?? '') || !SHA.test(controllerSha ?? '')) {
+    fail('INVALID_ATTESTATION_POLICY', 'repository and controller SHA are required');
+  }
+  return {
+    repository,
+    signerWorkflow: `${repository}/.github/workflows/deploy.yml`,
+    signerDigest: controllerSha,
+    sourceDigest: controllerSha,
+    sourceRef: SOURCE_REF,
+    certOidcIssuer: OIDC_ISSUER,
+    denySelfHostedRunners: true,
+  };
+}
+
+export function attestationSubjects(rawBundle) {
+  const bundle = hydratedBundle(rawBundle);
+  const expected = validatePublicationBundle(bundle, { allowLegacy: true });
+  if (expected.requiredAssets.length !== 6) {
+    fail('INVALID_ATTESTATION_SUBJECTS', 'State 2 must contain exactly six subjects');
+  }
+  return expected.requiredAssets
+    .map(name => ({ name, digest: { sha256: sha256(bytes(expected.assets[name], name)) } }))
+    .sort((left, right) => compareUtf8(left.name, right.name));
+}
+
+function hydratedBundle(bundle) {
+  if (!bundle?.assets) return bundle;
+  return {
+    ...bundle,
+    assets: Object.fromEntries(
+      Object.entries(bundle.assets).map(([name, value]) => [
+        name,
+        Buffer.isBuffer(value) ? value : Buffer.from(value?.base64 ?? '', 'base64'),
+      ])
+    ),
+  };
+}
+
+function statementFromBundle(record) {
+  const payload = record?.dsseEnvelope?.payload;
+  if (typeof payload !== 'string') fail('INVALID_ATTESTATION', 'DSSE payload is missing');
+  let statement;
+  try {
+    statement = JSON.parse(Buffer.from(payload, 'base64').toString('utf8'));
+  } catch {
+    fail('INVALID_ATTESTATION', 'DSSE payload is not valid JSON');
+  }
+  return statement;
+}
+
+function exactSubjects(statement, subjects) {
+  const actual = [...(statement?.subject ?? [])]
+    .map(subject => ({ name: subject?.name, digest: subject?.digest }))
+    .sort((left, right) => compareUtf8(left.name ?? '', right.name ?? ''));
+  return (
+    statement?._type === 'https://in-toto.io/Statement/v1' &&
+    statement.predicateType === SLSA_PROVENANCE &&
+    canonicalize(actual) === canonicalize(subjects)
+  );
+}
+
+export function inspectPortableAttestation(attestationBytes, subjects) {
+  const text = bytes(attestationBytes, ATTESTATION_ASSET).toString('utf8');
+  const lines = text.split('\n').filter(Boolean);
+  if (lines.length !== 1 || !text.endsWith('\n')) {
+    fail('INVALID_ATTESTATION', 'portable evidence must be one newline-terminated bundle');
+  }
+  let record;
+  try {
+    record = JSON.parse(lines[0]);
+  } catch {
+    fail('INVALID_ATTESTATION', 'portable evidence is not JSON lines');
+  }
+  if (!exactSubjects(statementFromBundle(record), subjects)) {
+    fail('INVALID_ATTESTATION', 'portable evidence does not bind the exact six subjects');
+  }
+  return { bundleSha256: sha256(attestationBytes), subjects };
+}
+
+function verifierArgs(subjectPath, bundlePath, policy) {
+  return [
+    'attestation',
+    'verify',
+    subjectPath,
+    '--bundle',
+    bundlePath,
+    '--repo',
+    policy.repository,
+    '--signer-workflow',
+    policy.signerWorkflow,
+    '--signer-digest',
+    policy.signerDigest,
+    '--source-digest',
+    policy.sourceDigest,
+    '--source-ref',
+    policy.sourceRef,
+    '--cert-oidc-issuer',
+    policy.certOidcIssuer,
+    '--deny-self-hosted-runners',
+    '--predicate-type',
+    SLSA_PROVENANCE,
+    '--format',
+    'json',
+  ];
+}
+
+async function defaultRunVerifier(args, env) {
+  const result = await execFile('gh', args, { env, maxBuffer: 16 * 1024 * 1024 });
+  return result.stdout;
+}
+
+export async function verifyPortableAttestation({
+  bundle: rawBundle,
+  attestationBytes,
+  policy,
+  runVerifier = defaultRunVerifier,
+  token = process.env.BUGDROP_GITHUB_TOKEN,
+}) {
+  const bundle = hydratedBundle(rawBundle);
+  const subjects = attestationSubjects(bundle);
+  const inspected = inspectPortableAttestation(attestationBytes, subjects);
+  const root = await mkdtemp(join(tmpdir(), 'bugdrop-attestation-'));
+  try {
+    const bundlePath = join(root, ATTESTATION_ASSET);
+    await writeFile(bundlePath, attestationBytes, { mode: 0o600 });
+    for (const subject of subjects) {
+      const subjectPath = join(root, basename(subject.name));
+      await writeFile(subjectPath, bundle.assets[subject.name], { mode: 0o600 });
+      let output;
+      try {
+        output = await runVerifier(verifierArgs(subjectPath, bundlePath, policy), {
+          ...process.env,
+          ...(token ? { GH_TOKEN: token } : {}),
+        });
+      } catch {
+        fail('ATTESTATION_VERIFICATION_FAILED', `GitHub rejected ${subject.name}`);
+      }
+      let results;
+      try {
+        results = JSON.parse(output);
+      } catch {
+        fail('ATTESTATION_VERIFICATION_FAILED', 'GitHub verifier output is not JSON');
+      }
+      if (
+        !Array.isArray(results) ||
+        results.length !== 1 ||
+        !exactSubjects(results[0]?.verificationResult?.statement, subjects)
+      ) {
+        fail('ATTESTATION_VERIFICATION_FAILED', 'GitHub verifier returned ambiguous provenance');
+      }
+    }
+    return {
+      protocol: 'bugdrop.release-attestation/v1',
+      status: 'verified',
+      asset: ATTESTATION_ASSET,
+      bundleSha256: inspected.bundleSha256,
+      policy,
+      subjects,
+    };
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+export async function stageAttestationSubjects({ bundle: rawBundle, outputDir }) {
+  const bundle = hydratedBundle(rawBundle);
+  const subjects = attestationSubjects(bundle);
+  await mkdir(outputDir, { recursive: false });
+  for (const subject of subjects)
+    await writeFile(join(outputDir, subject.name), bundle.assets[subject.name]);
+  return subjects;
+}
+
+async function runCli() {
+  const [mode, inputPath] = process.argv.slice(2);
+  if (!['stage', 'verify'].includes(mode) || !inputPath) {
+    fail('INVALID_CLI', 'usage: attestation.mjs stage|verify INPUT.json');
+  }
+  const input = JSON.parse(await readFile(resolve(inputPath), 'utf8'));
+  const bundle = JSON.parse(await readFile(resolve(input.bundlePath), 'utf8'));
+  const output =
+    mode === 'stage'
+      ? {
+          protocol: 'bugdrop.release-attestation/v1',
+          status: 'staged',
+          subjects: await stageAttestationSubjects({ bundle, outputDir: resolve(input.outputDir) }),
+        }
+      : await verifyPortableAttestation({
+          bundle,
+          attestationBytes: await readFile(resolve(input.attestationPath)),
+          policy: attestationPolicy(input),
+        });
+  process.stdout.write(`${canonicalize(output)}\n`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  runCli().catch(error => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release/github-adapter.mjs
+++ b/scripts/release/github-adapter.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { canonicalize, compareUtf8 } from './canonical-json.mjs';
 import { observeGitRange } from './git-observer.mjs';
 import {
+  buildPublicationMarker,
   buildReleaseInventory,
   buildRequestPlan,
   calculateNextTag,
@@ -20,6 +21,7 @@ import {
 import { validatePublicationBundle } from './publication.mjs';
 import { deriveRetentionRequest, writeRetentionInput } from './retention.mjs';
 import { MAX_RETAINED_BYTES, MAX_SNAPSHOT_BYTES, MAX_WIDGET_BYTES } from './limits.mjs';
+import { ATTESTATION_ASSET, attestationPolicy, verifyPortableAttestation } from './attestation.mjs';
 
 const API_VERSION = '2022-11-28';
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
@@ -384,7 +386,7 @@ function validateActiveManifest({
   }
 }
 
-export function authenticatePublishedAssets({ release, assets }) {
+export function authenticatePublishedAssets({ release, assets, attestation }) {
   if (release?.published !== true || release.draft !== false || release.prerelease !== false) {
     fail('PUBLISHED_RELEASE_INVALID', 'completed-plan assets must belong to a stable publication');
   }
@@ -393,7 +395,10 @@ export function authenticatePublishedAssets({ release, assets }) {
   const finalPlan = canonicalAsset(assets, 'final-release-plan.json');
   let expected;
   try {
-    expected = validatePublicationBundle({ requestPlan, releaseContent, finalPlan, assets });
+    expected = validatePublicationBundle(
+      { requestPlan, releaseContent, finalPlan, assets, ...(attestation ? { attestation } : {}) },
+      { allowLegacy: !attestation, requireAttestation: Boolean(attestation) }
+    );
   } catch (error) {
     fail('PUBLISHED_ASSET_INVALID', 'published assets do not authenticate', {
       cause: error instanceof Error ? error.message : String(error),
@@ -412,14 +417,17 @@ export function authenticatePublishedAssets({ release, assets }) {
     requestPlan,
     releaseContent,
     finalPlan,
-    marker: expected.marker,
+    // The planning protocol authenticates its historical marker shape separately. The durable
+    // Release marker (checked above) may additionally require provenance evidence without changing
+    // deterministic State 2 identities.
+    marker: buildPublicationMarker(finalPlan),
     assetVerification: {
       complete: true,
       checksumsMatch: true,
       unexpectedConflicts: false,
       planIdentity: expected.planIdentity,
       contentIdentity: expected.marker.contentIdentity,
-      verifiedAssetNames: expected.requiredAssets,
+      verifiedAssetNames: expected.contentAssets,
     },
     publishedAssets: assets,
   };
@@ -429,6 +437,7 @@ export async function loadPublishedReleaseAssets({
   transport,
   release,
   repository = release?.repository,
+  verifyAttestation = verifyPortableAttestation,
 }) {
   if (!Array.isArray(release?.assets) || release.assets.length === 0) {
     fail('PUBLISHED_ASSET_MISSING', 'published Release has no inspectable assets');
@@ -463,7 +472,38 @@ export async function loadPublishedReleaseAssets({
     });
     budget.used += assets[asset.name].length;
   }
-  return authenticatePublishedAssets({ release, assets });
+  if (!Object.hasOwn(assets, ATTESTATION_ASSET)) {
+    return authenticatePublishedAssets({ release, assets });
+  }
+  const coreAssets = { ...assets };
+  const attestationBytes = coreAssets[ATTESTATION_ASSET];
+  delete coreAssets[ATTESTATION_ASSET];
+  const coreFinalPlan = canonicalAsset(coreAssets, 'final-release-plan.json');
+  const core = authenticatePublishedAssets({
+    release: { ...release, marker: buildPublicationMarker(coreFinalPlan) },
+    assets: coreAssets,
+  });
+  let attestation;
+  try {
+    attestation = await verifyAttestation({
+      bundle: {
+        requestPlan: core.requestPlan,
+        releaseContent: core.releaseContent,
+        finalPlan: core.finalPlan,
+        assets: coreAssets,
+      },
+      attestationBytes,
+      policy: attestationPolicy({
+        repository,
+        controllerSha: core.requestPlan.source.controllerSha,
+      }),
+    });
+  } catch (error) {
+    fail('PUBLISHED_ASSET_INVALID', 'published attestation does not authenticate', {
+      cause: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return authenticatePublishedAssets({ release, assets, attestation });
 }
 
 function tagName(ref) {
@@ -618,6 +658,7 @@ export async function createRequestPlanFromGithub({
   transport,
   context,
   gitObserver = observeGitRange,
+  verifyAttestation,
 }) {
   const dispatch = normalizeDispatch({
     ...context?.dispatch,
@@ -666,6 +707,7 @@ export async function createRequestPlanFromGithub({
     const hydrated = await loadPublishedReleaseAssets({
       transport,
       release: exactPublished[0],
+      ...(verifyAttestation ? { verifyAttestation } : {}),
     });
     const completed = findCompletedPlan({
       dispatch,
@@ -740,6 +782,7 @@ export async function createRequestPlanFromGithub({
       transport,
       release,
       repository: dispatch.repository,
+      ...(verifyAttestation ? { verifyAttestation } : {}),
     });
     if (hydrated.requestPlan.protocol !== 'release-plan/v2') {
       fail('PUBLISHED_ASSET_INVALID', `${release.tag} v2 marker does not authenticate v2 assets`);

--- a/scripts/release/github-adapter.mjs
+++ b/scripts/release/github-adapter.mjs
@@ -8,6 +8,8 @@ import { fileURLToPath } from 'node:url';
 import { canonicalize, compareUtf8 } from './canonical-json.mjs';
 import { observeGitRange } from './git-observer.mjs';
 import {
+  RELEASE_PROTOCOL,
+  RELEASE_PROTOCOL_V2,
   buildPublicationMarker,
   buildReleaseInventory,
   buildRequestPlan,
@@ -27,6 +29,8 @@ const API_VERSION = '2022-11-28';
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const TAG_PATTERN = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
+const IDENTITY_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const MARKERLESS_HISTORY_MAX_TAG = 'v1.55.0';
 const ASSET_TIMEOUT_MS = 30_000;
 const sha256Bytes = bytes => createHash('sha256').update(bytes).digest('hex');
 
@@ -55,6 +59,9 @@ function assertInput(repository, targetSha) {
 }
 
 function compareReleaseTags(left, right) {
+  if (!TAG_PATTERN.test(left?.tag ?? '') || !TAG_PATTERN.test(right?.tag ?? '')) {
+    fail('INVALID_STABLE_TAG', 'release tag comparison requires stable SemVer tags');
+  }
   const a = left.tag.slice(1).split('.').map(BigInt);
   const b = right.tag.slice(1).split('.').map(BigInt);
   for (let index = 0; index < 3; index += 1) {
@@ -241,6 +248,68 @@ function decodeMarker(body) {
   } catch {
     fail('INVALID_MARKER', 'release body identity marker is invalid');
   }
+}
+
+function validatePublicationMarker(marker, ref) {
+  if (!marker || typeof marker !== 'object' || Array.isArray(marker)) {
+    fail('PUBLISHED_RELEASE_CONFLICT', 'publication marker must be a canonical object');
+  }
+  if (![RELEASE_PROTOCOL, RELEASE_PROTOCOL_V2].includes(marker.protocol)) {
+    fail('PUBLISHED_RELEASE_CONFLICT', 'publication marker protocol is unsupported');
+  }
+  let expected;
+  try {
+    expected = buildPublicationMarker(marker);
+  } catch {
+    fail('PUBLISHED_RELEASE_CONFLICT', 'publication marker fields are invalid');
+  }
+  if (Object.hasOwn(marker, 'requiredEvidence')) {
+    if (marker.protocol !== RELEASE_PROTOCOL_V2) {
+      fail('PUBLISHED_RELEASE_CONFLICT', 'only v2 publication markers may require evidence');
+    }
+    expected = { ...expected, requiredEvidence: [ATTESTATION_ASSET] };
+  }
+  if (
+    canonicalize(marker) !== canonicalize(expected) ||
+    !IDENTITY_PATTERN.test(marker.planIdentity ?? '') ||
+    !IDENTITY_PATTERN.test(marker.requestIdentity ?? '') ||
+    !IDENTITY_PATTERN.test(marker.contentIdentity ?? '') ||
+    !SHA_PATTERN.test(marker.targetSha ?? '') ||
+    !TAG_PATTERN.test(marker.tag ?? '') ||
+    marker.targetSha !== ref.sha ||
+    marker.tag !== ref.tag
+  ) {
+    fail(
+      'PUBLISHED_RELEASE_CONFLICT',
+      'publication marker schema, identities, evidence, tag, or target are invalid'
+    );
+  }
+  return expected;
+}
+
+function releaseMarker(ref, body) {
+  const bodyMarker = decodeMarker(body);
+  const tagMarker = ref.kind === 'annotated' ? ref.marker : null;
+  if (
+    bodyMarker === null &&
+    tagMarker === null &&
+    compareReleaseTags(ref, { tag: MARKERLESS_HISTORY_MAX_TAG }) <= 0
+  ) {
+    return null;
+  }
+  if (bodyMarker === null || tagMarker === null) {
+    fail(
+      'PUBLISHED_RELEASE_CONFLICT',
+      'Release body and immutable annotated-tag markers must either both be absent or both be present'
+    );
+  }
+  if (canonicalize(bodyMarker) !== canonicalize(tagMarker)) {
+    fail(
+      'PUBLISHED_RELEASE_CONFLICT',
+      'Release body marker differs from the immutable annotated-tag marker'
+    );
+  }
+  return validatePublicationMarker(tagMarker, ref);
 }
 
 function canonicalAsset(assets, name) {
@@ -586,7 +655,7 @@ export async function observeGithubState({ transport, repository, targetSha }) {
         downloadUrl: String(asset?.browser_download_url ?? ''),
         size: Number(asset?.size),
       })),
-      marker: decodeMarker(release.body),
+      marker: releaseMarker(ref, release.body),
       relationToTarget:
         published && release.prerelease !== true
           ? await relationToTarget(transport, repository, ref.sha, targetSha)

--- a/scripts/release/github-adapter.mjs
+++ b/scripts/release/github-adapter.mjs
@@ -257,6 +257,12 @@ function validatePublicationMarker(marker, ref) {
   if (![RELEASE_PROTOCOL, RELEASE_PROTOCOL_V2].includes(marker.protocol)) {
     fail('PUBLISHED_RELEASE_CONFLICT', 'publication marker protocol is unsupported');
   }
+  if (
+    marker.protocol === RELEASE_PROTOCOL &&
+    compareReleaseTags(ref, { tag: MARKERLESS_HISTORY_MAX_TAG }) > 0
+  ) {
+    fail('PUBLISHED_RELEASE_CONFLICT', 'v1 publication marker is beyond its historical boundary');
+  }
   let expected;
   try {
     expected = buildPublicationMarker(marker);

--- a/scripts/release/github-adapter.mjs
+++ b/scripts/release/github-adapter.mjs
@@ -31,6 +31,7 @@ const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const TAG_PATTERN = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
 const IDENTITY_PATTERN = /^sha256:[0-9a-f]{64}$/;
 const MARKERLESS_HISTORY_MAX_TAG = 'v1.55.0';
+const UNATTESTED_V2_HISTORY_MAX_TAG = 'v1.55.2';
 const ASSET_TIMEOUT_MS = 30_000;
 const sha256Bytes = bytes => createHash('sha256').update(bytes).digest('hex');
 
@@ -68,6 +69,10 @@ function compareReleaseTags(left, right) {
     if (a[index] !== b[index]) return a[index] < b[index] ? -1 : 1;
   }
   return 0;
+}
+
+export function requiresReleaseAttestation(tag) {
+  return compareReleaseTags({ tag }, { tag: UNATTESTED_V2_HISTORY_MAX_TAG }) > 0;
 }
 
 function activeAliasTargets(artifacts) {
@@ -263,13 +268,24 @@ function validatePublicationMarker(marker, ref) {
   ) {
     fail('PUBLISHED_RELEASE_CONFLICT', 'v1 publication marker is beyond its historical boundary');
   }
+  const requiresEvidence = Object.hasOwn(marker, 'requiredEvidence');
+  if (
+    marker.protocol === RELEASE_PROTOCOL_V2 &&
+    requiresReleaseAttestation(ref.tag) &&
+    !requiresEvidence
+  ) {
+    fail(
+      'PUBLISHED_RELEASE_CONFLICT',
+      'post-boundary v2 publication marker must require attestation evidence'
+    );
+  }
   let expected;
   try {
     expected = buildPublicationMarker(marker);
   } catch {
     fail('PUBLISHED_RELEASE_CONFLICT', 'publication marker fields are invalid');
   }
-  if (Object.hasOwn(marker, 'requiredEvidence')) {
+  if (requiresEvidence) {
     if (marker.protocol !== RELEASE_PROTOCOL_V2) {
       fail('PUBLISHED_RELEASE_CONFLICT', 'only v2 publication markers may require evidence');
     }

--- a/scripts/release/live-release.mjs
+++ b/scripts/release/live-release.mjs
@@ -20,6 +20,7 @@ import {
   pollLiveVerification,
 } from './verify-live.mjs';
 import { assertStaticTree } from './static-tree.mjs';
+import { ATTESTATION_ASSET, attestationPolicy, verifyPortableAttestation } from './attestation.mjs';
 
 const PROTOCOL = 'bugdrop.live-release/v1';
 const SHA = /^[0-9a-f]{40}$/;
@@ -325,18 +326,73 @@ export async function deployCandidate({
   };
 }
 
-export async function publishCandidate({ authorization, bundle: rawBundle, adapter }) {
+async function authenticatedPublicationBundle({
+  rawBundle,
+  attestationBytes,
+  controllerSha,
+  repository,
+  verifyAttestation = verifyPortableAttestation,
+}) {
   const bundle = hydratedBundle(rawBundle);
-  const expected = validatePublicationBundle(bundle);
+  if (!Buffer.isBuffer(attestationBytes)) {
+    fail('INVALID_ATTESTATION', 'portable attestation bytes are required');
+  }
+  const attestation = await verifyAttestation({
+    bundle,
+    attestationBytes,
+    policy: attestationPolicy({ repository, controllerSha }),
+  });
+  return {
+    ...bundle,
+    attestation,
+    assets: { ...bundle.assets, [ATTESTATION_ASSET]: attestationBytes },
+  };
+}
+
+export async function publishCandidate({
+  authorization,
+  bundle: rawBundle,
+  adapter,
+  attestationBytes,
+  controllerSha,
+  repository,
+  verifyAttestation,
+}) {
+  const bundle = await authenticatedPublicationBundle({
+    rawBundle,
+    attestationBytes,
+    controllerSha,
+    repository,
+    ...(verifyAttestation ? { verifyAttestation } : {}),
+  });
+  const expected = validatePublicationBundle(bundle, { requireAttestation: true });
   requireAuthorization(authorization, {
     planIdentity: expected.planIdentity,
   });
   return { protocol: PROTOCOL, ...(await executePublication({ adapter, bundle })) };
 }
 
-export async function inspectPublication({ bundle: rawBundle, adapter }) {
-  const bundle = hydratedBundle(rawBundle);
-  const expected = validatePublicationBundle(bundle);
+export async function inspectPublication({
+  bundle: rawBundle,
+  adapter,
+  attestationBytes,
+  controllerSha,
+  repository,
+  verifyAttestation,
+}) {
+  const bundle = Buffer.isBuffer(attestationBytes)
+    ? await authenticatedPublicationBundle({
+        rawBundle,
+        attestationBytes,
+        controllerSha,
+        repository,
+        ...(verifyAttestation ? { verifyAttestation } : {}),
+      })
+    : hydratedBundle(rawBundle);
+  const expected = validatePublicationBundle(bundle, {
+    allowLegacy: !Buffer.isBuffer(attestationBytes),
+    requireAttestation: Buffer.isBuffer(attestationBytes),
+  });
   let observation;
   try {
     observation = await adapter.inspect(expected.tag);
@@ -556,6 +612,9 @@ async function runCli() {
     output = await publishCandidate({
       authorization: await jsonFile(input.authorizationPath),
       bundle,
+      attestationBytes: await readFile(resolve(input.attestationPath)),
+      controllerSha: input.controllerSha,
+      repository: input.repository,
       adapter: createGithubPublicationAdapter({
         repository: input.repository,
         token: process.env.BUGDROP_GITHUB_TOKEN,
@@ -564,6 +623,11 @@ async function runCli() {
   } else if (mode === 'inspect-publication') {
     output = await inspectPublication({
       bundle: await jsonFile(input.bundlePath),
+      ...(input.attestationPath
+        ? { attestationBytes: await readFile(resolve(input.attestationPath)) }
+        : {}),
+      controllerSha: input.controllerSha,
+      repository: input.repository,
       adapter: createGithubPublicationAdapter({
         repository: input.repository,
         token: process.env.BUGDROP_GITHUB_TOKEN,
@@ -573,6 +637,11 @@ async function runCli() {
     const bundle = await jsonFile(input.bundlePath);
     const publication = await inspectPublication({
       bundle,
+      ...(input.attestationPath
+        ? { attestationBytes: await readFile(resolve(input.attestationPath)) }
+        : {}),
+      controllerSha: input.controllerSha,
+      repository: input.repository,
       adapter: createGithubPublicationAdapter({
         repository: input.repository,
         token: process.env.BUGDROP_GITHUB_TOKEN,

--- a/scripts/release/live-release.mjs
+++ b/scripts/release/live-release.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { reconcileDeployment, verifyRollback } from './cloudflare-adapter.mjs';
 import { createProductionCloudflareClient } from './cloudflare-client.mjs';
 import { createGithubPublicationAdapter } from './github-publication-adapter.mjs';
+import { requiresReleaseAttestation } from './github-adapter.mjs';
 import {
   classifyPublicationState,
   executePublication,
@@ -393,6 +394,14 @@ export async function inspectPublication({
     allowLegacy: !Buffer.isBuffer(attestationBytes),
     requireAttestation: Buffer.isBuffer(attestationBytes),
   });
+  if (!Buffer.isBuffer(attestationBytes) && requiresReleaseAttestation(expected.tag)) {
+    return {
+      protocol: PROTOCOL,
+      status: 'conflict',
+      reason: 'post-boundary-attestation-required',
+      planIdentity: expected.planIdentity,
+    };
+  }
   let observation;
   try {
     observation = await adapter.inspect(expected.tag);

--- a/scripts/release/live-release.mjs
+++ b/scripts/release/live-release.mjs
@@ -381,20 +381,34 @@ export async function inspectPublication({
   repository,
   verifyAttestation,
 }) {
-  const bundle = Buffer.isBuffer(attestationBytes)
-    ? await authenticatedPublicationBundle({
+  const hasAttestation = Buffer.isBuffer(attestationBytes);
+  let bundle;
+  if (hasAttestation) {
+    try {
+      bundle = await authenticatedPublicationBundle({
         rawBundle,
         attestationBytes,
         controllerSha,
         repository,
         ...(verifyAttestation ? { verifyAttestation } : {}),
-      })
-    : hydratedBundle(rawBundle);
+      });
+    } catch {
+      const untrusted = validatePublicationBundle(hydratedBundle(rawBundle), { allowLegacy: true });
+      return {
+        protocol: PROTOCOL,
+        status: 'conflict',
+        reason: 'attestation-verification-failed',
+        planIdentity: untrusted.planIdentity,
+      };
+    }
+  } else {
+    bundle = hydratedBundle(rawBundle);
+  }
   const expected = validatePublicationBundle(bundle, {
-    allowLegacy: !Buffer.isBuffer(attestationBytes),
-    requireAttestation: Buffer.isBuffer(attestationBytes),
+    allowLegacy: !hasAttestation,
+    requireAttestation: hasAttestation,
   });
-  if (!Buffer.isBuffer(attestationBytes) && requiresReleaseAttestation(expected.tag)) {
+  if (!hasAttestation && requiresReleaseAttestation(expected.tag)) {
     return {
       protocol: PROTOCOL,
       status: 'conflict',
@@ -570,6 +584,45 @@ export async function finalizeRelease({
       };
 }
 
+export async function finalizeInspectedRelease({
+  bundle,
+  adapter,
+  attestationBytes,
+  controllerSha,
+  repository,
+  verifyAttestation,
+  baseline,
+  client,
+  deployment,
+  expected,
+  inspectionAttempts,
+  inspectionIntervalMs,
+  observe,
+  sleep,
+  verify,
+}) {
+  const publication = await inspectPublication({
+    bundle,
+    adapter,
+    ...(Buffer.isBuffer(attestationBytes) ? { attestationBytes } : {}),
+    controllerSha,
+    repository,
+    ...(verifyAttestation ? { verifyAttestation } : {}),
+  });
+  return finalizeRelease({
+    baseline,
+    client,
+    deployment,
+    expected,
+    publication,
+    ...(inspectionAttempts !== undefined ? { inspectionAttempts } : {}),
+    ...(inspectionIntervalMs !== undefined ? { inspectionIntervalMs } : {}),
+    ...(observe ? { observe } : {}),
+    ...(sleep ? { sleep } : {}),
+    ...(verify ? { verify } : {}),
+  });
+}
+
 async function jsonFile(path) {
   return JSON.parse(await readFile(resolve(path), 'utf8'));
 }
@@ -644,7 +697,7 @@ async function runCli() {
     });
   } else if (mode === 'finalize') {
     const bundle = await jsonFile(input.bundlePath);
-    const publication = await inspectPublication({
+    output = await finalizeInspectedRelease({
       bundle,
       ...(input.attestationPath
         ? { attestationBytes: await readFile(resolve(input.attestationPath)) }
@@ -655,13 +708,10 @@ async function runCli() {
         repository: input.repository,
         token: process.env.BUGDROP_GITHUB_TOKEN,
       }),
-    });
-    output = await finalizeRelease({
       baseline: await jsonFile(input.baselinePath),
       client: await cloudflareClient(input),
       deployment: await jsonFile(input.deploymentPath),
       expected: await jsonFile(input.expectedPath),
-      publication,
     });
   } else {
     fail('INVALID_CLI', `unsupported mode ${mode ?? '<missing>'}`);

--- a/scripts/release/publication.mjs
+++ b/scripts/release/publication.mjs
@@ -4,6 +4,7 @@ import { buildPublicationMarker } from './plan.mjs';
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const TAG_PATTERN = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
 const ASSET_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/;
+const ATTESTATION_ASSET = 'attestation.intoto.jsonl';
 const CORE_ASSETS = [
   'checksums.sha256',
   'final-release-plan.json',
@@ -48,7 +49,10 @@ function expectedChecksumBytes(hashes) {
       .join('\n')}\n`
   );
 }
-export function validatePublicationBundle(input) {
+export function validatePublicationBundle(
+  input,
+  { allowLegacy = false, requireAttestation = false } = {}
+) {
   const { requestPlan, releaseContent, finalPlan } = input ?? {};
   if (![requestPlan, releaseContent, finalPlan].every(value => value?.constructor === Object)) {
     fail('INVALID_BUNDLE', 'request, content, and final plan records are required');
@@ -99,12 +103,15 @@ export function validatePublicationBundle(input) {
     fail('INVALID_BUNDLE', 'requiredAssets must exactly match the request attestation');
   }
   const assets = input.assets;
-  if (
-    !assets ||
-    assets.constructor !== Object ||
-    !same(Object.keys(assets).sort(compareUtf8), required)
-  ) {
-    fail('INVALID_BUNDLE', 'asset names do not exactly match the final plan');
+  const assetNames = Object.keys(assets ?? {}).sort(compareUtf8);
+  const releaseRequired = [...required, ATTESTATION_ASSET].sort(compareUtf8);
+  const hasAttestation = assetNames.includes(ATTESTATION_ASSET);
+  const validNames =
+    same(assetNames, hasAttestation ? releaseRequired : required) &&
+    (!requireAttestation || hasAttestation) &&
+    (hasAttestation || allowLegacy || !input.attestation);
+  if (!assets || assets.constructor !== Object || !validNames) {
+    fail('INVALID_BUNDLE', 'asset names do not exactly match the release boundary');
   }
   const expectedBytes = {
     'request-plan.json': Buffer.from(`${canonicalize(requestPlan)}\n`),
@@ -131,7 +138,37 @@ export function validatePublicationBundle(input) {
     fail('INVALID_BUNDLE', 'checksums do not bind every published asset');
   }
   hashes['checksums.sha256'] = sha256(checksumBytes);
-  const marker = buildPublicationMarker(finalPlan);
+  if (hasAttestation) {
+    const evidenceBytes = exactBuffer(assets[ATTESTATION_ASSET], ATTESTATION_ASSET);
+    const evidence = input.attestation;
+    const subjectHashes = Object.fromEntries(
+      required
+        .map(name => [name, { sha256: hashes[name] }])
+        .sort(([left], [right]) => compareUtf8(left, right))
+    );
+    if (
+      evidence?.protocol !== 'bugdrop.release-attestation/v1' ||
+      evidence.status !== 'verified' ||
+      evidence.asset !== ATTESTATION_ASSET ||
+      evidence.bundleSha256 !== sha256(evidenceBytes) ||
+      evidence.policy?.repository !== finalPlan.repository ||
+      evidence.policy?.signerDigest !== requestPlan.source?.controllerSha ||
+      evidence.policy?.sourceDigest !== requestPlan.source?.controllerSha ||
+      !same(
+        Object.fromEntries(
+          (evidence.subjects ?? []).map(subject => [subject.name, subject.digest])
+        ),
+        subjectHashes
+      )
+    ) {
+      fail('INVALID_BUNDLE', 'attestation evidence is missing or does not authenticate');
+    }
+    hashes[ATTESTATION_ASSET] = sha256(evidenceBytes);
+  }
+  const historicalMarker = buildPublicationMarker(finalPlan);
+  const marker = hasAttestation
+    ? { ...historicalMarker, requiredEvidence: [ATTESTATION_ASSET] }
+    : historicalMarker;
   const encodedMarker = Buffer.from(canonicalize(marker)).toString('base64url');
   const bodyMarker = `<!-- bugdrop-publication ${encodedMarker} -->`;
   return {
@@ -144,7 +181,8 @@ export function validatePublicationBundle(input) {
     planIdentity: finalPlan.planIdentity,
     protocol: finalPlan.protocol,
     repository: finalPlan.repository,
-    requiredAssets: required,
+    contentAssets: required,
+    requiredAssets: hasAttestation ? releaseRequired : required,
     ...(finalPlan.staticPackageIdentity
       ? { staticPackageIdentity: finalPlan.staticPackageIdentity }
       : {}),
@@ -382,7 +420,7 @@ export async function executePublication({
   ) {
     fail('INVALID_CONVERGENCE_OPTIONS', 'publication convergence options are invalid');
   }
-  const expected = validatePublicationBundle(bundle);
+  const expected = validatePublicationBundle(bundle, { requireAttestation: true });
   const history = [];
   const attemptedActions = new Set();
   let mutated = false;

--- a/test/github-actions-pinning.test.sh
+++ b/test/github-actions-pinning.test.sh
@@ -11,13 +11,14 @@ write_workflow() {
   local reference=$1
   local version=$2
   local uses_key=${3:-uses}
+  local action=${4:-actions/checkout}
   printf '%s\n' \
     'name: fixture' \
     'jobs:' \
     '  check:' \
     '    runs-on: ubuntu-latest' \
     '    steps:' \
-    "      - ${uses_key}: actions/checkout@${reference} # ${version}" \
+    "      - ${uses_key}: ${action}@${reference} # ${version}" \
     > "$fixture_root/fixture.yml"
 }
 
@@ -35,6 +36,21 @@ expect_failure() {
 
 write_workflow fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 v5.1.0
 node "$checker" "$fixture_root" > /dev/null
+
+write_workflow a1948c3f048ba23858d222213b7c278aabede763 v4.1.1 uses actions/attest
+node "$checker" "$fixture_root" > /dev/null
+
+write_workflow b1948c3f048ba23858d222213b7c278aabede763 v4.1.1 uses actions/attest
+expect_failure 'is not approved as v4.1.1'
+
+write_workflow a1948c3f048ba23858d222213b7c278aabede763 v4.1.0 uses actions/attest
+expect_failure 'is not approved as v4.1.0'
+
+write_workflow a1948c3f048ba23858d222213b7c278aabede763 v3.9.9 uses actions/attest
+expect_failure 'below the Node 24-ready v4 floor'
+
+write_workflow v4 v4.1.1 uses actions/attest
+expect_failure 'not pinned to a full commit SHA'
 
 write_workflow v5 v5.1.0
 expect_failure 'not pinned to a full commit SHA'

--- a/test/release-workflow-contract.test.sh
+++ b/test/release-workflow-contract.test.sh
@@ -58,6 +58,14 @@ job_block() {
   ' "$workflow"
 }
 
+job_needs_block() {
+  job_block "$1" | awk '
+    /^    needs:/ { found = 1 }
+    found && /^    [[:alnum:]_-]+:/ && $0 !~ /^    needs:/ { exit }
+    found { print }
+  '
+}
+
 line_of() {
   grep -nF -- "$1" "$workflow" | head -1 | cut -d: -f1
 }
@@ -112,6 +120,7 @@ for job in \
   approval-baseline \
   deploy-candidate \
   live-e2e \
+  attest-release \
   publish-release \
   notify \
   finalize-cancelled; do
@@ -331,12 +340,41 @@ for literal in \
   grep -Fq -- "$literal" <<< "$live_block" || fail "live-e2e lacks: $literal"
 done
 
-publish_block=$(job_block publish-release)
+attest_block=$(job_block attest-release)
 for literal in \
-  'needs: [guard-and-plan, verify-candidate, approval-baseline, deploy-candidate, live-e2e]' \
+  "needs.approval-baseline.outputs.proceed == 'true'" \
+  'environment: production' \
+  'contents: read' \
+  'id-token: write' \
+  'attestations: write' \
+  'artifact-ids: ${{ needs.verify-candidate.outputs.artifact_id }}' \
+  'node controller/scripts/release/attestation.mjs stage' \
+  "test \"\$(jq -er '.subjects | length' attestation-subjects.json)\" = '6'" \
+  'attestation-subjects.sha256' \
+  'uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1' \
+  'subject-checksums: ${{ runner.temp }}/attestation-subjects.sha256' \
+  'attestation.intoto.jsonl' \
+  'node controller/scripts/release/attestation.mjs verify' \
+  'name: release-attestation-${{ needs.verify-candidate.outputs.plan_key }}'; do
+  grep -Fq -- "$literal" <<< "$attest_block" || fail "attest-release lacks: $literal"
+done
+if grep -Eq 'contents: write|CLOUDFLARE_|DISCORD_' <<< "$attest_block"; then
+  fail 'attestation job combines provenance with publication, deployment, or notification authority'
+fi
+if grep -Fq 'attest-release' <<< "$dry_block$completed_block"; then
+  fail 'dry-run or completed-plan no-op can reach attestation'
+fi
+
+publish_block=$(job_block publish-release)
+publish_needs=$(job_needs_block publish-release)
+grep -Fq 'attest-release' <<< "$publish_needs" ||
+  fail 'publish-release does not depend on attest-release'
+for literal in \
   'environment: production' \
   'timeout-minutes: 15' \
   'contents: write' \
+  'needs.attest-release.outputs.artifact_id' \
+  '--arg attestationPath "$GITHUB_WORKSPACE/release-state/attestation.intoto.jsonl"' \
   'node controller/scripts/release/live-release.mjs publish' \
   'BUGDROP_GITHUB_TOKEN: ${{ github.token }}'; do
   grep -Fq -- "$literal" <<< "$publish_block" || fail "publish-release lacks: $literal"
@@ -344,7 +382,13 @@ done
 if grep -Eq 'CLOUDFLARE_|DISCORD_' <<< "$publish_block"; then
   fail 'publication job must not receive deployment or notification credentials'
 fi
+if grep -Eq 'id-token: write|attestations: write' <<< "$publish_block"; then
+  fail 'publication job must not receive attestation authority'
+fi
 [[ $(grep -Fc 'contents: write' "$workflow") -eq 1 ]] || fail 'write permission must exist only on publish-release'
+[[ $(grep -Fc 'id-token: write' "$workflow") -eq 1 ]] || fail 'OIDC write must exist only on attest-release'
+[[ $(grep -Fc 'attestations: write' "$workflow") -eq 1 ]] ||
+  fail 'attestation write must exist only on attest-release'
 
 notify_block=$(job_block notify)
 for literal in \
@@ -358,6 +402,9 @@ grep -Fq 'DISCORD_RELEASE_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }
   fail 'notification must receive only the named Discord credential'
 
 final_block=$(job_block finalize-cancelled)
+final_needs=$(job_needs_block finalize-cancelled)
+grep -Fq 'attest-release' <<< "$final_needs" ||
+  fail 'finalize-cancelled does not depend on attest-release'
 for literal in \
   'always()' \
   'environment: production' \
@@ -370,6 +417,9 @@ for literal in \
   'diff -qr release-state/static-package candidate/.release-static-package' \
   '--arg candidateAssets "$GITHUB_WORKSPACE/candidate/.release-static-package"' \
   '--arg bundlePath "$GITHUB_WORKSPACE/release-state/state2-bundle.json"' \
+  'needs.attest-release.outputs.artifact_id' \
+  '--arg attestationPath "$GITHUB_WORKSPACE/release-state/attestation.intoto.jsonl"' \
+  '--argjson hasAttestation' \
   'node controller/scripts/release/live-release.mjs finalize' \
   'Preserve finalization evidence' \
   'Upload authoritative finalization outcome' \

--- a/test/release/attestation.test.ts
+++ b/test/release/attestation.test.ts
@@ -1,0 +1,128 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  AttestationError,
+  attestationPolicy,
+  attestationSubjects,
+  inspectPortableAttestation,
+  verifyPortableAttestation,
+} from '../../scripts/release/attestation.mjs';
+import { workflowBundle } from '../fixtures/release/workflow/bundle';
+
+const sha256 = (bytes: Buffer) => createHash('sha256').update(bytes).digest('hex');
+
+function portable(subjects: ReturnType<typeof attestationSubjects>) {
+  const statement = {
+    _type: 'https://in-toto.io/Statement/v1',
+    subject: subjects,
+    predicateType: 'https://slsa.dev/provenance/v1',
+    predicate: { buildDefinition: {}, runDetails: {} },
+  };
+  return Buffer.from(
+    `${JSON.stringify({ dsseEnvelope: { payload: Buffer.from(JSON.stringify(statement)).toString('base64') } })}\n`
+  );
+}
+
+function verifierFor(originalBundle: Buffer) {
+  return vi.fn(async (args: string[]) => {
+    const subjectPath = args[2];
+    const bundlePath = args[args.indexOf('--bundle') + 1];
+    const [subject, evidence] = await Promise.all([readFile(subjectPath), readFile(bundlePath)]);
+    if (!evidence.equals(originalBundle)) throw new Error('signature rejected');
+    const statement = JSON.parse(
+      Buffer.from(JSON.parse(evidence.toString()).dsseEnvelope.payload, 'base64').toString()
+    );
+    const named = statement.subject.find(
+      (item: { name: string }) => item.name === subjectPath.split('/').at(-1)
+    );
+    if (!named || named.digest.sha256 !== sha256(subject)) throw new Error('digest rejected');
+    return JSON.stringify([{ verificationResult: { statement } }]);
+  });
+}
+
+describe('release attestation boundary', () => {
+  it('binds exactly the six deterministic final Release subjects', () => {
+    const bundle = workflowBundle();
+    expect(attestationSubjects(bundle).map(subject => subject.name)).toEqual([
+      'checksums.sha256',
+      'final-release-plan.json',
+      'release-content.json',
+      'request-plan.json',
+      'versions.json',
+      'widget.v1.55.1.js',
+    ]);
+  });
+
+  it('pins every verifier identity control and verifies every subject', async () => {
+    const bundle = workflowBundle();
+    const subjects = attestationSubjects(bundle);
+    const evidence = portable(subjects);
+    const runVerifier = verifierFor(evidence);
+    const policy = attestationPolicy({
+      repository: 'mean-weasel/bugdrop',
+      controllerSha: bundle.requestPlan.source.controllerSha,
+    });
+
+    await expect(
+      verifyPortableAttestation({ bundle, attestationBytes: evidence, policy, runVerifier })
+    ).resolves.toMatchObject({ status: 'verified', subjects });
+    expect(runVerifier).toHaveBeenCalledTimes(6);
+    const args = runVerifier.mock.calls[0][0];
+    for (const option of [
+      '--repo',
+      '--signer-workflow',
+      '--signer-digest',
+      '--source-digest',
+      '--source-ref',
+      '--cert-oidc-issuer',
+      '--deny-self-hosted-runners',
+    ]) {
+      expect(args).toContain(option);
+    }
+  });
+
+  it('rejects a one-byte subject mutation and a one-byte portable-bundle mutation', async () => {
+    const bundle = workflowBundle();
+    const evidence = portable(attestationSubjects(bundle));
+    const policy = attestationPolicy({
+      repository: 'mean-weasel/bugdrop',
+      controllerSha: bundle.requestPlan.source.controllerSha,
+    });
+    const changed = {
+      ...bundle,
+      assets: { ...bundle.assets, 'widget.v1.55.1.js': Buffer.from('changed') },
+    };
+
+    await expect(
+      verifyPortableAttestation({
+        bundle: changed,
+        attestationBytes: evidence,
+        policy,
+        runVerifier: verifierFor(evidence),
+      })
+    ).rejects.toThrow(/widget\.v1\.55\.1\.js does not match release content/);
+
+    const mutatedEvidence = Buffer.from(evidence);
+    mutatedEvidence[mutatedEvidence.length - 2] ^= 1;
+    expect(() => inspectPortableAttestation(mutatedEvidence, attestationSubjects(bundle))).toThrow(
+      AttestationError
+    );
+  });
+
+  it('rejects missing, extra, and self-referential subjects', () => {
+    const bundle = workflowBundle();
+    const subjects = attestationSubjects(bundle);
+    for (const changed of [
+      subjects.slice(1),
+      [...subjects, { name: 'unexpected.bin', digest: { sha256: '0'.repeat(64) } }],
+      [...subjects, { name: 'attestation.intoto.jsonl', digest: { sha256: '0'.repeat(64) } }],
+    ]) {
+      expect(() => inspectPortableAttestation(portable(changed), subjects)).toThrow(
+        AttestationError
+      );
+    }
+  });
+});

--- a/test/release/github-adapter.test.ts
+++ b/test/release/github-adapter.test.ts
@@ -194,6 +194,15 @@ async function planFromPublishedBundles({
   const records = bundles.map((bundle, index) =>
     publishedBundleRecord(bundle, index + 1, immutableTagMarkers, tagMarkerMode, markerTransform)
   );
+  const bundledAttestation = bundles
+    .map(
+      bundle =>
+        (bundle as ReturnType<typeof disabledV2WorkflowBundle> & { attestation?: unknown })
+          .attestation
+    )
+    .find(Boolean);
+  const effectiveVerifyAttestation =
+    verifyAttestation ?? (bundledAttestation ? async () => bundledAttestation : undefined);
   records.forEach((record, index) => {
     record.release = releaseTransform(record.release, index) as typeof record.release;
   });
@@ -300,7 +309,7 @@ async function planFromPublishedBundles({
         targetStrictlyLater: true,
       },
     }),
-    ...(verifyAttestation ? { verifyAttestation } : {}),
+    ...(effectiveVerifyAttestation ? { verifyAttestation: effectiveVerifyAttestation } : {}),
   });
 }
 
@@ -353,7 +362,7 @@ function activeHistoryBundles({
     manifestTransform: continuationManifestTransform,
     staticManifestHashOverride: continuationStaticManifestHash,
   });
-  return [bootstrap, continuation];
+  return [bootstrap, withAttestation(continuation)];
 }
 
 function rebindPublishedBundle(bundle: ReturnType<typeof disabledV2WorkflowBundle>) {
@@ -384,11 +393,27 @@ function rebindPublishedBundle(bundle: ReturnType<typeof disabledV2WorkflowBundl
     'final-release-plan.json': Buffer.from(`${canonicalize(bundle.finalPlan)}\n`),
   });
   const checksums = Object.entries(bundle.assets)
-    .filter(([name]) => name !== 'checksums.sha256')
+    .filter(([name]) => !['checksums.sha256', 'attestation.intoto.jsonl'].includes(name))
     .sort(([left], [right]) => compareUtf8(left, right))
     .map(([name, bytes]) => `${createHash('sha256').update(bytes).digest('hex')}  ${name}`)
     .join('\n');
   bundle.assets['checksums.sha256'] = Buffer.from(`${checksums}\n`);
+  const attested = bundle as ReturnType<typeof disabledV2WorkflowBundle> & {
+    attestation?: Record<string, unknown>;
+  };
+  if (attested.attestation) {
+    const coreAssets = { ...bundle.assets };
+    delete coreAssets['attestation.intoto.jsonl'];
+    attested.attestation = {
+      ...attested.attestation,
+      subjects: attestationSubjects({
+        requestPlan: bundle.requestPlan,
+        releaseContent: bundle.releaseContent,
+        finalPlan: bundle.finalPlan,
+        assets: coreAssets,
+      }),
+    };
+  }
   return bundle;
 }
 
@@ -951,6 +976,153 @@ describe('GitHub release-state observation', () => {
     }
   );
 
+  it.each([
+    [
+      'completed-plan',
+      (bundle: ReturnType<typeof disabledV2WorkflowBundle>) => bundle.finalPlan.targetSha,
+    ],
+    ['N+1', () => '4'.repeat(40)],
+  ])(
+    'rejects post-attestation-boundary six-asset v2 on the %s path before downloads',
+    async (_path, candidateShaFor) => {
+      const bundle = disabledV2WorkflowBundle({
+        previousTag: 'v1.55.2',
+        nextTag: 'v1.55.3',
+        targetSha: '3'.repeat(40),
+      });
+      const requestBytes = vi.fn(async () =>
+        expect.unreachable('unattested post-boundary release must reject before downloads')
+      );
+
+      await expect(
+        planFromPublishedBundles({
+          bundles: [bundle],
+          candidateSha: candidateShaFor(bundle),
+          requestBytes,
+        })
+      ).rejects.toMatchObject({ code: 'PUBLISHED_RELEASE_CONFLICT' });
+      expect(requestBytes).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects an attested N followed by an unattested N+1 before lineage classification', async () => {
+    const attestedN = withAttestation(
+      disabledV2WorkflowBundle({
+        previousTag: 'v1.55.2',
+        nextTag: 'v1.55.3',
+        targetSha: '3'.repeat(40),
+      })
+    );
+    const unattestedN1 = disabledV2WorkflowBundle({
+      previousTag: 'v1.55.3',
+      nextTag: 'v1.55.4',
+      targetSha: '4'.repeat(40),
+    });
+    const requestBytes = vi.fn(async () =>
+      expect.unreachable('invalid lineage must reject before downloads')
+    );
+    const verifyAttestation = vi.fn(async () => attestedN.attestation);
+
+    await expect(
+      planFromPublishedBundles({
+        bundles: [attestedN, unattestedN1],
+        candidateSha: '5'.repeat(40),
+        requestBytes,
+        verifyAttestation,
+      })
+    ).rejects.toMatchObject({ code: 'PUBLISHED_RELEASE_CONFLICT' });
+    expect(requestBytes).not.toHaveBeenCalled();
+    expect(verifyAttestation).not.toHaveBeenCalled();
+  });
+
+  it('rejects post-boundary unattested v2 before retention traversal', async () => {
+    const historical = disabledV2WorkflowBundle({
+      previousTag: 'v1.55.1',
+      nextTag: 'v1.55.2',
+      targetSha: '2'.repeat(40),
+    });
+    const postBoundary = disabledV2WorkflowBundle({
+      previousTag: 'v1.55.2',
+      nextTag: 'v1.55.3',
+      targetSha: '3'.repeat(40),
+    });
+    const requestBytes = vi.fn(async () =>
+      expect.unreachable('invalid retention history must reject before downloads')
+    );
+
+    await expect(
+      planFromPublishedBundles({
+        bundles: [historical, postBoundary],
+        candidateSha: '4'.repeat(40),
+        retentionBootstrap: true,
+        requestBytes,
+      })
+    ).rejects.toMatchObject({ code: 'PUBLISHED_RELEASE_CONFLICT' });
+    expect(requestBytes).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'completed-plan',
+      (bundle: ReturnType<typeof disabledV2WorkflowBundle>) => bundle.finalPlan.targetSha,
+    ],
+    ['N+1', () => '4'.repeat(40)],
+  ])(
+    'requires the declared seventh asset on the post-boundary %s path',
+    async (_path, candidateShaFor) => {
+      const attested = withAttestation(
+        disabledV2WorkflowBundle({
+          previousTag: 'v1.55.2',
+          nextTag: 'v1.55.3',
+          targetSha: '3'.repeat(40),
+        })
+      );
+      const verifyAttestation = vi.fn(async () => attested.attestation);
+
+      await expect(
+        planFromPublishedBundles({
+          bundles: [attested],
+          candidateSha: candidateShaFor(attested),
+          releaseTransform: release => ({
+            ...release,
+            assets: (release.assets as Array<{ name: string }>).filter(
+              asset => asset.name !== 'attestation.intoto.jsonl'
+            ),
+          }),
+          verifyAttestation,
+        })
+      ).rejects.toBeInstanceOf(GithubAdapterError);
+      expect(verifyAttestation).not.toHaveBeenCalled();
+    }
+  );
+
+  it('accepts valid post-boundary seven-asset completed and N+1 behavior', async () => {
+    const attested = withAttestation(
+      disabledV2WorkflowBundle({
+        previousTag: 'v1.55.2',
+        nextTag: 'v1.55.3',
+        targetSha: '3'.repeat(40),
+      })
+    );
+    const verifyAttestation = vi.fn(async () => attested.attestation);
+
+    await expect(
+      planFromPublishedBundles({
+        bundles: [attested],
+        candidateSha: attested.finalPlan.targetSha,
+        verifyAttestation,
+      })
+    ).resolves.toMatchObject({ status: 'completed', tag: 'v1.55.3' });
+    await expect(
+      planFromPublishedBundles({
+        bundles: [attested],
+        candidateSha: '4'.repeat(40),
+        verifyAttestation,
+      })
+    ).resolves.toMatchObject({ request: { previousTag: 'v1.55.3' } });
+    expect(verifyAttestation).toHaveBeenCalledTimes(2);
+  });
+
   it('accepts legitimate immutable historical and attested markers but rejects disagreement', async () => {
     const historical = disabledV2WorkflowBundle();
     const attested = withAttestation(historical);
@@ -959,6 +1131,17 @@ describe('GitHub release-state observation', () => {
     await expect(
       planFromPublishedBundles({ bundles: [historical], immutableTagMarkers: true })
     ).resolves.toMatchObject({ request: { previousTag: historical.finalPlan.tag } });
+    const latestPreAttestation = disabledV2WorkflowBundle({
+      previousTag: 'v1.55.1',
+      nextTag: 'v1.55.2',
+      targetSha: '2'.repeat(40),
+    });
+    await expect(
+      planFromPublishedBundles({
+        bundles: [latestPreAttestation],
+        candidateSha: '3'.repeat(40),
+      })
+    ).resolves.toMatchObject({ request: { previousTag: 'v1.55.2' } });
     await expect(
       planFromPublishedBundles({
         bundles: [historical],

--- a/test/release/github-adapter.test.ts
+++ b/test/release/github-adapter.test.ts
@@ -3,6 +3,8 @@ import { createHash } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 
 import { canonicalHash, canonicalize, compareUtf8 } from '../../scripts/release/canonical-json.mjs';
+import { attestationPolicy, attestationSubjects } from '../../scripts/release/attestation.mjs';
+import { validatePublicationBundle } from '../../scripts/release/publication.mjs';
 import {
   authenticatePublishedAssets,
   createGithubTransport,
@@ -78,7 +80,12 @@ function observationEntries() {
 }
 
 function publishedBundleRecord(bundle: ReturnType<typeof disabledV2WorkflowBundle>, index: number) {
-  const marker = buildPublicationMarker(bundle.finalPlan);
+  const attested = bundle as ReturnType<typeof disabledV2WorkflowBundle> & {
+    attestation?: Record<string, unknown>;
+  };
+  const marker = attested.attestation
+    ? validatePublicationBundle(attested, { requireAttestation: true }).marker
+    : buildPublicationMarker(bundle.finalPlan);
   const authorityIndex = Number.parseInt(bundle.finalPlan.targetSha[0], 16) || index;
   return {
     release: {
@@ -112,6 +119,8 @@ async function planFromPublishedBundles({
   legacy = [],
   reverseAssets = false,
   downloadDelay = 0,
+  releaseTransform = (release: Record<string, unknown>) => release,
+  verifyAttestation,
 }: {
   bundles: ReturnType<typeof disabledV2WorkflowBundle>[];
   candidateSha?: string;
@@ -119,8 +128,13 @@ async function planFromPublishedBundles({
   legacy?: Array<{ tag: string; targetSha: string }>;
   reverseAssets?: boolean;
   downloadDelay?: number;
+  releaseTransform?: (release: Record<string, unknown>, index: number) => Record<string, unknown>;
+  verifyAttestation?: (input: unknown) => Promise<unknown>;
 }) {
   const records = bundles.map((bundle, index) => publishedBundleRecord(bundle, index + 1));
+  records.forEach((record, index) => {
+    record.release = releaseTransform(record.release, index) as typeof record.release;
+  });
   if (reverseAssets) records.forEach(record => record.release.assets.reverse());
   const assetBytes = new Map<string, Buffer>();
   for (const record of records) {
@@ -217,6 +231,7 @@ async function planFromPublishedBundles({
         targetStrictlyLater: true,
       },
     }),
+    ...(verifyAttestation ? { verifyAttestation } : {}),
   });
 }
 
@@ -536,6 +551,133 @@ describe('GitHub release-state observation', () => {
       assetVerification: { complete: true, checksumsMatch: true },
     });
     expect(requestBytes).toHaveBeenCalledTimes(bundle.finalPlan.requiredAssets.length);
+  });
+
+  it('cryptographically authenticates the seventh evidence asset for completed-plan reuse', async () => {
+    const bundle = workflowBundle();
+    const evidence = Buffer.from('{"signed":"portable"}\n');
+    const assets = { ...bundle.assets, 'attestation.intoto.jsonl': evidence };
+    const names = Object.keys(assets);
+    const attestation = {
+      protocol: 'bugdrop.release-attestation/v1',
+      status: 'verified',
+      asset: 'attestation.intoto.jsonl',
+      bundleSha256: createHash('sha256').update(evidence).digest('hex'),
+      policy: attestationPolicy({
+        repository: REPOSITORY,
+        controllerSha: bundle.requestPlan.source.controllerSha,
+      }),
+      subjects: attestationSubjects(bundle),
+    };
+    const marker = validatePublicationBundle(
+      { ...bundle, assets, attestation },
+      { requireAttestation: true }
+    ).marker;
+    const release = {
+      tag: bundle.finalPlan.tag,
+      targetSha: bundle.finalPlan.targetSha,
+      resolvedTagSha: bundle.finalPlan.targetSha,
+      published: true,
+      draft: false,
+      prerelease: false,
+      marker,
+      repository: REPOSITORY,
+      assets: names.map((name, index) => ({
+        id: String(index + 1),
+        name,
+        apiUrl: `https://api.github.test/repos/${REPOSITORY}/releases/assets/${index + 1}`,
+        size: assets[name].length,
+      })),
+    };
+    const verifyAttestation = vi.fn(async () => attestation);
+    const requestBytes = vi.fn(async (_url: string, options: { assetId: string }) => {
+      if (options.assetId === '99') return Buffer.from('x');
+      return assets[names[Number(options.assetId) - 1]];
+    });
+
+    const hydrated = await loadPublishedReleaseAssets({
+      transport: { requestBytes },
+      release,
+      verifyAttestation,
+    });
+    expect(hydrated).toMatchObject({
+      assetVerification: {
+        complete: true,
+        verifiedAssetNames: expect.arrayContaining(bundle.finalPlan.requiredAssets),
+      },
+    });
+    expect(
+      findCompletedPlan({
+        dispatch: normalizeDispatch(workflowContext(false).dispatch),
+        releases: [hydrated],
+        containsTarget: () => false,
+      })
+    ).toMatchObject({ kind: 'completed', planIdentity: bundle.finalPlan.planIdentity });
+    expect(verifyAttestation).toHaveBeenCalledOnce();
+
+    await expect(
+      loadPublishedReleaseAssets({
+        transport: { requestBytes },
+        release: {
+          ...release,
+          assets: release.assets.filter(asset => asset.name !== 'attestation.intoto.jsonl'),
+        },
+        verifyAttestation,
+      })
+    ).rejects.toBeInstanceOf(GithubAdapterError);
+
+    await expect(
+      loadPublishedReleaseAssets({
+        transport: { requestBytes },
+        release: { ...release, marker: buildPublicationMarker(bundle.finalPlan) },
+        verifyAttestation,
+      })
+    ).rejects.toBeInstanceOf(GithubAdapterError);
+
+    release.assets.push({
+      id: '99',
+      name: 'unexpected.bin',
+      apiUrl: `https://api.github.test/repos/${REPOSITORY}/releases/assets/99`,
+      size: 1,
+    });
+    await expect(
+      loadPublishedReleaseAssets({ transport: { requestBytes }, release, verifyAttestation })
+    ).rejects.toBeInstanceOf(GithubAdapterError);
+  });
+
+  it('requires marked provenance while loading the N+1 publication frontier', async () => {
+    const bundle = disabledV2WorkflowBundle();
+    const evidence = Buffer.from('{"signed":"portable"}\n');
+    const assets = { ...bundle.assets, 'attestation.intoto.jsonl': evidence };
+    const attestation = {
+      protocol: 'bugdrop.release-attestation/v1',
+      status: 'verified',
+      asset: 'attestation.intoto.jsonl',
+      bundleSha256: createHash('sha256').update(evidence).digest('hex'),
+      policy: attestationPolicy({
+        repository: REPOSITORY,
+        controllerSha: bundle.requestPlan.source.controllerSha,
+      }),
+      subjects: attestationSubjects(bundle),
+    };
+    const attested = { ...bundle, assets, attestation };
+    const verifyAttestation = vi.fn(async () => attestation);
+
+    await expect(
+      planFromPublishedBundles({ bundles: [attested], verifyAttestation })
+    ).resolves.toMatchObject({ request: { previousTag: bundle.finalPlan.tag } });
+    await expect(
+      planFromPublishedBundles({
+        bundles: [attested],
+        verifyAttestation,
+        releaseTransform: release => ({
+          ...release,
+          assets: (release.assets as Array<{ name: string }>).filter(
+            asset => asset.name !== 'attestation.intoto.jsonl'
+          ),
+        }),
+      })
+    ).rejects.toBeInstanceOf(GithubAdapterError);
   });
 
   it('authenticates retention mode before charging an exact asset to cumulative history', async () => {

--- a/test/release/github-adapter.test.ts
+++ b/test/release/github-adapter.test.ts
@@ -34,6 +34,30 @@ const SHA = {
 };
 const REPOSITORY = 'mean-weasel/bugdrop';
 
+function releaseBody(marker: unknown) {
+  return `<!-- bugdrop-publication ${Buffer.from(canonicalize(marker)).toString('base64url')} -->`;
+}
+
+function withAttestation(bundle: ReturnType<typeof disabledV2WorkflowBundle>) {
+  const evidence = Buffer.from('{"signed":"portable"}\n');
+  const attestation = {
+    protocol: 'bugdrop.release-attestation/v1',
+    status: 'verified',
+    asset: 'attestation.intoto.jsonl',
+    bundleSha256: createHash('sha256').update(evidence).digest('hex'),
+    policy: attestationPolicy({
+      repository: REPOSITORY,
+      controllerSha: bundle.requestPlan.source.controllerSha,
+    }),
+    subjects: attestationSubjects(bundle),
+  };
+  return {
+    ...bundle,
+    assets: { ...bundle.assets, 'attestation.intoto.jsonl': evidence },
+    attestation,
+  };
+}
+
 function transportFor(entries: Record<string, unknown>) {
   return {
     request: vi.fn(async (path: string) => {
@@ -79,14 +103,28 @@ function observationEntries() {
   };
 }
 
-function publishedBundleRecord(bundle: ReturnType<typeof disabledV2WorkflowBundle>, index: number) {
+function publishedBundleRecord(
+  bundle: ReturnType<typeof disabledV2WorkflowBundle>,
+  index: number,
+  immutableMarker = true,
+  tagMarkerMode: 'valid' | 'missing' | 'malformed' = 'valid',
+  markerTransform: (marker: unknown) => unknown = marker => marker
+) {
   const attested = bundle as ReturnType<typeof disabledV2WorkflowBundle> & {
     attestation?: Record<string, unknown>;
   };
-  const marker = attested.attestation
-    ? validatePublicationBundle(attested, { requireAttestation: true }).marker
-    : buildPublicationMarker(bundle.finalPlan);
+  const marker = markerTransform(
+    attested.attestation
+      ? validatePublicationBundle(attested, { requireAttestation: true }).marker
+      : buildPublicationMarker(bundle.finalPlan)
+  );
   const authorityIndex = Number.parseInt(bundle.finalPlan.targetSha[0], 16) || index;
+  const tagObjectSha = authorityIndex.toString(16).slice(-1).repeat(40);
+  const tagMessage = {
+    valid: `BugDrop ${bundle.finalPlan.tag}\n\n${canonicalize(marker)}`,
+    missing: `BugDrop ${bundle.finalPlan.tag}`,
+    malformed: `BugDrop ${bundle.finalPlan.tag}\n\n{not-json`,
+  }[tagMarkerMode];
   return {
     release: {
       id: 100 + authorityIndex,
@@ -95,7 +133,7 @@ function publishedBundleRecord(bundle: ReturnType<typeof disabledV2WorkflowBundl
       prerelease: false,
       published_at: bundle.requestPlan.attestation.candidateCommitTimestamp,
       html_url: `https://github.test/releases/${bundle.finalPlan.tag}`,
-      body: `<!-- bugdrop-publication ${Buffer.from(canonicalize(marker)).toString('base64url')} -->`,
+      body: releaseBody(marker),
       assets: Object.keys(bundle.assets).map((name, assetIndex) => ({
         id: authorityIndex * 100 + assetIndex + 1,
         name,
@@ -106,8 +144,22 @@ function publishedBundleRecord(bundle: ReturnType<typeof disabledV2WorkflowBundl
     },
     ref: {
       ref: `refs/tags/${bundle.finalPlan.tag}`,
-      object: { type: 'commit', sha: bundle.finalPlan.targetSha },
+      object: immutableMarker
+        ? { type: 'tag', sha: tagObjectSha }
+        : { type: 'commit', sha: bundle.finalPlan.targetSha },
     },
+    tagObject: immutableMarker
+      ? {
+          path: `/repos/${REPOSITORY}/git/tags/${tagObjectSha}`,
+          response: {
+            data: {
+              object: { type: 'commit', sha: bundle.finalPlan.targetSha },
+              message: tagMessage,
+            },
+            hasNext: false,
+          },
+        }
+      : null,
     bundle,
   };
 }
@@ -120,6 +172,10 @@ async function planFromPublishedBundles({
   reverseAssets = false,
   downloadDelay = 0,
   releaseTransform = (release: Record<string, unknown>) => release,
+  immutableTagMarkers = true,
+  tagMarkerMode = 'valid',
+  markerTransform = (marker: unknown) => marker,
+  requestBytes,
   verifyAttestation,
 }: {
   bundles: ReturnType<typeof disabledV2WorkflowBundle>[];
@@ -129,9 +185,15 @@ async function planFromPublishedBundles({
   reverseAssets?: boolean;
   downloadDelay?: number;
   releaseTransform?: (release: Record<string, unknown>, index: number) => Record<string, unknown>;
+  immutableTagMarkers?: boolean;
+  tagMarkerMode?: 'valid' | 'missing' | 'malformed';
+  markerTransform?: (marker: unknown) => unknown;
+  requestBytes?: (_url: string, options: { assetId: string }) => Promise<Buffer>;
   verifyAttestation?: (input: unknown) => Promise<unknown>;
 }) {
-  const records = bundles.map((bundle, index) => publishedBundleRecord(bundle, index + 1));
+  const records = bundles.map((bundle, index) =>
+    publishedBundleRecord(bundle, index + 1, immutableTagMarkers, tagMarkerMode, markerTransform)
+  );
   records.forEach((record, index) => {
     record.release = releaseTransform(record.release, index) as typeof record.release;
   });
@@ -169,6 +231,11 @@ async function planFromPublishedBundles({
       hasNext: false,
     },
     ...Object.fromEntries(
+      records
+        .filter(record => record.tagObject)
+        .map(record => [record.tagObject!.path, record.tagObject!.response])
+    ),
+    ...Object.fromEntries(
       [
         ...records.map(record => record.bundle.finalPlan.targetSha),
         ...legacy.map(x => x.targetSha),
@@ -198,12 +265,14 @@ async function planFromPublishedBundles({
     },
   });
   Object.assign(transport, {
-    requestBytes: vi.fn(async (_url: string, options: { assetId: string }) => {
-      if (downloadDelay) await new Promise(resolve => setTimeout(resolve, downloadDelay));
-      const bytes = assetBytes.get(options.assetId);
-      if (!bytes) throw new Error(`missing asset ${options.assetId}`);
-      return bytes;
-    }),
+    requestBytes:
+      requestBytes ??
+      vi.fn(async (_url: string, options: { assetId: string }) => {
+        if (downloadDelay) await new Promise(resolve => setTimeout(resolve, downloadDelay));
+        const bytes = assetBytes.get(options.assetId);
+        if (!bytes) throw new Error(`missing asset ${options.assetId}`);
+        return bytes;
+      }),
   });
   return createRequestPlanFromGithub({
     transport,
@@ -680,6 +749,223 @@ describe('GitHub release-state observation', () => {
     ).rejects.toBeInstanceOf(GithubAdapterError);
   });
 
+  it('rejects deletion plus editable body downgrade against the immutable tag marker', async () => {
+    const original = disabledV2WorkflowBundle();
+    const attested = withAttestation(original);
+    const verifyAttestation = vi.fn(async () => attested.attestation);
+    const historicalBody = releaseBody(buildPublicationMarker(original.finalPlan));
+    const deleteEvidenceAndRewriteBody = (release: Record<string, unknown>) => ({
+      ...release,
+      body: historicalBody,
+      assets: (release.assets as Array<{ name: string }>).filter(
+        asset => asset.name !== 'attestation.intoto.jsonl'
+      ),
+    });
+
+    for (const candidateSha of [original.finalPlan.targetSha, '9'.repeat(40)]) {
+      await expect(
+        planFromPublishedBundles({
+          bundles: [attested],
+          candidateSha,
+          immutableTagMarkers: true,
+          releaseTransform: deleteEvidenceAndRewriteBody,
+          verifyAttestation,
+        })
+      ).rejects.toMatchObject({ code: 'PUBLISHED_RELEASE_CONFLICT' });
+    }
+    expect(verifyAttestation).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'completed-plan',
+      (bundle: ReturnType<typeof disabledV2WorkflowBundle>) => bundle.finalPlan.targetSha,
+    ],
+    ['N+1', () => '9'.repeat(40)],
+  ])(
+    'rejects evidence deletion plus body-marker removal on the %s path',
+    async (_path, candidateShaFor) => {
+      const original = disabledV2WorkflowBundle();
+      const attested = withAttestation(original);
+      const verifyAttestation = vi.fn(async () => attested.attestation);
+
+      await expect(
+        planFromPublishedBundles({
+          bundles: [attested],
+          candidateSha: candidateShaFor(original),
+          immutableTagMarkers: true,
+          releaseTransform: release => ({
+            ...release,
+            body: '',
+            assets: (release.assets as Array<{ name: string }>).filter(
+              asset => asset.name !== 'attestation.intoto.jsonl'
+            ),
+          }),
+          verifyAttestation,
+        })
+      ).rejects.toMatchObject({ code: 'PUBLISHED_RELEASE_CONFLICT' });
+      expect(verifyAttestation).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects lightweight, markerless, and malformed tag replacements after body downgrade', async () => {
+    const original = disabledV2WorkflowBundle();
+    const attested = withAttestation(original);
+    const historicalBody = releaseBody(buildPublicationMarker(original.finalPlan));
+    const downgradedRelease = (release: Record<string, unknown>) => ({
+      ...release,
+      body: historicalBody,
+      assets: (release.assets as Array<{ name: string }>).filter(
+        asset => asset.name !== 'attestation.intoto.jsonl'
+      ),
+    });
+    const variants = [
+      { immutableTagMarkers: false as const, tagMarkerMode: 'valid' as const },
+      { immutableTagMarkers: true as const, tagMarkerMode: 'missing' as const },
+      { immutableTagMarkers: true as const, tagMarkerMode: 'malformed' as const },
+    ];
+
+    for (const variant of variants) {
+      for (const candidateSha of [original.finalPlan.targetSha, '9'.repeat(40)]) {
+        await expect(
+          planFromPublishedBundles({
+            bundles: [attested],
+            candidateSha,
+            releaseTransform: downgradedRelease,
+            ...variant,
+          })
+        ).rejects.toMatchObject({ code: 'PUBLISHED_RELEASE_CONFLICT' });
+      }
+    }
+  });
+
+  it.each([
+    [
+      'completed-plan',
+      (bundle: ReturnType<typeof disabledV2WorkflowBundle>) => bundle.finalPlan.targetSha,
+    ],
+    ['N+1', () => '9'.repeat(40)],
+  ])(
+    'rejects protocol-era marker deletion plus tag replacement before downloads on the %s path',
+    async (_path, candidateShaFor) => {
+      const original = disabledV2WorkflowBundle();
+      const attested = withAttestation(original);
+
+      for (const variant of [
+        { immutableTagMarkers: false as const, tagMarkerMode: 'valid' as const },
+        { immutableTagMarkers: true as const, tagMarkerMode: 'missing' as const },
+      ]) {
+        const requestBytes = vi.fn(async () => expect.unreachable('must reject before downloads'));
+        await expect(
+          planFromPublishedBundles({
+            bundles: [attested],
+            candidateSha: candidateShaFor(original),
+            releaseTransform: release => ({
+              ...release,
+              body: '',
+              assets: (release.assets as Array<{ name: string }>).filter(
+                asset => asset.name !== 'attestation.intoto.jsonl'
+              ),
+            }),
+            requestBytes,
+            ...variant,
+          })
+        ).rejects.toMatchObject({ code: 'PUBLISHED_RELEASE_CONFLICT' });
+        expect(requestBytes).not.toHaveBeenCalled();
+      }
+    }
+  );
+
+  it.each([
+    [
+      'completed-plan',
+      (bundle: ReturnType<typeof disabledV2WorkflowBundle>) => bundle.finalPlan.targetSha,
+    ],
+    ['N+1', () => '9'.repeat(40)],
+  ])(
+    'rejects equal malformed markers before classification on the %s path',
+    async (_path, candidateShaFor) => {
+      const bundle = disabledV2WorkflowBundle();
+      const invalidMarkers: Array<[string, (marker: Record<string, unknown>) => unknown]> = [
+        ['scalar', () => 'release-plan/v1'],
+        ['array', () => []],
+        ['empty object', () => ({})],
+        ['wrong protocol', marker => ({ ...marker, protocol: 'release-plan/v3' })],
+        ['wrong schema', marker => ({ ...marker, schema: 'bugdrop.publication-marker/v9' })],
+        ['wrong tag', marker => ({ ...marker, tag: 'v9.9.9' })],
+        ['wrong target', marker => ({ ...marker, targetSha: '0'.repeat(40) })],
+        ['malformed identity', marker => ({ ...marker, planIdentity: 'sha256:bad' })],
+        [
+          'malformed digest',
+          marker => ({ ...marker, contentIdentity: `sha512:${'0'.repeat(64)}` }),
+        ],
+        ['invalid requiredEvidence', marker => ({ ...marker, requiredEvidence: [] })],
+        ['unexpected key', marker => ({ ...marker, legacy: true })],
+      ];
+
+      for (const [name, markerTransform] of invalidMarkers) {
+        const requestBytes = vi.fn(async () =>
+          expect.unreachable(`${name} must reject before downloads`)
+        );
+        await expect(
+          planFromPublishedBundles({
+            bundles: [bundle],
+            candidateSha: candidateShaFor(bundle),
+            markerTransform: markerTransform as (marker: unknown) => unknown,
+            requestBytes,
+          }),
+          name
+        ).rejects.toMatchObject({ code: 'PUBLISHED_RELEASE_CONFLICT' });
+        expect(requestBytes, name).not.toHaveBeenCalled();
+      }
+    }
+  );
+
+  it('accepts legitimate immutable historical and attested markers but rejects disagreement', async () => {
+    const historical = disabledV2WorkflowBundle();
+    const attested = withAttestation(historical);
+    const verifyAttestation = vi.fn(async () => attested.attestation);
+
+    await expect(
+      planFromPublishedBundles({ bundles: [historical], immutableTagMarkers: true })
+    ).resolves.toMatchObject({ request: { previousTag: historical.finalPlan.tag } });
+    await expect(
+      planFromPublishedBundles({
+        bundles: [historical],
+        immutableTagMarkers: true,
+        markerTransform: marker => ({
+          ...(marker as Record<string, unknown>),
+          schema: 'bugdrop.publication-marker/v1',
+          protocol: 'release-plan/v1',
+        }),
+      })
+    ).resolves.toMatchObject({ request: { previousTag: historical.finalPlan.tag } });
+    await expect(
+      planFromPublishedBundles({
+        bundles: [historical],
+        immutableTagMarkers: false,
+        releaseTransform: release => ({ ...release, body: '' }),
+      })
+    ).rejects.toMatchObject({ code: 'PUBLISHED_RELEASE_CONFLICT' });
+    await expect(
+      planFromPublishedBundles({
+        bundles: [attested],
+        immutableTagMarkers: true,
+        verifyAttestation,
+      })
+    ).resolves.toMatchObject({ request: { previousTag: historical.finalPlan.tag } });
+    await expect(
+      planFromPublishedBundles({
+        bundles: [historical],
+        immutableTagMarkers: true,
+        releaseTransform: release => ({
+          ...release,
+          body: releaseBody({ ...buildPublicationMarker(historical.finalPlan), mismatch: true }),
+        }),
+      })
+    ).rejects.toMatchObject({ code: 'PUBLISHED_RELEASE_CONFLICT' });
+  });
+
   it('authenticates retention mode before charging an exact asset to cumulative history', async () => {
     const bundle = disabledV2WorkflowBundle();
     const exactName = `widget.${bundle.finalPlan.tag}.js`;
@@ -870,6 +1156,7 @@ describe('GitHub release-state observation', () => {
     expect(state.published).toEqual([
       expect.objectContaining({
         tag: 'v1.55.0',
+        marker: null,
         targetSha: SHA.release,
         resolvedTagSha: SHA.release,
         relationToTarget: 'ancestor',
@@ -990,11 +1277,16 @@ describe('authenticated disabled v2 frontier history', () => {
   });
 
   it.each([
-    ['disabled', () => second(), []],
-    ['legacy', () => null, [{ tag: 'v1.55.1', targetSha: '2'.repeat(40) }]],
+    ['disabled', () => second(), [], /RETENTION_HISTORY_INCOMPLETE/],
+    [
+      'legacy',
+      () => null,
+      [{ tag: 'v1.55.1', targetSha: '2'.repeat(40) }],
+      /PUBLISHED_RELEASE_CONFLICT/,
+    ],
   ])(
     'rejects %s history at or above an authenticated active boundary',
-    async (_kind, later, legacy) => {
+    async (_kind, later, legacy, expected) => {
       const active = bootstrapV2WorkflowBundle({
         previousTag: 'v1.54.0',
         nextTag: 'v1.55.0',
@@ -1008,7 +1300,7 @@ describe('authenticated disabled v2 frontier history', () => {
           bundles: laterBundle ? [active, laterBundle] : [active],
           legacy,
         })
-      ).rejects.toThrow(/RETENTION_HISTORY_INCOMPLETE/);
+      ).rejects.toThrow(expected);
     }
   );
 

--- a/test/release/github-adapter.test.ts
+++ b/test/release/github-adapter.test.ts
@@ -921,6 +921,36 @@ describe('GitHub release-state observation', () => {
     }
   );
 
+  it.each([
+    [
+      'completed-plan',
+      (bundle: ReturnType<typeof disabledV2WorkflowBundle>) => bundle.finalPlan.targetSha,
+    ],
+    ['N+1', () => '9'.repeat(40)],
+  ])(
+    'rejects post-cutoff v1 markers before classification on the %s path',
+    async (_path, candidateShaFor) => {
+      const bundle = disabledV2WorkflowBundle();
+      const requestBytes = vi.fn(async () =>
+        expect.unreachable('post-cutoff v1 marker must reject before downloads')
+      );
+
+      await expect(
+        planFromPublishedBundles({
+          bundles: [bundle],
+          candidateSha: candidateShaFor(bundle),
+          markerTransform: marker => ({
+            ...(marker as Record<string, unknown>),
+            schema: 'bugdrop.publication-marker/v1',
+            protocol: 'release-plan/v1',
+          }),
+          requestBytes,
+        })
+      ).rejects.toMatchObject({ code: 'PUBLISHED_RELEASE_CONFLICT' });
+      expect(requestBytes).not.toHaveBeenCalled();
+    }
+  );
+
   it('accepts legitimate immutable historical and attested markers but rejects disagreement', async () => {
     const historical = disabledV2WorkflowBundle();
     const attested = withAttestation(historical);
@@ -928,17 +958,6 @@ describe('GitHub release-state observation', () => {
 
     await expect(
       planFromPublishedBundles({ bundles: [historical], immutableTagMarkers: true })
-    ).resolves.toMatchObject({ request: { previousTag: historical.finalPlan.tag } });
-    await expect(
-      planFromPublishedBundles({
-        bundles: [historical],
-        immutableTagMarkers: true,
-        markerTransform: marker => ({
-          ...(marker as Record<string, unknown>),
-          schema: 'bugdrop.publication-marker/v1',
-          protocol: 'release-plan/v1',
-        }),
-      })
     ).resolves.toMatchObject({ request: { previousTag: historical.finalPlan.tag } });
     await expect(
       planFromPublishedBundles({
@@ -1001,7 +1020,7 @@ describe('GitHub release-state observation', () => {
   });
 
   it('returns an authenticated completed no-op before local Git planning', async () => {
-    const bundle = workflowBundle();
+    const bundle = disabledV2WorkflowBundle();
     const marker = buildPublicationMarker(bundle.finalPlan);
     const encodedMarker = Buffer.from(canonicalize(marker)).toString('base64url');
     const tagObjectSha = '9'.repeat(40);
@@ -1061,7 +1080,7 @@ describe('GitHub release-state observation', () => {
       createRequestPlanFromGithub({
         transport,
         gitObserver,
-        context: workflowContext(false),
+        context: { ...workflowContext(false), retentionBootstrap: false },
       })
     ).resolves.toEqual({
       status: 'completed',
@@ -1073,6 +1092,7 @@ describe('GitHub release-state observation', () => {
 
     const recoveryContext = {
       ...workflowContext(false),
+      retentionBootstrap: false,
       controllerReachableFromCurrent: true,
       identityMainReachableFromCurrent: true,
       identityMainSha: bundle.requestPlan.source.remoteMainSha,

--- a/test/release/live-release.test.ts
+++ b/test/release/live-release.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../../scripts/release/live-release.mjs';
 import { validatePublicationBundle } from '../../scripts/release/publication.mjs';
 import { attestationPolicy, attestationSubjects } from '../../scripts/release/attestation.mjs';
-import { workflowBundle } from '../fixtures/release/workflow/bundle';
+import { disabledV2WorkflowBundle, workflowBundle } from '../fixtures/release/workflow/bundle';
 
 const SHA = 'a'.repeat(40);
 const PLAN = `sha256:${'b'.repeat(64)}`;
@@ -26,8 +26,7 @@ const expected = {
 const authorization = { status: 'mutation-authorized', planIdentity: PLAN };
 const digest = (bytes: Buffer) => createHash('sha256').update(bytes).digest('hex');
 
-function attestedBundle() {
-  const bundle = workflowBundle();
+function attestedBundle(bundle = workflowBundle()) {
   const attestationBytes = Buffer.from('{"signed":"portable"}\n');
   const attestation = {
     protocol: 'bugdrop.release-attestation/v1',
@@ -238,8 +237,100 @@ describe('live release production orchestration', () => {
     });
   });
 
+  it('preserves exact six-asset recovery through v1.55.2', async () => {
+    const bundle = disabledV2WorkflowBundle({
+      previousTag: 'v1.55.1',
+      nextTag: 'v1.55.2',
+    });
+    const publication = validatePublicationBundle(bundle);
+    const adapter = {
+      inspect: vi.fn(async () => ({
+        complete: true,
+        tagRef: { objectSha: 'c'.repeat(40) },
+        tagObject: {
+          annotation: publication.tagAnnotation,
+          kind: 'annotated',
+          objectSha: 'c'.repeat(40),
+          targetSha: publication.targetSha,
+          targetType: 'commit',
+        },
+        releases: [
+          {
+            assets: Object.entries(bundle.assets).map(([name, bytes]) => ({ name, bytes })),
+            body: publication.body,
+            bodyMarker: publication.bodyMarker,
+            draft: false,
+            id: '123',
+            marker: publication.marker,
+            name: publication.name,
+            prerelease: false,
+            published: true,
+            tag: publication.tag,
+            targetSha: publication.targetSha,
+          },
+        ],
+      })),
+    };
+
+    await expect(inspectPublication({ bundle, adapter })).resolves.toMatchObject({
+      status: 'already-published',
+      planIdentity: bundle.finalPlan.planIdentity,
+    });
+  });
+
+  it('rejects post-boundary six-asset workflow input without attestationPath and rolls back', async () => {
+    const bundle = disabledV2WorkflowBundle({
+      previousTag: 'v1.55.2',
+      nextTag: 'v1.55.3',
+    });
+    const adapter = { inspect: vi.fn(() => expect.unreachable('must reject before inspection')) };
+    const publication = await inspectPublication({ bundle, adapter });
+    expect(publication).toMatchObject({
+      status: 'conflict',
+      reason: 'post-boundary-attestation-required',
+      planIdentity: bundle.finalPlan.planIdentity,
+    });
+    expect(adapter.inspect).not.toHaveBeenCalled();
+
+    const postExpected = {
+      origin: expected.origin,
+      planIdentity: bundle.finalPlan.planIdentity,
+      targetSha: bundle.finalPlan.targetSha,
+    };
+    const cloudflare = client();
+    const baseline = await captureBaseline({
+      client: cloudflare,
+      expected: postExpected,
+      observe: cloudflare.observe,
+    });
+    const deployment = await deployCandidate({
+      authorization: { status: 'mutation-authorized', planIdentity: postExpected.planIdentity },
+      baseline,
+      client: cloudflare,
+      expected: postExpected,
+      observe: cloudflare.observe,
+      verify: async () => ({ status: 'verified', targetSha: postExpected.targetSha }),
+    });
+    await expect(
+      finalizeRelease({
+        baseline,
+        client: cloudflare,
+        deployment,
+        expected: postExpected,
+        publication,
+        observe: cloudflare.observe,
+        verify: async () => ({ status: 'verified', targetSha: postExpected.targetSha }),
+      })
+    ).resolves.toMatchObject({ status: 'rollback-verified' });
+  });
+
   it('requires the exact seventh evidence asset during authoritative finalization inspection', async () => {
-    const { bundle, attestation, attestationBytes, verifyAttestation } = attestedBundle();
+    const { bundle, attestation, attestationBytes, verifyAttestation } = attestedBundle(
+      disabledV2WorkflowBundle({
+        previousTag: 'v1.55.2',
+        nextTag: 'v1.55.3',
+      })
+    );
     const releaseBundle = {
       ...bundle,
       attestation,
@@ -282,7 +373,39 @@ describe('live release production orchestration', () => {
       verifyAttestation,
     };
 
-    await expect(inspectPublication(input)).resolves.toMatchObject({ status: 'already-published' });
+    const inspected = await inspectPublication(input);
+    expect(inspected).toMatchObject({ status: 'already-published' });
+
+    const postExpected = {
+      origin: expected.origin,
+      planIdentity: bundle.finalPlan.planIdentity,
+      targetSha: bundle.finalPlan.targetSha,
+    };
+    const stableClient = client();
+    const stableBaseline = await captureBaseline({
+      client: stableClient,
+      expected: postExpected,
+      observe: stableClient.observe,
+    });
+    const stableDeployment = await deployCandidate({
+      authorization: { status: 'mutation-authorized', planIdentity: postExpected.planIdentity },
+      baseline: stableBaseline,
+      client: stableClient,
+      expected: postExpected,
+      observe: stableClient.observe,
+      verify: async () => ({ status: 'verified', targetSha: postExpected.targetSha }),
+    });
+    await expect(
+      finalizeRelease({
+        baseline: stableBaseline,
+        client: stableClient,
+        deployment: stableDeployment,
+        expected: postExpected,
+        publication: inspected,
+        observe: stableClient.observe,
+        verify: async () => ({ status: 'verified', targetSha: postExpected.targetSha }),
+      })
+    ).resolves.toMatchObject({ status: 'published-stable' });
     observation.releases[0].assets = observation.releases[0].assets.filter(
       asset => asset.name !== 'attestation.intoto.jsonl'
     );

--- a/test/release/live-release.test.ts
+++ b/test/release/live-release.test.ts
@@ -9,6 +9,7 @@ import {
   buildExpectedLive,
   captureBaseline,
   deployCandidate,
+  finalizeInspectedRelease,
   finalizeRelease,
   inspectPublication,
 } from '../../scripts/release/live-release.mjs';
@@ -322,6 +323,76 @@ describe('live release production orchestration', () => {
         verify: async () => ({ status: 'verified', targetSha: postExpected.targetSha }),
       })
     ).resolves.toMatchObject({ status: 'rollback-verified' });
+  });
+
+  it('routes finalization verifier failure into verified rollback without GitHub inspection', async () => {
+    const { bundle, attestationBytes } = attestedBundle(
+      disabledV2WorkflowBundle({
+        previousTag: 'v1.55.2',
+        nextTag: 'v1.55.3',
+      })
+    );
+    const adapter = {
+      inspect: vi.fn(() => expect.unreachable('untrusted state is not inspected')),
+    };
+    const verifierFailure = vi.fn(async () => {
+      throw new Error('trusted-root verification failed');
+    });
+    await expect(
+      inspectPublication({
+        bundle,
+        adapter,
+        attestationBytes,
+        controllerSha: bundle.requestPlan.source.controllerSha,
+        repository: 'mean-weasel/bugdrop',
+        verifyAttestation: verifierFailure,
+      })
+    ).resolves.toMatchObject({
+      status: 'conflict',
+      reason: 'attestation-verification-failed',
+      planIdentity: bundle.finalPlan.planIdentity,
+    });
+    const postExpected = {
+      origin: expected.origin,
+      planIdentity: bundle.finalPlan.planIdentity,
+      targetSha: bundle.finalPlan.targetSha,
+    };
+    const cloudflare = client();
+    const baseline = await captureBaseline({
+      client: cloudflare,
+      expected: postExpected,
+      observe: cloudflare.observe,
+    });
+    const deployment = await deployCandidate({
+      authorization: { status: 'mutation-authorized', planIdentity: postExpected.planIdentity },
+      baseline,
+      client: cloudflare,
+      expected: postExpected,
+      observe: cloudflare.observe,
+      verify: async () => ({ status: 'verified', targetSha: postExpected.targetSha }),
+    });
+
+    await expect(
+      finalizeInspectedRelease({
+        bundle,
+        adapter,
+        attestationBytes,
+        controllerSha: bundle.requestPlan.source.controllerSha,
+        repository: 'mean-weasel/bugdrop',
+        verifyAttestation: verifierFailure,
+        baseline,
+        client: cloudflare,
+        deployment,
+        expected: postExpected,
+        observe: cloudflare.observe,
+        verify: async () => ({ status: 'verified', targetSha: postExpected.targetSha }),
+      })
+    ).resolves.toMatchObject({
+      status: 'rollback-verified',
+      rollbackAttempted: true,
+    });
+    expect(adapter.inspect).not.toHaveBeenCalled();
+    expect(cloudflare.rollback).toHaveBeenCalledOnce();
   });
 
   it('requires the exact seventh evidence asset during authoritative finalization inspection', async () => {

--- a/test/release/live-release.test.ts
+++ b/test/release/live-release.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -12,6 +13,7 @@ import {
   inspectPublication,
 } from '../../scripts/release/live-release.mjs';
 import { validatePublicationBundle } from '../../scripts/release/publication.mjs';
+import { attestationPolicy, attestationSubjects } from '../../scripts/release/attestation.mjs';
 import { workflowBundle } from '../fixtures/release/workflow/bundle';
 
 const SHA = 'a'.repeat(40);
@@ -22,6 +24,29 @@ const expected = {
   targetSha: SHA,
 };
 const authorization = { status: 'mutation-authorized', planIdentity: PLAN };
+const digest = (bytes: Buffer) => createHash('sha256').update(bytes).digest('hex');
+
+function attestedBundle() {
+  const bundle = workflowBundle();
+  const attestationBytes = Buffer.from('{"signed":"portable"}\n');
+  const attestation = {
+    protocol: 'bugdrop.release-attestation/v1',
+    status: 'verified',
+    asset: 'attestation.intoto.jsonl',
+    bundleSha256: digest(attestationBytes),
+    policy: attestationPolicy({
+      repository: 'mean-weasel/bugdrop',
+      controllerSha: bundle.requestPlan.source.controllerSha,
+    }),
+    subjects: attestationSubjects(bundle),
+  };
+  return {
+    bundle,
+    attestation,
+    attestationBytes,
+    verifyAttestation: vi.fn(async () => attestation),
+  };
+}
 
 function state(name: string, buildSha: string | null) {
   return {
@@ -211,6 +236,87 @@ describe('live release production orchestration', () => {
       nextAction: { kind: 'create-draft', tag: publication.tag },
       planIdentity: bundle.finalPlan.planIdentity,
     });
+  });
+
+  it('requires the exact seventh evidence asset during authoritative finalization inspection', async () => {
+    const { bundle, attestation, attestationBytes, verifyAttestation } = attestedBundle();
+    const releaseBundle = {
+      ...bundle,
+      attestation,
+      assets: { ...bundle.assets, 'attestation.intoto.jsonl': attestationBytes },
+    };
+    const publication = validatePublicationBundle(releaseBundle, { requireAttestation: true });
+    const observation = {
+      complete: true,
+      tagRef: { objectSha: 'c'.repeat(40) },
+      tagObject: {
+        annotation: publication.tagAnnotation,
+        kind: 'annotated',
+        objectSha: 'c'.repeat(40),
+        targetSha: publication.targetSha,
+        targetType: 'commit',
+      },
+      releases: [
+        {
+          assets: Object.entries(releaseBundle.assets).map(([name, bytes]) => ({ name, bytes })),
+          body: publication.body,
+          bodyMarker: publication.bodyMarker,
+          draft: false,
+          id: '123',
+          marker: publication.marker,
+          name: publication.name,
+          prerelease: false,
+          published: true,
+          tag: publication.tag,
+          targetSha: publication.targetSha,
+        },
+      ],
+    };
+    const adapter = { inspect: vi.fn(async () => observation) };
+    const input = {
+      bundle,
+      adapter,
+      attestationBytes,
+      controllerSha: bundle.requestPlan.source.controllerSha,
+      repository: 'mean-weasel/bugdrop',
+      verifyAttestation,
+    };
+
+    await expect(inspectPublication(input)).resolves.toMatchObject({ status: 'already-published' });
+    observation.releases[0].assets = observation.releases[0].assets.filter(
+      asset => asset.name !== 'attestation.intoto.jsonl'
+    );
+    const missing = await inspectPublication(input);
+    expect(missing).toMatchObject({
+      status: 'conflict',
+      reason: 'published-assets-incomplete',
+    });
+
+    const cloudflare = client();
+    const baseline = await captureBaseline({
+      client: cloudflare,
+      expected,
+      observe: cloudflare.observe,
+    });
+    const deployment = await deployCandidate({
+      authorization,
+      baseline,
+      client: cloudflare,
+      expected,
+      observe: cloudflare.observe,
+      verify: async () => ({ status: 'verified', targetSha: SHA }),
+    });
+    await expect(
+      finalizeRelease({
+        baseline,
+        client: cloudflare,
+        deployment,
+        expected,
+        publication: missing,
+        observe: cloudflare.observe,
+        verify: async () => ({ status: 'verified', targetSha: SHA }),
+      })
+    ).resolves.toMatchObject({ status: 'rollback-verified' });
   });
 
   it('reconciles a lost deploy response only after source and asset live proof', async () => {

--- a/test/release/publication.test.ts
+++ b/test/release/publication.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 import { canonicalHash, canonicalize } from '../../scripts/release/canonical-json.mjs';
 import {
   buildFinalPlan,
+  buildPublicationMarker,
   buildReleaseContent,
   buildReleaseInventory,
   buildRequestPlan,
@@ -187,7 +188,24 @@ function publicationBundle(verificationResult: 'passed' | 'failed' = 'passed') {
     .map(([name, bytes]) => `${sha256(bytes)}  ${name}`)
     .join('\n');
   assets['checksums.sha256'] = Buffer.from(`${checksums}\n`);
-  return { requestPlan, releaseContent, finalPlan, assets };
+  const attestationBytes = Buffer.from('{"portable":"evidence"}\n');
+  assets['attestation.intoto.jsonl'] = attestationBytes;
+  const subjects = finalPlan.requiredAssets
+    .map(name => ({ name, digest: { sha256: sha256(assets[name]) } }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+  const attestation = {
+    protocol: 'bugdrop.release-attestation/v1',
+    status: 'verified',
+    asset: 'attestation.intoto.jsonl',
+    bundleSha256: sha256(attestationBytes),
+    policy: {
+      repository: 'mean-weasel/bugdrop',
+      signerDigest: SHA.controller,
+      sourceDigest: SHA.controller,
+    },
+    subjects,
+  };
+  return { requestPlan, releaseContent, finalPlan, assets, attestation };
 }
 
 async function publishedAdapter() {
@@ -278,7 +296,9 @@ describe('complete publication and exact retry', () => {
     expect(adapter.applied).toEqual([
       'create-tag',
       'create-draft',
-      ...bundle.finalPlan.requiredAssets.map(name => `upload-asset:${name}`),
+      ...Object.keys(bundle.assets)
+        .sort()
+        .map(name => `upload-asset:${name}`),
       'publish-draft',
     ]);
     expect(adapter.log.filter(item => item.startsWith('inspect')).length).toBe(
@@ -311,10 +331,10 @@ describe('complete publication and exact retry', () => {
         status: 'published',
       });
       expect(adapter.applied.filter(item => item.startsWith(point))).toHaveLength(
-        point === 'upload-asset' ? bundle.finalPlan.requiredAssets.length : 1
+        point === 'upload-asset' ? Object.keys(bundle.assets).length : 1
       );
       expect(adapter.log.filter(item => item.startsWith(point))).toHaveLength(
-        point === 'upload-asset' ? bundle.finalPlan.requiredAssets.length : 1
+        point === 'upload-asset' ? Object.keys(bundle.assets).length : 1
       );
     }
   );
@@ -798,10 +818,10 @@ describe('complete publication and exact retry', () => {
         status: 'published',
       });
       expect(adapter.applied.filter(item => item.startsWith(point))).toHaveLength(
-        point === 'upload-asset' ? bundle.finalPlan.requiredAssets.length : 1
+        point === 'upload-asset' ? Object.keys(bundle.assets).length : 1
       );
       expect(adapter.log.filter(item => item.startsWith(point))).toHaveLength(
-        point === 'upload-asset' ? bundle.finalPlan.requiredAssets.length : 1
+        point === 'upload-asset' ? Object.keys(bundle.assets).length : 1
       );
     }
   );
@@ -821,7 +841,7 @@ describe('complete publication and exact retry', () => {
         status: 'published',
       });
       expect(adapter.applied.filter(item => item.startsWith(point))).toHaveLength(
-        point === 'upload-asset' ? bundle.finalPlan.requiredAssets.length : 1
+        point === 'upload-asset' ? Object.keys(bundle.assets).length : 1
       );
     }
   );
@@ -929,7 +949,7 @@ describe('complete publication and exact retry', () => {
       new FakeGitHubPublicationAdapter(),
       'upload-asset',
       (_before, after) => {
-        if (after.releases![0].assets.length !== bundle.finalPlan.requiredAssets.length) return [];
+        if (after.releases![0].assets.length !== Object.keys(bundle.assets).length) return [];
         const duplicate = clonePublicationState(after.releases![0]);
         duplicate.id = '456';
         after.releases!.push(duplicate);
@@ -942,10 +962,10 @@ describe('complete publication and exact retry', () => {
       reason: 'duplicate-release',
     });
     expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(
-      bundle.finalPlan.requiredAssets.length
+      Object.keys(bundle.assets).length
     );
     expect(adapter.applied.filter(item => item.startsWith('upload-asset'))).toHaveLength(
-      bundle.finalPlan.requiredAssets.length
+      Object.keys(bundle.assets).length
     );
     expect(adapter.log.filter(item => item === 'publish-draft')).toHaveLength(0);
   });
@@ -972,7 +992,7 @@ describe('complete publication and exact retry', () => {
     expect(adapter.applied.filter(item => item === 'publish-draft')).toHaveLength(1);
     expect(adapter.log.filter(item => item === 'create-draft')).toHaveLength(1);
     expect(adapter.log.filter(item => item.startsWith('upload-asset'))).toHaveLength(
-      bundle.finalPlan.requiredAssets.length
+      Object.keys(bundle.assets).length
     );
   });
 
@@ -1239,6 +1259,97 @@ describe('conflicts, unknown state, and bundle authentication', () => {
     await expect(executePublication({ adapter, bundle })).rejects.toThrow(/requiredAssets/);
     expect(adapter.log).toEqual([]);
     expect(adapter.applied).toEqual([]);
+  });
+
+  it('rejects a missing provenance bundle and an unexpected eighth Release asset', async () => {
+    const missing = publicationBundle();
+    delete missing.assets['attestation.intoto.jsonl'];
+    const unexpected = publicationBundle();
+    unexpected.assets['unexpected.bin'] = Buffer.from('x');
+    const adapter = new FakeGitHubPublicationAdapter();
+
+    await expect(executePublication({ adapter, bundle: missing })).rejects.toThrow(
+      /asset names do not exactly match the release boundary/
+    );
+    await expect(executePublication({ adapter, bundle: unexpected })).rejects.toThrow(
+      /asset names do not exactly match the release boundary/
+    );
+    expect(adapter.applied).toEqual([]);
+  });
+
+  it('binds only the required evidence filename into new markers and preserves history', () => {
+    const attested = publicationBundle();
+    const expected = validatePublicationBundle(attested, { requireAttestation: true });
+    const { attestation: _attestation, ...historical } = publicationBundle();
+    delete historical.assets['attestation.intoto.jsonl'];
+    const legacy = validatePublicationBundle(historical, { allowLegacy: true });
+
+    expect(expected.marker).toEqual({
+      ...buildPublicationMarker(attested.finalPlan),
+      requiredEvidence: ['attestation.intoto.jsonl'],
+    });
+    expect(legacy.marker).toEqual(buildPublicationMarker(attested.finalPlan));
+    expect(expected.marker).not.toEqual(legacy.marker);
+    expect(canonicalize(expected.marker)).not.toContain(
+      expected.expectedHashes['attestation.intoto.jsonl']
+    );
+  });
+
+  it('rejects deletion, replacement, and addition against an attested marker', () => {
+    const bundle = publicationBundle();
+    const expected = validatePublicationBundle(bundle, { requireAttestation: true });
+    const release = {
+      assets: Object.entries(bundle.assets).map(([name, bytes]) => ({ name, bytes })),
+      body: expected.body,
+      bodyMarker: expected.bodyMarker,
+      draft: false,
+      id: '123',
+      marker: expected.marker,
+      name: expected.name,
+      prerelease: false,
+      published: true,
+      tag: expected.tag,
+      targetSha: expected.targetSha,
+    };
+    const observation = {
+      complete: true,
+      tagRef: { objectSha: '7'.repeat(40) },
+      tagObject: {
+        kind: 'annotated',
+        objectSha: '7'.repeat(40),
+        targetType: 'commit',
+        targetSha: expected.targetSha,
+        annotation: expected.tagAnnotation,
+      },
+      releases: [release],
+    };
+
+    const classify = (assets: Array<{ name: string; bytes: Buffer }>) =>
+      classifyPublicationState(expected, {
+        ...observation,
+        releases: [{ ...release, assets }],
+      });
+    expect(
+      classify(release.assets.filter(asset => asset.name !== 'attestation.intoto.jsonl'))
+    ).toMatchObject({ status: 'conflict', reason: 'published-assets-incomplete' });
+    expect(
+      classify(
+        release.assets.map(asset =>
+          asset.name === 'attestation.intoto.jsonl'
+            ? { ...asset, bytes: Buffer.from('bad') }
+            : asset
+        )
+      )
+    ).toMatchObject({
+      status: 'conflict',
+      reason: 'asset-content-mismatch:attestation.intoto.jsonl',
+    });
+    expect(
+      classify([...release.assets, { name: 'extra.bin', bytes: Buffer.from('x') }])
+    ).toMatchObject({
+      status: 'conflict',
+      reason: 'unexpected-asset',
+    });
   });
 
   it('classifies a tag-only state as the same-version draft continuation', () => {

--- a/test/release/retention-integration.test.ts
+++ b/test/release/retention-integration.test.ts
@@ -146,6 +146,17 @@ async function vertical({ postBoundaryLegacy = false } = {}) {
   });
   const marker = buildPublicationMarker(bundleN.finalPlan);
   const legacySha = '7'.repeat(40);
+  const tagObjectSha = '8'.repeat(40);
+  const legacyTagObjectSha = '9'.repeat(40);
+  const postBoundaryMarker = {
+    schema: 'bugdrop.publication-marker/v1',
+    protocol: 'release-plan/v1',
+    planIdentity: `sha256:${'7'.repeat(64)}`,
+    requestIdentity: `sha256:${'8'.repeat(64)}`,
+    contentIdentity: `sha256:${'9'.repeat(64)}`,
+    targetSha: legacySha,
+    tag: 'v1.55.1',
+  };
   const assetEntries = Object.entries(bundleN.assets).map(([name, bytes], index) => ({
     id: 1000 + index,
     name,
@@ -179,7 +190,7 @@ async function vertical({ postBoundaryLegacy = false } = {}) {
                   prerelease: false,
                   published_at: '2026-08-01T12:00:00Z',
                   html_url: 'https://github.test/releases/56',
-                  body: '',
+                  body: `<!-- bugdrop-publication ${Buffer.from(canonicalize(postBoundaryMarker)).toString('base64url')} -->`,
                   assets: [],
                 },
               ]
@@ -190,11 +201,32 @@ async function vertical({ postBoundaryLegacy = false } = {}) {
     if (path === `/repos/${REPOSITORY}/git/matching-refs/tags/v?per_page=100&page=1`)
       return {
         data: [
-          { ref: 'refs/tags/v1.55.0', object: { type: 'commit', sha: N_SHA } },
+          { ref: 'refs/tags/v1.55.0', object: { type: 'tag', sha: tagObjectSha } },
           ...(postBoundaryLegacy
-            ? [{ ref: 'refs/tags/v1.55.1', object: { type: 'commit', sha: legacySha } }]
+            ? [
+                {
+                  ref: 'refs/tags/v1.55.1',
+                  object: { type: 'tag', sha: legacyTagObjectSha },
+                },
+              ]
             : []),
         ],
+        hasNext: false,
+      };
+    if (path === `/repos/${REPOSITORY}/git/tags/${tagObjectSha}`)
+      return {
+        data: {
+          object: { type: 'commit', sha: N_SHA },
+          message: `BugDrop v1.55.0\n\n${canonicalize(marker)}`,
+        },
+        hasNext: false,
+      };
+    if (path === `/repos/${REPOSITORY}/git/tags/${legacyTagObjectSha}`)
+      return {
+        data: {
+          object: { type: 'commit', sha: legacySha },
+          message: `BugDrop v1.55.1\n\n${canonicalize(postBoundaryMarker)}`,
+        },
         hasNext: false,
       };
     if (path === `/repos/${REPOSITORY}/compare/${N_SHA}...${N1_SHA}`)

--- a/test/release/retention-integration.test.ts
+++ b/test/release/retention-integration.test.ts
@@ -22,6 +22,7 @@ import { resolveStaticArtifactRetry } from '../../scripts/release/static-assets.
 import { hashStaticTree } from '../../scripts/release/static-tree.mjs';
 import { createState2BundleFromStaticPackage } from '../../scripts/release/workflow.mjs';
 import { buildExpectedLive } from '../../scripts/release/live-release.mjs';
+import { disabledV2WorkflowBundle } from '../fixtures/release/workflow/bundle';
 
 const ROOT = resolve(import.meta.dirname, '../..');
 const CANDIDATE = join(ROOT, 'test/fixtures/release/static-assets/older-candidate');
@@ -148,15 +149,13 @@ async function vertical({ postBoundaryLegacy = false } = {}) {
   const legacySha = '7'.repeat(40);
   const tagObjectSha = '8'.repeat(40);
   const legacyTagObjectSha = '9'.repeat(40);
-  const postBoundaryMarker = {
-    schema: 'bugdrop.publication-marker/v1',
-    protocol: 'release-plan/v1',
-    planIdentity: `sha256:${'7'.repeat(64)}`,
-    requestIdentity: `sha256:${'8'.repeat(64)}`,
-    contentIdentity: `sha256:${'9'.repeat(64)}`,
+  const postBoundaryBundle = disabledV2WorkflowBundle({
+    previousTag: 'v1.55.0',
+    nextTag: 'v1.55.1',
     targetSha: legacySha,
-    tag: 'v1.55.1',
-  };
+    timestamp: '2026-08-01T12:00:00Z',
+  });
+  const postBoundaryMarker = buildPublicationMarker(postBoundaryBundle.finalPlan);
   const assetEntries = Object.entries(bundleN.assets).map(([name, bytes], index) => ({
     id: 1000 + index,
     name,
@@ -164,9 +163,22 @@ async function vertical({ postBoundaryLegacy = false } = {}) {
     browser_download_url: `https://github.com/${REPOSITORY}/releases/download/v1.55.0/${name}`,
     size: bytes.length,
   }));
-  const bytesById = Object.fromEntries(
-    assetEntries.map(asset => [String(asset.id), bundleN.assets[asset.name]])
+  const postBoundaryAssetEntries = Object.entries(postBoundaryBundle.assets).map(
+    ([name, bytes], index) => ({
+      id: 2000 + index,
+      name,
+      url: `https://api.github.test/repos/${REPOSITORY}/releases/assets/${2000 + index}`,
+      browser_download_url: `https://github.com/${REPOSITORY}/releases/download/v1.55.1/${name}`,
+      size: bytes.length,
+    })
   );
+  const bytesById = Object.fromEntries([
+    ...assetEntries.map(asset => [String(asset.id), bundleN.assets[asset.name]]),
+    ...postBoundaryAssetEntries.map(asset => [
+      String(asset.id),
+      postBoundaryBundle.assets[asset.name],
+    ]),
+  ]);
   const request = async (path: string) => {
     if (path === `/repos/${REPOSITORY}/releases?per_page=100&page=1`)
       return {
@@ -191,7 +203,7 @@ async function vertical({ postBoundaryLegacy = false } = {}) {
                   published_at: '2026-08-01T12:00:00Z',
                   html_url: 'https://github.test/releases/56',
                   body: `<!-- bugdrop-publication ${Buffer.from(canonicalize(postBoundaryMarker)).toString('base64url')} -->`,
-                  assets: [],
+                  assets: postBoundaryAssetEntries,
                 },
               ]
             : []),

--- a/test/workflow-permissions.test.sh
+++ b/test/workflow-permissions.test.sh
@@ -30,6 +30,40 @@ expect_failure() {
 
 node "$checker" "$repo_root/.github/workflows" > /dev/null
 
+missing_attestation_oidc=$(make_fixture missing-attestation-oidc)
+perl -0pi -e \
+  's/(  attest-release:.*?    permissions:\n      contents: read\n)      id-token: write\n/$1/s' \
+  "$missing_attestation_oidc/deploy.yml"
+expect_failure "$missing_attestation_oidc" \
+  'deploy.yml:attest-release: effective permissions must be {"attestations":"write","contents":"read","id-token":"write"}'
+
+missing_attestation_write=$(make_fixture missing-attestation-write)
+perl -0pi -e \
+  's/(  attest-release:.*?    permissions:\n      contents: read\n      id-token: write\n)      attestations: write\n/$1/s' \
+  "$missing_attestation_write/deploy.yml"
+expect_failure "$missing_attestation_write" \
+  'deploy.yml:attest-release: effective permissions must be {"attestations":"write","contents":"read","id-token":"write"}'
+
+misplaced_attestation_write=$(make_fixture misplaced-attestation-write)
+perl -0pi -e \
+  's/(  publish-release:.*?    permissions:\n      contents: write\n)/$1      attestations: write\n/s' \
+  "$misplaced_attestation_write/deploy.yml"
+expect_failure "$misplaced_attestation_write" \
+  'deploy.yml:publish-release: attestations: write is not an approved grant'
+
+broad_attestation_job=$(make_fixture broad-attestation-job)
+perl -0pi -e \
+  's/(  attest-release:.*?    permissions:\n)      contents: read\n/$1      contents: write\n/s' \
+  "$broad_attestation_job/deploy.yml"
+expect_failure "$broad_attestation_job" \
+  'deploy.yml:attest-release: contents: write is not an approved grant'
+
+top_level_oidc=$(make_fixture top-level-oidc)
+perl -0pi -e 's/(permissions:\n  contents: read\n)/$1  id-token: write\n/' \
+  "$top_level_oidc/deploy.yml"
+expect_failure "$top_level_oidc" \
+  'deploy.yml: top-level permissions must be {"contents":"read"}'
+
 missing_top=$(make_fixture missing-top)
 perl -0pi -e 's/\npermissions: \{\}\n/\n/' "$missing_top/benchmark-ci.yml"
 expect_failure "$missing_top" 'benchmark-ci.yml: top-level permissions must be explicitly declared'


### PR DESCRIPTION
## Summary

- add a least-privilege attestation job between live verification and Release publication
- attest the six immutable State 2 release files and publish one portable `attestation.intoto.jsonl` evidence asset
- authenticate exact release bytes during publication, completed-plan reuse, N+1 planning, and finalization
- preserve real pre-protocol history through `v1.55.0` while requiring canonical annotated-tag and Release-body markers for protocol-era releases
- document online and genuinely offline verification with exact statement cardinality, subject-set, identity, and trusted-root checks
- extend fail-closed Action pinning and workflow-permission policy for the attestation boundary

## Security boundaries

- `attest-release`: `contents: read`, `id-token: write`, `attestations: write`
- `publish-release`: `contents: write` only
- `actions/attest` pinned to `a1948c3f048ba23858d222213b7c278aabede763` (`v4.1.1`)
- six exact signed subjects; `attestation.intoto.jsonl` is evidence-only and cannot attest itself
- dry-run and completed-no-op paths cannot mint attestations
- protocol-era tag/body metadata must be present, canonical, structurally valid, and equal before release state is trusted

## Verification

- `make check`
- `npm run validate` — 73 files / 1,040 tests
- `npm run test:release` — 20 files / 437 tests
- `npm run test:release-workflow` — 181 tests plus workflow contract
- focused provenance suite — 159 tests
- `npm run build:widget`
- `git diff --check`

The strongest reproduced downgrade cases cover removed or rewritten evidence, Release-body metadata, annotated-tag metadata, lightweight and malformed tag replacements, equal-but-invalid marker schemas, completed-plan reuse, N+1 planning, retention, and finalization.

## Remaining operator gates

This PR does not dispatch a workflow or publish a Release. Merge/merge-queue action and the first live seven-asset release proof remain separate explicit approvals.
