### PR TITLE
feat: add backwards-compatible composable feedback flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 Follow `CLAUDE.md` for repo-level agent guidance.
 
+## Local Servers
+
+When starting or handing off a local server, always use a named `.localhost`
+subdomain (for example, `bugdrop.localhost`) instead of bare `localhost` or
+`127.0.0.1`.
+
 ## Pull Request Review
 
 For every pull request, run `codex-pr-review-toolkit:review-pull-request` against its base before merge.

--- a/e2e/default-flow-compatibility.spec.ts
+++ b/e2e/default-flow-compatibility.spec.ts
@@ -1,0 +1,1002 @@
+import { expect, test, type Browser, type BrowserContext, type Page } from '@playwright/test';
+
+type Runner = 'fixed' | 'private';
+type FeedbackPayload = Record<string, unknown> & {
+  title: string;
+  description: string;
+  category: string;
+  screenshot: string | null;
+  attachments: unknown[];
+  consoleLogs?: Array<Record<string, unknown>>;
+  submitter?: { name?: string; email?: string };
+  metadata: Record<string, unknown> & {
+    timestamp?: string;
+    elementSelector?: string | null;
+    fullElementSelector?: string | null;
+  };
+};
+type JourneyResult = { trace: string[]; requests: FeedbackPayload[] };
+type Journey = (page: Page, trace: string[], requests: FeedbackPayload[]) => Promise<void>;
+
+const welcomeStorageKey = 'bugdrop_welcomed_mean-weasel/bugdrop-widget-test';
+const stubPng =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+function host(page: Page) {
+  return page.locator('#bugdrop-host');
+}
+
+async function prepareContext(context: BrowserContext, runner: Runner, captureHook?: string) {
+  if (runner === 'private') {
+    await context.addInitScript(() => {
+      (window as unknown as { __bugdropDefaultFlowRuntime?: string }).__bugdropDefaultFlowRuntime =
+        'private';
+    });
+  }
+  if (captureHook) await context.addInitScript({ content: captureHook });
+}
+
+async function runJourney(
+  browser: Browser,
+  runner: Runner,
+  journey: Journey,
+  captureHook?: string
+): Promise<JourneyResult> {
+  const context = await browser.newContext();
+  await prepareContext(context, runner, captureHook);
+  const page = await context.newPage();
+  const requests: FeedbackPayload[] = [];
+  const trace: string[] = [];
+
+  await page.route('**/api/check**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ installed: true }),
+    })
+  );
+  await page.route('**/feedback', async route => {
+    requests.push(route.request().postDataJSON() as FeedbackPayload);
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        issueNumber: 42,
+        issueUrl: 'https://github.com/example/project/issues/42',
+        isPublic: false,
+      }),
+    });
+  });
+
+  try {
+    await journey(page, trace, requests);
+    return { trace, requests: requests.map(normalizePayload) };
+  } finally {
+    await context.close();
+  }
+}
+
+async function expectPairedJourney(
+  browser: Browser,
+  journey: Journey,
+  captureHook?: string
+): Promise<JourneyResult> {
+  const fixed = await runJourney(browser, 'fixed', journey, captureHook);
+  const privateRuntime = await runJourney(browser, 'private', journey, captureHook);
+  expect(privateRuntime.trace).toEqual(fixed.trace);
+  expect(privateRuntime.requests).toEqual(fixed.requests);
+  return fixed;
+}
+
+function normalizePayload(payload: FeedbackPayload): FeedbackPayload {
+  return {
+    ...payload,
+    ...(payload.consoleLogs
+      ? {
+          consoleLogs: payload.consoleLogs.map(entry => ({
+            ...entry,
+            ...('timestamp' in entry ? { timestamp: '<timestamp>' } : {}),
+          })),
+        }
+      : {}),
+    metadata: { ...payload.metadata, timestamp: '<timestamp>' },
+  };
+}
+
+async function observe(page: Page, trace: string[], label: string) {
+  const state = await page.evaluate(() => {
+    const root = document.querySelector('#bugdrop-host')?.shadowRoot;
+    const visible = (element: Element | null) =>
+      element instanceof HTMLElement && element.getClientRects().length > 0;
+    const value = (selector: string) =>
+      (root?.querySelector(selector) as HTMLInputElement | HTMLTextAreaElement | null)?.value ??
+      null;
+    const checked = (selector: string) =>
+      (root?.querySelector(selector) as HTMLInputElement | null)?.checked ?? null;
+
+    return {
+      title: root?.querySelector('.bd-title')?.textContent?.trim() ?? null,
+      actions: [...(root?.querySelectorAll('[data-action]') ?? [])]
+        .filter(visible)
+        .map(element => (element as HTMLElement).dataset.action),
+      form: {
+        title: value('#title'),
+        description: value('#description'),
+        category: value('input[name="category"]:checked'),
+        name: value('#name'),
+        email: value('#email'),
+        screenshot: checked('#include-screenshot'),
+        consoleLogs: checked('#send-console-logs'),
+        uploads:
+          root?.querySelector('#attachment-list')?.textContent?.replace(/\s+/g, ' ').trim() ?? null,
+      },
+      annotation: visible(root?.querySelector('#annotation-canvas') ?? null),
+      error: root?.querySelector('.bd-error-message__text')?.textContent?.trim() ?? null,
+      success: visible(root?.querySelector('.bd-success-icon') ?? null),
+    };
+  });
+  trace.push(JSON.stringify({ state: label, ...state }));
+}
+
+async function act(page: Page, trace: string[], action: string, selector: string) {
+  trace.push(`action:${action}`);
+  await host(page).locator(`css=${selector}`).click();
+}
+
+async function waitForWidget(page: Page) {
+  await expect(host(page).locator('css=.bd-trigger')).toBeVisible({ timeout: 5000 });
+}
+
+async function openFromPublicApi(page: Page, trace: string[]) {
+  await page.waitForFunction(() => typeof window.BugDrop !== 'undefined');
+  trace.push('action:public-open');
+  await page.evaluate(() => window.BugDrop?.open());
+  await expect(host(page).locator('css=#title')).toBeVisible();
+  await observe(page, trace, 'details');
+}
+
+async function fillBaseForm(page: Page, title: string, description = `${title} description`) {
+  const widget = host(page);
+  await widget.locator('css=#title').fill(title);
+  await widget.locator('css=#description').fill(description);
+}
+
+function successfulCaptureHook() {
+  return `window.__bugdropMockToPng = function() {
+    window.__captureCount = (window.__captureCount || 0) + 1;
+    return Promise.resolve('${stubPng}');
+  };`;
+}
+
+function firstCaptureFailsHook() {
+  return `window.__bugdropMockToPng = function() {
+    window.__captureCount = (window.__captureCount || 0) + 1;
+    if (window.__captureCount === 1) return Promise.reject(new Error('paired failure'));
+    return Promise.resolve('${stubPng}');
+  };`;
+}
+
+function viewportCaptureHook() {
+  return `window.__bugdropMockViewportCapture = function() {
+    window.__viewportCaptureCount = (window.__viewportCaptureCount || 0) + 1;
+    return Promise.resolve('${stubPng}');
+  };`;
+}
+
+function redactionAwareCaptureHook() {
+  return `window.__bugdropMockToPng = function(el, opts) {
+    var canvas = document.createElement('canvas');
+    var pixelRatio = opts && opts.pixelRatio ? opts.pixelRatio : 1;
+    canvas.width = Math.max(1, Math.ceil((opts && opts.width ? opts.width : document.documentElement.scrollWidth) * pixelRatio));
+    canvas.height = Math.max(1, Math.ceil((opts && opts.height ? opts.height : document.documentElement.scrollHeight) * pixelRatio));
+    var ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    return Promise.resolve(canvas.toDataURL('image/png'));
+  };`;
+}
+
+function assertLegacySchema(payload: FeedbackPayload) {
+  expect(Object.keys(payload).sort()).toEqual([
+    'attachments',
+    'category',
+    'consoleLogs',
+    'description',
+    'metadata',
+    'repo',
+    'screenshot',
+    'submitter',
+    'title',
+  ]);
+  expect(Object.keys(payload.metadata).sort()).toEqual([
+    'browser',
+    'devicePixelRatio',
+    'domNodeCount',
+    'elementSelector',
+    'fullElementSelector',
+    'fullPageDisabled',
+    'language',
+    'os',
+    'timestamp',
+    'url',
+    'userAgent',
+    'viewport',
+  ]);
+}
+
+test.describe('paired default-flow screenshot compatibility oracle', () => {
+  test('preserves the trigger journey and explicit legacy request schema', async ({ browser }) => {
+    const result = await expectPairedJourney(browser, async (page, trace, requests) => {
+      await page.goto('/test/?showName=true&showEmail=true&sendConsoleLogs=true');
+      await page.evaluate(key => localStorage.removeItem(key), welcomeStorageKey);
+      await page.reload();
+      await waitForWidget(page);
+
+      await act(page, trace, 'trigger', '.bd-trigger');
+      await expect(host(page).locator('css=[data-action="continue"]')).toBeVisible();
+      await observe(page, trace, 'welcome');
+      await act(page, trace, 'continue', '[data-action="continue"]');
+      await observe(page, trace, 'details');
+
+      const widget = host(page);
+      await widget.locator('css=input[name="category"][value="feature"]').check();
+      await widget.locator('css=#title').fill('  Compatibility title  ');
+      await widget.locator('css=#description').fill('  Compatibility description  ');
+      await widget.locator('css=#name').fill('  Ada  ');
+      await widget.locator('css=#email').fill('  ada@example.com  ');
+      await widget.locator('css=#include-screenshot').uncheck();
+      await observe(page, trace, 'completed-details');
+      await act(page, trace, 'submit', '#submit-btn');
+      await expect(widget.locator('css=.bd-success-icon')).toBeVisible();
+      await observe(page, trace, 'success');
+      expect(requests).toHaveLength(1);
+
+      await act(page, trace, 'done', '[data-action="done"]');
+      await act(page, trace, 'trigger', '.bd-trigger');
+      await expect(widget.locator('css=[data-action="continue"]')).not.toBeAttached();
+      await expect(widget.locator('css=#title')).toBeVisible();
+      await observe(page, trace, 'details-after-welcome-persistence');
+    });
+
+    const payload = result.requests[0];
+    assertLegacySchema(payload);
+    expect(payload).toMatchObject({
+      repo: 'mean-weasel/bugdrop-widget-test',
+      title: 'Compatibility title',
+      description: 'Compatibility description',
+      category: 'feature',
+      screenshot: null,
+      attachments: [],
+      submitter: { name: 'Ada', email: 'ada@example.com' },
+      metadata: {
+        elementSelector: null,
+        fullElementSelector: null,
+        fullPageDisabled: false,
+      },
+    });
+  });
+
+  test('optional annotated capture preserves details through Retake and Close', async ({
+    browser,
+  }) => {
+    const result = await expectPairedJourney(
+      browser,
+      async (page, trace, requests) => {
+        await page.goto('/test/?showName=true&showEmail=true');
+        await waitForWidget(page);
+        await openFromPublicApi(page, trace);
+
+        const widget = host(page);
+        await widget.locator('css=input[name="category"][value="question"]').check();
+        await fillBaseForm(page, 'Retained optional title', 'Retained optional description');
+        await widget.locator('css=#name').fill('Grace');
+        await widget.locator('css=#email').fill('grace@example.com');
+        await widget.locator('css=#attachment-upload').setInputFiles({
+          name: 'evidence.png',
+          mimeType: 'image/png',
+          buffer: Buffer.from('paired optional evidence'),
+        });
+        await observe(page, trace, 'completed-details');
+
+        await act(page, trace, 'continue-to-capture', '#submit-btn');
+        await observe(page, trace, 'screenshot-options');
+        await act(page, trace, 'capture', '[data-action="capture"]');
+        await expect(widget.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+        await observe(page, trace, 'annotation');
+        await act(page, trace, 'retake', '[data-action="retake"]');
+        await observe(page, trace, 'screenshot-options-after-retake');
+        await act(page, trace, 'capture', '[data-action="capture"]');
+        await expect(widget.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+        await act(page, trace, 'close-annotation', '.bd-close');
+
+        await expect(widget.locator('css=#title')).toHaveValue('Retained optional title');
+        await expect(widget.locator('css=#description')).toHaveValue(
+          'Retained optional description'
+        );
+        await expect(widget.locator('css=input[name="category"][value="question"]')).toBeChecked();
+        await expect(widget.locator('css=#name')).toHaveValue('Grace');
+        await expect(widget.locator('css=#email')).toHaveValue('grace@example.com');
+        await expect(widget.locator('css=.bd-upload-item')).toContainText('evidence.png');
+        await observe(page, trace, 'retained-details-after-close');
+
+        await act(page, trace, 'continue-to-capture', '#submit-btn');
+        await act(page, trace, 'capture', '[data-action="capture"]');
+        await expect(widget.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+        await act(page, trace, 'submit-annotation', '[data-action="done"]');
+        await expect(widget.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+        await observe(page, trace, 'success');
+        expect(requests).toHaveLength(1);
+      },
+      successfulCaptureHook()
+    );
+
+    expect(result.requests[0]).toMatchObject({
+      title: 'Retained optional title',
+      description: 'Retained optional description',
+      category: 'question',
+      screenshot: expect.stringMatching(/^data:image\/png;base64,/),
+      attachments: [
+        expect.objectContaining({
+          name: 'evidence.png',
+          type: 'image/png',
+          dataUrl: expect.stringMatching(/^data:image\/png;base64,/),
+        }),
+      ],
+      metadata: { elementSelector: null, fullElementSelector: null },
+    });
+  });
+
+  test('viewport capture exposes privacy limits and submits empty selector metadata', async ({
+    browser,
+  }) => {
+    const result = await expectPairedJourney(
+      browser,
+      async (page, trace, requests) => {
+        await page.goto('/test/complex-dom.html?nodes=12000&private=redacted#secret');
+        await waitForWidget(page);
+        await openFromPublicApi(page, trace);
+        await fillBaseForm(page, 'Viewport privacy proof');
+        await act(page, trace, 'continue-to-capture', '#submit-btn');
+
+        const widget = host(page);
+        await expect(widget.locator('css=[data-action="viewport"]')).toBeVisible();
+        await expect(widget.locator('css=.bd-redaction-note')).toContainText(
+          'cannot apply automatic private-field masks'
+        );
+        await observe(page, trace, 'viewport-options-with-privacy-notice');
+        await act(page, trace, 'capture-viewport', '[data-action="viewport"]');
+        await expect(widget.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+        await expect(widget.locator('css=.bd-redaction-note')).toContainText(
+          'could not apply automatic private-field masks'
+        );
+        await observe(page, trace, 'viewport-annotation-with-privacy-notice');
+        await act(page, trace, 'submit-viewport', '[data-action="done"]');
+        await expect(widget.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+        expect(requests).toHaveLength(1);
+        expect(
+          await page.evaluate(
+            () => (window as Window & { __viewportCaptureCount?: number }).__viewportCaptureCount
+          )
+        ).toBe(1);
+      },
+      viewportCaptureHook()
+    );
+
+    expect(result.requests[0]).toMatchObject({
+      screenshot: expect.stringMatching(/^data:image\/png;base64,/),
+      metadata: {
+        url: 'http://localhost:8787/test/complex-dom',
+        elementSelector: null,
+        fullElementSelector: null,
+      },
+    });
+  });
+
+  test('area capture reports redaction and annotation Undo restores its baseline', async ({
+    browser,
+  }) => {
+    const result = await expectPairedJourney(
+      browser,
+      async (page, trace, requests) => {
+        await page.goto('/test/redaction.html?private=redacted#secret');
+        await page.locator('#redacted-test-input').scrollIntoViewIfNeeded();
+        await waitForWidget(page);
+        await openFromPublicApi(page, trace);
+        await fillBaseForm(page, 'Area redaction and undo');
+        await act(page, trace, 'continue-to-capture', '#submit-btn');
+        await expect(host(page).locator('css=.bd-redaction-note')).toContainText(
+          'marked some fields for redaction'
+        );
+        await act(page, trace, 'select-area', '[data-action="area"]');
+        await expect(page.locator('#bugdrop-area-picker-overlay')).toBeVisible();
+        await expect(page.locator('#bugdrop-area-picker-tooltip')).toContainText(
+          'Marked private fields may be masked if included'
+        );
+
+        const box = await page.locator('#redacted-test-input').boundingBox();
+        expect(box).not.toBeNull();
+        trace.push('action:drag-redacted-area');
+        await page.mouse.move(box!.x - 8, box!.y - 8);
+        await page.mouse.down();
+        await page.mouse.move(box!.x + box!.width + 8, box!.y + box!.height + 8);
+        await page.mouse.up();
+
+        const canvas = host(page).locator('css=#annotation-canvas canvas');
+        await expect(canvas).toBeVisible({ timeout: 10000 });
+        await expect(host(page).locator('css=.bd-redaction-note')).toContainText(
+          '1 private item was marked for redaction'
+        );
+        const baseline = await canvas.evaluate(element =>
+          (element as HTMLCanvasElement).toDataURL()
+        );
+        const canvasBox = await canvas.boundingBox();
+        expect(canvasBox).not.toBeNull();
+        trace.push('action:draw-annotation');
+        await page.mouse.move(canvasBox!.x + 20, canvasBox!.y + 20);
+        await page.mouse.down();
+        await page.mouse.move(canvasBox!.x + 100, canvasBox!.y + 70, { steps: 5 });
+        await page.mouse.up();
+        expect(
+          await canvas.evaluate(element => (element as HTMLCanvasElement).toDataURL())
+        ).not.toBe(baseline);
+        await act(page, trace, 'undo-annotation', '[data-action="undo"]');
+        expect(await canvas.evaluate(element => (element as HTMLCanvasElement).toDataURL())).toBe(
+          baseline
+        );
+        await act(page, trace, 'submit-area', '[data-action="done"]');
+        await expect(host(page).locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+        expect(requests).toHaveLength(1);
+      },
+      redactionAwareCaptureHook()
+    );
+
+    expect(result.requests[0]).toMatchObject({
+      screenshot: expect.stringMatching(/^data:image\/png;base64,/),
+      metadata: {
+        url: 'http://localhost:8787/test/redaction',
+        elementSelector: null,
+        fullElementSelector: null,
+      },
+    });
+  });
+
+  test('automatic capture succeeds without exposing the picker or annotation', async ({
+    browser,
+  }) => {
+    const result = await expectPairedJourney(
+      browser,
+      async (page, trace, requests) => {
+        await page.goto('/test/?screenshot=auto');
+        await waitForWidget(page);
+        await openFromPublicApi(page, trace);
+        await fillBaseForm(page, 'Automatic success');
+        await act(page, trace, 'submit', '#submit-btn');
+        await expect(host(page).locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+        await expect(host(page).locator('css=[data-action="capture"]')).not.toBeAttached();
+        await expect(host(page).locator('css=#annotation-canvas')).not.toBeAttached();
+        await observe(page, trace, 'success');
+        expect(requests).toHaveLength(1);
+        expect(
+          await page.evaluate(() => (window as Window & { __captureCount?: number }).__captureCount)
+        ).toBe(1);
+      },
+      successfulCaptureHook()
+    );
+
+    expect(result.requests[0].screenshot).toBe(stubPng);
+  });
+
+  test('automatic capture failure offers only skip and submits without a screenshot', async ({
+    browser,
+  }) => {
+    const result = await expectPairedJourney(
+      browser,
+      async (page, trace, requests) => {
+        await page.goto('/test/?screenshot=auto');
+        await waitForWidget(page);
+        await openFromPublicApi(page, trace);
+        await fillBaseForm(page, 'Automatic failure');
+        await act(page, trace, 'submit', '#submit-btn');
+        await expect(host(page).locator('css=.bd-error-message__text')).toBeVisible();
+        await expect(host(page).locator('css=[data-action="choose-again"]')).not.toBeAttached();
+        await observe(page, trace, 'capture-failure');
+        await act(page, trace, 'skip-failed-capture', '[data-action="skip"]');
+        await expect(host(page).locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+        await observe(page, trace, 'success');
+        expect(requests).toHaveLength(1);
+      },
+      `window.__bugdropMockToPng = function() { return Promise.reject(new Error('auto failure')); };`
+    );
+
+    expect(result.requests[0].screenshot).toBeNull();
+  });
+
+  test('automatic capture bypasses capture entirely on a very complex page', async ({
+    browser,
+  }) => {
+    const result = await expectPairedJourney(
+      browser,
+      async (page, trace, requests) => {
+        await page.goto('/test/complex-dom.html?nodes=12000&screenshot=auto');
+        await waitForWidget(page);
+        await openFromPublicApi(page, trace);
+        await fillBaseForm(page, 'Automatic complex bypass');
+        await act(page, trace, 'submit', '#submit-btn');
+        await expect(host(page).locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+        await observe(page, trace, 'success');
+        expect(requests).toHaveLength(1);
+        expect(
+          await page.evaluate(() => (window as Window & { __captureCount?: number }).__captureCount)
+        ).toBeUndefined();
+      },
+      successfulCaptureHook()
+    );
+
+    expect(result.requests[0]).toMatchObject({
+      screenshot: null,
+      metadata: { fullPageDisabled: true },
+    });
+  });
+
+  test('required mode omits skip, recovers from failure, and submits attachment and selector metadata', async ({
+    browser,
+  }) => {
+    const result = await expectPairedJourney(
+      browser,
+      async (page, trace, requests) => {
+        await page.goto('/test/?screenshot=required');
+        await waitForWidget(page);
+        await openFromPublicApi(page, trace);
+        await fillBaseForm(page, 'Required recovery');
+        await host(page)
+          .locator('css=#attachment-upload')
+          .setInputFiles({
+            name: 'notes.pdf',
+            mimeType: 'application/pdf',
+            buffer: Buffer.from('%PDF-1.4\npaired required evidence'),
+          });
+        await observe(page, trace, 'completed-details');
+        await act(page, trace, 'continue-to-capture', '#submit-btn');
+        await expect(host(page).locator('css=[data-action="skip"]')).not.toBeAttached();
+        await observe(page, trace, 'required-screenshot-options');
+
+        await act(page, trace, 'capture', '[data-action="capture"]');
+        await expect(host(page).locator('css=.bd-error-message__text')).toBeVisible();
+        await expect(host(page).locator('css=[data-action="skip"]')).not.toBeAttached();
+        await observe(page, trace, 'required-capture-failure');
+        await act(page, trace, 'choose-again', '[data-action="choose-again"]');
+        await expect(host(page).locator('css=[data-action="skip"]')).not.toBeAttached();
+        await observe(page, trace, 'required-options-after-failure');
+
+        await act(page, trace, 'select-element', '[data-action="element"]');
+        await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible();
+        trace.push('action:pick-h1');
+        const targetBox = await page.locator('h1').boundingBox();
+        expect(targetBox).not.toBeNull();
+        await page.mouse.click(
+          targetBox!.x + targetBox!.width / 2,
+          targetBox!.y + targetBox!.height / 2
+        );
+        await expect(host(page).locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });
+        await observe(page, trace, 'required-annotation');
+        await act(page, trace, 'submit-annotation', '[data-action="done"]');
+        await expect(host(page).locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+        await observe(page, trace, 'success');
+        expect(requests).toHaveLength(1);
+      },
+      firstCaptureFailsHook()
+    );
+
+    const payload = result.requests[0];
+    expect(payload).toMatchObject({
+      screenshot: expect.stringMatching(/^data:image\/png;base64,/),
+      attachments: [
+        expect.objectContaining({
+          name: 'notes.pdf',
+          type: 'application/pdf',
+          dataUrl: expect.stringMatching(/^data:application\/pdf;base64,/),
+        }),
+      ],
+      metadata: {
+        elementSelector: expect.stringContaining('h1'),
+        fullElementSelector: expect.stringContaining('html > body'),
+      },
+    });
+    expect(payload.metadata.fullElementSelector).toContain('h1');
+  });
+
+  for (const mode of ['auto', 'manual'] as const) {
+    test(`pairs ${mode} capture cancellation and retained details`, async ({ browser }) => {
+      await expectPairedJourney(
+        browser,
+        async (page, trace, requests) => {
+          await page.goto(mode === 'auto' ? '/test/?screenshot=auto' : '/test/');
+          await waitForWidget(page);
+          await openFromPublicApi(page, trace);
+          await fillBaseForm(page, `${mode} cancellation`, 'Retained after capture cancellation');
+          await act(page, trace, 'submit-details', '#submit-btn');
+          if (mode === 'manual') {
+            await act(page, trace, 'capture-full-page', '[data-action="capture"]');
+          }
+          await expect(host(page).locator('css=.bd-error-message__text')).toBeVisible();
+          await observe(page, trace, `${mode}-capture-failure`);
+          await act(page, trace, 'close-capture-failure', '.bd-close');
+          await expect(host(page).locator('css=#title')).toHaveValue(`${mode} cancellation`);
+          await expect(host(page).locator('css=#description')).toHaveValue(
+            'Retained after capture cancellation'
+          );
+          await observe(page, trace, `${mode}-retained-details`);
+          expect(requests).toHaveLength(0);
+          trace.push('action:public-close');
+          await page.evaluate(() => window.BugDrop?.close());
+        },
+        `window.__bugdropMockToPng = function() { return Promise.reject(new Error('${mode} cancellation')); };`
+      );
+    });
+  }
+
+  for (const dismissal of ['close', 'cancel'] as const) {
+    test(`submission-error ${dismissal} clears the draft before a clean reopen`, async ({
+      browser,
+    }) => {
+      await expectPairedJourney(browser, async (page, trace, requests) => {
+        await page.unroute('**/feedback');
+        await page.route('**/feedback', async route => {
+          requests.push(route.request().postDataJSON() as FeedbackPayload);
+          await route.fulfill({
+            status: 500,
+            contentType: 'application/json',
+            body: JSON.stringify({ success: false, error: 'Dismiss and reopen' }),
+          });
+        });
+
+        await page.goto('/test/');
+        await waitForWidget(page);
+        await openFromPublicApi(page, trace);
+        await fillBaseForm(page, `Discarded ${dismissal} draft`, 'Must not survive reopen');
+        await host(page).locator('css=#include-screenshot').uncheck();
+        await act(page, trace, 'submit', '#submit-btn');
+        await expect(host(page).locator('css=.bd-error-message__text')).toHaveText(
+          'Dismiss and reopen'
+        );
+        await observe(page, trace, 'submission-error');
+        await act(
+          page,
+          trace,
+          `dismiss-error-${dismissal}`,
+          dismissal === 'close' ? '.bd-close' : '[data-action="cancel"]'
+        );
+        await expect(host(page).locator('css=.bd-modal')).toHaveCount(0);
+        await expect.poll(() => page.evaluate(() => window.BugDrop?.isOpen())).toBe(false);
+
+        await openFromPublicApi(page, trace);
+        await expect(host(page).locator('css=#title')).toHaveValue('');
+        await expect(host(page).locator('css=#description')).toHaveValue('');
+        await observe(page, trace, 'clean-details-after-error-dismissal');
+        expect(requests).toHaveLength(1);
+        trace.push('action:public-close');
+        await page.evaluate(() => window.BugDrop?.close());
+      });
+    });
+  }
+
+  test('submission retry reuses the identical legacy request data', async ({ browser }) => {
+    const journey: Journey = async (page, trace, requests) => {
+      let attempts = 0;
+      await page.unroute('**/feedback');
+      await page.route('**/feedback', async route => {
+        requests.push(route.request().postDataJSON() as FeedbackPayload);
+        attempts += 1;
+        await route.fulfill({
+          status: attempts === 1 ? 500 : 200,
+          contentType: 'application/json',
+          body: JSON.stringify(
+            attempts === 1
+              ? { success: false, error: 'Compatibility failure' }
+              : { success: true, issueNumber: 43, issueUrl: '#', isPublic: false }
+          ),
+        });
+      });
+
+      await page.goto('/test/');
+      await waitForWidget(page);
+      await openFromPublicApi(page, trace);
+      await host(page).locator('css=input[name="category"][value="question"]').check();
+      await fillBaseForm(page, 'Retry title', 'Retry description');
+      await host(page).locator('css=#include-screenshot').uncheck();
+      await act(page, trace, 'submit', '#submit-btn');
+      await expect(host(page).locator('css=.bd-error-message__text')).toHaveText(
+        'Compatibility failure'
+      );
+      await observe(page, trace, 'submission-error');
+      await act(page, trace, 'retry', '[data-action="retry"]');
+      await expect(host(page).locator('css=.bd-success-icon')).toBeVisible();
+      await observe(page, trace, 'success');
+      expect(requests).toHaveLength(2);
+    };
+
+    const result = await expectPairedJourney(browser, journey);
+    expect(result.requests[1]).toEqual(result.requests[0]);
+  });
+
+  for (const failure of ['rate-limit', 'network'] as const) {
+    test(`recollects console logs and metadata after ${failure} retry`, async ({ browser }) => {
+      const result = await expectPairedJourney(browser, async (page, trace, requests) => {
+        let attempts = 0;
+        await page.unroute('**/feedback');
+        await page.route('**/feedback', async route => {
+          requests.push(route.request().postDataJSON() as FeedbackPayload);
+          attempts += 1;
+          if (attempts === 1 && failure === 'network') {
+            await route.abort('failed');
+            return;
+          }
+          await route.fulfill({
+            status: attempts === 1 ? 429 : 200,
+            headers: attempts === 1 ? { 'Retry-After': '60' } : undefined,
+            contentType: 'application/json',
+            body: JSON.stringify(
+              attempts === 1
+                ? { success: false }
+                : { success: true, issueNumber: 45, issueUrl: '#', isPublic: false }
+            ),
+          });
+        });
+
+        await page.goto('/test/?sendConsoleLogs=true');
+        await waitForWidget(page);
+        await openFromPublicApi(page, trace);
+        await fillBaseForm(page, `${failure} recollection`);
+        await host(page).locator('css=#include-screenshot').uncheck();
+        await act(page, trace, 'submit', '#submit-btn');
+        await expect(host(page).locator('css=.bd-error-message__text')).toBeVisible();
+        await page.evaluate(() => console.warn('paired retry-time evidence'));
+        await page.setViewportSize({ width: 777, height: 555 });
+        await act(page, trace, 'retry', '[data-action="retry"]');
+        await expect(host(page).locator('css=.bd-success-icon')).toBeVisible();
+        expect(requests).toHaveLength(2);
+      });
+
+      expect(result.requests[0].metadata.viewport).not.toEqual(
+        result.requests[1].metadata.viewport
+      );
+      expect(result.requests[1].metadata.viewport).toEqual({ width: 777, height: 555 });
+      expect(result.requests[1].consoleLogs).toEqual(
+        expect.arrayContaining([expect.objectContaining({ message: 'paired retry-time evidence' })])
+      );
+    });
+  }
+
+  for (const preflight of ['not_installed', 'unreachable'] as const) {
+    test(`owns ${preflight} preflight while suppressing duplicate opens`, async ({ browser }) => {
+      await expectPairedJourney(browser, async (page, trace, requests) => {
+        let checks = 0;
+        await page.unroute('**/api/check**');
+        await page.route('**/api/check**', async route => {
+          checks += 1;
+          if (preflight === 'unreachable') {
+            await route.fulfill({ status: 503, body: 'unavailable' });
+          } else {
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify({ installed: false, appName: 'paired-app' }),
+            });
+          }
+        });
+
+        await page.goto('/test/');
+        await waitForWidget(page);
+        trace.push('action:duplicate-public-open');
+        await page.evaluate(() => {
+          window.BugDrop?.open();
+          window.BugDrop?.open();
+        });
+        await expect(host(page).locator('css=.bd-title')).toHaveText(
+          preflight === 'unreachable' ? 'Connection Error' : 'Install Required'
+        );
+        expect(checks).toBe(1);
+        expect(await page.evaluate(() => window.BugDrop?.isOpen())).toBe(true);
+        await observe(page, trace, `preflight-${preflight}`);
+
+        trace.push('action:public-close');
+        await page.evaluate(() => window.BugDrop?.close());
+        expect(await page.evaluate(() => window.BugDrop?.isOpen())).toBe(false);
+        await expect(host(page).locator('css=.bd-modal')).toHaveCount(0);
+        expect(requests).toHaveLength(0);
+      });
+    });
+  }
+
+  test('pairs API state, invalid-field focus, keyboard submit, mobile layout, and reduced motion', async ({
+    browser,
+  }) => {
+    await expectPairedJourney(browser, async (page, trace, requests) => {
+      await page.setViewportSize({ width: 390, height: 720 });
+      await page.emulateMedia({ reducedMotion: 'reduce' });
+      await page.goto('/test/');
+      await waitForWidget(page);
+
+      await openFromPublicApi(page, trace);
+      await page.evaluate(() => window.BugDrop?.open());
+      await expect(host(page).locator('css=.bd-modal')).toHaveCount(1);
+      expect(await page.evaluate(() => window.BugDrop?.isOpen())).toBe(true);
+
+      await act(page, trace, 'invalid-submit', '#submit-btn');
+      expect(
+        await host(page)
+          .locator('css=#title')
+          .evaluate(element =>
+            element.getRootNode() instanceof ShadowRoot
+              ? (element.getRootNode() as ShadowRoot).activeElement?.id
+              : null
+          )
+      ).toBe('title');
+
+      const modalBox = await host(page).locator('css=.bd-modal').boundingBox();
+      expect(modalBox).not.toBeNull();
+      expect(modalBox!.x).toBeGreaterThanOrEqual(0);
+      expect(modalBox!.width).toBeLessThanOrEqual(390);
+      expect(
+        await host(page)
+          .locator('css=.bd-modal')
+          .evaluate(element => getComputedStyle(element).transitionDuration)
+      ).toBe('1e-05s');
+
+      await fillBaseForm(page, 'Keyboard mobile submission');
+      await host(page).locator('css=#include-screenshot').uncheck();
+      trace.push('action:keyboard-submit');
+      await host(page).locator('css=#title').press('Enter');
+      await expect(host(page).locator('css=.bd-success-icon')).toBeVisible();
+      await observe(page, trace, 'mobile-success');
+      expect(requests).toHaveLength(1);
+      expect(requests[0].metadata.viewport).toEqual({ width: 390, height: 720 });
+    });
+  });
+
+  test('pairs optional skip and element-picker cancellation retention boundaries', async ({
+    browser,
+  }) => {
+    const result = await expectPairedJourney(browser, async (page, trace, requests) => {
+      await page.goto('/test/complex-dom.html?nodes=12000');
+      await waitForWidget(page);
+      await openFromPublicApi(page, trace);
+      await fillBaseForm(page, 'Picker cancellation');
+      await act(page, trace, 'continue-to-capture', '#submit-btn');
+      await act(page, trace, 'select-element', '[data-action="element"]');
+      await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible();
+      trace.push('action:cancel-picker');
+      await page.keyboard.press('Escape');
+      await expect(host(page).locator('css=.bd-success-icon')).toBeVisible();
+      expect(requests).toHaveLength(1);
+
+      await act(page, trace, 'done', '[data-action="done"]');
+      await openFromPublicApi(page, trace);
+      await expect(host(page).locator('css=#include-screenshot')).toBeChecked();
+      await fillBaseForm(page, 'Explicit optional skip');
+      await host(page).locator('css=#include-screenshot').uncheck();
+      await act(page, trace, 'explicit-skip-submit', '#submit-btn');
+      await expect(host(page).locator('css=.bd-success-icon')).toBeVisible();
+      expect(requests).toHaveLength(2);
+    });
+
+    expect(result.requests.map(request => request.screenshot)).toEqual([null, null]);
+    expect(result.requests[0].metadata).toMatchObject({
+      elementSelector: null,
+      fullElementSelector: null,
+    });
+  });
+
+  test('pairs optional capture-failure skip and complex-page preference retention', async ({
+    browser,
+  }) => {
+    const result = await expectPairedJourney(
+      browser,
+      async (page, trace, requests) => {
+        await page.goto('/test/complex-dom.html?nodes=12000');
+        await waitForWidget(page);
+        await openFromPublicApi(page, trace);
+        await fillBaseForm(page, 'Remember complex failure skip');
+        await act(page, trace, 'continue-to-capture', '#submit-btn');
+        await act(page, trace, 'select-element', '[data-action="element"]');
+        await expect(page.locator('#bugdrop-element-picker-tooltip')).toBeVisible();
+        trace.push('action:pick-heading');
+        const headingBox = await page.locator('h1').boundingBox();
+        expect(headingBox).not.toBeNull();
+        await page.mouse.click(
+          headingBox!.x + headingBox!.width / 2,
+          headingBox!.y + headingBox!.height / 2
+        );
+        await expect(host(page).locator('css=.bd-error-message__text')).toBeVisible();
+        await act(page, trace, 'skip-failed-capture', '[data-action="skip"]');
+        await expect(host(page).locator('css=.bd-success-icon')).toBeVisible();
+        expect(requests).toHaveLength(1);
+
+        await act(page, trace, 'done', '[data-action="done"]');
+        await openFromPublicApi(page, trace);
+        await expect(host(page).locator('css=#include-screenshot')).not.toBeChecked();
+        await observe(page, trace, 'remembered-complex-skip');
+      },
+      `window.__bugdropMockToPng = function() { return Promise.reject(new Error('complex optional failure')); };`
+    );
+
+    expect(result.requests[0].screenshot).toBeNull();
+  });
+
+  test('pairs default and modal-variant coordination', async ({ browser }) => {
+    await expectPairedJourney(browser, async (page, trace, requests) => {
+      await page.goto('/test/');
+      await waitForWidget(page);
+      await openFromPublicApi(page, trace);
+
+      const busyStatus = await page.evaluate(async () => {
+        const handle = window.BugDrop!.registerVariant({
+          id: 'paired-modal-coordination',
+          presentation: { kind: 'modal' },
+          content: { title: 'Paired modal variant' },
+          fields: [{ id: 'message', type: 'shortText', label: 'Message', required: true }],
+          issue: { title: 'Paired {{message}}' },
+        });
+        (
+          window as Window & {
+            __pairedVariant?: ReturnType<typeof window.BugDrop.registerVariant>;
+          }
+        ).__pairedVariant = handle;
+        return (await handle.open().result).status;
+      });
+      expect(busyStatus).toBe('busy');
+      trace.push(`variant-while-default:${busyStatus}`);
+
+      await page.evaluate(() => window.BugDrop?.close());
+      await page.evaluate(() =>
+        (
+          window as Window & {
+            __pairedVariant?: ReturnType<NonNullable<typeof window.BugDrop>['registerVariant']>;
+          }
+        ).__pairedVariant?.open()
+      );
+      await expect(page.locator('[data-bugdrop-owned]')).toBeVisible();
+      trace.push('variant-open');
+
+      await page.evaluate(() => window.BugDrop?.open());
+      await expect(page.locator('[data-bugdrop-owned]')).toHaveCount(0);
+      await expect(host(page).locator('css=#title')).toBeVisible();
+      trace.push('default-replaced-variant');
+      expect(requests).toHaveLength(0);
+    });
+  });
+
+  for (const policy of [
+    { query: 'showIssueLink=always', isPublic: false, visible: true },
+    { query: 'showIssueLink=never', isPublic: true, visible: false },
+  ]) {
+    test(`pairs issue-link policy ${policy.query}`, async ({ browser }) => {
+      await expectPairedJourney(browser, async (page, trace, requests) => {
+        await page.unroute('**/feedback');
+        await page.route('**/feedback', async route => {
+          requests.push(route.request().postDataJSON() as FeedbackPayload);
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              success: true,
+              issueNumber: 44,
+              issueUrl: 'https://github.com/example/project/issues/44',
+              isPublic: policy.isPublic,
+            }),
+          });
+        });
+        await page.goto(`/test/?${policy.query}`);
+        await waitForWidget(page);
+        await openFromPublicApi(page, trace);
+        await fillBaseForm(page, 'Issue link policy');
+        await host(page).locator('css=#include-screenshot').uncheck();
+        await act(page, trace, 'submit', '#submit-btn');
+        await expect(host(page).locator('css=.bd-success-icon')).toBeVisible();
+        await expect(host(page).locator('css=.bd-issue-link')).toHaveCount(policy.visible ? 1 : 0);
+        trace.push(`issue-link:${policy.visible}`);
+      });
+    });
+  }
+});

--- a/e2e/default-flow-production.spec.ts
+++ b/e2e/default-flow-production.spec.ts
@@ -1,0 +1,386 @@
+import { expect, test, type Page } from '@playwright/test';
+
+type FeedbackPayload = Record<string, unknown> & {
+  title: string;
+  screenshot: string | null;
+  metadata: Record<string, unknown> & { viewport?: { width: number; height: number } };
+};
+
+type AccessibilityTrace = {
+  step: string;
+  semanticName?: string | null;
+  heading?: string | null;
+  focus?: string | null;
+  liveRegions?: Array<{ id: string; politeness: string | null }>;
+  keyboard?: string;
+  mobileBounds?: { x: number; width: number; viewportWidth: number };
+  transitionDuration?: string;
+};
+
+function host(page: Page) {
+  return page.locator('#bugdrop-host');
+}
+
+async function waitForWidget(page: Page) {
+  await expect(host(page).locator('css=.bd-trigger')).toBeVisible({ timeout: 5000 });
+}
+
+test('serves a test-hook-free authoritative artifact with the unchanged API', async ({ page }) => {
+  const manifest = await page.request.get('/versions.json').then(response => response.json());
+  expect(manifest).toMatchObject({ authoritative: true, mode: 'release', current: '9.9.9' });
+  expect((await page.request.get('/static-package.json')).ok()).toBe(true);
+
+  await page.route('**/api/check/**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ installed: true }),
+    })
+  );
+  await page.goto('/test/');
+  await waitForWidget(page);
+
+  expect(
+    await page.evaluate(() => ({
+      api: Object.keys(window.BugDrop ?? {}).sort(),
+      runtimeSelector: (window as Window & { __bugdropDefaultFlowRuntime?: unknown })
+        .__bugdropDefaultFlowRuntime,
+      captureHook: (window as Window & { __bugdropMockToPng?: unknown }).__bugdropMockToPng,
+    }))
+  ).toEqual({
+    api: [
+      'close',
+      'hide',
+      'isButtonVisible',
+      'isOpen',
+      'open',
+      'registerVariant',
+      'setTheme',
+      'show',
+    ],
+    runtimeSelector: undefined,
+    captureHook: undefined,
+  });
+});
+
+test('owns preflight without opening details or submitting', async ({ page }) => {
+  let feedbackRequests = 0;
+  await page.route('**/api/check/**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ installed: false, appName: 'production-proof' }),
+    })
+  );
+  await page.route('**/feedback', route => {
+    feedbackRequests += 1;
+    return route.abort();
+  });
+  await page.goto('/test/');
+  await waitForWidget(page);
+  await page.evaluate(() => window.BugDrop?.open());
+
+  await expect(host(page).locator('css=.bd-title')).toHaveText('Install Required');
+  await expect(host(page).locator('css=#title')).not.toBeAttached();
+  expect(await page.evaluate(() => window.BugDrop?.isOpen())).toBe(true);
+  expect(feedbackRequests).toBe(0);
+});
+
+test('captures and submits a real screenshot without test hooks or mocked bytes', async ({
+  page,
+}) => {
+  const requests: FeedbackPayload[] = [];
+  await page.route('**/api/check/**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ installed: true }),
+    })
+  );
+  await page.route('**/feedback', async route => {
+    requests.push(route.request().postDataJSON() as FeedbackPayload);
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        issueNumber: 98,
+        issueUrl: 'https://github.com/example/project/issues/98',
+        isPublic: false,
+      }),
+    });
+  });
+  await page.goto('/test/');
+  await waitForWidget(page);
+  await page.evaluate(() => window.BugDrop?.open());
+
+  const widget = host(page);
+  await widget.locator('css=#title').fill('Real release capture');
+  await widget
+    .locator('css=#description')
+    .fill('Bundled html-to-image capture with no browser test globals');
+  await widget.locator('css=#submit-btn').click();
+  await widget.locator('css=[data-action="capture"]').click();
+  await expect(widget.locator('css=#annotation-canvas canvas')).toBeVisible({ timeout: 15000 });
+  expect(
+    await page.evaluate(() => ({
+      captureHook: (window as Window & { __bugdropMockToPng?: unknown }).__bugdropMockToPng,
+      viewportHook: (window as Window & { __bugdropMockViewportCapture?: unknown })
+        .__bugdropMockViewportCapture,
+    }))
+  ).toEqual({ captureHook: undefined, viewportHook: undefined });
+  await widget.locator('css=[data-action="done"]').click();
+  await expect(widget.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10000 });
+
+  expect(requests).toHaveLength(1);
+  expect(requests[0].screenshot).toMatch(/^data:image\/png;base64,/);
+  expect(requests[0].screenshot!.length).toBeGreaterThan(1000);
+  expect(requests[0].metadata).toMatchObject({
+    elementSelector: null,
+    fullElementSelector: null,
+  });
+});
+
+test('normalizes modal, inline, and headless variants without changing their envelope', async ({
+  page,
+}) => {
+  const requests: Array<Record<string, unknown>> = [];
+  await page.route('**/api/check/**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ installed: true }),
+    })
+  );
+  await page.route('**/api/feedback', route => {
+    requests.push(route.request().postDataJSON() as Record<string, unknown>);
+    const issueNumber = 300 + requests.length;
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        issueNumber,
+        issueUrl: `https://github.com/mean-weasel/bugdrop-widget-test/issues/${issueNumber}`,
+        isPublic: false,
+      }),
+    });
+  });
+  await page.goto('/test/?private=redacted#secret');
+  await waitForWidget(page);
+
+  await page.evaluate(async () => {
+    const inlineConfig = {
+      id: 'release-inline',
+      presentation: { kind: 'inline' as const },
+      content: { title: 'Release inline', submitLabel: 'Send inline' },
+      fields: [{ id: 'answer', type: 'shortText' as const, label: 'Inline answer' }],
+      issue: { title: 'Inline {{answer}}' },
+    };
+    const slot = document.createElement('div');
+    slot.id = 'release-inline-slot';
+    document.body.appendChild(slot);
+    window.BugDrop!.registerVariant(inlineConfig).mount(slot);
+
+    await window
+      .BugDrop!.registerVariant({
+        ...inlineConfig,
+        id: 'release-headless',
+        issue: { title: 'Headless {{answer}}' },
+      })
+      .submit(
+        { answer: 'exact' },
+        { context: { surface: 'release' }, submissionId: 'release-headless-proof' }
+      );
+
+    const modal = window.BugDrop!.registerVariant({
+      id: 'release-modal',
+      presentation: { kind: 'modal', size: 'compact' },
+      content: { title: 'Release modal', submitLabel: 'Send modal' },
+      fields: [{ id: 'answer', type: 'longText', label: 'Modal answer', required: true }],
+      issue: { title: 'Modal {{answer}}' },
+    });
+    (window as Window & { __openReleaseModal?: () => void }).__openReleaseModal = () => {
+      modal.open();
+    };
+  });
+
+  const inline = page.locator('#release-inline-slot > [data-bugdrop-owned]');
+  await inline.getByRole('textbox', { name: 'Inline answer' }).fill('visible');
+  await inline.getByRole('button', { name: 'Send inline' }).click();
+  await expect(inline.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+
+  await page.evaluate(() => {
+    (window as Window & { __openReleaseModal?: () => void }).__openReleaseModal?.();
+  });
+  const modal = page.locator('body > [data-bugdrop-owned]');
+  await expect(modal.getByRole('dialog', { name: 'Release modal' })).toBeVisible();
+  await modal.getByRole('textbox', { name: 'Modal answer' }).fill('visible');
+  await modal.getByRole('button', { name: 'Send modal' }).click();
+  await expect(modal.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+
+  expect(requests).toHaveLength(3);
+  for (const request of requests) {
+    expect(Object.keys(request).sort()).toEqual([
+      'issue',
+      'kind',
+      'metadata',
+      'repo',
+      'schemaVersion',
+      'submissionId',
+      'variantId',
+    ]);
+    expect(request).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      repo: 'mean-weasel/bugdrop-widget-test',
+      metadata: { url: 'http://bugdrop.localhost:8787/test/' },
+    });
+  }
+  expect(requests.map(request => request.variantId)).toEqual([
+    'release-headless',
+    'release-inline',
+    'release-modal',
+  ]);
+  expect(requests[0]).toMatchObject({
+    submissionId: 'release-headless-proof',
+    issue: { title: 'Headless exact' },
+  });
+  expect(requests[1]).toMatchObject({ issue: { title: 'Inline visible' } });
+  expect(requests[2]).toMatchObject({ issue: { title: 'Modal visible' } });
+});
+
+test('records payload and an explicit accessibility, keyboard, mobile, and motion trace', async ({
+  page,
+}) => {
+  const requests: FeedbackPayload[] = [];
+  const accessibilityTrace: AccessibilityTrace[] = [];
+  await page.setViewportSize({ width: 390, height: 720 });
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.route('**/api/check/**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ installed: true }),
+    })
+  );
+  await page.route('**/feedback', async route => {
+    requests.push(route.request().postDataJSON() as FeedbackPayload);
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        issueNumber: 99,
+        issueUrl: 'https://github.com/example/project/issues/99',
+        isPublic: false,
+      }),
+    });
+  });
+  await page.goto('/test/?showIssueLink=always&showName=true&sendConsoleLogs=true');
+  await waitForWidget(page);
+
+  await expect(host(page).locator('css=.bd-trigger')).toHaveAttribute(
+    'aria-label',
+    'Report a bug or send feedback'
+  );
+  accessibilityTrace.push({
+    step: 'trigger',
+    semanticName: await host(page).locator('css=.bd-trigger').getAttribute('aria-label'),
+  });
+  await page.evaluate(() => window.BugDrop?.open());
+  const widget = host(page);
+  await expect(widget.locator('css=.bd-title')).toHaveText('Send Feedback');
+  await expect(widget.locator('css=label[for="title"]')).toContainText('Title');
+  await expect(widget.locator('css=#attachment-list')).toHaveAttribute('aria-live', 'polite');
+  accessibilityTrace.push({
+    step: 'details',
+    heading: await widget.locator('css=.bd-title').textContent(),
+    semanticName: await widget.locator('css=label[for="title"]').textContent(),
+    liveRegions: await widget.locator('css=[aria-live]').evaluateAll(elements =>
+      elements.map(element => ({
+        id: element.id,
+        politeness: element.getAttribute('aria-live'),
+      }))
+    ),
+  });
+
+  await widget.locator('css=#submit-btn').click();
+  const invalidFocus = await widget
+    .locator('css=#title')
+    .evaluate(element => (element.getRootNode() as ShadowRoot).activeElement?.id ?? null);
+  expect(invalidFocus).toBe('title');
+
+  const modalBox = await widget.locator('css=.bd-modal').boundingBox();
+  expect(modalBox).not.toBeNull();
+  expect(modalBox!.x).toBeGreaterThanOrEqual(0);
+  expect(modalBox!.width).toBeLessThanOrEqual(390);
+  const transitionDuration = await widget
+    .locator('css=.bd-modal')
+    .evaluate(element => getComputedStyle(element).transitionDuration);
+  expect(transitionDuration).toBe('1e-05s');
+  accessibilityTrace.push({
+    step: 'invalid-submit',
+    focus: invalidFocus,
+    mobileBounds: { x: modalBox!.x, width: modalBox!.width, viewportWidth: 390 },
+    transitionDuration,
+  });
+
+  await widget.locator('css=#title').fill('Production parity');
+  await widget.locator('css=#description').fill('Production-built private and fixed proof');
+  await widget.locator('css=#name').fill('Release proof');
+  await widget.locator('css=#include-screenshot').uncheck();
+  await widget.locator('css=#title').press('Enter');
+  await expect(widget.locator('css=.bd-success-icon')).toBeVisible();
+  await expect(widget.locator('css=.bd-issue-link')).toHaveAttribute(
+    'href',
+    'https://github.com/example/project/issues/99'
+  );
+  accessibilityTrace.push({
+    step: 'keyboard-success',
+    keyboard: 'Enter',
+    heading: await widget.locator('css=.bd-title').textContent(),
+    semanticName: await widget.locator('css=.bd-issue-link').textContent(),
+  });
+
+  expect(accessibilityTrace).toEqual([
+    { step: 'trigger', semanticName: 'Report a bug or send feedback' },
+    {
+      step: 'details',
+      heading: 'Send Feedback',
+      semanticName: 'Title *',
+      liveRegions: [{ id: 'attachment-list', politeness: 'polite' }],
+    },
+    {
+      step: 'invalid-submit',
+      focus: 'title',
+      mobileBounds: expect.objectContaining({ viewportWidth: 390 }),
+      transitionDuration: '1e-05s',
+    },
+    {
+      step: 'keyboard-success',
+      keyboard: 'Enter',
+      heading: 'Feedback Submitted!',
+      semanticName: expect.stringContaining('View on GitHub'),
+    },
+  ]);
+
+  expect(requests).toHaveLength(1);
+  expect(Object.keys(requests[0]).sort()).toEqual([
+    'attachments',
+    'category',
+    'consoleLogs',
+    'description',
+    'metadata',
+    'repo',
+    'screenshot',
+    'submitter',
+    'title',
+  ]);
+  expect(requests[0]).toMatchObject({
+    repo: 'mean-weasel/bugdrop-widget-test',
+    title: 'Production parity',
+    screenshot: null,
+    metadata: { viewport: { width: 390, height: 720 } },
+  });
+});

--- a/e2e/local-submissions.spec.ts
+++ b/e2e/local-submissions.spec.ts
@@ -28,9 +28,12 @@ test('local QA submissions can be created, viewed, edited, and deleted', async (
 
   await widget(page).locator('.bd-trigger').click();
   const getStarted = widget(page).getByRole('button', { name: 'Get Started' });
-  if (await getStarted.isVisible()) await getStarted.click();
+  await expect(getStarted).toBeVisible();
+  await getStarted.click();
 
-  await widget(page).getByLabel('Title *', { exact: true }).fill('Local CRUD submission');
+  const title = widget(page).getByLabel('Title *', { exact: true });
+  await expect(title).toBeVisible();
+  await title.fill('Local CRUD submission');
   await widget(page).getByLabel('Description', { exact: true }).fill('Created from the widget.');
   await widget(page).getByLabel('Name', { exact: true }).fill('Local tester');
   await widget(page).getByLabel('📸 Include a screenshot').uncheck();

--- a/e2e/local-submissions.spec.ts
+++ b/e2e/local-submissions.spec.ts
@@ -4,6 +4,24 @@ function widget(page: import('@playwright/test').Page) {
   return page.locator('#bugdrop-host');
 }
 
+test('local QA fails closed when the submissions helper cannot load', async ({ page }) => {
+  const escapedRequests: string[] = [];
+  const widgetRequests: string[] = [];
+  page.on('request', request => {
+    const url = request.url();
+    if (url.includes('/api/check/') || url.includes('/feedback')) escapedRequests.push(url);
+    if (new URL(url).pathname === '/widget.js') widgetRequests.push(url);
+  });
+  await page.route('**/test/local-submissions.js', route => route.abort());
+
+  await page.goto('/test/?localQa=1');
+  await page.waitForTimeout(500);
+
+  await expect(widget(page)).toHaveCount(0);
+  expect(widgetRequests).toEqual([]);
+  expect(escapedRequests).toEqual([]);
+});
+
 test('local QA submissions can be created, viewed, edited, and deleted', async ({ page }) => {
   await page.goto('/test/?localQa=1&showName=true&showIssueLink=always');
   await expect(page.getByRole('link', { name: 'Local submissions' })).toBeVisible();

--- a/e2e/local-submissions.spec.ts
+++ b/e2e/local-submissions.spec.ts
@@ -4,6 +4,24 @@ function widget(page: import('@playwright/test').Page) {
   return page.locator('#bugdrop-host');
 }
 
+function watchForProhibitedRequests(page: import('@playwright/test').Page): string[] {
+  const prohibitedRequests: string[] = [];
+  page.on('request', request => {
+    const url = new URL(request.url());
+    const isLocal =
+      url.hostname === 'localhost' ||
+      url.hostname === '127.0.0.1' ||
+      url.hostname.endsWith('.localhost');
+    const isGitHub = url.hostname === 'github.com' || url.hostname === 'api.github.com';
+    const isFeedbackApi =
+      url.pathname.endsWith('/feedback') || url.pathname.includes('/api/check/');
+    if (!isLocal && (isGitHub || isFeedbackApi)) {
+      prohibitedRequests.push(request.url());
+    }
+  });
+  return prohibitedRequests;
+}
+
 test('local QA fails closed when the submissions helper cannot load', async ({ page }) => {
   const escapedRequests: string[] = [];
   const widgetRequests: string[] = [];
@@ -23,6 +41,7 @@ test('local QA fails closed when the submissions helper cannot load', async ({ p
 });
 
 test('local QA submissions can be created, viewed, edited, and deleted', async ({ page }) => {
+  const prohibitedRequests = watchForProhibitedRequests(page);
   await page.goto('/test/?localQa=1&showName=true&showIssueLink=always');
   await expect(page.getByRole('link', { name: 'Local submissions' })).toBeVisible();
 
@@ -61,4 +80,146 @@ test('local QA submissions can be created, viewed, edited, and deleted', async (
   await expect(
     viewer.getByText('Select a submission or create one from the widget.')
   ).toBeVisible();
+  expect(prohibitedRequests).toEqual([]);
+});
+
+test('local QA preserves native fetch pass-through input forms', async ({ page }) => {
+  const prohibitedRequests = watchForProhibitedRequests(page);
+  const requests: Array<{ url: string; method: string; body: string | null }> = [];
+  await page.route('**/test/fetch-passthrough/**', async route => {
+    const request = route.request();
+    requests.push({
+      url: request.url(),
+      method: request.method(),
+      body: request.postData(),
+    });
+    await route.fulfill({ status: 204 });
+  });
+
+  await page.goto('/test/?localQa=1');
+  const origin = new URL(page.url()).origin;
+  const statuses = await page.evaluate(async () => {
+    const origin = window.location.origin;
+    const responses = await Promise.all([
+      fetch('/test/fetch-passthrough/string', { method: 'POST', body: 'string-body' }),
+      fetch(
+        new Request(origin + '/test/fetch-passthrough/request', {
+          method: 'POST',
+          body: 'request-body',
+        })
+      ),
+      fetch(new URL('/test/fetch-passthrough/url', origin), {
+        method: 'POST',
+        body: 'url-body',
+      }),
+    ]);
+    return responses.map(response => response.status);
+  });
+
+  expect(statuses).toEqual([204, 204, 204]);
+  expect(requests).toEqual([
+    {
+      url: origin + '/test/fetch-passthrough/string',
+      method: 'POST',
+      body: 'string-body',
+    },
+    {
+      url: origin + '/test/fetch-passthrough/request',
+      method: 'POST',
+      body: 'request-body',
+    },
+    {
+      url: origin + '/test/fetch-passthrough/url',
+      method: 'POST',
+      body: 'url-body',
+    },
+  ]);
+  expect(prohibitedRequests).toEqual([]);
+});
+
+test('local QA variants submit headlessly and through inline and modal presentations', async ({
+  page,
+}) => {
+  const prohibitedRequests = watchForProhibitedRequests(page);
+  await page.goto('/test/?localQa=1');
+  await page.waitForFunction(() => Boolean(window.BugDrop?.registerVariant));
+
+  const headlessResult = await page.evaluate(async () => {
+    const baseConfig = {
+      presentation: { kind: 'inline' as const },
+      content: { title: 'Local variant' },
+      fields: [{ id: 'answer', type: 'shortText' as const, label: 'Answer', required: true }],
+      issue: { title: 'Local {{answer}}' },
+    };
+    const headless = window.BugDrop!.registerVariant({
+      ...baseConfig,
+      id: 'local-headless',
+    });
+    const inline = window.BugDrop!.registerVariant({
+      ...baseConfig,
+      id: 'local-inline',
+      content: { title: 'Local inline', submitLabel: 'Send inline' },
+    });
+    const inlineSlot = document.createElement('div');
+    inlineSlot.id = 'local-inline-slot';
+    document.body.appendChild(inlineSlot);
+    inline.mount(inlineSlot);
+
+    const modal = window.BugDrop!.registerVariant({
+      ...baseConfig,
+      id: 'local-modal',
+      presentation: { kind: 'modal' as const },
+      content: { title: 'Local modal', submitLabel: 'Send modal' },
+    });
+    (window as Window & { openLocalModal?: () => void }).openLocalModal = () => {
+      modal.open();
+    };
+    return headless.submit(
+      { answer: 'headless answer' },
+      { submissionId: 'local-headless-submission' }
+    );
+  });
+
+  expect(headlessResult).toMatchObject({
+    issueNumber: expect.any(Number),
+    issueUrl: `https://github.com/mean-weasel/bugdrop-widget-test/issues/${headlessResult.issueNumber}`,
+    isPublic: true,
+  });
+
+  const inline = page.locator('#local-inline-slot > [data-bugdrop-owned]');
+  await inline.getByRole('textbox', { name: 'Answer' }).fill('inline answer');
+  await inline.getByRole('button', { name: 'Send inline' }).click();
+  await expect(inline.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+  const inlineLink = inline.getByRole('link', { name: 'View local submission' });
+  await expect(inlineLink).toHaveAttribute('href', /\/test\/submissions\.html\?id=\d+$/);
+
+  const [inlineViewer] = await Promise.all([page.waitForEvent('popup'), inlineLink.click()]);
+  await inlineViewer.waitForLoadState('domcontentloaded');
+  await expect(inlineViewer.locator('#raw-payload')).toContainText('"variantId": "local-inline"');
+  await inlineViewer.close();
+
+  await page.evaluate(() => {
+    (window as Window & { openLocalModal?: () => void }).openLocalModal?.();
+  });
+  const modal = page.locator('body > [data-bugdrop-owned]').last();
+  await modal.getByRole('textbox', { name: 'Answer' }).fill('modal answer');
+  await modal.getByRole('button', { name: 'Send modal' }).click();
+  await expect(modal.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+  const modalLink = modal.getByRole('link', { name: 'View local submission' });
+  await expect(modalLink).toHaveAttribute('href', /\/test\/submissions\.html\?id=\d+$/);
+
+  const [modalViewer] = await Promise.all([page.waitForEvent('popup'), modalLink.click()]);
+  await modalViewer.waitForLoadState('domcontentloaded');
+  await expect(modalViewer.locator('#raw-payload')).toContainText('"variantId": "local-modal"');
+  await modalViewer.close();
+
+  const headlessViewer = await page.context().newPage();
+  await headlessViewer.goto(`/test/submissions.html?id=${headlessResult.issueNumber}`);
+  await expect(headlessViewer.locator('#raw-payload')).toContainText(
+    '"variantId": "local-headless"'
+  );
+  await expect(headlessViewer.locator('#raw-payload')).toContainText(
+    '"submissionId": "local-headless-submission"'
+  );
+  expect(prohibitedRequests).toEqual([]);
 });

--- a/e2e/local-submissions.spec.ts
+++ b/e2e/local-submissions.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+
+function widget(page: import('@playwright/test').Page) {
+  return page.locator('#bugdrop-host');
+}
+
+test('local QA submissions can be created, viewed, edited, and deleted', async ({ page }) => {
+  await page.goto('/test/?localQa=1&showName=true&showIssueLink=always');
+  await expect(page.getByRole('link', { name: 'Local submissions' })).toBeVisible();
+
+  await widget(page).locator('.bd-trigger').click();
+  const getStarted = widget(page).getByRole('button', { name: 'Get Started' });
+  if (await getStarted.isVisible()) await getStarted.click();
+
+  await widget(page).getByLabel('Title *', { exact: true }).fill('Local CRUD submission');
+  await widget(page).getByLabel('Description', { exact: true }).fill('Created from the widget.');
+  await widget(page).getByLabel('Name', { exact: true }).fill('Local tester');
+  await widget(page).getByLabel('📸 Include a screenshot').uncheck();
+  await widget(page).getByRole('button', { name: 'Continue' }).click();
+
+  await expect(widget(page).getByRole('heading', { name: 'Feedback Submitted!' })).toBeVisible();
+  const localIssueLink = widget(page).getByRole('link', { name: 'View local submission' });
+  await expect(localIssueLink).toHaveText('View local submission');
+  await expect(localIssueLink).toHaveAttribute('href', /\/test\/submissions\.html\?id=\d+$/);
+
+  const [viewer] = await Promise.all([page.waitForEvent('popup'), localIssueLink.click()]);
+  await viewer.waitForLoadState('domcontentloaded');
+
+  await expect(viewer.getByRole('heading', { name: /Submission #\d+/ })).toBeVisible();
+  await expect(viewer.getByLabel('Title')).toHaveValue('Local CRUD submission');
+  await expect(viewer.getByText('Local CRUD submission', { exact: true })).toBeVisible();
+
+  await viewer.getByLabel('Title').fill('Edited local submission');
+  await viewer.getByRole('button', { name: 'Save changes' }).click();
+  await expect(viewer.getByRole('status')).toHaveText('Saved.');
+  await expect(viewer.getByText('Edited local submission', { exact: true })).toBeVisible();
+
+  await viewer.getByRole('button', { name: 'Delete submission' }).click();
+  await expect(viewer.getByText('No local submissions yet.')).toBeVisible();
+  await expect(
+    viewer.getByText('Select a submission or create one from the widget.')
+  ).toBeVisible();
+});

--- a/e2e/local-submissions.spec.ts
+++ b/e2e/local-submissions.spec.ts
@@ -187,14 +187,56 @@ test('local QA variants submit headlessly and through inline and modal presentat
   });
 
   const inline = page.locator('#local-inline-slot > [data-bugdrop-owned]');
+  await page.evaluate(() => {
+    const host = document.querySelector('#local-inline-slot > [data-bugdrop-owned]');
+    if (!host?.shadowRoot) throw new Error('Expected an open inline variant shadow root');
+    const state = {
+      activationHref: null as string | null,
+      attempted: false,
+      mutationTypes: [] as string[],
+    };
+    (window as Window & { localLinkRace?: typeof state }).localLinkRace = state;
+    const observer = new MutationObserver(records => {
+      state.mutationTypes.push(...records.map(record => record.type));
+      const link = host.shadowRoot?.querySelector<HTMLAnchorElement>('.bdv-success-link');
+      if (!link?.hasAttribute('href') || state.attempted) return;
+      state.attempted = true;
+      window.setTimeout(() => {
+        state.activationHref = link.href;
+        link.click();
+        observer.disconnect();
+      }, 0);
+    });
+    observer.observe(host.shadowRoot, {
+      attributes: true,
+      attributeFilter: ['href'],
+      childList: true,
+      subtree: true,
+    });
+  });
   await inline.getByRole('textbox', { name: 'Answer' }).fill('inline answer');
+  const inlineViewerPromise = page.waitForEvent('popup');
   await inline.getByRole('button', { name: 'Send inline' }).click();
   await expect(inline.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
   const inlineLink = inline.getByRole('link', { name: 'View local submission' });
   await expect(inlineLink).toHaveAttribute('href', /\/test\/submissions\.html\?id=\d+$/);
+  const linkRace = await page.evaluate(
+    () => (window as Window & { localLinkRace?: unknown }).localLinkRace
+  );
+  expect(linkRace).toMatchObject({
+    activationHref: expect.stringMatching(/\/test\/submissions\.html\?id=\d+$/),
+    attempted: true,
+    mutationTypes: expect.arrayContaining(['childList', 'attributes']),
+  });
 
-  const [inlineViewer] = await Promise.all([page.waitForEvent('popup'), inlineLink.click()]);
+  const inlineViewer = await inlineViewerPromise;
   await inlineViewer.waitForLoadState('domcontentloaded');
+  const inlineViewerHostname = new URL(inlineViewer.url()).hostname;
+  expect(
+    inlineViewerHostname === 'localhost' ||
+      inlineViewerHostname === '127.0.0.1' ||
+      inlineViewerHostname.endsWith('.localhost')
+  ).toBe(true);
   await expect(inlineViewer.locator('#raw-payload')).toContainText('"variantId": "local-inline"');
   await inlineViewer.close();
 

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -380,7 +380,7 @@ test.describe('Widget Loading', () => {
   test('widget test fixtures use shared local config loader', async () => {
     const fixtureDir = join(process.cwd(), 'public', 'test');
     const fixtureNames = (await readdir(fixtureDir)).filter(name => name.endsWith('.html'));
-    const nonWidgetFixtures = new Set(['pull-tab-mock.html']);
+    const nonWidgetFixtures = new Set(['pull-tab-mock.html', 'submissions.html']);
 
     for (const fixtureName of fixtureNames) {
       const source = await readFile(join(fixtureDir, fixtureName), 'utf8');

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -62,7 +62,10 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
-      testIgnore: /.*\.(?:live|live-radix|cross-browser-live|issue-canary|radix)\.spec\.ts$/,
+      testIgnore: [
+        /.*\.(?:live|live-radix|cross-browser-live|issue-canary|radix)\.spec\.ts$/,
+        /default-flow-production\.spec\.ts$/,
+      ],
     },
     {
       name: 'chromium-radix',

--- a/playwright.default-flow-production.config.ts
+++ b/playwright.default-flow-production.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const generatedAssetPattern =
+  '^(?:widget\\.js|widget\\.v[^/]+\\.js|versions\\.json|checksums\\.sha256|static-package\\.json)$';
+const cleanGeneratedAssets = `node -e "const fs=require('fs');const pattern=new RegExp('${generatedAssetPattern}');for(const name of fs.readdirSync('public'))if(pattern.test(name))fs.rmSync('public/'+name)"`;
+const releaseInputs = [
+  'BUGDROP_BUILD_MODE=release',
+  'BUGDROP_VERSION=9.9.9',
+  'BUGDROP_RELEASE_TIMESTAMP=2026-08-11T00:00:00Z',
+  `BUGDROP_TARGET_SHA=${'a'.repeat(40)}`,
+  'BUGDROP_REPOSITORY=mean-weasel/bugdrop',
+  `BUGDROP_CONTROLLER_IDENTITY=sha256:${'b'.repeat(64)}`,
+  `BUGDROP_TOOL_IDENTITY=sha256:${'c'.repeat(64)}`,
+  `BUGDROP_SOURCE_DIGEST=${'d'.repeat(64)}`,
+].join(' ');
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: /default-flow-production\.spec\.ts/,
+  fullyParallel: false,
+  forbidOnly: true,
+  retries: 0,
+  workers: 1,
+  reporter: 'line',
+  use: {
+    baseURL: 'http://bugdrop.localhost:8787',
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: `${cleanGeneratedAssets} && ${releaseInputs} npm run build:widget && npm run dev`,
+    url: 'http://bugdrop.localhost:8787',
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/public/test/load-widget.js
+++ b/public/test/load-widget.js
@@ -66,9 +66,26 @@
     });
   }
 
+  function loadLocalQaStore() {
+    var params = new URLSearchParams(window.location.search);
+    var isLocalHost =
+      window.location.hostname === 'localhost' ||
+      window.location.hostname === '127.0.0.1' ||
+      window.location.hostname.endsWith('.localhost');
+
+    if (params.get('localQa') !== '1' || !isLocalHost) {
+      return Promise.resolve();
+    }
+
+    return loadOptionalScript('/test/local-submissions.js');
+  }
+
   window.loadBugDropTestWidget = function loadBugDropTestWidget(options) {
     var opts = options || {};
-    return loadScript('/test/config.js')
+    return loadLocalQaStore()
+      .then(function () {
+        return loadScript('/test/config.js');
+      })
       .then(function () {
         return loadOptionalScript('/test/local-config.js');
       })

--- a/public/test/load-widget.js
+++ b/public/test/load-widget.js
@@ -13,6 +13,20 @@
     });
   }
 
+  function loadRequiredScript(src) {
+    return new Promise(function (resolve, reject) {
+      var script = document.createElement('script');
+      script.src = src;
+      script.onload = function () {
+        resolve();
+      };
+      script.onerror = function () {
+        reject(new Error('Failed to load required script: ' + src));
+      };
+      document.head.appendChild(script);
+    });
+  }
+
   function loadOptionalScript(src) {
     return fetch(src)
       .then(function (response) {
@@ -77,7 +91,7 @@
       return Promise.resolve();
     }
 
-    return loadOptionalScript('/test/local-submissions.js');
+    return loadRequiredScript('/test/local-submissions.js');
   }
 
   window.loadBugDropTestWidget = function loadBugDropTestWidget(options) {

--- a/public/test/local-submissions.js
+++ b/public/test/local-submissions.js
@@ -136,13 +136,22 @@
     document.body.appendChild(link);
   }
 
-  function relabelLocalIssueLink() {
+  function relabelLocalIssueLink(issueUrl, localUrl) {
     var attempts = 0;
     var timer = window.setInterval(function () {
       attempts += 1;
       var root = document.querySelector('#bugdrop-host');
-      var link = root && root.shadowRoot && root.shadowRoot.querySelector('.bd-issue-link');
-      if (link && link.getAttribute('href').indexOf('/test/submissions.html') !== -1) {
+      var legacyLink = root && root.shadowRoot && root.shadowRoot.querySelector('.bd-issue-link');
+      var variantLinks = Array.from(document.querySelectorAll('[data-bugdrop-owned]'))
+        .map(function (host) {
+          return host.shadowRoot && host.shadowRoot.querySelector('.bdv-success-link');
+        })
+        .filter(Boolean);
+      var link = [legacyLink].concat(variantLinks).find(function (candidate) {
+        return candidate && candidate.href === issueUrl;
+      });
+      if (link) {
+        link.href = localUrl;
         Array.from(link.childNodes).forEach(function (node) {
           if (node.nodeType === Node.TEXT_NODE) node.remove();
         });
@@ -173,24 +182,38 @@
   }
 
   window.fetch = async function (input, init) {
-    var url = typeof input === 'string' ? input : input.url;
+    var url =
+      typeof input === 'string'
+        ? input
+        : typeof URL !== 'undefined' && input instanceof URL
+          ? input.href
+          : input.url;
 
-    if (url.indexOf('/api/check/') !== -1) {
+    if (typeof url === 'string' && url.indexOf('/api/check/') !== -1) {
       return new Response(JSON.stringify({ installed: true }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
     }
 
-    if (url.endsWith('/feedback')) {
+    if (typeof url === 'string' && url.endsWith('/feedback')) {
       var payload = await readPayload(input, init);
       var id = await create(payload);
-      relabelLocalIssueLink();
+      var localUrl = window.location.origin + '/test/submissions.html?id=' + id;
+      var issueUrl = localUrl;
+      if (
+        payload &&
+        payload.kind === 'bugdrop.variant-submission' &&
+        typeof payload.repo === 'string'
+      ) {
+        issueUrl = 'https://github.com/' + payload.repo + '/issues/' + id;
+      }
+      relabelLocalIssueLink(issueUrl, localUrl);
       return new Response(
         JSON.stringify({
           success: true,
           issueNumber: id,
-          issueUrl: window.location.origin + '/test/submissions.html?id=' + id,
+          issueUrl: issueUrl,
           isPublic: true,
         }),
         { status: 200, headers: { 'content-type': 'application/json' } }

--- a/public/test/local-submissions.js
+++ b/public/test/local-submissions.js
@@ -1,0 +1,202 @@
+(function () {
+  var DB_NAME = 'bugdrop-local-qa';
+  var DB_VERSION = 1;
+  var STORE_NAME = 'submissions';
+  var originalFetch = window.fetch.bind(window);
+
+  function isLocalHost() {
+    return (
+      window.location.hostname === 'localhost' ||
+      window.location.hostname === '127.0.0.1' ||
+      window.location.hostname.endsWith('.localhost')
+    );
+  }
+
+  function requestResult(request) {
+    return new Promise(function (resolve, reject) {
+      request.onsuccess = function () {
+        resolve(request.result);
+      };
+      request.onerror = function () {
+        reject(request.error);
+      };
+    });
+  }
+
+  function transactionDone(transaction) {
+    return new Promise(function (resolve, reject) {
+      transaction.oncomplete = function () {
+        resolve();
+      };
+      transaction.onerror = function () {
+        reject(transaction.error);
+      };
+      transaction.onabort = function () {
+        reject(transaction.error);
+      };
+    });
+  }
+
+  function openDatabase() {
+    return new Promise(function (resolve, reject) {
+      var request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = function () {
+        var database = request.result;
+        if (!database.objectStoreNames.contains(STORE_NAME)) {
+          database.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
+        }
+      };
+      request.onsuccess = function () {
+        resolve(request.result);
+      };
+      request.onerror = function () {
+        reject(request.error);
+      };
+    });
+  }
+
+  async function withStore(mode, callback) {
+    var database = await openDatabase();
+    try {
+      var transaction = database.transaction(STORE_NAME, mode);
+      var result = await callback(transaction.objectStore(STORE_NAME));
+      await transactionDone(transaction);
+      return result;
+    } finally {
+      database.close();
+    }
+  }
+
+  async function create(payload) {
+    var now = new Date().toISOString();
+    return withStore('readwrite', async function (store) {
+      return requestResult(
+        store.add({
+          createdAt: now,
+          updatedAt: now,
+          payload: payload,
+        })
+      );
+    });
+  }
+
+  async function list() {
+    var records = await withStore('readonly', function (store) {
+      return requestResult(store.getAll());
+    });
+    return records.sort(function (left, right) {
+      return right.id - left.id;
+    });
+  }
+
+  function get(id) {
+    return withStore('readonly', function (store) {
+      return requestResult(store.get(Number(id)));
+    });
+  }
+
+  function update(record) {
+    return withStore('readwrite', function (store) {
+      record.updatedAt = new Date().toISOString();
+      return requestResult(store.put(record));
+    });
+  }
+
+  function remove(id) {
+    return withStore('readwrite', function (store) {
+      return requestResult(store.delete(Number(id)));
+    });
+  }
+
+  function clear() {
+    return withStore('readwrite', function (store) {
+      return requestResult(store.clear());
+    });
+  }
+
+  async function readPayload(input, init) {
+    if (init && typeof init.body === 'string') {
+      return JSON.parse(init.body);
+    }
+    if (typeof Request !== 'undefined' && input instanceof Request) {
+      return input.clone().json();
+    }
+    return null;
+  }
+
+  function addInboxLink() {
+    if (window.location.pathname.indexOf('/test/submissions') === 0) return;
+    if (document.getElementById('bugdrop-local-inbox-link')) return;
+    var link = document.createElement('a');
+    link.id = 'bugdrop-local-inbox-link';
+    link.href = '/test/submissions.html';
+    link.textContent = 'Local submissions';
+    link.style.cssText =
+      'position:fixed;top:12px;right:12px;z-index:2147483000;padding:9px 12px;border:1px solid #ff9e64;border-radius:8px;background:#24283b;color:#fff;text-decoration:none;font:600 14px/1.2 system-ui,sans-serif;box-shadow:0 8px 24px rgba(0,0,0,.25)';
+    document.body.appendChild(link);
+  }
+
+  function relabelLocalIssueLink() {
+    var attempts = 0;
+    var timer = window.setInterval(function () {
+      attempts += 1;
+      var root = document.querySelector('#bugdrop-host');
+      var link = root && root.shadowRoot && root.shadowRoot.querySelector('.bd-issue-link');
+      if (link && link.getAttribute('href').indexOf('/test/submissions.html') !== -1) {
+        Array.from(link.childNodes).forEach(function (node) {
+          if (node.nodeType === Node.TEXT_NODE) node.remove();
+        });
+        link.appendChild(document.createTextNode(' View local submission'));
+        link.setAttribute('aria-label', 'View local submission');
+        window.clearInterval(timer);
+      } else if (attempts >= 100) {
+        window.clearInterval(timer);
+      }
+    }, 50);
+  }
+
+  window.BugDropLocalSubmissions = {
+    create: create,
+    list: list,
+    get: get,
+    update: update,
+    remove: remove,
+    clear: clear,
+  };
+
+  if (!isLocalHost() || window.__BugDropLocalQaFetchInstalled) return;
+  window.__BugDropLocalQaFetchInstalled = true;
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', addInboxLink, { once: true });
+  } else {
+    addInboxLink();
+  }
+
+  window.fetch = async function (input, init) {
+    var url = typeof input === 'string' ? input : input.url;
+
+    if (url.indexOf('/api/check/') !== -1) {
+      return new Response(JSON.stringify({ installed: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    if (url.endsWith('/feedback')) {
+      var payload = await readPayload(input, init);
+      var id = await create(payload);
+      relabelLocalIssueLink();
+      return new Response(
+        JSON.stringify({
+          success: true,
+          issueNumber: id,
+          issueUrl: window.location.origin + '/test/submissions.html?id=' + id,
+          isPublic: true,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }
+
+    return originalFetch(input, init);
+  };
+})();

--- a/public/test/local-submissions.js
+++ b/public/test/local-submissions.js
@@ -137,31 +137,57 @@
   }
 
   function relabelLocalIssueLink(issueUrl, localUrl) {
-    var attempts = 0;
-    var timer = window.setInterval(function () {
-      attempts += 1;
-      var root = document.querySelector('#bugdrop-host');
-      var legacyLink = root && root.shadowRoot && root.shadowRoot.querySelector('.bd-issue-link');
-      var variantLinks = Array.from(document.querySelectorAll('[data-bugdrop-owned]'))
-        .map(function (host) {
-          return host.shadowRoot && host.shadowRoot.querySelector('.bdv-success-link');
-        })
-        .filter(Boolean);
-      var link = [legacyLink].concat(variantLinks).find(function (candidate) {
-        return candidate && candidate.href === issueUrl;
+    var observedRoots = [];
+    var observer;
+    var timeout;
+
+    function rewriteLink(link) {
+      if (!link || link.href !== issueUrl) return false;
+      link.href = localUrl;
+      Array.from(link.childNodes).forEach(function (node) {
+        if (node.nodeType === Node.TEXT_NODE) node.remove();
       });
-      if (link) {
-        link.href = localUrl;
-        Array.from(link.childNodes).forEach(function (node) {
-          if (node.nodeType === Node.TEXT_NODE) node.remove();
-        });
-        link.appendChild(document.createTextNode(' View local submission'));
-        link.setAttribute('aria-label', 'View local submission');
-        window.clearInterval(timer);
-      } else if (attempts >= 100) {
-        window.clearInterval(timer);
+      link.appendChild(document.createTextNode(' View local submission'));
+      link.setAttribute('aria-label', 'View local submission');
+      return true;
+    }
+
+    function observeRoot(root) {
+      if (!root || observedRoots.indexOf(root) !== -1) return;
+      observedRoots.push(root);
+      observer.observe(root, {
+        attributes: true,
+        attributeFilter: ['href'],
+        childList: true,
+        subtree: true,
+      });
+    }
+
+    function scan() {
+      var root = document.querySelector('#bugdrop-host');
+      var hosts = [root].concat(Array.from(document.querySelectorAll('[data-bugdrop-owned]')));
+      var links = [];
+      hosts.forEach(function (host) {
+        if (!host || !host.shadowRoot) return;
+        observeRoot(host.shadowRoot);
+        links = links.concat(
+          Array.from(host.shadowRoot.querySelectorAll('.bd-issue-link, .bdv-success-link'))
+        );
+      });
+      if (links.some(rewriteLink)) {
+        observer.disconnect();
+        window.clearTimeout(timeout);
+        return true;
       }
-    }, 50);
+      return false;
+    }
+
+    observer = new MutationObserver(scan);
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    if (scan()) return;
+    timeout = window.setTimeout(function () {
+      observer.disconnect();
+    }, 5000);
   }
 
   window.BugDropLocalSubmissions = {

--- a/public/test/submissions.html
+++ b/public/test/submissions.html
@@ -1,0 +1,360 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BugDrop Local QA Submissions</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #171824;
+      --panel: #232638;
+      --panel-strong: #2d3148;
+      --border: #414866;
+      --text: #c8d1f3;
+      --muted: #8790b2;
+      --accent: #ff9e64;
+      --danger: #f7768e;
+      --success: #9ece6a;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--text);
+      font: 15px/1.5 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    button, input, textarea, select { font: inherit; }
+
+    button, .button-link {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 0.65rem 0.9rem;
+      background: var(--panel-strong);
+      color: var(--text);
+      cursor: pointer;
+      text-decoration: none;
+    }
+
+    button:hover, .button-link:hover { border-color: var(--accent); }
+    button:focus-visible, .button-link:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible {
+      outline: 3px solid color-mix(in srgb, var(--accent) 60%, transparent);
+      outline-offset: 2px;
+    }
+
+    .danger { color: #ffd5dc; border-color: color-mix(in srgb, var(--danger) 55%, var(--border)); }
+    .primary { background: var(--accent); border-color: var(--accent); color: #20170f; font-weight: 700; }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 1.25rem clamp(1rem, 4vw, 3rem);
+      border-bottom: 1px solid var(--border);
+      background: rgba(35, 38, 56, 0.8);
+    }
+
+    h1, h2, h3, p { margin-top: 0; }
+    h1 { margin-bottom: 0.2rem; font-size: clamp(1.35rem, 3vw, 1.8rem); }
+    .eyebrow { color: var(--accent); font-size: 0.75rem; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; }
+    .muted { color: var(--muted); }
+
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(250px, 340px) minmax(0, 1fr);
+      min-height: calc(100vh - 96px);
+    }
+
+    aside { border-right: 1px solid var(--border); padding: 1rem; }
+    main { padding: clamp(1rem, 4vw, 2.5rem); }
+    .toolbar { display: flex; gap: 0.6rem; justify-content: space-between; margin-bottom: 1rem; }
+    .submission-list { display: grid; gap: 0.65rem; }
+
+    .submission-card {
+      width: 100%;
+      text-align: left;
+      display: grid;
+      gap: 0.25rem;
+      padding: 0.85rem;
+      background: var(--panel);
+    }
+
+    .submission-card[aria-current="true"] { border-color: var(--accent); background: var(--panel-strong); }
+    .submission-card strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .submission-card span { color: var(--muted); font-size: 0.82rem; }
+
+    .empty, .notice {
+      border: 1px dashed var(--border);
+      border-radius: 12px;
+      padding: 1.5rem;
+      color: var(--muted);
+      background: var(--panel);
+    }
+
+    form { display: grid; gap: 1rem; max-width: 760px; }
+    label { display: grid; gap: 0.4rem; font-weight: 650; }
+    input, textarea, select {
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 0.75rem;
+      background: #191b29;
+      color: var(--text);
+    }
+    textarea { min-height: 130px; resize: vertical; }
+    .actions { display: flex; flex-wrap: wrap; gap: 0.65rem; }
+
+    .details-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 0.75rem;
+      margin: 1.5rem 0;
+    }
+
+    .detail {
+      padding: 0.85rem;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--panel);
+    }
+    .detail dt { color: var(--muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.08em; }
+    .detail dd { margin: 0.35rem 0 0; overflow-wrap: anywhere; }
+
+    .screenshot {
+      display: block;
+      max-width: min(100%, 900px);
+      max-height: 520px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      object-fit: contain;
+      background: white;
+    }
+
+    details { margin-top: 1.5rem; max-width: 960px; }
+    pre { overflow: auto; padding: 1rem; border-radius: 10px; background: #10111a; color: #b4f9f8; }
+    #status { min-height: 1.5rem; color: var(--success); }
+
+    @media (max-width: 760px) {
+      header { align-items: flex-start; flex-direction: column; }
+      .layout { grid-template-columns: 1fr; }
+      aside { border-right: 0; border-bottom: 1px solid var(--border); }
+      .submission-list { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <div class="eyebrow">Local QA only</div>
+      <h1>BugDrop submissions</h1>
+      <div class="muted">Create through the widget, then inspect, edit, or delete here.</div>
+    </div>
+    <a class="button-link" href="/test/?localQa=1&showIssueLink=always&showName=true&sendConsoleLogs=true">Back to widget</a>
+  </header>
+
+  <div class="layout">
+    <aside>
+      <div class="toolbar">
+        <button id="refresh" type="button">Refresh</button>
+        <button id="clear-all" class="danger" type="button">Delete all</button>
+      </div>
+      <div id="submission-list" class="submission-list" aria-label="Local submissions"></div>
+    </aside>
+
+    <main>
+      <div id="local-only" class="notice" hidden>This page is available only on localhost subdomains.</div>
+      <div id="empty" class="empty">Select a submission or create one from the widget.</div>
+      <section id="detail" hidden>
+        <h2 id="detail-heading">Submission</h2>
+        <p id="status" role="status" aria-live="polite"></p>
+        <form id="edit-form">
+          <label>
+            Title
+            <input id="title" name="title" required>
+          </label>
+          <label>
+            Description
+            <textarea id="description" name="description"></textarea>
+          </label>
+          <label>
+            Category
+            <select id="category" name="category">
+              <option value="bug">Bug</option>
+              <option value="feature">Feature</option>
+              <option value="question">Question</option>
+            </select>
+          </label>
+          <div class="actions">
+            <button class="primary" type="submit">Save changes</button>
+            <button id="delete" class="danger" type="button">Delete submission</button>
+          </div>
+        </form>
+
+        <dl class="details-grid">
+          <div class="detail"><dt>ID</dt><dd id="record-id"></dd></div>
+          <div class="detail"><dt>Created</dt><dd id="created-at"></dd></div>
+          <div class="detail"><dt>Updated</dt><dd id="updated-at"></dd></div>
+          <div class="detail"><dt>Screenshot</dt><dd id="screenshot-size"></dd></div>
+        </dl>
+
+        <section id="screenshot-section" hidden>
+          <h3>Screenshot</h3>
+          <img id="screenshot" class="screenshot" alt="Captured feedback screenshot">
+        </section>
+
+        <details>
+          <summary>Raw legacy payload</summary>
+          <pre id="raw-payload"></pre>
+        </details>
+      </section>
+    </main>
+  </div>
+
+  <script src="/test/local-submissions.js"></script>
+  <script>
+    (function () {
+      var api = window.BugDropLocalSubmissions;
+      var listElement = document.getElementById('submission-list');
+      var emptyElement = document.getElementById('empty');
+      var detailElement = document.getElementById('detail');
+      var localOnlyElement = document.getElementById('local-only');
+      var selectedRecord = null;
+
+      function isLocalHost() {
+        return location.hostname === 'localhost' || location.hostname === '127.0.0.1' || location.hostname.endsWith('.localhost');
+      }
+
+      function formatDate(value) {
+        return value ? new Date(value).toLocaleString() : '—';
+      }
+
+      function formatBytes(value) {
+        if (!value) return 'None';
+        if (value < 1024) return value + ' bytes';
+        return (value / 1024).toFixed(1) + ' KB';
+      }
+
+      function selectedIdFromUrl() {
+        var value = new URLSearchParams(location.search).get('id');
+        return value ? Number(value) : null;
+      }
+
+      function setSelectedUrl(id) {
+        var url = new URL(location.href);
+        if (id) url.searchParams.set('id', id);
+        else url.searchParams.delete('id');
+        history.replaceState(null, '', url);
+      }
+
+      function renderDetail(record) {
+        selectedRecord = record || null;
+        emptyElement.hidden = Boolean(record);
+        detailElement.hidden = !record;
+        if (!record) return;
+
+        var payload = record.payload || {};
+        document.getElementById('detail-heading').textContent = 'Submission #' + record.id;
+        document.getElementById('title').value = payload.title || '';
+        document.getElementById('description').value = payload.description || '';
+        document.getElementById('category').value = payload.category || 'bug';
+        document.getElementById('record-id').textContent = String(record.id);
+        document.getElementById('created-at').textContent = formatDate(record.createdAt);
+        document.getElementById('updated-at').textContent = formatDate(record.updatedAt);
+        document.getElementById('screenshot-size').textContent = formatBytes(payload.screenshot ? payload.screenshot.length : 0);
+        var displayPayload = Object.assign({}, payload, {
+          screenshot: payload.screenshot
+            ? '[Screenshot data URL omitted from JSON view · ' + payload.screenshot.length + ' characters]'
+            : null,
+        });
+        document.getElementById('raw-payload').textContent = JSON.stringify(displayPayload, null, 2);
+
+        var screenshotSection = document.getElementById('screenshot-section');
+        var screenshot = document.getElementById('screenshot');
+        screenshotSection.hidden = !payload.screenshot;
+        if (payload.screenshot) screenshot.src = payload.screenshot;
+        else screenshot.removeAttribute('src');
+      }
+
+      function renderList(records) {
+        listElement.replaceChildren();
+        if (!records.length) {
+          var message = document.createElement('div');
+          message.className = 'empty';
+          message.textContent = 'No local submissions yet.';
+          listElement.appendChild(message);
+          return;
+        }
+
+        records.forEach(function (record) {
+          var button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'submission-card';
+          button.setAttribute('aria-current', selectedRecord && selectedRecord.id === record.id ? 'true' : 'false');
+
+          var title = document.createElement('strong');
+          title.textContent = record.payload && record.payload.title ? record.payload.title : 'Untitled submission';
+          var meta = document.createElement('span');
+          meta.textContent = '#' + record.id + ' · ' + formatDate(record.createdAt);
+          button.append(title, meta);
+          button.addEventListener('click', function () {
+            setSelectedUrl(record.id);
+            renderDetail(record);
+            renderList(records);
+          });
+          listElement.appendChild(button);
+        });
+      }
+
+      async function refresh() {
+        var records = await api.list();
+        var requestedId = selectedRecord ? selectedRecord.id : selectedIdFromUrl();
+        var next = records.find(function (record) { return record.id === requestedId; }) || records[0] || null;
+        renderDetail(next);
+        if (next) setSelectedUrl(next.id);
+        renderList(records);
+      }
+
+      if (!isLocalHost() || !api) {
+        localOnlyElement.hidden = false;
+        emptyElement.hidden = true;
+        document.querySelector('aside').hidden = true;
+        return;
+      }
+
+      document.getElementById('refresh').addEventListener('click', refresh);
+      document.getElementById('edit-form').addEventListener('submit', async function (event) {
+        event.preventDefault();
+        if (!selectedRecord) return;
+        selectedRecord.payload.title = document.getElementById('title').value;
+        selectedRecord.payload.description = document.getElementById('description').value;
+        selectedRecord.payload.category = document.getElementById('category').value;
+        await api.update(selectedRecord);
+        document.getElementById('status').textContent = 'Saved.';
+        await refresh();
+      });
+      document.getElementById('delete').addEventListener('click', async function () {
+        if (!selectedRecord) return;
+        await api.remove(selectedRecord.id);
+        selectedRecord = null;
+        setSelectedUrl(null);
+        await refresh();
+      });
+      document.getElementById('clear-all').addEventListener('click', async function () {
+        await api.clear();
+        selectedRecord = null;
+        setSelectedUrl(null);
+        await refresh();
+      });
+
+      refresh().catch(function (error) {
+        emptyElement.textContent = 'Could not load local submissions: ' + error.message;
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/scripts/build-widget.js
+++ b/scripts/build-widget.js
@@ -33,6 +33,7 @@ const VALUE_OPTIONS = new Set([
   'tool-identity',
   'source-digest',
   'development-id',
+  'default-flow-runtime',
 ]);
 
 function usage() {
@@ -46,6 +47,7 @@ Common options:
   --source-dir PATH           Candidate checkout (default: repository root)
   --output-dir PATH           Clean output tree (default: <source>/public)
   --development-id ID         Visible identity for development output
+  --default-flow-runtime ID   Internal default controller: fixed (default) or private
 
 Release options:
   --version MAJOR.MINOR.PATCH  Required planned stable version
@@ -150,13 +152,14 @@ function repositoryFromRemote(remote) {
   return match?.[1];
 }
 
-async function bundleCandidate({ sourceDir, version, enableTestHooks }) {
+async function bundleCandidate({ sourceDir, version, enableTestHooks, defaultFlowRuntime }) {
   const entry = join(sourceDir, 'src/widget/index.ts');
   const result = await build({
     absWorkingDir: sourceDir,
     bundle: true,
     define: {
       __BUGDROP_ENABLE_TEST_HOOKS__: enableTestHooks ? 'true' : 'false',
+      __BUGDROP_DEFAULT_FLOW_RUNTIME__: JSON.stringify(defaultFlowRuntime),
       __BUGDROP_VERSION__: JSON.stringify(version),
     },
     entryPoints: [entry],
@@ -208,6 +211,15 @@ async function main() {
     option(options, 'output-dir', 'BUGDROP_OUTPUT_DIR', join(sourceDir, 'public'))
   );
   const enableTestHooks = process.env.BUGDROP_TEST_HOOKS === '1';
+  const defaultFlowRuntime = option(
+    options,
+    'default-flow-runtime',
+    'BUGDROP_DEFAULT_FLOW_RUNTIME',
+    'fixed'
+  );
+  if (defaultFlowRuntime !== 'fixed' && defaultFlowRuntime !== 'private') {
+    throw new Error('Unsupported default flow runtime: expected fixed or private');
+  }
 
   if (mode === 'development') {
     const developmentId = option(options, 'development-id', 'BUGDROP_DEVELOPMENT_ID', 'local');
@@ -215,6 +227,7 @@ async function main() {
       sourceDir,
       version: `development:${developmentId}`,
       enableTestHooks,
+      defaultFlowRuntime,
     });
     await createDevelopmentStaticPackage({
       bundleBytes,
@@ -249,7 +262,12 @@ async function main() {
     option(options, 'request-plan', 'BUGDROP_REQUEST_PLAN')
   );
   const retentionMode = retention.mode ?? (retention.retainedReleases ? undefined : 'disabled');
-  const bundleBytes = await bundleCandidate({ sourceDir, version, enableTestHooks: false });
+  const bundleBytes = await bundleCandidate({
+    sourceDir,
+    version,
+    enableTestHooks: false,
+    defaultFlowRuntime,
+  });
   const exactName = `widget.v${version}.js`;
   const result = await createReleaseStaticPackage({
     bundleBytes,

--- a/src/widget/default-flow/definition.ts
+++ b/src/widget/default-flow/definition.ts
@@ -1,0 +1,142 @@
+import type { BugDropAuthTokenProvider } from '../auth-token';
+import type { IssueLinkVisibility } from '../ui';
+
+export const DEFAULT_DEFINITION_ID = 'bugdrop-default@1' as const;
+
+export type DefaultWelcomePolicy = 'once' | 'always' | 'never';
+export type DefaultScreenshotMode = 'optional' | 'auto' | 'required';
+type DefaultCategory = 'bug' | 'feature' | 'question';
+type DefaultCategoryLabels = Partial<Record<DefaultCategory, string | readonly string[]>>;
+
+export interface DefaultDefinitionInput {
+  repo: string;
+  apiUrl: string;
+  authTokenProvider?: BugDropAuthTokenProvider;
+  welcome: DefaultWelcomePolicy;
+  screenshotMode: DefaultScreenshotMode;
+  skipWelcome: boolean;
+  hasSeenWelcome: boolean;
+  showName: boolean;
+  requireName: boolean;
+  showEmail: boolean;
+  requireEmail: boolean;
+  sendConsoleLogs: boolean;
+  screenshotScale?: number;
+  elementContextMaxArea?: number;
+  accentColor?: string;
+  categoryLabels?: DefaultCategoryLabels;
+  issueLinkVisibility: IssueLinkVisibility;
+}
+
+export interface DefaultDefinition {
+  readonly id: typeof DEFAULT_DEFINITION_ID;
+  readonly steps: readonly [
+    Readonly<{ kind: 'welcome'; enabled: boolean; remember: boolean }>,
+    Readonly<{
+      kind: 'details';
+      repo: string;
+      showName: boolean;
+      requireName: boolean;
+      showEmail: boolean;
+      requireEmail: boolean;
+      sendConsoleLogs: boolean;
+    }>,
+    Readonly<{
+      kind: 'screenshot';
+      mode: DefaultScreenshotMode;
+      repo: string;
+      screenshotScale?: number;
+      elementContextMaxArea?: number;
+      accentColor?: string;
+    }>,
+  ];
+  readonly system: Readonly<{
+    preflight: Readonly<{
+      kind: 'installation';
+      repo: string;
+      apiUrl: string;
+      authTokenProvider?: BugDropAuthTokenProvider;
+    }>;
+    submission: Readonly<{
+      kind: 'legacy-feedback';
+      repo: string;
+      apiUrl: string;
+      authTokenProvider?: BugDropAuthTokenProvider;
+      categoryLabels?: Readonly<DefaultCategoryLabels>;
+      issueLinkVisibility: IssueLinkVisibility;
+    }>;
+  }>;
+}
+
+export type DefaultWelcomeStep = DefaultDefinition['steps'][0];
+export type DefaultDetailsStep = DefaultDefinition['steps'][1];
+export type DefaultScreenshotStep = DefaultDefinition['steps'][2];
+export type DefaultPreflightRecipe = DefaultDefinition['system']['preflight'];
+export type DefaultSubmissionRecipe = DefaultDefinition['system']['submission'];
+
+function freezeCategoryLabels(
+  labels: DefaultCategoryLabels | undefined
+): Readonly<DefaultCategoryLabels> | undefined {
+  if (!labels) return undefined;
+  return Object.freeze(
+    Object.fromEntries(
+      Object.entries(labels).map(([category, value]) => [
+        category,
+        Array.isArray(value) ? Object.freeze([...value]) : value,
+      ])
+    ) as DefaultCategoryLabels
+  );
+}
+
+export function normalizeDefaultDefinition(input: DefaultDefinitionInput): DefaultDefinition {
+  const welcomeEnabled =
+    !input.skipWelcome &&
+    input.welcome !== 'never' &&
+    !(input.welcome === 'once' && input.hasSeenWelcome);
+
+  const steps = Object.freeze([
+    Object.freeze({
+      kind: 'welcome' as const,
+      enabled: welcomeEnabled,
+      remember: welcomeEnabled && input.welcome === 'once',
+    }),
+    Object.freeze({
+      kind: 'details' as const,
+      repo: input.repo,
+      showName: input.showName,
+      requireName: input.requireName,
+      showEmail: input.showEmail,
+      requireEmail: input.requireEmail,
+      sendConsoleLogs: input.sendConsoleLogs,
+    }),
+    Object.freeze({
+      kind: 'screenshot' as const,
+      mode: input.screenshotMode,
+      repo: input.repo,
+      screenshotScale: input.screenshotScale,
+      elementContextMaxArea: input.elementContextMaxArea,
+      accentColor: input.accentColor,
+    }),
+  ]) as DefaultDefinition['steps'];
+
+  return Object.freeze({
+    id: DEFAULT_DEFINITION_ID,
+    steps,
+    system: Object.freeze({
+      preflight: Object.freeze({
+        kind: 'installation' as const,
+        repo: input.repo,
+        apiUrl: input.apiUrl,
+        authTokenProvider: input.authTokenProvider,
+      }),
+      submission: Object.freeze({
+        kind: 'legacy-feedback' as const,
+        repo: input.repo,
+        apiUrl: input.apiUrl,
+        authTokenProvider: input.authTokenProvider,
+        categoryLabels: freezeCategoryLabels(input.categoryLabels),
+        issueLinkVisibility: input.issueLinkVisibility,
+      }),
+    }),
+  });
+}

--- a/src/widget/default-flow/definition.ts
+++ b/src/widget/default-flow/definition.ts
@@ -3,8 +3,8 @@ import type { IssueLinkVisibility } from '../ui';
 
 export const DEFAULT_DEFINITION_ID = 'bugdrop-default@1' as const;
 
-export type DefaultWelcomePolicy = 'once' | 'always' | 'never';
-export type DefaultScreenshotMode = 'optional' | 'auto' | 'required';
+type DefaultWelcomePolicy = 'once' | 'always' | 'never';
+type DefaultScreenshotMode = 'optional' | 'auto' | 'required';
 type DefaultCategory = 'bug' | 'feature' | 'question';
 type DefaultCategoryLabels = Partial<Record<DefaultCategory, string | readonly string[]>>;
 

--- a/src/widget/default-flow/runtime.ts
+++ b/src/widget/default-flow/runtime.ts
@@ -7,7 +7,7 @@ import type {
   DefaultWelcomeStep,
 } from './definition';
 
-export type DefaultPreflightResult =
+type DefaultPreflightResult =
   { status: 'installed' } | { status: 'not_installed' | 'unreachable'; appName?: string };
 
 export interface DefaultJourneyPorts<Details, Capture> {

--- a/src/widget/default-flow/runtime.ts
+++ b/src/widget/default-flow/runtime.ts
@@ -1,0 +1,55 @@
+import type {
+  DefaultDefinition,
+  DefaultDetailsStep,
+  DefaultPreflightRecipe,
+  DefaultScreenshotStep,
+  DefaultSubmissionRecipe,
+  DefaultWelcomeStep,
+} from './definition';
+
+export type DefaultPreflightResult =
+  { status: 'installed' } | { status: 'not_installed' | 'unreachable'; appName?: string };
+
+export interface DefaultJourneyPorts<Details, Capture> {
+  preflight: (recipe: DefaultPreflightRecipe) => Promise<DefaultPreflightResult>;
+  showPreflightFailure: (result: Exclude<DefaultPreflightResult, { status: 'installed' }>) => void;
+  showWelcome: (step: DefaultWelcomeStep) => Promise<boolean>;
+  rememberWelcome: (step: DefaultWelcomeStep) => void;
+  showDetails: (step: DefaultDetailsStep, previous: Details | null) => Promise<Details | null>;
+  capture: (
+    step: DefaultScreenshotStep,
+    details: Details
+  ) => Promise<Capture & { returnToDetails: boolean }>;
+  submit: (recipe: DefaultSubmissionRecipe, details: Details, capture: Capture) => Promise<void>;
+}
+
+export async function runDefaultJourney<Details, Capture>(
+  definition: DefaultDefinition,
+  ports: DefaultJourneyPorts<Details, Capture>
+): Promise<'finished' | 'preflight-blocked'> {
+  const preflight = await ports.preflight(definition.system.preflight);
+  if (preflight.status !== 'installed') {
+    ports.showPreflightFailure(preflight);
+    return 'preflight-blocked';
+  }
+
+  const welcome = definition.steps[0];
+  if (welcome.enabled) {
+    if (!(await ports.showWelcome(welcome))) return 'finished';
+    if (welcome.remember) ports.rememberWelcome(welcome);
+  }
+
+  const detailsStep = definition.steps[1];
+  const screenshotStep = definition.steps[2];
+  let details: Details | null = null;
+  while (true) {
+    details = await ports.showDetails(detailsStep, details);
+    if (!details) return 'finished';
+
+    const capture = await ports.capture(screenshotStep, details);
+    if (capture.returnToDetails) continue;
+
+    await ports.submit(definition.system.submission, details, capture);
+    return 'finished';
+  }
+}

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -35,6 +35,11 @@ import { closeActiveVariantModal } from './variants/modal-coordinator';
 import { resolveAccentColor } from '../defaults';
 import type { BugDropPublicAPI } from './variants/public-types';
 import { createVariantManager, type VariantManager } from './variants/manager';
+import { runDefaultJourney } from './default-flow/runtime';
+import { normalizeDefaultDefinition } from './default-flow/definition';
+
+declare const __BUGDROP_ENABLE_TEST_HOOKS__: boolean;
+declare const __BUGDROP_DEFAULT_FLOW_RUNTIME__: 'fixed' | 'private';
 
 type FeedbackCategory = 'bug' | 'feature' | 'question';
 type CategoryLabelConfig = Partial<Record<FeedbackCategory, string | string[]>>;
@@ -1065,17 +1070,43 @@ async function openFeedbackFlow(
   // Mark modal as open
   _isModalOpen = true;
 
-  // Check if app is installed
-  const { status: installStatus, appName } = await checkInstallation(config);
-  if (installStatus === 'not_installed') {
-    showInstallPrompt(root, config, undefined, appName);
-    return;
-  }
-  if (installStatus === 'unreachable') {
-    showInstallPrompt(root, config, t().apiUnreachableMessage, appName);
-    return;
+  if (
+    __BUGDROP_DEFAULT_FLOW_RUNTIME__ === 'private' ||
+    (__BUGDROP_ENABLE_TEST_HOOKS__ && shouldUsePrivateDefaultJourney())
+  ) {
+    const outcome = await runPrivateDefaultJourney(root, config, opts);
+    if (outcome === 'preflight-blocked') return;
+  } else {
+    // Check if app is installed
+    const { status: installStatus, appName } = await checkInstallation(config);
+    if (installStatus === 'not_installed') {
+      showInstallPrompt(root, config, undefined, appName);
+      return;
+    }
+    if (installStatus === 'unreachable') {
+      showInstallPrompt(root, config, t().apiUnreachableMessage, appName);
+      return;
+    }
+
+    await runFixedDefaultJourney(root, config, opts);
   }
 
+  // Flow complete
+  _isModalOpen = false;
+}
+
+function shouldUsePrivateDefaultJourney(): boolean {
+  return (
+    (window as unknown as { __bugdropDefaultFlowRuntime?: unknown }).__bugdropDefaultFlowRuntime ===
+    'private'
+  );
+}
+
+async function runFixedDefaultJourney(
+  root: HTMLElement,
+  config: WidgetConfig,
+  opts?: { skipWelcome?: boolean }
+) {
   // Step 1: Welcome screen (conditional)
   const skipWelcome =
     opts?.skipWelcome ||
@@ -1131,9 +1162,113 @@ async function openFeedbackFlow(
     });
     break;
   }
+}
 
-  // Flow complete
-  _isModalOpen = false;
+async function runPrivateDefaultJourney(
+  root: HTMLElement,
+  config: WidgetConfig,
+  opts?: { skipWelcome?: boolean }
+) {
+  const definition = normalizeDefaultDefinition({
+    repo: config.repo,
+    apiUrl: config.apiUrl,
+    authTokenProvider: config.authTokenProvider,
+    welcome: config.welcome,
+    screenshotMode: config.screenshotMode,
+    skipWelcome: Boolean(opts?.skipWelcome),
+    hasSeenWelcome: hasSeenWelcome(config.repo),
+    showName: config.showName,
+    requireName: config.requireName,
+    showEmail: config.showEmail,
+    requireEmail: config.requireEmail,
+    sendConsoleLogs: config.sendConsoleLogs,
+    screenshotScale: config.screenshotScale,
+    elementContextMaxArea: config.elementContextMaxArea,
+    accentColor: config.accentColor,
+    categoryLabels: config.categoryLabels,
+    issueLinkVisibility: config.issueLinkVisibility,
+  });
+
+  return runDefaultJourney<
+    FeedbackFormResult,
+    Awaited<ReturnType<typeof runScreenshotCaptureFlow>>
+  >(definition, {
+    preflight: recipe =>
+      checkInstallation({
+        ...config,
+        repo: recipe.repo,
+        apiUrl: recipe.apiUrl,
+        authTokenProvider: recipe.authTokenProvider,
+      }),
+    showPreflightFailure: result =>
+      showInstallPrompt(
+        root,
+        config,
+        result.status === 'unreachable' ? t().apiUnreachableMessage : undefined,
+        result.appName
+      ),
+    showWelcome: () => showWelcomeScreen(root),
+    rememberWelcome: () => markWelcomeSeen(definition.steps[1].repo),
+    showDetails: (step, previous) =>
+      showFeedbackFormWithScreenshotOption(
+        root,
+        {
+          ...config,
+          repo: step.repo,
+          showName: step.showName,
+          requireName: step.requireName,
+          showEmail: step.showEmail,
+          requireEmail: step.requireEmail,
+          sendConsoleLogs: step.sendConsoleLogs,
+          screenshotMode: definition.steps[2].mode,
+        },
+        previous
+      ),
+    capture: async (step, details) => {
+      const captureConfig: WidgetConfig = {
+        ...config,
+        repo: step.repo,
+        screenshotMode: step.mode,
+        screenshotScale: step.screenshotScale,
+        elementContextMaxArea: step.elementContextMaxArea,
+        accentColor: step.accentColor,
+      };
+      const result = await runScreenshotCaptureFlow(
+        root,
+        captureConfig,
+        details.includeScreenshot,
+        () => rememberComplexScreenshotSkip(captureConfig, details)
+      );
+      return { ...result, returnToDetails: result.returnToForm };
+    },
+    submit: (recipe, details, capture) =>
+      submitFeedback(
+        root,
+        {
+          ...config,
+          repo: recipe.repo,
+          apiUrl: recipe.apiUrl,
+          authTokenProvider: recipe.authTokenProvider,
+          categoryLabels: recipe.categoryLabels as CategoryLabelConfig | undefined,
+          issueLinkVisibility: recipe.issueLinkVisibility,
+        },
+        {
+          title: details.title,
+          description: details.description,
+          category: details.category,
+          name: details.name,
+          email: details.email,
+          screenshot: capture.screenshot,
+          attachments: details.attachments,
+          elementSelector: capture.elementSelector,
+          fullElementSelector: capture.fullElementSelector,
+          selectedElementHighlightColor: capture.elementSelector
+            ? resolveAccentColor(config.accentColor)
+            : null,
+          sendConsoleLogs: details.sendConsoleLogs,
+        }
+      ),
+  });
 }
 
 async function checkInstallation(

--- a/src/widget/variants/flow-definition.ts
+++ b/src/widget/variants/flow-definition.ts
@@ -1,0 +1,25 @@
+import type { VariantConfig } from './public-types';
+
+export const VARIANT_DEFINITION_ID = 'bugdrop-variant@1' as const;
+
+export interface VariantDefinition {
+  readonly id: typeof VARIANT_DEFINITION_ID;
+  readonly variantId: string;
+  readonly screens: readonly [
+    Readonly<{
+      kind: 'variant';
+      config: Readonly<VariantConfig>;
+    }>,
+  ];
+}
+
+export function normalizeVariantDefinition(config: Readonly<VariantConfig>): VariantDefinition {
+  const screen = Object.freeze({ kind: 'variant' as const, config });
+  const screens = Object.freeze([screen]) as VariantDefinition['screens'];
+
+  return Object.freeze({
+    id: VARIANT_DEFINITION_ID,
+    variantId: config.id,
+    screens,
+  });
+}

--- a/src/widget/variants/manager.ts
+++ b/src/widget/variants/manager.ts
@@ -4,6 +4,7 @@ import type {
   VariantMountOptions,
   VariantOpenOptions,
 } from './public-types';
+import { normalizeVariantDefinition, type VariantDefinition } from './flow-definition';
 import { mountInlineVariant } from './presentations/inline';
 import { createBusyOpenedVariant, openModalVariant } from './presentations/modal';
 import { validateAndFreezeVariantConfig } from './validate-config';
@@ -17,7 +18,7 @@ export function createVariantManager(
   transport: VariantTransportConfig,
   runtime: { isLegacyModalOpen(): boolean } = { isLegacyModalOpen: () => false }
 ): VariantManager {
-  const variants = new Map<string, Readonly<VariantConfig>>();
+  const variants = new Map<string, VariantDefinition>();
 
   return {
     register(config) {
@@ -25,33 +26,39 @@ export function createVariantManager(
       if (variants.has(normalized.id)) {
         throw new TypeError(`BugDrop variant is already registered: ${normalized.id}`);
       }
-      variants.set(normalized.id, normalized);
+      const definition = normalizeVariantDefinition(normalized);
+      variants.set(normalized.id, definition);
+
+      const screen = definition.screens[0];
+      const screenConfig = screen.config;
+      const submitFromDefinition = (
+        answers: Record<string, unknown>,
+        options: Parameters<typeof submitVariant>[3] = {}
+      ) => submitVariant(transport, screenConfig, answers, options);
 
       return Object.freeze({
-        id: normalized.id,
+        id: definition.variantId,
         open(options?: VariantOpenOptions) {
-          if (normalized.presentation.kind !== 'modal') {
+          if (screenConfig.presentation.kind !== 'modal') {
             throw new TypeError('BugDrop open() requires a modal variant');
           }
-          if (runtime.isLegacyModalOpen()) return createBusyOpenedVariant(normalized.id);
+          if (runtime.isLegacyModalOpen()) return createBusyOpenedVariant(definition.variantId);
           return openModalVariant({
-            config: normalized,
+            config: screenConfig,
             options,
-            submit: (answers, submitOptions) =>
-              submitVariant(transport, normalized, answers, submitOptions),
+            submit: submitFromDefinition,
           });
         },
         mount(target: HTMLElement, options?: VariantMountOptions) {
           return mountInlineVariant({
-            config: normalized,
+            config: screenConfig,
             target,
             options,
-            submit: (answers, submitOptions) =>
-              submitVariant(transport, normalized, answers, submitOptions),
+            submit: submitFromDefinition,
           });
         },
         submit(answers: Record<string, unknown>, options = {}) {
-          return submitVariant(transport, normalized, answers, options);
+          return submitFromDefinition(answers, options);
         },
       });
     },

--- a/test/defaultFlowBuild.test.ts
+++ b/test/defaultFlowBuild.test.ts
@@ -1,0 +1,110 @@
+import { spawnSync } from 'node:child_process';
+import { cp, mkdtemp, mkdir, readFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, relative, resolve } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const GENERATED_ASSET =
+  /^(?:widget\.js|widget\.v[^/]+\.js|versions\.json|checksums\.sha256|static-package\.json)$/;
+const tempRoots: string[] = [];
+let candidate = '';
+
+async function snapshot(root: string, current = root): Promise<Record<string, Buffer>> {
+  const result: Record<string, Buffer> = {};
+  for (const entry of await readdir(current, { withFileTypes: true })) {
+    const path = join(current, entry.name);
+    if (entry.isDirectory()) Object.assign(result, await snapshot(root, path));
+    else result[relative(root, path)] = await readFile(path);
+  }
+  return result;
+}
+
+async function build(runtime: 'fixed' | 'private' | undefined, label: string) {
+  const outputDir = join(await mkdtemp(join(tmpdir(), `bugdrop-default-${label}-`)), 'public');
+  tempRoots.push(resolve(outputDir, '..'));
+  const environment = { ...process.env };
+  delete environment.BUGDROP_TEST_HOOKS;
+  if (runtime) environment.BUGDROP_DEFAULT_FLOW_RUNTIME = runtime;
+  else delete environment.BUGDROP_DEFAULT_FLOW_RUNTIME;
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      join(ROOT, 'scripts/build-widget.js'),
+      '--mode',
+      'release',
+      '--source-dir',
+      candidate,
+      '--output-dir',
+      outputDir,
+      '--version',
+      '9.9.9',
+      '--timestamp',
+      '2026-08-11T00:00:00Z',
+      '--target-sha',
+      'a'.repeat(40),
+      '--repository',
+      'mean-weasel/bugdrop',
+      '--controller-identity',
+      `sha256:${'b'.repeat(64)}`,
+      '--tool-identity',
+      `sha256:${'c'.repeat(64)}`,
+      '--source-digest',
+      'd'.repeat(64),
+    ],
+    { cwd: ROOT, encoding: 'utf8', env: environment }
+  );
+  expect(result.status, result.stderr).toBe(0);
+  return { outputDir, files: await snapshot(outputDir) };
+}
+
+beforeEach(async () => {
+  candidate = await mkdtemp(join(ROOT, '.default-flow-candidate-'));
+  tempRoots.push(candidate);
+  await mkdir(join(candidate, 'src'), { recursive: true });
+  await cp(join(ROOT, 'src'), join(candidate, 'src'), { recursive: true });
+  await cp(join(ROOT, 'public'), join(candidate, 'public'), {
+    recursive: true,
+    filter: source =>
+      source === join(ROOT, 'public') || !GENERATED_ASSET.test(source.split('/').at(-1) ?? ''),
+  });
+});
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map(path => rm(path, { recursive: true, force: true })));
+});
+
+describe('internal default-flow build selector', () => {
+  it('defaults to fixed and restores byte-identical fixed output after a private build', async () => {
+    const fixedBefore = await build(undefined, 'fixed-before');
+    const privateBuild = await build('private', 'private');
+    const fixedAfter = await build('fixed', 'fixed-after');
+
+    expect(fixedAfter.files).toEqual(fixedBefore.files);
+    expect(privateBuild.files['widget.js']).not.toEqual(fixedBefore.files['widget.js']);
+
+    const fixedSource = fixedBefore.files['widget.js'].toString('utf8');
+    const privateSource = privateBuild.files['widget.js'].toString('utf8');
+    for (const source of [fixedSource, privateSource]) {
+      expect(source).not.toContain('__bugdropDefaultFlowRuntime');
+      expect(source).not.toContain('__bugdropMockToPng');
+      expect(source).not.toContain('registerFlow');
+      expect(source).not.toContain('FlowConfig');
+    }
+    expect(fixedSource).not.toContain('bugdrop-default@1');
+    expect(privateSource).toContain('bugdrop-default@1');
+  }, 20_000);
+
+  it('rejects unsupported selector values', () => {
+    const result = spawnSync(process.execPath, [join(ROOT, 'scripts/build-widget.js')], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, BUGDROP_DEFAULT_FLOW_RUNTIME: 'public-choice' },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Unsupported default flow runtime');
+  });
+});

--- a/test/defaultFlowDefinition.test.ts
+++ b/test/defaultFlowDefinition.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_DEFINITION_ID,
+  normalizeDefaultDefinition,
+  type DefaultDefinitionInput,
+} from '../src/widget/default-flow/definition';
+
+function input(overrides: Partial<DefaultDefinitionInput> = {}): DefaultDefinitionInput {
+  return {
+    repo: 'owner/repo',
+    apiUrl: 'https://bugdrop.example/api',
+    welcome: 'once',
+    screenshotMode: 'optional',
+    skipWelcome: false,
+    hasSeenWelcome: false,
+    showName: true,
+    requireName: false,
+    showEmail: true,
+    requireEmail: true,
+    sendConsoleLogs: true,
+    screenshotScale: 1.5,
+    elementContextMaxArea: 2,
+    accentColor: '#123456',
+    categoryLabels: { bug: ['defect', 'triage'] },
+    issueLinkVisibility: 'always',
+    ...overrides,
+  };
+}
+
+describe('private default definition normalizer', () => {
+  it.each([
+    ['always', false, false, true, false],
+    ['once', false, false, true, true],
+    ['once', false, true, false, false],
+    ['never', false, false, false, false],
+    ['always', true, false, false, false],
+  ] as const)(
+    'normalizes welcome=%s skip=%s seen=%s',
+    (welcome, skipWelcome, hasSeenWelcome, enabled, remember) => {
+      const definition = normalizeDefaultDefinition(
+        input({
+          welcome,
+          skipWelcome,
+          hasSeenWelcome,
+        })
+      );
+
+      expect(definition.id).toBe(DEFAULT_DEFINITION_ID);
+      expect(definition.steps[0]).toEqual({ kind: 'welcome', enabled, remember });
+    }
+  );
+
+  it.each(['optional', 'auto', 'required'] as const)('preserves screenshot mode %s', mode => {
+    const definition = normalizeDefaultDefinition(
+      input({
+        welcome: 'never',
+        screenshotMode: mode,
+      })
+    );
+
+    expect(definition.steps).toEqual([
+      { kind: 'welcome', enabled: false, remember: false },
+      {
+        kind: 'details',
+        repo: 'owner/repo',
+        showName: true,
+        requireName: false,
+        showEmail: true,
+        requireEmail: true,
+        sendConsoleLogs: true,
+      },
+      {
+        kind: 'screenshot',
+        mode,
+        repo: 'owner/repo',
+        screenshotScale: 1.5,
+        elementContextMaxArea: 2,
+        accentColor: '#123456',
+      },
+    ]);
+    expect(definition.system).toEqual({
+      preflight: {
+        kind: 'installation',
+        repo: 'owner/repo',
+        apiUrl: 'https://bugdrop.example/api',
+        authTokenProvider: undefined,
+      },
+      submission: {
+        kind: 'legacy-feedback',
+        repo: 'owner/repo',
+        apiUrl: 'https://bugdrop.example/api',
+        authTokenProvider: undefined,
+        categoryLabels: { bug: ['defect', 'triage'] },
+        issueLinkVisibility: 'always',
+      },
+    });
+  });
+
+  it('returns a deeply immutable built-in definition', () => {
+    const definition = normalizeDefaultDefinition(
+      input({
+        screenshotMode: 'required',
+      })
+    );
+
+    expect(Object.isFrozen(definition)).toBe(true);
+    expect(Object.isFrozen(definition.steps)).toBe(true);
+    expect(definition.steps.every(Object.isFrozen)).toBe(true);
+    expect(Object.isFrozen(definition.system)).toBe(true);
+    expect(Object.isFrozen(definition.system.preflight)).toBe(true);
+    expect(Object.isFrozen(definition.system.submission)).toBe(true);
+    expect(Object.isFrozen(definition.system.submission.categoryLabels)).toBe(true);
+    expect(Object.isFrozen(definition.system.submission.categoryLabels?.bug)).toBe(true);
+  });
+});

--- a/test/defaultFlowRuntime.test.ts
+++ b/test/defaultFlowRuntime.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runDefaultJourney, type DefaultJourneyPorts } from '../src/widget/default-flow/runtime';
+import { normalizeDefaultDefinition } from '../src/widget/default-flow/definition';
+import type {
+  DefaultDetailsStep,
+  DefaultScreenshotStep,
+} from '../src/widget/default-flow/definition';
+
+type Details = { title: string };
+type Capture = { screenshot: string | null };
+
+function createPorts(
+  overrides: Partial<DefaultJourneyPorts<Details, Capture>> = {}
+): DefaultJourneyPorts<Details, Capture> {
+  return {
+    preflight: vi.fn(async () => ({ status: 'installed' as const })),
+    showPreflightFailure: vi.fn(),
+    showWelcome: vi.fn(async () => true),
+    rememberWelcome: vi.fn(),
+    showDetails: vi.fn(async () => ({ title: 'kept' })),
+    capture: vi.fn(async () => ({ screenshot: 'image', returnToDetails: false })),
+    submit: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+function definition(welcome: 'once' | 'always' | 'never' = 'once') {
+  return normalizeDefaultDefinition({
+    repo: 'owner/repo',
+    apiUrl: 'https://bugdrop.example/api',
+    welcome,
+    screenshotMode: 'optional',
+    skipWelcome: false,
+    hasSeenWelcome: false,
+    showName: false,
+    requireName: false,
+    showEmail: false,
+    requireEmail: false,
+    sendConsoleLogs: false,
+    issueLinkVisibility: 'public',
+  });
+}
+
+describe('private default journey runtime', () => {
+  it('runs welcome, details, capture, and submission in order', async () => {
+    const trace: string[] = [];
+    const ports = createPorts({
+      showWelcome: async () => (trace.push('welcome'), true),
+      rememberWelcome: () => trace.push('remember-welcome'),
+      showDetails: async step => (trace.push(`details:${step.kind}`), { title: 'report' }),
+      capture: async step => (
+        trace.push(`capture:${step.mode}`),
+        { screenshot: 'image', returnToDetails: false }
+      ),
+      submit: async (recipe, details, capture) => {
+        trace.push(`recipe:${recipe.kind}`);
+        trace.push(`submit:${details.title}:${capture.screenshot}`);
+      },
+    });
+
+    await runDefaultJourney(definition(), ports);
+
+    expect(trace).toEqual([
+      'welcome',
+      'remember-welcome',
+      'details:details',
+      'capture:optional',
+      'recipe:legacy-feedback',
+      'submit:report:image',
+    ]);
+  });
+
+  it('stops when welcome is closed without remembering it', async () => {
+    const ports = createPorts({ showWelcome: vi.fn(async () => false) });
+
+    await runDefaultJourney(definition(), ports);
+
+    expect(ports.rememberWelcome).not.toHaveBeenCalled();
+    expect(ports.showDetails).not.toHaveBeenCalled();
+  });
+
+  it('skips welcome and stops when details are cancelled', async () => {
+    const ports = createPorts({
+      showDetails: vi.fn(async () => null),
+    });
+
+    await runDefaultJourney(definition('never'), ports);
+
+    expect(ports.showWelcome).not.toHaveBeenCalled();
+    expect(ports.capture).not.toHaveBeenCalled();
+    expect(ports.submit).not.toHaveBeenCalled();
+  });
+
+  it('returns to details with retained answers before submitting', async () => {
+    const first = { title: 'retained' };
+    const second = { title: 'updated' };
+    const showDetails = vi
+      .fn<(_step: DefaultDetailsStep, previous: Details | null) => Promise<Details | null>>()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second);
+    const capture = vi
+      .fn<
+        (
+          _step: DefaultScreenshotStep,
+          details: Details
+        ) => Promise<Capture & { returnToDetails: boolean }>
+      >()
+      .mockResolvedValueOnce({ screenshot: null, returnToDetails: true })
+      .mockResolvedValueOnce({ screenshot: 'final', returnToDetails: false });
+    const ports = createPorts({ showDetails, capture });
+
+    await runDefaultJourney(definition('never'), ports);
+
+    expect(showDetails).toHaveBeenNthCalledWith(1, definition('never').steps[1], null);
+    expect(showDetails).toHaveBeenNthCalledWith(2, definition('never').steps[1], first);
+    expect(capture).toHaveBeenNthCalledWith(1, definition('never').steps[2], first);
+    expect(capture).toHaveBeenNthCalledWith(2, definition('never').steps[2], second);
+    expect(ports.submit).toHaveBeenCalledWith(definition('never').system.submission, second, {
+      screenshot: 'final',
+      returnToDetails: false,
+    });
+  });
+
+  it.each(['not_installed', 'unreachable'] as const)(
+    'owns %s preflight and stops before user steps',
+    async status => {
+      const ports = createPorts({
+        preflight: vi.fn(async () => ({ status, appName: 'test-app' })),
+      });
+
+      await expect(runDefaultJourney(definition(), ports)).resolves.toBe('preflight-blocked');
+
+      expect(ports.showPreflightFailure).toHaveBeenCalledWith({ status, appName: 'test-app' });
+      expect(ports.showWelcome).not.toHaveBeenCalled();
+      expect(ports.showDetails).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/test/variantFlowDefinition.test.ts
+++ b/test/variantFlowDefinition.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeVariantDefinition,
+  VARIANT_DEFINITION_ID,
+} from '../src/widget/variants/flow-definition';
+import type { VariantConfig } from '../src/widget/variants/public-types';
+import { validateAndFreezeVariantConfig } from '../src/widget/variants/validate-config';
+
+function config(presentation: VariantConfig['presentation']): VariantConfig {
+  return {
+    id: presentation.kind === 'modal' ? 'provider-question' : 'export-review',
+    configVersion: 1,
+    presentation,
+    appearance: { theme: 'auto', accentColor: '#123456', density: 'comfortable' },
+    content: { title: 'Private one-screen definition', submitLabel: 'Send' },
+    fields: [{ id: 'response', type: 'longText', label: 'Response', required: true, rows: 4 }],
+    issue: {
+      classification: 'feedback',
+      title: 'Response: {{response}}',
+      sections: [{ heading: 'Response', field: 'response' }],
+    },
+  };
+}
+
+describe('private variant definition normalizer', () => {
+  it.each([
+    ['modal', { kind: 'modal', size: 'wide', columns: 2 }],
+    ['inline', { kind: 'inline', columns: 1 }],
+  ] as const)('normalizes a validated %s config into one immutable screen', (_, presentation) => {
+    const validated = validateAndFreezeVariantConfig(config(presentation));
+    const definition = normalizeVariantDefinition(validated);
+
+    expect(definition).toEqual({
+      id: VARIANT_DEFINITION_ID,
+      variantId: validated.id,
+      screens: [{ kind: 'variant', config: validated }],
+    });
+    expect(definition.screens).toHaveLength(1);
+    expect(definition.screens[0]?.config).toBe(validated);
+    expect(Object.isFrozen(definition)).toBe(true);
+    expect(Object.isFrozen(definition.screens)).toBe(true);
+    expect(Object.isFrozen(definition.screens[0])).toBe(true);
+    expect(Object.isFrozen(definition.screens[0]?.config)).toBe(true);
+    expect(Object.isFrozen(definition.screens[0]?.config.fields)).toBe(true);
+    expect(Object.isFrozen(definition.screens[0]?.config.fields[0])).toBe(true);
+  });
+});

--- a/test/variantManager.test.ts
+++ b/test/variantManager.test.ts
@@ -217,4 +217,57 @@ describe('rendered variant manager', () => {
     await Promise.resolve();
     expect(fetch).not.toHaveBeenCalled();
   });
+
+  it('submits headlessly through the normalized definition without changing the envelope', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            success: true,
+            issueNumber: 42,
+            issueUrl: 'https://github.com/owner/repo/issues/42',
+            isPublic: false,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const handle = createVariantManager({
+      repo: 'owner/repo',
+      apiUrl: 'https://example.test/api',
+    }).register(reviewConfig);
+
+    await expect(
+      handle.submit(
+        { rating: 4, message: 'Private definition' },
+        { context: { surface: 'unit' }, submissionId: 'definition-proof' }
+      )
+    ).resolves.toEqual({
+      issueNumber: 42,
+      issueUrl: 'https://github.com/owner/repo/issues/42',
+      isPublic: false,
+    });
+
+    const request = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(Object.keys(request).sort()).toEqual([
+      'issue',
+      'kind',
+      'metadata',
+      'repo',
+      'schemaVersion',
+      'submissionId',
+      'variantId',
+    ]);
+    expect(request).toMatchObject({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      repo: 'owner/repo',
+      variantId: 'export-review',
+      submissionId: 'definition-proof',
+      issue: {
+        title: 'Review 4/5',
+        sections: [],
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- express the existing BugDrop wizard as a private immutable flow definition and execute it through a private runtime while keeping the fixed implementation as the default build
- normalize existing composable variants through the same internal one-screen flow model without changing the public API or submission envelope
- add a local-only IndexedDB submissions viewer for creating, inspecting, editing, and deleting dogfood feedback without opening GitHub Issues
- require named `.localhost` hosts for local server handoffs and use `bugdrop.localhost` in production-flow browser verification

## Compatibility boundaries

- no public `FlowConfig`, `registerFlow`, or browser runtime selector
- the current fixed BugDrop flow remains the default production artifact
- legacy script-tag configuration, public API shape, request payloads, GitHub Issue behavior, and visible journeys remain unchanged
- local submissions activate only with `localQa=1` on loopback hosts and never provide production persistence

## Verification

- 27 focused default-flow and variant tests
- 23 paired fixed/private compatibility journeys
- 5 fixed and 5 private production-artifact journeys
- traced local CRUD journey with zero escaped installation, feedback, Worker, or GitHub requests
- `npm run validate`: 77 files, 1,072 tests
- `npm run verify:legacy-compat`: v1.1.0 and v1.53.1 fixtures
- complete default-fixed → private → explicit-fixed generated artifact tree identity
- final normal `development:local` fixed widget contains no private runtime or public Flow API markers
- exact 19-file scope audit against base, with the original dirty worktree preserved byte-for-byte

## Not included

This PR does not expose a public flow-builder API, add a visual configurator, add production submission storage, deploy or release anything, or include unrelated release/canary/heartbeat work.
