### PR TITLE
feat: add public composable feedback flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,119 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
 
 See [full documentation](https://bugdrop.dev/docs/configuration) for all options including styling, submitter info, and dismissible button.
 
+### Composable feedback flows
+
+`window.BugDrop.registerFlow` registers a versioned modal flow without changing the default BugDrop
+button or `registerVariant`. Forms are reusable configuration objects, screens determine their
+order and visibility, and submission still uses BugDrop's established feedback payload.
+
+A default-shaped message → details → optional screenshot journey:
+
+```js
+const defaultFlow = window.BugDrop.registerFlow({
+  configVersion: 1,
+  id: 'default-shaped-feedback',
+  presentation: { kind: 'modal' },
+  forms: [
+    {
+      id: 'details',
+      title: 'Tell us what happened',
+      fields: [
+        { id: 'summary', type: 'shortText', label: 'Title', required: true },
+        { id: 'description', type: 'longText', label: 'Description' },
+        { id: 'attachments', type: 'attachments', label: 'Attachments' },
+        { id: 'send-logs', type: 'checkbox', label: 'Include console logs' },
+        { id: 'name', type: 'shortText', label: 'Name' },
+        { id: 'email', type: 'shortText', label: 'Email' },
+      ],
+    },
+  ],
+  screens: [
+    { id: 'welcome', type: 'message', title: 'Share feedback' },
+    { id: 'details-screen', type: 'form', form: 'details' },
+    { id: 'screenshot', type: 'screenshot', mode: 'optional' },
+  ],
+  issue: {
+    classification: 'bug',
+    title: '{{details.summary}}',
+    sections: [
+      {
+        heading: 'Description',
+        answer: 'details.description',
+        omitWhenEmpty: true,
+      },
+    ],
+  },
+  evidence: {
+    attachments: 'details.attachments',
+    sendConsoleLogs: 'details.send-logs',
+    submitter: { name: 'details.name', email: 'details.email' },
+  },
+});
+
+defaultFlow.open();
+```
+
+A materially different product-triage flow can show follow-up and screenshot screens only for a
+bug or a low rating. Conditions are serializable and reference answers from earlier forms:
+
+```js
+const needsEvidence = {
+  any: [
+    { answer: 'triage.kind', equals: 'bug' },
+    { answer: 'triage.rating', equals: 1 },
+  ],
+};
+
+const triageFlow = window.BugDrop.registerFlow({
+  configVersion: 1,
+  id: 'product-triage',
+  presentation: { kind: 'modal' },
+  forms: [
+    {
+      id: 'triage',
+      title: 'Classify your feedback',
+      fields: [
+        {
+          id: 'kind',
+          type: 'singleChoice',
+          label: 'Type',
+          required: true,
+          options: [
+            { value: 'bug', label: 'Bug' },
+            { value: 'idea', label: 'Idea' },
+          ],
+        },
+        { id: 'rating', type: 'rating', label: 'Experience', required: true },
+        { id: 'summary', type: 'shortText', label: 'Summary', required: true },
+      ],
+    },
+    {
+      id: 'detail',
+      title: 'Add diagnostic detail',
+      fields: [{ id: 'steps', type: 'longText', label: 'Steps to reproduce' }],
+    },
+  ],
+  screens: [
+    { id: 'intro', type: 'message', title: 'Help us prioritize' },
+    { id: 'triage-screen', type: 'form', form: 'triage' },
+    { id: 'detail-screen', type: 'form', form: 'detail', when: needsEvidence },
+    { id: 'screenshot', type: 'screenshot', mode: 'optional', when: needsEvidence },
+  ],
+  issue: {
+    classification: 'bug',
+    title: '{{triage.summary}}',
+    sections: [
+      { heading: 'Type', answer: 'triage.kind', format: 'choice' },
+      { heading: 'Experience', answer: 'triage.rating', format: 'stars' },
+      { heading: 'Steps', answer: 'detail.steps', omitWhenEmpty: true },
+    ],
+  },
+});
+
+triageFlow.open();
+```
+
 ## Test a Local Widget on a Live Site
 
 Build the widget and start the local server:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See [full documentation](https://bugdrop.dev/docs/configuration) for all options
 ### Composable feedback flows
 
 `window.BugDrop.registerFlow` registers a versioned modal flow without changing the default BugDrop
-button or `registerVariant`. Forms are reusable configuration objects, screens determine their
+button or `registerVariant`. Forms define field groups, screens determine their
 order and visibility, and submission still uses BugDrop's established feedback payload.
 
 A default-shaped message → details → optional screenshot journey:

--- a/e2e/default-flow-production.spec.ts
+++ b/e2e/default-flow-production.spec.ts
@@ -54,6 +54,7 @@ test('serves a test-hook-free authoritative artifact with the unchanged API', as
       'isButtonVisible',
       'isOpen',
       'open',
+      'registerFlow',
       'registerVariant',
       'setTheme',
       'show',

--- a/e2e/local-submissions.spec.ts
+++ b/e2e/local-submissions.spec.ts
@@ -15,11 +15,47 @@ function watchForProhibitedRequests(page: import('@playwright/test').Page): stri
     const isGitHub = url.hostname === 'github.com' || url.hostname === 'api.github.com';
     const isFeedbackApi =
       url.pathname.endsWith('/feedback') || url.pathname.includes('/api/check/');
-    if (!isLocal && (isGitHub || isFeedbackApi)) {
-      prohibitedRequests.push(request.url());
-    }
+    if (!isLocal && (isGitHub || isFeedbackApi)) prohibitedRequests.push(request.url());
   });
   return prohibitedRequests;
+}
+
+function watchContextHttpRequests(context: import('@playwright/test').BrowserContext): string[] {
+  const prohibitedRequests: string[] = [];
+  context.on('request', request => {
+    const url = new URL(request.url());
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return;
+    const isLocal =
+      url.hostname === 'localhost' ||
+      url.hostname === '127.0.0.1' ||
+      url.hostname.endsWith('.localhost');
+    if (!isLocal) prohibitedRequests.push(request.url());
+  });
+  return prohibitedRequests;
+}
+
+async function readRawPayload(viewer: import('@playwright/test').Page) {
+  const rawPayload = viewer.locator('#raw-payload');
+  let parsedPayload: Record<string, unknown> | undefined;
+
+  await expect
+    .poll(async () => {
+      const textContent = await rawPayload.textContent();
+      try {
+        const candidate: unknown = JSON.parse(textContent ?? '');
+        if (candidate === null || typeof candidate !== 'object' || Array.isArray(candidate)) {
+          return false;
+        }
+        parsedPayload = candidate as Record<string, unknown>;
+        return true;
+      } catch {
+        return false;
+      }
+    })
+    .toBe(true);
+
+  if (!parsedPayload) throw new Error('Expected viewer-rendered raw payload JSON');
+  return parsedPayload;
 }
 
 test('local QA fails closed when the submissions helper cannot load', async ({ page }) => {
@@ -264,4 +300,221 @@ test('local QA variants submit headlessly and through inline and modal presentat
     '"submissionId": "local-headless-submission"'
   );
   expect(prohibitedRequests).toEqual([]);
+});
+
+test('public flows submit and can be inspected through isolated local feedback storage', async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+  const prohibitedRequests = watchContextHttpRequests(page.context());
+  await page.goto(
+    'http://bugdrop.localhost:8787/test/welcome-disabled?localQa=1&showIssueLink=always&font=inherit'
+  );
+  expect(new URL(page.url()).hostname).toBe('bugdrop.localhost');
+  expect(new URL(page.url()).pathname).toBe('/test/welcome-disabled');
+  await page.waitForFunction(() => Boolean(window.BugDrop?.registerFlow));
+  expect(prohibitedRequests).toEqual([]);
+  await page.evaluate(async () => {
+    const localStore = (window as Window & { BugDropLocalSubmissions?: { clear(): Promise<void> } })
+      .BugDropLocalSubmissions;
+    if (!localStore) throw new Error('Expected isolated local submission storage');
+    await localStore.clear();
+  });
+
+  await page.evaluate(() => {
+    window
+      .BugDrop!.registerFlow({
+        configVersion: 1,
+        id: 'local-default-shaped-flow',
+        presentation: { kind: 'modal' },
+        forms: [
+          {
+            id: 'details',
+            title: 'Tell us what happened',
+            fields: [
+              { id: 'summary', type: 'shortText', label: 'Title', required: true },
+              { id: 'description', type: 'longText', label: 'Description' },
+              { id: 'attachments', type: 'attachments', label: 'Attachments' },
+              { id: 'send-logs', type: 'checkbox', label: 'Include console logs' },
+              { id: 'name', type: 'shortText', label: 'Name' },
+              { id: 'email', type: 'shortText', label: 'Email' },
+            ],
+          },
+        ],
+        screens: [
+          { id: 'welcome', type: 'message', title: 'Share feedback' },
+          { id: 'details-screen', type: 'form', form: 'details' },
+          { id: 'screenshot', type: 'screenshot', mode: 'optional' },
+        ],
+        issue: {
+          classification: 'bug',
+          title: '{{details.summary}}',
+          sections: [
+            {
+              heading: 'Description',
+              answer: 'details.description',
+              omitWhenEmpty: true,
+            },
+          ],
+        },
+        evidence: {
+          attachments: 'details.attachments',
+          sendConsoleLogs: 'details.send-logs',
+          submitter: { name: 'details.name', email: 'details.email' },
+        },
+      })
+      .open();
+  });
+
+  const defaultFlow = page.locator('body > [data-bugdrop-flow="local-default-shaped-flow"]');
+  await expect(defaultFlow.getByRole('heading', { name: 'Share feedback' })).toBeVisible();
+  await defaultFlow.getByRole('button', { name: 'Continue' }).click();
+  await defaultFlow.getByLabel('Title').fill('Default-shaped local feedback');
+  await defaultFlow.getByLabel('Description').fill('Stored through the legacy feedback recipe.');
+  await defaultFlow.getByLabel('Name').fill('Local Flow Tester');
+  await defaultFlow.getByLabel('Include console logs').check();
+  await page.evaluate(() => console.info('default-shaped flow local audit'));
+  await defaultFlow.getByRole('button', { name: 'Continue' }).click();
+  await defaultFlow.getByLabel('Include a screenshot', { exact: true }).uncheck();
+  await defaultFlow.getByRole('button', { name: 'Submit' }).click();
+  await expect(
+    defaultFlow.getByRole('heading', { name: 'Thanks for your feedback!' })
+  ).toBeVisible();
+  const defaultLink = defaultFlow.getByRole('link', { name: 'View local submission' });
+  await expect(defaultLink).toHaveAttribute('href', /\/test\/submissions\.html\?id=\d+$/);
+  const [defaultViewer] = await Promise.all([page.waitForEvent('popup'), defaultLink.click()]);
+  await defaultViewer.waitForLoadState('domcontentloaded');
+  expect(new URL(defaultViewer.url()).hostname).toBe('bugdrop.localhost');
+  const defaultPayload = await readRawPayload(defaultViewer);
+  expect(defaultPayload).toMatchObject({
+    repo: 'mean-weasel/bugdrop-widget-test',
+    title: 'Default-shaped local feedback',
+    description: '## Description\n\nStored through the legacy feedback recipe.',
+    category: 'bug',
+    screenshot: null,
+    attachments: [],
+    submitter: { name: 'Local Flow Tester' },
+    metadata: { url: 'http://bugdrop.localhost:8787/test/welcome-disabled' },
+  });
+  expect(defaultPayload.consoleLogs).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ level: 'info', message: 'default-shaped flow local audit' }),
+    ])
+  );
+  expect(defaultPayload.kind).toBeUndefined();
+  expect(prohibitedRequests).toEqual([]);
+  await defaultViewer.close();
+  await defaultFlow.getByRole('button', { name: 'Done' }).click();
+
+  await page.evaluate(() => {
+    window
+      .BugDrop!.registerFlow({
+        configVersion: 1,
+        id: 'local-product-triage-flow',
+        presentation: { kind: 'modal' },
+        forms: [
+          {
+            id: 'triage',
+            title: 'Classify your feedback',
+            fields: [
+              {
+                id: 'kind',
+                type: 'singleChoice',
+                label: 'Type',
+                required: true,
+                options: [
+                  { value: 'bug', label: 'Bug' },
+                  { value: 'idea', label: 'Idea' },
+                ],
+              },
+              { id: 'rating', type: 'rating', label: 'Experience', required: true },
+              { id: 'summary', type: 'shortText', label: 'Summary', required: true },
+            ],
+          },
+          {
+            id: 'detail',
+            title: 'Add diagnostic detail',
+            fields: [{ id: 'steps', type: 'longText', label: 'Steps to reproduce' }],
+          },
+        ],
+        screens: [
+          { id: 'intro', type: 'message', title: 'Help us prioritize' },
+          { id: 'triage-screen', type: 'form', form: 'triage' },
+          {
+            id: 'detail-screen',
+            type: 'form',
+            form: 'detail',
+            when: {
+              any: [
+                { answer: 'triage.kind', equals: 'bug' },
+                { answer: 'triage.rating', equals: 1 },
+              ],
+            },
+          },
+          {
+            id: 'screenshot',
+            type: 'screenshot',
+            mode: 'optional',
+            when: {
+              any: [
+                { answer: 'triage.kind', equals: 'bug' },
+                { answer: 'triage.rating', equals: 1 },
+              ],
+            },
+          },
+        ],
+        issue: {
+          classification: 'bug',
+          title: '{{triage.summary}}',
+          sections: [
+            { heading: 'Type', answer: 'triage.kind', format: 'choice' },
+            { heading: 'Experience', answer: 'triage.rating', format: 'stars' },
+            { heading: 'Steps', answer: 'detail.steps', omitWhenEmpty: true },
+          ],
+        },
+      })
+      .open();
+  });
+
+  const triageFlow = page.locator('body > [data-bugdrop-flow="local-product-triage-flow"]');
+  await triageFlow.getByRole('button', { name: 'Continue' }).click();
+  await triageFlow.getByLabel('Bug').click();
+  await triageFlow.getByRole('radio', { name: '1 star' }).click();
+  await triageFlow.getByLabel('Summary').fill('Initial bug report');
+  await triageFlow.getByRole('button', { name: 'Continue' }).click();
+  await triageFlow.getByLabel('Steps to reproduce').fill('Hidden stale diagnostic detail');
+  await triageFlow.getByRole('button', { name: 'Continue' }).click();
+  await triageFlow.getByRole('button', { name: 'Back' }).click();
+  await expect(triageFlow.getByLabel('Steps to reproduce')).toHaveValue(
+    'Hidden stale diagnostic detail'
+  );
+  await triageFlow.getByRole('button', { name: 'Back' }).click();
+  await expect(triageFlow.getByLabel('Summary')).toHaveValue('Initial bug report');
+  await triageFlow.getByLabel('Idea').click();
+  await triageFlow.getByRole('radio', { name: '5 stars' }).click();
+  await triageFlow.getByLabel('Summary').fill('A different product idea');
+  await expect(triageFlow.getByRole('button', { name: 'Submit' })).toBeVisible();
+  await triageFlow.getByRole('button', { name: 'Submit' }).click();
+  await expect(
+    triageFlow.getByRole('heading', { name: 'Thanks for your feedback!' })
+  ).toBeVisible();
+  const triageLink = triageFlow.getByRole('link', { name: 'View local submission' });
+  await expect(triageLink).toHaveAttribute('href', /\/test\/submissions\.html\?id=\d+$/);
+  const [triageViewer] = await Promise.all([page.waitForEvent('popup'), triageLink.click()]);
+  await triageViewer.waitForLoadState('domcontentloaded');
+  expect(new URL(triageViewer.url()).hostname).toBe('bugdrop.localhost');
+  const triagePayload = await readRawPayload(triageViewer);
+  expect(triagePayload).toMatchObject({
+    repo: 'mean-weasel/bugdrop-widget-test',
+    title: 'A different product idea',
+    description: '## Type\n\nIdea\n\n## Experience\n\n★★★★★ (5/5)',
+    category: 'bug',
+    screenshot: null,
+    attachments: [],
+    metadata: { url: 'http://bugdrop.localhost:8787/test/welcome-disabled' },
+  });
+  expect(triagePayload.description).not.toContain('Hidden stale diagnostic detail');
+  expect(triagePayload.kind).toBeUndefined();
+  expect(prohibitedRequests).toEqual([]);
+  await triageViewer.close();
 });

--- a/e2e/public-flow.spec.ts
+++ b/e2e/public-flow.spec.ts
@@ -1,0 +1,174 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function ready(page: Page) {
+  await page.route('**/api/check/**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ installed: true, appName: 'neonwatty-bugdrop' }),
+    })
+  );
+  await page.goto('/test/welcome-disabled.html?private=redacted#secret');
+  await expect
+    .poll(() => page.evaluate(() => typeof window.BugDrop?.registerFlow))
+    .toBe('function');
+}
+
+async function register(page: Page) {
+  await page.evaluate(() => {
+    const opened = window
+      .BugDrop!.registerFlow({
+        configVersion: 1,
+        id: 'public-triage',
+        presentation: { kind: 'modal' },
+        forms: [
+          {
+            id: 'triage',
+            title: 'Classify your feedback',
+            fields: [
+              {
+                id: 'kind',
+                type: 'singleChoice',
+                label: 'Type',
+                required: true,
+                options: [
+                  { value: 'bug', label: 'Bug' },
+                  { value: 'idea', label: 'Idea' },
+                ],
+              },
+              { id: 'summary', type: 'shortText', label: 'Summary', required: true },
+            ],
+          },
+          {
+            id: 'detail',
+            title: 'Describe the bug',
+            fields: [{ id: 'description', type: 'longText', label: 'Steps' }],
+          },
+        ],
+        screens: [
+          {
+            id: 'intro',
+            type: 'message',
+            title: 'Help us improve',
+            when: { context: 'surface', equals: 'browser-test' },
+          },
+          { id: 'triage-screen', type: 'form', form: 'triage' },
+          {
+            id: 'detail-screen',
+            type: 'form',
+            form: 'detail',
+            when: { answer: 'triage.kind', equals: 'bug' },
+          },
+          {
+            id: 'screenshot',
+            type: 'screenshot',
+            mode: 'optional',
+            when: { answer: 'triage.kind', equals: 'bug' },
+          },
+        ],
+        issue: {
+          classification: 'bug',
+          title: '{{triage.summary}}',
+          sections: [{ heading: 'Steps', answer: 'detail.description', omitWhenEmpty: true }],
+        },
+      })
+      .open({ context: { surface: 'browser-test' } });
+    (window as Window & { __publicFlow?: typeof opened }).__publicFlow = opened;
+  });
+}
+
+test.describe('public modal FlowConfig V1', () => {
+  test('navigates conditionally, retains Back values, submits the legacy recipe, retries, and restores focus', async ({
+    page,
+  }) => {
+    const submissions: Array<Record<string, unknown>> = [];
+    let attempt = 0;
+    await page.route('**/api/feedback', route => {
+      submissions.push(route.request().postDataJSON() as Record<string, unknown>);
+      attempt += 1;
+      return route.fulfill(
+        attempt === 1
+          ? {
+              status: 500,
+              contentType: 'application/json',
+              body: JSON.stringify({ error: 'Temporary failure' }),
+            }
+          : {
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify({
+                success: true,
+                issueNumber: 44,
+                issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/44',
+                isPublic: false,
+              }),
+            }
+      );
+    });
+    await ready(page);
+    const trigger = page.getByRole('button', { name: /feedback/i });
+    await trigger.focus();
+    await register(page);
+    const host = page.locator('body > [data-bugdrop-flow="public-triage"]');
+    await expect(host.getByRole('heading', { name: 'Help us improve' })).toBeVisible();
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await host.getByLabel('Bug').click();
+    await host.getByLabel('Summary').fill('Save crashes');
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await host.getByLabel('Steps').fill('Click save twice');
+    await host.getByRole('button', { name: 'Back' }).click();
+    await expect(host.getByLabel('Summary')).toHaveValue('Save crashes');
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await expect(host.getByLabel('Steps')).toHaveValue('Click save twice');
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await host.getByLabel('Include a screenshot', { exact: true }).click();
+    await host.getByRole('button', { name: 'Submit' }).click();
+    await expect(host.getByText('Temporary failure')).toBeVisible();
+    await host.getByRole('button', { name: 'Try again' }).click();
+    await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+    expect(submissions).toHaveLength(2);
+    expect(submissions[0]).toMatchObject({
+      repo: 'mean-weasel/bugdrop-widget-test',
+      title: 'Save crashes',
+      description: '## Steps\n\nClick save twice',
+      screenshot: null,
+      attachments: [],
+    });
+    expect(submissions[0]?.kind).toBeUndefined();
+    await host.getByRole('button', { name: 'Done' }).click();
+    await expect(trigger).toBeFocused();
+  });
+
+  test('clears hidden answers after predicate changes and shares modal ownership', async ({
+    page,
+  }) => {
+    const submissions: Array<Record<string, unknown>> = [];
+    await page.route('**/api/feedback', route => {
+      submissions.push(route.request().postDataJSON() as Record<string, unknown>);
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          issueNumber: 45,
+          issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/45',
+          isPublic: false,
+        }),
+      });
+    });
+    await ready(page);
+    await register(page);
+    const host = page.locator('body > [data-bugdrop-flow="public-triage"]');
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await host.getByLabel('Bug').click();
+    await host.getByLabel('Summary').fill('First');
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await host.getByLabel('Steps').fill('Secret stale detail');
+    await host.getByRole('button', { name: 'Back' }).click();
+    await host.getByLabel('Idea').click();
+    await host.getByLabel('Summary').fill('Idea title');
+    await host.getByRole('button', { name: 'Submit' }).click();
+    await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+    expect(submissions[0]).toMatchObject({ title: 'Idea title', description: '' });
+  });
+});

--- a/e2e/public-flow.spec.ts
+++ b/e2e/public-flow.spec.ts
@@ -171,4 +171,32 @@ test.describe('public modal FlowConfig V1', () => {
     await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
     expect(submissions[0]).toMatchObject({ title: 'Idea title', description: '' });
   });
+
+  test('close tears down an in-progress screenshot chooser', async ({ page }) => {
+    await ready(page);
+    await register(page);
+    const host = page.locator('body > [data-bugdrop-flow="public-triage"]');
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await host.getByLabel('Bug').click();
+    await host.getByLabel('Summary').fill('Close capture');
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await host.getByRole('button', { name: 'Submit' }).click();
+    const chooser = page.locator('#bugdrop-host .bd-overlay');
+    await expect(chooser.getByRole('heading', { name: 'Capture Screenshot' })).toBeVisible();
+    await page.evaluate(() =>
+      (window as Window & { __publicFlow?: { close(): void } }).__publicFlow?.close()
+    );
+    await expect(host).toHaveCount(0);
+    await expect(chooser).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as Window & { __publicFlow?: { result: Promise<unknown> } }).__publicFlow
+              ?.result
+        )
+      )
+      .toEqual({ status: 'closed' });
+  });
 });

--- a/e2e/variant-modal.spec.ts
+++ b/e2e/variant-modal.spec.ts
@@ -84,7 +84,122 @@ async function openCompactSuggestion(page: Page) {
   });
 }
 
+async function openTallSuggestion(page: Page) {
+  await page.evaluate(() => {
+    window
+      .BugDrop!.registerVariant({
+        id: 'tall-suggestion',
+        presentation: { kind: 'modal', size: 'default' },
+        content: { title: 'Tall suggestion', submitLabel: 'Send tall suggestion' },
+        fields: Array.from({ length: 6 }, (_, index) => ({
+          id: `detail-${index + 1}`,
+          type: 'longText' as const,
+          label: `Detail ${index + 1}`,
+          required: index === 0,
+        })),
+        issue: {
+          classification: 'feature',
+          title: 'Tall suggestion — {{detail-1}}',
+        },
+      })
+      .open();
+  });
+}
+
+async function modalGeometry(host: import('@playwright/test').Locator) {
+  return host.evaluate(element => {
+    const overlay = element.shadowRoot?.querySelector<HTMLElement>('.bdv-overlay');
+    const surface = element.shadowRoot?.querySelector<HTMLElement>('.bdv-surface');
+    if (!overlay || !surface) throw new Error('Expected rendered modal geometry');
+    const overlayRect = overlay.getBoundingClientRect();
+    const surfaceRect = surface.getBoundingClientRect();
+    const style = getComputedStyle(overlay);
+    return {
+      overlayTop: overlayRect.top,
+      overlayBottom: overlayRect.bottom,
+      overlayClientHeight: overlay.clientHeight,
+      overlayScrollHeight: overlay.scrollHeight,
+      overlayScrollTop: overlay.scrollTop,
+      surfaceTop: surfaceRect.top,
+      surfaceBottom: surfaceRect.bottom,
+      paddingTop: Number.parseFloat(style.paddingTop),
+      paddingBottom: Number.parseFloat(style.paddingBottom),
+    };
+  });
+}
+
 test.describe('rendered CTA modal variant', () => {
+  for (const viewport of [
+    { name: 'desktop', width: 1280, height: 720 },
+    { name: 'mobile', width: 375, height: 667 },
+  ]) {
+    test(`centers short dialogs and makes tall controls ${viewport.name}-actionable`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await page.route('**/api/feedback', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            issueNumber: 207,
+            issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/207',
+            isPublic: false,
+          }),
+        })
+      );
+      await ready(page);
+      await registerProviderQuestion(page);
+      await page.getByRole('button', { name: 'Request a provider' }).click();
+
+      const shortHost = page.locator('body > [data-bugdrop-owned]');
+      const short = await modalGeometry(shortHost);
+      expect(short.overlayClientHeight).toBe(viewport.height);
+      expect(short.overlayScrollHeight).toBe(short.overlayClientHeight);
+      expect(Math.abs(short.surfaceTop - (short.overlayBottom - short.surfaceBottom))).toBeLessThan(
+        2
+      );
+      await shortHost.getByRole('button', { name: 'Not now' }).click();
+
+      await openTallSuggestion(page);
+      const tallHost = page.locator('body > [data-bugdrop-owned]');
+      const firstDetail = tallHost.getByRole('textbox', { name: 'Detail 1' });
+      const submit = tallHost.getByRole('button', { name: 'Send tall suggestion' });
+      const initial = await modalGeometry(tallHost);
+      expect(initial.overlayClientHeight).toBe(viewport.height);
+      expect(initial.overlayScrollHeight).toBeGreaterThan(initial.overlayClientHeight);
+      expect(initial.surfaceTop - initial.overlayTop).toBeGreaterThanOrEqual(
+        initial.paddingTop - 1
+      );
+      expect(initial.overlayScrollHeight - initial.surfaceBottom).toBeGreaterThanOrEqual(
+        initial.paddingBottom - 1
+      );
+
+      await firstDetail.fill(`${viewport.name} tall modal`);
+      if (viewport.name === 'desktop') {
+        await submit.hover();
+        const scrolled = await modalGeometry(tallHost);
+        expect(scrolled.overlayScrollTop).toBeGreaterThan(0);
+        await submit.click();
+      } else {
+        await expect(firstDetail).toBeFocused();
+        for (let index = 0; index < 6; index += 1) await page.keyboard.press('Tab');
+        await expect(submit).toBeFocused();
+        const submitBox = await submit.boundingBox();
+        expect(submitBox).not.toBeNull();
+        expect(submitBox!.y).toBeGreaterThanOrEqual(0);
+        expect(submitBox!.y + submitBox!.height).toBeLessThanOrEqual(viewport.height);
+        const scrolled = await modalGeometry(tallHost);
+        expect(scrolled.overlayScrollTop).toBeGreaterThan(0);
+        await page.keyboard.press('Enter');
+      }
+      await expect(
+        tallHost.getByRole('heading', { name: 'Thanks for your feedback!' })
+      ).toBeVisible();
+    });
+  }
+
   test('composes the compact suggestion and intercepts its exact draft', async ({ page }) => {
     const submissions: Array<Record<string, unknown>> = [];
     await page.route('**/api/feedback', route => {

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -195,6 +195,9 @@ test.describe('Widget Loading', () => {
     const trigger = host.locator('css=.bd-trigger');
     const handle = host.locator('css=.bd-trigger-drag-handle');
     await expect(handle).toBeVisible({ timeout: 5000 });
+    await trigger.evaluate(async el => {
+      await Promise.all(el.getAnimations().map(animation => animation.finished));
+    });
 
     await dragTriggerHandle(page, -160);
     const repo = await getWidgetRepo(page);
@@ -220,7 +223,7 @@ test.describe('Widget Loading', () => {
     await page.mouse.up();
     await expect
       .poll(() => page.evaluate(key => Number(localStorage.getItem(key)), storageKey))
-      .toBeCloseTo(activeDragTop, 0);
+      .toBe(Math.round(activeDragTop));
   });
 
   test('hidden feedback button keeps saved position across viewport resize', async ({ page }) => {
@@ -2589,6 +2592,7 @@ test.describe('JavaScript API', () => {
     expect(apiMethods).toContain('show');
     expect(apiMethods).toContain('isOpen');
     expect(apiMethods).toContain('isButtonVisible');
+    expect(apiMethods).toContain('registerFlow');
     expect(apiMethods).toContain('registerVariant');
   });
 
@@ -2661,6 +2665,7 @@ test.describe('JavaScript API', () => {
             'isButtonVisible',
             'isOpen',
             'open',
+            'registerFlow',
             'registerVariant',
             'setTheme',
             'show',
@@ -5626,6 +5631,9 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
     await expect(modal).toBeVisible({ timeout: 10000 });
     await expect(stage).toBeVisible();
     await expect(canvas).toBeVisible();
+    await modal.evaluate(async el => {
+      await Promise.all(el.getAnimations().map(animation => animation.finished));
+    });
 
     const modalBox = await modal.boundingBox();
     const stageBox = await stage.boundingBox();
@@ -5693,6 +5701,9 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
       '/test/annotation-preview-size.html',
       '#preview-size-target'
     );
+    await modal.evaluate(async el => {
+      await Promise.all(el.getAnimations().map(animation => animation.finished));
+    });
 
     const modalBox = await modal.boundingBox();
     const stageBox = await stage.boundingBox();

--- a/public/test/local-submissions.js
+++ b/public/test/local-submissions.js
@@ -227,11 +227,7 @@
       var id = await create(payload);
       var localUrl = window.location.origin + '/test/submissions.html?id=' + id;
       var issueUrl = localUrl;
-      if (
-        payload &&
-        payload.kind === 'bugdrop.variant-submission' &&
-        typeof payload.repo === 'string'
-      ) {
+      if (payload && typeof payload.repo === 'string') {
         issueUrl = 'https://github.com/' + payload.repo + '/issues/' + id;
       }
       relabelLocalIssueLink(issueUrl, localUrl);

--- a/public/test/welcome-disabled.html
+++ b/public/test/welcome-disabled.html
@@ -12,6 +12,7 @@
   <script>
     window.loadBugDropTestWidget({
       dataset: { theme: 'dark', welcome: 'false' },
+      queryDataset: { font: 'font' },
     });
   </script>
 </body>

--- a/src/widget/area-picker.ts
+++ b/src/widget/area-picker.ts
@@ -7,11 +7,13 @@ type ResolvedAreaPickerStyle = ReturnType<typeof resolvePickerStyle>;
 
 export function createAreaPicker(
   style?: PickerStyle,
-  opts?: { redactionsAvailable?: boolean }
+  opts?: { redactionsAvailable?: boolean },
+  signal?: AbortSignal
 ): Promise<DOMRect | null> {
   return new Promise(resolve => {
     setTimeout(() => {
-      startAreaPicker(resolve, style, opts);
+      if (signal?.aborted) resolve(null);
+      else startAreaPicker(resolve, style, opts, signal);
     }, 50);
   });
 }
@@ -19,7 +21,8 @@ export function createAreaPicker(
 function startAreaPicker(
   resolve: (rect: DOMRect | null) => void,
   style?: PickerStyle,
-  opts?: { redactionsAvailable?: boolean }
+  opts?: { redactionsAvailable?: boolean },
+  signal?: AbortSignal
 ): void {
   const { accent, fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder } =
     resolvePickerStyle(style);
@@ -129,6 +132,11 @@ function startAreaPicker(
     resolve(null);
   }
 
+  const onAbort = () => {
+    cleanup();
+    resolve(null);
+  };
+
   function cleanup() {
     overlay.removeEventListener('pointerdown', onPointerDown);
     document.removeEventListener('pointermove', onPointerMove);
@@ -136,6 +144,7 @@ function startAreaPicker(
     document.removeEventListener('pointercancel', onPointerCancel);
     document.removeEventListener('keydown', onKeyDown);
     cancelButton?.removeEventListener('click', onCancelClick);
+    signal?.removeEventListener('abort', onAbort);
     overlay.remove();
     selectionBorder.remove();
     tooltip.remove();
@@ -147,6 +156,7 @@ function startAreaPicker(
   document.addEventListener('pointercancel', onPointerCancel);
   document.addEventListener('keydown', onKeyDown);
   cancelButton?.addEventListener('click', onCancelClick);
+  signal?.addEventListener('abort', onAbort, { once: true });
 }
 
 function createOverlay(): HTMLDivElement {

--- a/src/widget/capture-cancellation.ts
+++ b/src/widget/capture-cancellation.ts
@@ -36,10 +36,11 @@ export function abortableCapture<T>(
 }
 
 function cancelCaptureUi(root: HTMLElement): void {
-  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
   const overlays = Array.from(root.querySelectorAll('.bd-overlay')) as HTMLElement[];
   for (const overlay of overlays) {
     (overlay.querySelector('.bd-close') as HTMLButtonElement | null)?.click();
     overlay.remove();
   }
+  document.querySelector<HTMLButtonElement>('#bugdrop-element-picker-cancel')?.click();
+  document.querySelector<HTMLButtonElement>('#bugdrop-area-picker-cancel')?.click();
 }

--- a/src/widget/capture-cancellation.ts
+++ b/src/widget/capture-cancellation.ts
@@ -6,18 +6,14 @@ export function abortableCapture<T>(
 ): Promise<T> {
   return new Promise((resolve, reject) => {
     let aborted = false;
-    let observer: MutationObserver | null = null;
     const cleanup = () => {
       signal.removeEventListener('abort', abort);
-      observer?.disconnect();
     };
     const abort = () => {
       if (aborted) return;
       aborted = true;
       cancelCaptureUi(root);
-      observer = new MutationObserver(() => cancelCaptureUi(root));
-      observer.observe(root, { childList: true, subtree: true });
-      observer.observe(document.body, { childList: true, subtree: true });
+      cleanup();
       resolve(cancelledValue);
     };
     signal.addEventListener('abort', abort, { once: true });

--- a/src/widget/capture-cancellation.ts
+++ b/src/widget/capture-cancellation.ts
@@ -1,0 +1,45 @@
+export function abortableCapture<T>(
+  root: HTMLElement,
+  operation: Promise<T>,
+  signal: AbortSignal,
+  cancelledValue: T
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    let aborted = false;
+    let observer: MutationObserver | null = null;
+    const cleanup = () => {
+      signal.removeEventListener('abort', abort);
+      observer?.disconnect();
+    };
+    const abort = () => {
+      if (aborted) return;
+      aborted = true;
+      cancelCaptureUi(root);
+      observer = new MutationObserver(() => cancelCaptureUi(root));
+      observer.observe(root, { childList: true, subtree: true });
+      observer.observe(document.body, { childList: true, subtree: true });
+      resolve(cancelledValue);
+    };
+    signal.addEventListener('abort', abort, { once: true });
+    if (signal.aborted) abort();
+    operation.then(
+      value => {
+        cleanup();
+        if (!aborted) resolve(value);
+      },
+      error => {
+        cleanup();
+        if (!aborted) reject(error);
+      }
+    );
+  });
+}
+
+function cancelCaptureUi(root: HTMLElement): void {
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+  const overlays = Array.from(root.querySelectorAll('.bd-overlay')) as HTMLElement[];
+  for (const overlay of overlays) {
+    (overlay.querySelector('.bd-close') as HTMLButtonElement | null)?.click();
+    overlay.remove();
+  }
+}

--- a/src/widget/capture-flow-result.ts
+++ b/src/widget/capture-flow-result.ts
@@ -1,0 +1,13 @@
+import type { CaptureFlowResult } from './capture-flow';
+
+export function emptyCaptureResult(): CaptureFlowResult {
+  return {
+    screenshot: null,
+    ...emptyElementMetadata(),
+    returnToForm: false,
+  };
+}
+
+export function emptyElementMetadata() {
+  return { elementSelector: null, fullElementSelector: null };
+}

--- a/src/widget/capture-flow-result.ts
+++ b/src/widget/capture-flow-result.ts
@@ -1,4 +1,5 @@
 import type { CaptureFlowResult } from './capture-flow';
+import type { EmptyCaptureReason } from './capture-flow';
 
 export function emptyCaptureResult(): CaptureFlowResult {
   return {
@@ -10,4 +11,12 @@ export function emptyCaptureResult(): CaptureFlowResult {
 
 export function emptyElementMetadata() {
   return { elementSelector: null, fullElementSelector: null };
+}
+
+export function shouldRememberComplexScreenshotSkip(reason: EmptyCaptureReason): boolean {
+  return reason === 'explicit-skip' || reason === 'capture-failure-skip';
+}
+
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled screenshot choice: ${JSON.stringify(value)}`);
 }

--- a/src/widget/capture-flow-style.ts
+++ b/src/widget/capture-flow-style.ts
@@ -1,0 +1,14 @@
+import type { CaptureFlowConfig } from './capture-flow';
+
+export function getCapturePickerStyle(config: CaptureFlowConfig) {
+  return {
+    accentColor: config.accentColor,
+    font: config.font,
+    radius: config.radius,
+    borderWidth: config.borderWidth,
+    bgColor: config.bgColor,
+    textColor: config.textColor,
+    borderColor: config.borderColor,
+    theme: config.theme,
+  };
+}

--- a/src/widget/capture-flow.ts
+++ b/src/widget/capture-flow.ts
@@ -11,6 +11,9 @@ import { getElementSelector, getFullElementSelector } from './selector-metadata'
 import { getRedactionCount, isFullPageDisabled } from './screenshot';
 import { showScreenshotOptions, type ScreenshotChoice } from './screenshot-options';
 import { DEFAULT_SELECTED_ELEMENT_SCREENSHOT_PIXEL_RATIO } from '../defaults';
+import { abortableCapture } from './capture-cancellation';
+import { emptyCaptureResult, emptyElementMetadata } from './capture-flow-result';
+import { getCapturePickerStyle } from './capture-flow-style';
 
 export interface CaptureFlowConfig {
   screenshotMode: 'optional' | 'auto' | 'required';
@@ -56,7 +59,28 @@ export async function runScreenshotCaptureFlow(
   root: HTMLElement,
   config: CaptureFlowConfig,
   includeScreenshot: boolean,
-  onComplexScreenshotSkipped: () => void
+  onComplexScreenshotSkipped: () => void,
+  signal?: AbortSignal
+): Promise<CaptureFlowResult> {
+  if (signal?.aborted) return { ...emptyCaptureResult(), returnToForm: true };
+  const operation = runScreenshotCaptureFlowInternal(
+    root,
+    config,
+    includeScreenshot,
+    onComplexScreenshotSkipped,
+    signal
+  );
+  return signal
+    ? abortableCapture(root, operation, signal, { ...emptyCaptureResult(), returnToForm: true })
+    : operation;
+}
+
+async function runScreenshotCaptureFlowInternal(
+  root: HTMLElement,
+  config: CaptureFlowConfig,
+  includeScreenshot: boolean,
+  onComplexScreenshotSkipped: () => void,
+  signal?: AbortSignal
 ): Promise<CaptureFlowResult> {
   if (config.screenshotMode === 'auto') return captureAutomaticScreenshot(root, config);
 
@@ -65,6 +89,7 @@ export async function runScreenshotCaptureFlow(
   const screenshotRequired = config.screenshotMode === 'required';
   while (true) {
     const result = await captureChosenScreenshot(root, config, screenshotRequired);
+    if (signal?.aborted) return { ...emptyCaptureResult(), returnToForm: true };
     if (result.kind === 'returnToForm') {
       return { ...emptyCaptureResult(), returnToForm: true };
     }
@@ -93,6 +118,7 @@ export async function runScreenshotCaptureFlow(
         ...(result.elementSelector ? { selectedElementCapture: true } : {}),
       }
     );
+    if (signal?.aborted) return { ...emptyCaptureResult(), returnToForm: true };
 
     if (annotatedScreenshot === 'retake') continue;
     if (annotatedScreenshot === 'cancel') {
@@ -216,7 +242,7 @@ async function captureFromElementChoice(
   config: CaptureFlowConfig,
   screenshotRequired: boolean
 ): Promise<ChosenCaptureResult> {
-  const element = await createElementPicker(getPickerStyle(config));
+  const element = await createElementPicker(getCapturePickerStyle(config));
   if (!element) {
     return emptyChosenCaptureResult('selection-cancelled');
   }
@@ -260,7 +286,7 @@ async function captureFromAreaChoice(
   config: CaptureFlowConfig,
   screenshotRequired: boolean
 ): Promise<ChosenCaptureResult> {
-  const rect = await createAreaPicker(getPickerStyle(config), {
+  const rect = await createAreaPicker(getCapturePickerStyle(config), {
     redactionsAvailable: getRedactionCount() > 0,
   });
   if (!rect) {
@@ -286,36 +312,11 @@ async function captureFromAreaChoice(
   };
 }
 
-function getPickerStyle(config: CaptureFlowConfig) {
-  return {
-    accentColor: config.accentColor,
-    font: config.font,
-    radius: config.radius,
-    borderWidth: config.borderWidth,
-    bgColor: config.bgColor,
-    textColor: config.textColor,
-    borderColor: config.borderColor,
-    theme: config.theme,
-  };
-}
-
-function emptyCaptureResult(): CaptureFlowResult {
-  return {
-    screenshot: null,
-    ...emptyElementMetadata(),
-    returnToForm: false,
-  };
-}
-
 function emptyChosenCaptureResult(
   reason: EmptyCaptureReason,
   metadata: ElementMetadata = emptyElementMetadata()
 ): ChosenCaptureResult {
   return { kind: 'empty', reason, ...metadata };
-}
-
-function emptyElementMetadata(): ElementMetadata {
-  return { elementSelector: null, fullElementSelector: null };
 }
 
 function assertNever(value: never): never {

--- a/src/widget/capture-flow.ts
+++ b/src/widget/capture-flow.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { createAreaPicker } from './area-picker';
 import { showAnnotationStep } from './annotation-flow';
 import {
@@ -12,7 +13,12 @@ import { getRedactionCount, isFullPageDisabled } from './screenshot';
 import { showScreenshotOptions, type ScreenshotChoice } from './screenshot-options';
 import { DEFAULT_SELECTED_ELEMENT_SCREENSHOT_PIXEL_RATIO } from '../defaults';
 import { abortableCapture } from './capture-cancellation';
-import { emptyCaptureResult, emptyElementMetadata } from './capture-flow-result';
+import {
+  assertNever,
+  emptyCaptureResult,
+  emptyElementMetadata,
+  shouldRememberComplexScreenshotSkip,
+} from './capture-flow-result';
 import { getCapturePickerStyle } from './capture-flow-style';
 
 export interface CaptureFlowConfig {
@@ -88,7 +94,7 @@ async function runScreenshotCaptureFlowInternal(
 
   const screenshotRequired = config.screenshotMode === 'required';
   while (true) {
-    const result = await captureChosenScreenshot(root, config, screenshotRequired);
+    const result = await captureChosenScreenshot(root, config, screenshotRequired, signal);
     if (signal?.aborted) return { ...emptyCaptureResult(), returnToForm: true };
     if (result.kind === 'returnToForm') {
       return { ...emptyCaptureResult(), returnToForm: true };
@@ -157,14 +163,13 @@ async function captureAutomaticScreenshot(
   };
 }
 
-export function shouldRememberComplexScreenshotSkip(reason: EmptyCaptureReason): boolean {
-  return reason === 'explicit-skip' || reason === 'capture-failure-skip';
-}
+export { shouldRememberComplexScreenshotSkip } from './capture-flow-result';
 
 async function captureChosenScreenshot(
   root: HTMLElement,
   config: CaptureFlowConfig,
-  screenshotRequired: boolean
+  screenshotRequired: boolean,
+  signal?: AbortSignal
 ): Promise<ChosenCaptureResult> {
   const screenshotChoice = await showScreenshotOptions(root, {
     allowSkip: !screenshotRequired,
@@ -180,9 +185,9 @@ async function captureChosenScreenshot(
     case 'capture':
       return captureFromFullPageChoice(root, config, screenshotRequired);
     case 'element':
-      return captureFromElementChoice(root, config, screenshotRequired);
+      return captureFromElementChoice(root, config, screenshotRequired, signal);
     case 'area':
-      return captureFromAreaChoice(root, config, screenshotRequired);
+      return captureFromAreaChoice(root, config, screenshotRequired, signal);
     default:
       return assertNever(screenshotChoice);
   }
@@ -240,9 +245,10 @@ async function captureFromFullPageChoice(
 async function captureFromElementChoice(
   root: HTMLElement,
   config: CaptureFlowConfig,
-  screenshotRequired: boolean
+  screenshotRequired: boolean,
+  signal?: AbortSignal
 ): Promise<ChosenCaptureResult> {
-  const element = await createElementPicker(getCapturePickerStyle(config));
+  const element = await createElementPicker(getCapturePickerStyle(config), signal);
   if (!element) {
     return emptyChosenCaptureResult('selection-cancelled');
   }
@@ -284,11 +290,16 @@ async function captureFromElementChoice(
 async function captureFromAreaChoice(
   root: HTMLElement,
   config: CaptureFlowConfig,
-  screenshotRequired: boolean
+  screenshotRequired: boolean,
+  signal?: AbortSignal
 ): Promise<ChosenCaptureResult> {
-  const rect = await createAreaPicker(getCapturePickerStyle(config), {
-    redactionsAvailable: getRedactionCount() > 0,
-  });
+  const rect = await createAreaPicker(
+    getCapturePickerStyle(config),
+    {
+      redactionsAvailable: getRedactionCount() > 0,
+    },
+    signal
+  );
   if (!rect) {
     return emptyChosenCaptureResult('selection-cancelled');
   }
@@ -317,8 +328,4 @@ function emptyChosenCaptureResult(
   metadata: ElementMetadata = emptyElementMetadata()
 ): ChosenCaptureResult {
   return { kind: 'empty', reason, ...metadata };
-}
-
-function assertNever(value: never): never {
-  throw new Error(`Unhandled screenshot choice: ${JSON.stringify(value)}`);
 }

--- a/src/widget/capture-flow.ts
+++ b/src/widget/capture-flow.ts
@@ -88,7 +88,7 @@ async function runScreenshotCaptureFlowInternal(
   onComplexScreenshotSkipped: () => void,
   signal?: AbortSignal
 ): Promise<CaptureFlowResult> {
-  if (config.screenshotMode === 'auto') return captureAutomaticScreenshot(root, config);
+  if (config.screenshotMode === 'auto') return captureAutomaticScreenshot(root, config, signal);
 
   if (!includeScreenshot) return emptyCaptureResult();
 
@@ -142,7 +142,8 @@ async function runScreenshotCaptureFlowInternal(
 
 async function captureAutomaticScreenshot(
   root: HTMLElement,
-  config: CaptureFlowConfig
+  config: CaptureFlowConfig,
+  signal?: AbortSignal
 ): Promise<CaptureFlowResult> {
   if (isFullPageDisabled()) {
     return emptyCaptureResult();
@@ -150,6 +151,7 @@ async function captureAutomaticScreenshot(
 
   const result = await captureWithLoading(root, undefined, config.screenshotScale, {
     allowChooseAgain: false,
+    signal,
   });
   if (result.kind === 'cancelled') {
     return { ...emptyCaptureResult(), returnToForm: true };
@@ -181,9 +183,9 @@ async function captureChosenScreenshot(
     case 'skip':
       return emptyChosenCaptureResult('explicit-skip');
     case 'viewport':
-      return captureFromViewportChoice(root, screenshotChoice, screenshotRequired);
+      return captureFromViewportChoice(root, screenshotChoice, screenshotRequired, signal);
     case 'capture':
-      return captureFromFullPageChoice(root, config, screenshotRequired);
+      return captureFromFullPageChoice(root, config, screenshotRequired, signal);
     case 'element':
       return captureFromElementChoice(root, config, screenshotRequired, signal);
     case 'area':
@@ -196,11 +198,13 @@ async function captureChosenScreenshot(
 async function captureFromViewportChoice(
   root: HTMLElement,
   choice: Extract<ScreenshotChoice, { kind: 'viewport' }>,
-  screenshotRequired: boolean
+  screenshotRequired: boolean,
+  signal?: AbortSignal
 ): Promise<ChosenCaptureResult> {
   const result = await capturePromiseWithLoading(root, choice.capture, {
     allowSkip: !screenshotRequired,
     showLoading: false,
+    signal,
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'choose-again') return { kind: 'chooseAgain' };
@@ -221,10 +225,12 @@ async function captureFromViewportChoice(
 async function captureFromFullPageChoice(
   root: HTMLElement,
   config: CaptureFlowConfig,
-  screenshotRequired: boolean
+  screenshotRequired: boolean,
+  signal?: AbortSignal
 ): Promise<ChosenCaptureResult> {
   const result = await captureWithLoading(root, undefined, config.screenshotScale, {
     allowSkip: !screenshotRequired,
+    signal,
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'choose-again') return { kind: 'chooseAgain' };
@@ -271,6 +277,7 @@ async function captureFromElementChoice(
       },
       pixelRatio: DEFAULT_SELECTED_ELEMENT_SCREENSHOT_PIXEL_RATIO,
     },
+    signal,
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'choose-again') return { kind: 'chooseAgain' };
@@ -306,6 +313,7 @@ async function captureFromAreaChoice(
 
   const result = await captureAreaWithLoading(root, rect, config.screenshotScale, {
     allowSkip: !screenshotRequired,
+    signal,
   });
   if (result.kind === 'cancelled') return { kind: 'returnToForm' };
   if (result.kind === 'choose-again') return { kind: 'chooseAgain' };

--- a/src/widget/capture-loading.ts
+++ b/src/widget/capture-loading.ts
@@ -67,6 +67,10 @@ export async function capturePromiseWithLoading(
     if (loadingModal) {
       await waitForLoadingPaint();
     }
+    if (opts?.signal?.aborted) {
+      loadingModal?.remove();
+      return { kind: 'cancelled' };
+    }
     const capturePromise =
       typeof captureOperation === 'function' ? captureOperation() : captureOperation;
     const screenshot = await captureUntilAborted(capturePromise, opts?.signal);

--- a/src/widget/capture-loading.ts
+++ b/src/widget/capture-loading.ts
@@ -20,6 +20,7 @@ type CaptureLoadingOptions = {
   allowChooseAgain?: boolean;
   showLoading?: boolean;
   captureOptions?: CaptureScreenshotOptions;
+  signal?: AbortSignal;
 };
 type CaptureOperation = Promise<CapturePayload> | (() => Promise<CapturePayload>);
 
@@ -68,12 +69,14 @@ export async function capturePromiseWithLoading(
     }
     const capturePromise =
       typeof captureOperation === 'function' ? captureOperation() : captureOperation;
-    const screenshot = await capturePromise;
+    const screenshot = await captureUntilAborted(capturePromise, opts?.signal);
     loadingModal?.remove();
+    if (screenshot === null) return { kind: 'cancelled' };
     return normalizeCaptureResult(screenshot);
   } catch (error) {
-    console.warn('[BugDrop] Screenshot capture failed:', error);
     loadingModal?.remove();
+    if (opts?.signal?.aborted) return { kind: 'cancelled' };
+    console.warn('[BugDrop] Screenshot capture failed:', error);
     const allowSkip = opts?.allowSkip !== false;
     const allowChooseAgain = opts?.allowChooseAgain !== false;
 
@@ -122,6 +125,28 @@ export async function capturePromiseWithLoading(
       });
     });
   }
+}
+
+function captureUntilAborted(
+  capture: Promise<CapturePayload>,
+  signal: AbortSignal | undefined
+): Promise<CapturePayload | null> {
+  if (!signal) return capture;
+  if (signal.aborted) return Promise.resolve(null);
+  return new Promise((resolve, reject) => {
+    const abort = () => resolve(null);
+    signal.addEventListener('abort', abort, { once: true });
+    capture.then(
+      value => {
+        signal.removeEventListener('abort', abort);
+        resolve(value);
+      },
+      error => {
+        signal.removeEventListener('abort', abort);
+        reject(error);
+      }
+    );
+  });
 }
 
 function waitForLoadingPaint(): Promise<void> {

--- a/src/widget/flows/busy-opened-flow.ts
+++ b/src/widget/flows/busy-opened-flow.ts
@@ -1,0 +1,10 @@
+import { createRuntimeId } from '../variants/form';
+import type { FlowOutcome, OpenedFlow } from './public-types';
+
+export function createBusyOpenedFlow(flowId: string): OpenedFlow {
+  return Object.freeze({
+    instanceId: createRuntimeId(flowId),
+    result: Promise.resolve<FlowOutcome>({ status: 'busy' }),
+    close() {},
+  });
+}

--- a/src/widget/flows/conditions.ts
+++ b/src/widget/flows/conditions.ts
@@ -1,0 +1,40 @@
+import type { FlowCondition, FlowScalar } from './public-types';
+
+const MAX_CONDITION_DEPTH = 4;
+const MAX_CONDITION_NODES = 32;
+
+export function evaluateCondition(
+  condition: FlowCondition | undefined,
+  answers: Readonly<Record<string, unknown>>,
+  context: Readonly<Record<string, FlowScalar>>
+): boolean {
+  if (!condition) return true;
+  if ('answer' in condition) return hasEqualValue(answers, condition.answer, condition.equals);
+  if ('context' in condition) return hasEqualValue(context, condition.context, condition.equals);
+  if ('all' in condition) {
+    return condition.all.every(child => evaluateCondition(child, answers, context));
+  }
+  return condition.any.some(child => evaluateCondition(child, answers, context));
+}
+
+function hasEqualValue(
+  values: Readonly<Record<string, unknown>>,
+  key: string,
+  expected: FlowScalar
+): boolean {
+  return Object.prototype.hasOwnProperty.call(values, key) && values[key] === expected;
+}
+
+export function countConditionNodes(condition: FlowCondition, depth = 1): number {
+  if (depth > MAX_CONDITION_DEPTH) {
+    throw new TypeError(`BugDrop flow condition depth cannot exceed ${MAX_CONDITION_DEPTH}`);
+  }
+  if ('answer' in condition || 'context' in condition) return 1;
+  const children = 'all' in condition ? condition.all : condition.any;
+  let count = 1;
+  for (const child of children) count += countConditionNodes(child, depth + 1);
+  if (count > MAX_CONDITION_NODES) {
+    throw new TypeError(`BugDrop flow conditions cannot exceed ${MAX_CONDITION_NODES} nodes`);
+  }
+  return count;
+}

--- a/src/widget/flows/definition.ts
+++ b/src/widget/flows/definition.ts
@@ -1,0 +1,52 @@
+import type { FlowConfig, FlowField, FlowScreen } from './public-types';
+
+export interface FlowDefinition {
+  readonly compiler: 'bugdrop-flow@1';
+  readonly flowId: string;
+  readonly config: Readonly<FlowConfig>;
+  readonly fields: ReadonlyMap<string, Readonly<FlowField>>;
+  readonly contextKeys: ReadonlySet<string>;
+  readonly screenAnswerPaths: ReadonlyMap<string, readonly string[]>;
+  readonly screens: readonly Readonly<FlowScreen>[];
+}
+
+export function normalizeFlowDefinition(config: Readonly<FlowConfig>): FlowDefinition {
+  const fields = new Map<string, Readonly<FlowField>>();
+  for (const form of config.forms) {
+    for (const field of form.fields) fields.set(`${form.id}.${field.id}`, field);
+  }
+  const screenAnswerPaths = new Map<string, readonly string[]>();
+  const contextKeys = new Set<string>();
+  for (const screen of config.screens) {
+    collectConditionContextKeys(screen.when, contextKeys);
+    screenAnswerPaths.set(
+      screen.id,
+      screen.type === 'form'
+        ? config.forms
+            .find(form => form.id === screen.form)!
+            .fields.map(field => `${screen.form}.${field.id}`)
+        : []
+    );
+  }
+  for (const section of config.issue.sections ?? []) {
+    if ('context' in section) contextKeys.add(section.context);
+  }
+  return Object.freeze({
+    compiler: 'bugdrop-flow@1' as const,
+    flowId: config.id,
+    config,
+    fields,
+    contextKeys,
+    screenAnswerPaths,
+    screens: config.screens,
+  });
+}
+
+function collectConditionContextKeys(condition: FlowScreen['when'], keys: Set<string>): void {
+  if (!condition) return;
+  if ('context' in condition) keys.add(condition.context);
+  else if ('all' in condition)
+    condition.all.forEach(child => collectConditionContextKeys(child, keys));
+  else if ('any' in condition)
+    condition.any.forEach(child => collectConditionContextKeys(child, keys));
+}

--- a/src/widget/flows/extra-fields.ts
+++ b/src/widget/flows/extra-fields.ts
@@ -67,16 +67,19 @@ export function createAttachmentsController(
   let values = Array.isArray(initialValue) ? ([...initialValue] as FlowAttachment[]) : [];
   let readFailed = false;
   let pending: Promise<void> = Promise.resolve();
+  let readVersion = 0;
   renderNames(
     list,
     values.map(value => value.name)
   );
   const onChange = () => {
+    const version = ++readVersion;
     readFailed = false;
     scaffold.setError(input, null);
     const files = Array.from(input.files ?? []);
     pending = readFiles(files, field)
       .then(next => {
+        if (version !== readVersion) return;
         values = next;
         renderNames(
           list,
@@ -84,6 +87,7 @@ export function createAttachmentsController(
         );
       })
       .catch(error => {
+        if (version !== readVersion) return;
         readFailed = true;
         scaffold.setError(
           input,
@@ -104,7 +108,10 @@ export function createAttachmentsController(
       if (!readFailed) scaffold.setError(input, show ? 'Select at least one attachment.' : null);
     },
     focus: () => input.focus(),
-    dispose: () => input.removeEventListener('change', onChange),
+    dispose: () => {
+      readVersion += 1;
+      input.removeEventListener('change', onChange);
+    },
   };
 }
 
@@ -175,12 +182,20 @@ async function readFiles(
 ): Promise<FlowAttachment[]> {
   if (files.length > (field.maxFiles ?? 5))
     throw new TypeError(`Select at most ${field.maxFiles ?? 5} attachments.`);
-  return Promise.all(files.map(file => readAttachment(file, field.maxFileSize ?? 5 * 1024 * 1024)));
+  return Promise.all(
+    files.map(file => readAttachment(file, field.maxFileSize ?? 5 * 1024 * 1024, field.accept))
+  );
 }
 
-async function readAttachment(file: File, maxSize: number): Promise<FlowAttachment> {
+async function readAttachment(
+  file: File,
+  maxSize: number,
+  accept: ReadonlyArray<string> | undefined
+): Promise<FlowAttachment> {
   if (!isAllowedFlowAttachmentType(file.type))
     throw new TypeError(`${file.name} has an unsupported file type.`);
+  if (accept && !accept.includes(file.type))
+    throw new TypeError(`${file.name} is not an accepted file type.`);
   if (file.size > maxSize) throw new TypeError(`${file.name} is too large.`);
   const dataUrl = await new Promise<string>((resolve, reject) => {
     const reader = new FileReader();

--- a/src/widget/flows/extra-fields.ts
+++ b/src/widget/flows/extra-fields.ts
@@ -101,7 +101,11 @@ export function createAttachmentsController(
     required: Boolean(field.required),
     element: scaffold.wrapper,
     async read(validate) {
-      await pending;
+      while (true) {
+        const currentRead = pending;
+        await currentRead;
+        if (currentRead === pending) break;
+      }
       return readFailed && validate ? { ok: false } : { ok: true, value: values };
     },
     setRequiredError(show) {

--- a/src/widget/flows/extra-fields.ts
+++ b/src/widget/flows/extra-fields.ts
@@ -1,0 +1,206 @@
+import type { FlowAttachment } from './field-validation';
+import type { AttachmentsField, CheckboxField } from './public-types';
+
+export interface ExtraFieldController {
+  readonly id: string;
+  readonly required: boolean;
+  readonly element: HTMLElement;
+  read(validate: boolean): Promise<{ ok: true; value: unknown } | { ok: false }>;
+  setRequiredError(show: boolean): void;
+  focus(): void;
+  dispose(): void;
+}
+
+export function createCheckboxController(
+  field: Readonly<CheckboxField>,
+  formId: string,
+  instanceId: string,
+  answers: Readonly<Record<string, unknown>>
+): ExtraFieldController {
+  const scaffold = createScaffold(field, instanceId);
+  const input = document.createElement('input');
+  input.type = 'checkbox';
+  input.id = scaffold.controlId;
+  input.checked =
+    typeof answers[`${formId}.${field.id}`] === 'boolean'
+      ? Boolean(answers[`${formId}.${field.id}`])
+      : Boolean(field.initialValue);
+  input.setAttribute('aria-required', String(field.required ?? false));
+  if (scaffold.describedBy) input.setAttribute('aria-describedby', scaffold.describedBy);
+  scaffold.wrapper.classList.add('bdf-checkbox');
+  scaffold.wrapper.insertBefore(input, scaffold.label);
+  return {
+    id: field.id,
+    required: Boolean(field.required),
+    element: scaffold.wrapper,
+    read: async () => ({ ok: true, value: input.checked }),
+    setRequiredError(show) {
+      scaffold.setError(input, show ? 'This checkbox is required.' : null);
+    },
+    focus: () => input.focus(),
+    dispose() {},
+  };
+}
+
+export function createAttachmentsController(
+  field: Readonly<AttachmentsField>,
+  formId: string,
+  instanceId: string,
+  answers: Readonly<Record<string, unknown>>
+): ExtraFieldController {
+  const scaffold = createScaffold(field, instanceId);
+  scaffold.wrapper.classList.add('bdf-attachment');
+  const input = document.createElement('input');
+  input.className = 'bdv-input';
+  input.type = 'file';
+  input.id = scaffold.controlId;
+  input.multiple = (field.maxFiles ?? 5) > 1;
+  input.setAttribute('aria-required', String(field.required ?? false));
+  if (field.accept) input.accept = field.accept.join(',');
+  if (scaffold.describedBy) input.setAttribute('aria-describedby', scaffold.describedBy);
+  const list = document.createElement('ul');
+  list.className = 'bdf-file-list';
+  list.setAttribute('aria-live', 'polite');
+  scaffold.wrapper.insertBefore(input, scaffold.error);
+  scaffold.wrapper.insertBefore(list, scaffold.error);
+  const initialValue = answers[`${formId}.${field.id}`];
+  let values = Array.isArray(initialValue) ? ([...initialValue] as FlowAttachment[]) : [];
+  let readFailed = false;
+  let pending: Promise<void> = Promise.resolve();
+  renderNames(
+    list,
+    values.map(value => value.name)
+  );
+  const onChange = () => {
+    readFailed = false;
+    scaffold.setError(input, null);
+    const files = Array.from(input.files ?? []);
+    pending = readFiles(files, field)
+      .then(next => {
+        values = next;
+        renderNames(
+          list,
+          next.map(value => value.name)
+        );
+      })
+      .catch(error => {
+        readFailed = true;
+        scaffold.setError(
+          input,
+          error instanceof Error ? error.message : 'Could not read the selected attachment.'
+        );
+      });
+  };
+  input.addEventListener('change', onChange);
+  return {
+    id: field.id,
+    required: Boolean(field.required),
+    element: scaffold.wrapper,
+    async read(validate) {
+      await pending;
+      return readFailed && validate ? { ok: false } : { ok: true, value: values };
+    },
+    setRequiredError(show) {
+      if (!readFailed) scaffold.setError(input, show ? 'Select at least one attachment.' : null);
+    },
+    focus: () => input.focus(),
+    dispose: () => input.removeEventListener('change', onChange),
+  };
+}
+
+interface ExtraScaffold {
+  wrapper: HTMLDivElement;
+  label: HTMLLabelElement;
+  error: HTMLDivElement;
+  controlId: string;
+  describedBy: string | null;
+  setError(target: HTMLElement, message: string | null): void;
+}
+
+function createScaffold(
+  field: Readonly<CheckboxField | AttachmentsField>,
+  instanceId: string
+): ExtraScaffold {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'bdv-field';
+  wrapper.dataset.bugdropField = field.id;
+  wrapper.dataset.span = String(field.layout?.span ?? 1);
+  const controlId = `${instanceId}-${field.id}`;
+  const label = document.createElement('label');
+  label.className = 'bdv-label';
+  label.htmlFor = controlId;
+  label.textContent = field.label;
+  if (field.required) {
+    const required = document.createElement('span');
+    required.className = 'bdv-required';
+    required.textContent = ' *';
+    required.setAttribute('aria-hidden', 'true');
+    label.appendChild(required);
+  }
+  wrapper.appendChild(label);
+  const describedBy: string[] = [];
+  if (field.helpText) {
+    const help = document.createElement('div');
+    help.className = 'bdv-help';
+    help.id = `${controlId}-help`;
+    help.textContent = field.helpText;
+    wrapper.appendChild(help);
+    describedBy.push(help.id);
+  }
+  const error = document.createElement('div');
+  error.className = 'bdv-error';
+  error.id = `${controlId}-error`;
+  error.hidden = true;
+  error.setAttribute('aria-live', 'polite');
+  wrapper.appendChild(error);
+  describedBy.push(error.id);
+  return {
+    wrapper,
+    label,
+    error,
+    controlId,
+    describedBy: describedBy.join(' ') || null,
+    setError(target, message) {
+      error.textContent = message ?? '';
+      error.hidden = !message;
+      if (message) target.setAttribute('aria-invalid', 'true');
+      else target.removeAttribute('aria-invalid');
+    },
+  };
+}
+
+async function readFiles(
+  files: File[],
+  field: Readonly<AttachmentsField>
+): Promise<FlowAttachment[]> {
+  if (files.length > (field.maxFiles ?? 5))
+    throw new TypeError(`Select at most ${field.maxFiles ?? 5} attachments.`);
+  return Promise.all(files.map(file => readAttachment(file, field.maxFileSize ?? 5 * 1024 * 1024)));
+}
+
+async function readAttachment(file: File, maxSize: number): Promise<FlowAttachment> {
+  if (file.size > maxSize) throw new TypeError(`${file.name} is too large.`);
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', () =>
+      typeof reader.result === 'string'
+        ? resolve(reader.result)
+        : reject(new Error('Could not read the selected attachment.'))
+    );
+    reader.addEventListener('error', () =>
+      reject(new Error('Could not read the selected attachment.'))
+    );
+    reader.readAsDataURL(file);
+  });
+  return { name: file.name, type: file.type, size: file.size, dataUrl };
+}
+
+function renderNames(list: HTMLUListElement, names: string[]): void {
+  list.replaceChildren(
+    ...names.map(name => {
+      const item = document.createElement('li');
+      item.textContent = name;
+      return item;
+    })
+  );
+}

--- a/src/widget/flows/extra-fields.ts
+++ b/src/widget/flows/extra-fields.ts
@@ -1,4 +1,4 @@
-import type { FlowAttachment } from './field-validation';
+import { isAllowedFlowAttachmentType, type FlowAttachment } from './field-validation';
 import type { AttachmentsField, CheckboxField } from './public-types';
 
 export interface ExtraFieldController {
@@ -179,6 +179,8 @@ async function readFiles(
 }
 
 async function readAttachment(file: File, maxSize: number): Promise<FlowAttachment> {
+  if (!isAllowedFlowAttachmentType(file.type))
+    throw new TypeError(`${file.name} has an unsupported file type.`);
   if (file.size > maxSize) throw new TypeError(`${file.name} is too large.`);
   const dataUrl = await new Promise<string>((resolve, reject) => {
     const reader = new FileReader();

--- a/src/widget/flows/field-validation.ts
+++ b/src/widget/flows/field-validation.ts
@@ -272,9 +272,8 @@ function normalizeAttachments(field: AttachmentsField, raw: unknown): FlowAttach
     )
       fail('attachment dataUrl is invalid');
     const encoded = value.dataUrl.slice(value.dataUrl.indexOf(',') + 1);
-    const decodedSize =
-      Math.floor((encoded.length * 3) / 4) -
-      (encoded.endsWith('==') ? 2 : encoded.endsWith('=') ? 1 : 0);
+    if (encoded.length % 4 !== 0) fail('attachment dataUrl is invalid');
+    const decodedSize = atob(encoded).length;
     if (decodedSize > (field.maxFileSize ?? 5 * 1024 * 1024)) fail('attachment size is invalid');
     return { name: value.name, type: value.type, size: value.size, dataUrl: value.dataUrl };
   });

--- a/src/widget/flows/field-validation.ts
+++ b/src/widget/flows/field-validation.ts
@@ -1,0 +1,256 @@
+import type { FlowDefinition } from './definition';
+import type {
+  AttachmentsField,
+  FlowField,
+  FlowConfig,
+  FlowOpenOptions,
+  FlowScalar,
+} from './public-types';
+
+export interface FlowAttachment {
+  name: string;
+  type: string;
+  size: number;
+  dataUrl: string;
+}
+
+export interface NormalizedFlowOpenOptions {
+  context: Readonly<Record<string, FlowScalar>>;
+  initialAnswers: Record<string, unknown>;
+}
+
+export function normalizeFlowOpenOptions(
+  definition: FlowDefinition,
+  options: FlowOpenOptions | undefined
+): NormalizedFlowOpenOptions {
+  const declaredOptions = options;
+  if (options !== undefined && !isObject(options)) fail('open options must be an object');
+  assertOnlyKeys(options ?? {}, new Set(['context', 'initialAnswers']), 'open options');
+  return {
+    context: Object.freeze(normalizeContext(definition, declaredOptions?.context)),
+    initialAnswers: normalizeInitialAnswers(definition, declaredOptions?.initialAnswers),
+  };
+}
+
+export function validateFlowFieldConfig(field: FlowField): void {
+  validateLayout(field);
+  if (field.type === 'shortText' || field.type === 'longText') validateTextField(field);
+  else if (field.type === 'rating') validateRatingField(field);
+  else if (field.type === 'singleChoice') validateChoiceField(field);
+  else if (field.type === 'checkbox') validateCheckboxField(field);
+  else validateAttachmentsField(field);
+}
+
+export function validateFlowShell(config: FlowConfig): void {
+  const { presentation, appearance, content } = config;
+  if (!isObject(presentation)) fail('presentation must be an object');
+  assertOnlyKeys(presentation, new Set(['kind', 'size', 'columns']), 'presentation');
+  if (presentation.kind !== 'modal') fail('presentation kind must be modal');
+  if (
+    presentation.size !== undefined &&
+    !['compact', 'default', 'wide'].includes(presentation.size)
+  )
+    fail('modal size is invalid');
+  if (
+    presentation.columns !== undefined &&
+    presentation.columns !== 1 &&
+    presentation.columns !== 2
+  )
+    fail('presentation columns must be 1 or 2');
+  if (appearance !== undefined) {
+    if (!isObject(appearance)) fail('appearance must be an object');
+    assertOnlyKeys(appearance, new Set(['theme', 'accentColor', 'density']), 'appearance');
+    if (appearance.theme !== undefined && !['light', 'dark', 'auto'].includes(appearance.theme))
+      fail('appearance theme is invalid');
+    optionalCopy(appearance.accentColor, 'appearance accentColor', 120);
+    if (
+      appearance.density !== undefined &&
+      !['compact', 'comfortable'].includes(appearance.density)
+    )
+      fail('appearance density is invalid');
+  }
+  if (content !== undefined) {
+    if (!isObject(content)) fail('content must be an object');
+    assertOnlyKeys(content, new Set(['successTitle', 'successMessage', 'cancelLabel']), 'content');
+    optionalCopy(content.successTitle, 'successTitle', 500);
+    optionalCopy(content.successMessage, 'successMessage', 2_000);
+    optionalCopy(content.cancelLabel, 'cancelLabel', 120);
+  }
+}
+
+function normalizeFlowFieldValue(field: Readonly<FlowField>, raw: unknown): unknown {
+  if (field.type === 'shortText' || field.type === 'longText') {
+    if (typeof raw !== 'string') fail(`initial answer ${field.id} must be text`);
+    const minimum = field.minLength ?? 0;
+    const maximum = field.maxLength ?? (field.type === 'shortText' ? 500 : 5_000);
+    const value = raw.trim();
+    if (value.length < minimum || value.length > maximum)
+      fail(`initial answer ${field.id} has invalid length`);
+    return value;
+  }
+  if (field.type === 'rating') {
+    const scale = field.scale ?? 5;
+    if (!Number.isInteger(raw) || (raw as number) < 1 || (raw as number) > scale)
+      fail(`initial answer ${field.id} must be a rating from 1-${scale}`);
+    return raw;
+  }
+  if (field.type === 'singleChoice') {
+    if (typeof raw !== 'string' || !field.options.some(option => option.value === raw))
+      fail(`initial answer ${field.id} must be a configured choice`);
+    return raw;
+  }
+  if (field.type === 'checkbox') {
+    if (typeof raw !== 'boolean') fail(`initial answer ${field.id} must be boolean`);
+    return raw;
+  }
+  return normalizeAttachments(field, raw);
+}
+
+function normalizeContext(
+  definition: FlowDefinition,
+  raw: FlowOpenOptions['context']
+): Record<string, FlowScalar> {
+  if (raw !== undefined && !isObject(raw)) fail('context must be an object');
+  const context = raw ?? {};
+  const unknown = Object.keys(context).find(key => !definition.contextKeys.has(key));
+  if (unknown) fail(`context contains unknown key ${unknown}`);
+  const output: Record<string, FlowScalar> = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (!isScalar(value) || (typeof value === 'number' && !Number.isFinite(value)))
+      fail(`context ${key} must be a finite scalar`);
+    output[key] = value;
+  }
+  return output;
+}
+
+function normalizeInitialAnswers(
+  definition: FlowDefinition,
+  raw: FlowOpenOptions['initialAnswers']
+): Record<string, unknown> {
+  if (raw !== undefined && !isObject(raw)) fail('initialAnswers must be an object');
+  const answers = raw ?? {};
+  const unknown = Object.keys(answers).find(key => !definition.fields.has(key));
+  if (unknown) fail(`initialAnswers contains unknown key ${unknown}`);
+  return Object.fromEntries(
+    Object.entries(answers).map(([path, value]) => [
+      path,
+      normalizeFlowFieldValue(definition.fields.get(path)!, value),
+    ])
+  );
+}
+
+function validateLayout(field: FlowField): void {
+  if (field.layout === undefined) return;
+  if (!isObject(field.layout)) fail(`field ${field.id} layout must be an object`);
+  assertOnlyKeys(field.layout, new Set(['span']), `field ${field.id} layout`);
+  if (field.layout.span !== undefined && field.layout.span !== 1 && field.layout.span !== 2)
+    fail(`field ${field.id} layout span must be 1 or 2`);
+}
+
+function validateTextField(field: Extract<FlowField, { type: 'shortText' | 'longText' }>): void {
+  optionalCopy(field.placeholder, `field ${field.id} placeholder`, 500);
+  const minimum = field.minLength ?? 0;
+  const maximum = field.maxLength ?? (field.type === 'shortText' ? 500 : 5_000);
+  if (!boundedInteger(minimum, 0, 5_000) || !boundedInteger(maximum, 1, 5_000) || minimum > maximum)
+    fail(`field ${field.id} has invalid text bounds`);
+  if (field.type === 'longText' && field.rows !== undefined && !boundedInteger(field.rows, 1, 50))
+    fail(`field ${field.id} rows must be 1-50`);
+}
+
+function validateRatingField(field: Extract<FlowField, { type: 'rating' }>): void {
+  if (field.scale !== undefined && field.scale !== 5 && field.scale !== 10)
+    fail(`field ${field.id} rating scale must be 5 or 10`);
+  if (field.icon !== undefined && field.icon !== 'star' && field.icon !== 'number')
+    fail(`field ${field.id} rating icon is invalid`);
+  optionalCopy(field.lowLabel, `field ${field.id} lowLabel`, 500);
+  optionalCopy(field.highLabel, `field ${field.id} highLabel`, 500);
+}
+
+function validateChoiceField(field: Extract<FlowField, { type: 'singleChoice' }>): void {
+  if (!Array.isArray(field.options) || field.options.length < 2 || field.options.length > 50)
+    fail(`field ${field.id} requires 2-50 choices`);
+  if (field.display !== undefined && !['radio', 'cards', 'buttons'].includes(field.display))
+    fail(`field ${field.id} choice display is invalid`);
+  const values = new Set<string>();
+  for (const option of field.options) {
+    if (!isObject(option)) fail(`field ${field.id} has an invalid choice`);
+    assertOnlyKeys(option, new Set(['value', 'label', 'description']), `field ${field.id} choice`);
+    requiredCopy(option.value, `field ${field.id} choice value`, 120);
+    requiredCopy(option.label, `field ${field.id} choice label`, 500);
+    optionalCopy(option.description, `field ${field.id} choice description`, 1_000);
+    if (values.has(option.value)) fail(`field ${field.id} has duplicate choices`);
+    values.add(option.value);
+  }
+}
+
+function validateCheckboxField(field: Extract<FlowField, { type: 'checkbox' }>): void {
+  if (field.initialValue !== undefined && typeof field.initialValue !== 'boolean')
+    fail(`field ${field.id} initialValue must be boolean`);
+}
+
+function validateAttachmentsField(field: AttachmentsField): void {
+  if (field.maxFiles !== undefined && !boundedInteger(field.maxFiles, 1, 5))
+    fail(`field ${field.id} maxFiles must be 1-5`);
+  if (field.maxFileSize !== undefined && !boundedInteger(field.maxFileSize, 1, 5 * 1024 * 1024))
+    fail(`field ${field.id} maxFileSize is invalid`);
+  if (
+    field.accept !== undefined &&
+    (!Array.isArray(field.accept) ||
+      field.accept.length === 0 ||
+      field.accept.length > 20 ||
+      field.accept.some(value => typeof value !== 'string' || !value.trim() || value.length > 120))
+  )
+    fail(`field ${field.id} accept is invalid`);
+}
+
+function normalizeAttachments(field: AttachmentsField, raw: unknown): FlowAttachment[] {
+  if (!Array.isArray(raw) || raw.length > (field.maxFiles ?? 5))
+    fail(`initial answer ${field.id} has too many attachments`);
+  return raw.map(value => {
+    if (!isObject(value)) fail(`initial answer ${field.id} has an invalid attachment`);
+    assertOnlyKeys(value, new Set(['name', 'type', 'size', 'dataUrl']), 'attachment');
+    requiredCopy(value.name, 'attachment name', 500);
+    if (typeof value.type !== 'string' || value.type.length > 200)
+      fail('attachment type is invalid');
+    if (!boundedInteger(value.size, 0, field.maxFileSize ?? 5 * 1024 * 1024))
+      fail('attachment size is invalid');
+    if (typeof value.dataUrl !== 'string' || !value.dataUrl.startsWith('data:'))
+      fail('attachment dataUrl is invalid');
+    return { name: value.name, type: value.type, size: value.size, dataUrl: value.dataUrl };
+  });
+}
+
+function requiredCopy(value: unknown, label: string, maximum: number): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    !value.trim() ||
+    value.length > maximum ||
+    hasControlChars(value)
+  )
+    fail(`${label} is invalid`);
+}
+function optionalCopy(value: unknown, label: string, maximum: number): void {
+  if (value !== undefined) requiredCopy(value, label, maximum);
+}
+function hasControlChars(value: string): boolean {
+  return [...value].some(character => {
+    const code = character.charCodeAt(0);
+    return (code < 32 && code !== 9 && code !== 10 && code !== 13) || code === 127;
+  });
+}
+function boundedInteger(value: unknown, minimum: number, maximum: number): value is number {
+  return Number.isInteger(value) && (value as number) >= minimum && (value as number) <= maximum;
+}
+function isScalar(value: unknown): value is FlowScalar {
+  return value === null || ['string', 'number', 'boolean'].includes(typeof value);
+}
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+function assertOnlyKeys(value: object, allowed: Set<string>, label: string): void {
+  const unknown = Object.keys(value).find(key => !allowed.has(key));
+  if (unknown) fail(`${label} contains unknown key ${unknown}`);
+}
+function fail(message: string): never {
+  throw new TypeError(`BugDrop flow ${message}`);
+}

--- a/src/widget/flows/field-validation.ts
+++ b/src/widget/flows/field-validation.ts
@@ -25,6 +25,10 @@ const ALLOWED_ATTACHMENT_TYPES = new Set([
   'video/quicktime',
 ]);
 
+export function isAllowedFlowAttachmentType(value: string): boolean {
+  return ALLOWED_ATTACHMENT_TYPES.has(value);
+}
+
 export interface NormalizedFlowOpenOptions {
   context: Readonly<Record<string, FlowScalar>>;
   initialAnswers: Record<string, unknown>;
@@ -236,7 +240,13 @@ function validateAttachmentsField(field: AttachmentsField): void {
     (!Array.isArray(field.accept) ||
       field.accept.length === 0 ||
       field.accept.length > 20 ||
-      field.accept.some(value => typeof value !== 'string' || !value.trim() || value.length > 120))
+      field.accept.some(
+        value =>
+          typeof value !== 'string' ||
+          !value.trim() ||
+          value.length > 120 ||
+          !isAllowedFlowAttachmentType(value)
+      ))
   )
     fail(`field ${field.id} accept is invalid`);
 }
@@ -248,7 +258,7 @@ function normalizeAttachments(field: AttachmentsField, raw: unknown): FlowAttach
     if (!isObject(value)) fail(`initial answer ${field.id} has an invalid attachment`);
     assertOnlyKeys(value, new Set(['name', 'type', 'size', 'dataUrl']), 'attachment');
     requiredCopy(value.name, 'attachment name', 500);
-    if (typeof value.type !== 'string' || !ALLOWED_ATTACHMENT_TYPES.has(value.type))
+    if (typeof value.type !== 'string' || !isAllowedFlowAttachmentType(value.type))
       fail('attachment type is invalid');
     if (!boundedInteger(value.size, 0, field.maxFileSize ?? 5 * 1024 * 1024))
       fail('attachment size is invalid');

--- a/src/widget/flows/field-validation.ts
+++ b/src/widget/flows/field-validation.ts
@@ -271,6 +271,11 @@ function normalizeAttachments(field: AttachmentsField, raw: unknown): FlowAttach
       )
     )
       fail('attachment dataUrl is invalid');
+    const encoded = value.dataUrl.slice(value.dataUrl.indexOf(',') + 1);
+    const decodedSize =
+      Math.floor((encoded.length * 3) / 4) -
+      (encoded.endsWith('==') ? 2 : encoded.endsWith('=') ? 1 : 0);
+    if (decodedSize > (field.maxFileSize ?? 5 * 1024 * 1024)) fail('attachment size is invalid');
     return { name: value.name, type: value.type, size: value.size, dataUrl: value.dataUrl };
   });
 }

--- a/src/widget/flows/field-validation.ts
+++ b/src/widget/flows/field-validation.ts
@@ -260,6 +260,8 @@ function normalizeAttachments(field: AttachmentsField, raw: unknown): FlowAttach
     requiredCopy(value.name, 'attachment name', 500);
     if (typeof value.type !== 'string' || !isAllowedFlowAttachmentType(value.type))
       fail('attachment type is invalid');
+    if (field.accept && !field.accept.includes(value.type))
+      fail(`initial answer ${field.id} has a disallowed attachment type`);
     if (!boundedInteger(value.size, 0, field.maxFileSize ?? 5 * 1024 * 1024))
       fail('attachment size is invalid');
     if (

--- a/src/widget/flows/field-validation.ts
+++ b/src/widget/flows/field-validation.ts
@@ -14,6 +14,17 @@ export interface FlowAttachment {
   dataUrl: string;
 }
 
+const ALLOWED_ATTACHMENT_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'video/mp4',
+  'video/webm',
+  'video/quicktime',
+]);
+
 export interface NormalizedFlowOpenOptions {
   context: Readonly<Record<string, FlowScalar>>;
   initialAnswers: Record<string, unknown>;
@@ -39,6 +50,33 @@ export function validateFlowFieldConfig(field: FlowField): void {
   else if (field.type === 'singleChoice') validateChoiceField(field);
   else if (field.type === 'checkbox') validateCheckboxField(field);
   else validateAttachmentsField(field);
+}
+
+export function validateFlowConditionValue(field: FlowField, value: FlowScalar): void {
+  if (field.type === 'rating') {
+    const scale = field.scale ?? 5;
+    if (!Number.isInteger(value) || (value as number) < 1 || (value as number) > scale)
+      fail(`condition equals is not a valid value for field ${field.id}`);
+    return;
+  }
+  if (field.type === 'singleChoice') {
+    if (typeof value !== 'string' || !field.options.some(option => option.value === value))
+      fail(`condition equals is not a valid value for field ${field.id}`);
+    return;
+  }
+  if (field.type === 'checkbox') {
+    if (typeof value !== 'boolean')
+      fail(`condition equals is not a valid value for field ${field.id}`);
+    return;
+  }
+  if (field.type === 'attachments')
+    fail(`condition answer cannot reference attachments field ${field.id}`);
+  if (typeof value !== 'string' || value !== value.trim())
+    fail(`condition equals is not a valid value for field ${field.id}`);
+  const minimum = field.minLength ?? 0;
+  const maximum = field.maxLength ?? (field.type === 'shortText' ? 500 : 5_000);
+  if (value.length < minimum || value.length > maximum)
+    fail(`condition equals is not a valid value for field ${field.id}`);
 }
 
 export function validateFlowShell(config: FlowConfig): void {
@@ -210,14 +248,22 @@ function normalizeAttachments(field: AttachmentsField, raw: unknown): FlowAttach
     if (!isObject(value)) fail(`initial answer ${field.id} has an invalid attachment`);
     assertOnlyKeys(value, new Set(['name', 'type', 'size', 'dataUrl']), 'attachment');
     requiredCopy(value.name, 'attachment name', 500);
-    if (typeof value.type !== 'string' || value.type.length > 200)
+    if (typeof value.type !== 'string' || !ALLOWED_ATTACHMENT_TYPES.has(value.type))
       fail('attachment type is invalid');
     if (!boundedInteger(value.size, 0, field.maxFileSize ?? 5 * 1024 * 1024))
       fail('attachment size is invalid');
-    if (typeof value.dataUrl !== 'string' || !value.dataUrl.startsWith('data:'))
+    if (
+      typeof value.dataUrl !== 'string' ||
+      !new RegExp(`^data:${escapeRegex(value.type)};base64,[A-Za-z0-9+/]+={0,2}$`).test(
+        value.dataUrl
+      )
+    )
       fail('attachment dataUrl is invalid');
     return { name: value.name, type: value.type, size: value.size, dataUrl: value.dataUrl };
   });
+}
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function requiredCopy(value: unknown, label: string, maximum: number): asserts value is string {

--- a/src/widget/flows/form-screen.ts
+++ b/src/widget/flows/form-screen.ts
@@ -1,0 +1,136 @@
+import { normalizeVariantAnswers, VariantAnswerError } from '../variants/answer-validation';
+import { createFieldController } from '../variants/fields';
+import type { FieldController } from '../variants/fields/types';
+import type { VariantField } from '../variants/public-types';
+import {
+  createAttachmentsController,
+  createCheckboxController,
+  type ExtraFieldController,
+} from './extra-fields';
+import type { FlowField, FlowForm } from './public-types';
+
+export interface FlowFormController {
+  readonly element: HTMLElement;
+  collect(): Promise<Record<string, unknown> | null>;
+  snapshot(): Promise<Record<string, unknown> | null>;
+  dispose(): void;
+}
+
+export function createFlowFormScreen(
+  formConfig: Readonly<FlowForm>,
+  instanceId: string,
+  answers: Readonly<Record<string, unknown>>
+): FlowFormController {
+  const section = createSurface(formConfig);
+  const fields = document.createElement('div');
+  fields.className = 'bdv-fields';
+  section.appendChild(fields);
+  const controllers = formConfig.fields.map(field =>
+    createController(field, formConfig.id, instanceId, answers)
+  );
+  for (const controller of controllers) fields.appendChild(controller.element);
+
+  const read = async (validate: boolean): Promise<Record<string, unknown> | null> => {
+    const standard = controllers.filter(isStandardController);
+    for (const controller of standard) controller.setError(null);
+    let values = Object.fromEntries(
+      standard.map(controller => [controller.field.id, controller.getValue()])
+    );
+    if (validate) {
+      try {
+        values = normalizeVariantAnswers(formConfig.fields.filter(isStandardField), values);
+      } catch (error) {
+        showStandardError(error, standard);
+        return null;
+      }
+    }
+    for (const controller of controllers.filter(isExtraController)) {
+      controller.setRequiredError(false);
+      const readResult = await controller.read(validate);
+      if (!readResult.ok) {
+        controller.focus();
+        return null;
+      }
+      if (
+        validate &&
+        controller.required &&
+        (readResult.value === false ||
+          (Array.isArray(readResult.value) && readResult.value.length === 0))
+      ) {
+        controller.setRequiredError(true);
+        controller.focus();
+        return null;
+      }
+      values[controller.id] = readResult.value;
+    }
+    return values;
+  };
+
+  return {
+    element: section,
+    collect: () => read(true),
+    snapshot: () => read(false),
+    dispose() {
+      for (const controller of controllers) controller.dispose();
+    },
+  };
+}
+
+type Controller = FieldController | ExtraFieldController;
+
+function createController(
+  field: Readonly<FlowField>,
+  formId: string,
+  instanceId: string,
+  answers: Readonly<Record<string, unknown>>
+): Controller {
+  if (field.type === 'checkbox') {
+    return createCheckboxController(field, formId, instanceId, answers);
+  }
+  if (field.type === 'attachments') {
+    return createAttachmentsController(field, formId, instanceId, answers);
+  }
+  const controller = createFieldController(field, instanceId);
+  controller.setValue(answers[`${formId}.${field.id}`] ?? '');
+  return controller;
+}
+
+function createSurface(formConfig: Readonly<FlowForm>): HTMLElement {
+  const section = document.createElement('section');
+  section.className = 'bdv-surface';
+  const header = document.createElement('div');
+  header.className = 'bdv-header';
+  const title = document.createElement('h2');
+  title.className = 'bdv-title';
+  title.textContent = formConfig.title;
+  header.appendChild(title);
+  if (formConfig.description) {
+    const description = document.createElement('p');
+    description.className = 'bdv-description';
+    description.textContent = formConfig.description;
+    header.appendChild(description);
+  }
+  section.appendChild(header);
+  return section;
+}
+
+function showStandardError(error: unknown, controllers: FieldController[]): void {
+  const target =
+    error instanceof VariantAnswerError
+      ? controllers.find(controller => controller.field.id === error.fieldId)
+      : undefined;
+  target?.setError(
+    error instanceof Error ? error.message.replace(/^Answer \S+ /, '') : 'Invalid answer'
+  );
+  target?.focus();
+}
+
+function isStandardField(field: Readonly<FlowField>): field is VariantField {
+  return field.type !== 'checkbox' && field.type !== 'attachments';
+}
+function isStandardController(controller: Controller): controller is FieldController {
+  return 'field' in controller;
+}
+function isExtraController(controller: Controller): controller is ExtraFieldController {
+  return 'read' in controller;
+}

--- a/src/widget/flows/issue-draft.ts
+++ b/src/widget/flows/issue-draft.ts
@@ -11,7 +11,7 @@ export function compileFlowIssueDraft(
   answers: Readonly<Record<string, unknown>>,
   context: Readonly<Record<string, FlowScalar>>
 ): FlowIssueDraft {
-  const title = interpolate(config.issue.title, answers).trim();
+  const title = interpolate(config.issue.title, answers).trim().slice(0, 256);
   if (!title) throw new TypeError('BugDrop flow Issue title cannot be empty');
   const sections = (config.issue.sections ?? [])
     .map(section => compileSection(config, section, answers, context))

--- a/src/widget/flows/issue-draft.ts
+++ b/src/widget/flows/issue-draft.ts
@@ -53,7 +53,7 @@ function formatValue(
       .split('\n')
       .map(line => `> ${line}`)
       .join('\n');
-  if (format === 'code') return `\`${rendered.replaceAll('`', '\\`')}\``;
+  if (format === 'code') return formatInlineCode(rendered);
   if (format === 'stars' && typeof value === 'number' && 'answer' in section) {
     const field = findField(config, section.answer);
     const scale = field?.type === 'rating' ? (field.scale ?? 5) : 5;
@@ -65,6 +65,13 @@ function formatValue(
       return field.options.find(option => option.value === value)?.label ?? rendered;
   }
   return rendered;
+}
+
+function formatInlineCode(value: string): string {
+  const longestRun = Math.max(0, ...[...value.matchAll(/`+/g)].map(match => match[0].length));
+  const delimiter = '`'.repeat(longestRun + 1);
+  const padding = value.startsWith('`') || value.endsWith('`') ? ' ' : '';
+  return `${delimiter}${padding}${value}${padding}${delimiter}`;
 }
 
 function findField(config: Readonly<FlowConfig>, path: string) {

--- a/src/widget/flows/issue-draft.ts
+++ b/src/widget/flows/issue-draft.ts
@@ -1,0 +1,81 @@
+import type { FlowConfig, FlowIssueSection, FlowScalar } from './public-types';
+
+export interface FlowIssueDraft {
+  title: string;
+  description: string;
+  category: 'bug' | 'feature' | 'question';
+}
+
+export function compileFlowIssueDraft(
+  config: Readonly<FlowConfig>,
+  answers: Readonly<Record<string, unknown>>,
+  context: Readonly<Record<string, FlowScalar>>
+): FlowIssueDraft {
+  const title = interpolate(config.issue.title, answers).trim();
+  if (!title) throw new TypeError('BugDrop flow Issue title cannot be empty');
+  const sections = (config.issue.sections ?? [])
+    .map(section => compileSection(config, section, answers, context))
+    .filter((value): value is string => value !== null);
+  return {
+    title,
+    description: sections.join('\n\n'),
+    category: config.issue.classification ?? 'bug',
+  };
+}
+
+function interpolate(template: string, answers: Readonly<Record<string, unknown>>): string {
+  return template.replace(/{{\s*([^{}]+?)\s*}}/g, (_, path: string) =>
+    stringify(answers[path.trim()])
+  );
+}
+
+function compileSection(
+  config: Readonly<FlowConfig>,
+  section: FlowIssueSection,
+  answers: Readonly<Record<string, unknown>>,
+  context: Readonly<Record<string, FlowScalar>>
+): string | null {
+  const value = 'answer' in section ? answers[section.answer] : context[section.context];
+  if (section.omitWhenEmpty && (value === undefined || value === null || value === '')) return null;
+  const rendered = formatValue(config, section, value);
+  return `## ${section.heading}\n\n${rendered}`;
+}
+
+function formatValue(
+  config: Readonly<FlowConfig>,
+  section: FlowIssueSection,
+  value: unknown
+): string {
+  const format = section.format;
+  const rendered = stringify(value);
+  if (format === 'quote')
+    return rendered
+      .split('\n')
+      .map(line => `> ${line}`)
+      .join('\n');
+  if (format === 'code') return `\`${rendered.replaceAll('`', '\\`')}\``;
+  if (format === 'stars' && typeof value === 'number' && 'answer' in section) {
+    const field = findField(config, section.answer);
+    const scale = field?.type === 'rating' ? (field.scale ?? 5) : 5;
+    return `${'★'.repeat(value)}${'☆'.repeat(Math.max(0, scale - value))} (${value}/${scale})`;
+  }
+  if (format === 'choice' && typeof value === 'string' && 'answer' in section) {
+    const field = findField(config, section.answer);
+    if (field?.type === 'singleChoice')
+      return field.options.find(option => option.value === value)?.label ?? rendered;
+  }
+  return rendered;
+}
+
+function findField(config: Readonly<FlowConfig>, path: string) {
+  const separator = path.indexOf('.');
+  const formId = path.slice(0, separator);
+  const fieldId = path.slice(separator + 1);
+  return config.forms.find(form => form.id === formId)?.fields.find(field => field.id === fieldId);
+}
+
+function stringify(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value.trim();
+  return String(value);
+}

--- a/src/widget/flows/manager.ts
+++ b/src/widget/flows/manager.ts
@@ -1,6 +1,7 @@
 import type { FlowConfig, FlowHandle, FlowOpenOptions } from './public-types';
 import { normalizeFlowDefinition, type FlowDefinition } from './definition';
-import { createBusyOpenedFlow, openFlowModal, type FlowModalPorts } from './modal';
+import { createBusyOpenedFlow } from './busy-opened-flow';
+import { openFlowModal, type FlowModalPorts } from './modal';
 import { submitFlow, type FlowTransportConfig } from './submission';
 import { validateAndFreezeFlowConfig } from './validate-config';
 import { normalizeFlowOpenOptions } from './field-validation';

--- a/src/widget/flows/manager.ts
+++ b/src/widget/flows/manager.ts
@@ -1,0 +1,46 @@
+import type { FlowConfig, FlowHandle, FlowOpenOptions } from './public-types';
+import { normalizeFlowDefinition, type FlowDefinition } from './definition';
+import { createBusyOpenedFlow, openFlowModal, type FlowModalPorts } from './modal';
+import { submitFlow, type FlowTransportConfig } from './submission';
+import { validateAndFreezeFlowConfig } from './validate-config';
+import { normalizeFlowOpenOptions } from './field-validation';
+
+export interface FlowManager {
+  register(config: FlowConfig): FlowHandle;
+}
+export function createFlowManager(
+  transport: FlowTransportConfig,
+  ports: Pick<FlowModalPorts, 'preflight' | 'capture'>,
+  runtime: { isLegacyModalOpen(): boolean } = { isLegacyModalOpen: () => false }
+): FlowManager {
+  const flows = new Map<string, FlowDefinition>();
+  return {
+    register(config) {
+      const normalized = validateAndFreezeFlowConfig(config);
+      if (flows.has(normalized.id))
+        throw new TypeError(`BugDrop flow is already registered: ${normalized.id}`);
+      const definition = normalizeFlowDefinition(normalized);
+      flows.set(normalized.id, definition);
+      return Object.freeze({
+        id: normalized.id,
+        open(options?: FlowOpenOptions) {
+          if (runtime.isLegacyModalOpen()) {
+            normalizeFlowOpenOptions(definition, options);
+            return createBusyOpenedFlow(normalized.id);
+          }
+          return openFlowModal(definition, options, {
+            ...ports,
+            submit: flowRuntime =>
+              submitFlow(
+                transport,
+                normalized,
+                flowRuntime.answers,
+                flowRuntime.context,
+                flowRuntime.capture
+              ),
+          });
+        },
+      });
+    },
+  };
+}

--- a/src/widget/flows/message-screen.ts
+++ b/src/widget/flows/message-screen.ts
@@ -1,0 +1,20 @@
+import type { MessageScreen } from './public-types';
+
+export function createMessageScreen(screen: Readonly<MessageScreen>): HTMLElement {
+  const section = document.createElement('section');
+  section.className = 'bdv-surface bdf-message';
+  const header = document.createElement('div');
+  header.className = 'bdv-header';
+  const title = document.createElement('h2');
+  title.className = 'bdv-title';
+  title.textContent = screen.title;
+  header.appendChild(title);
+  if (screen.description) {
+    const description = document.createElement('p');
+    description.className = 'bdv-description';
+    description.textContent = screen.description;
+    header.appendChild(description);
+  }
+  section.appendChild(header);
+  return section;
+}

--- a/src/widget/flows/modal-state.ts
+++ b/src/widget/flows/modal-state.ts
@@ -1,0 +1,63 @@
+import { installRadixDialogCompatibility } from '../radix-compat';
+import { setActiveVariantModal } from '../variants/modal-coordinator';
+
+export interface FlowModalState {
+  readonly host: HTMLElement;
+  readonly shadow: ShadowRoot;
+  readonly overlay: HTMLElement;
+  activate(close: () => void): void;
+  dispose(): void;
+}
+
+export function createFlowModalState(
+  flowId: string,
+  instanceId: string,
+  createRoot: (shadow: ShadowRoot) => { root: HTMLElement; dispose(): void },
+  onKeydown: (event: Event) => void,
+  onBackdrop: (event: PointerEvent) => void
+): FlowModalState {
+  const previousFocus =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const previousOverflow = document.body.style.getPropertyValue('overflow');
+  const previousOverflowPriority = document.body.style.getPropertyPriority('overflow');
+  const host = document.createElement('div');
+  host.dataset.bugdropOwned = '';
+  host.dataset.bugdropFlow = flowId;
+  host.dataset.bugdropInstance = instanceId;
+  Object.assign(host.style, { position: 'fixed', inset: '0', zIndex: '2147483646' });
+  const shadow = host.attachShadow({ mode: 'open' });
+  const styled = createRoot(shadow);
+  const overlay = document.createElement('div');
+  overlay.className = 'bdv-overlay';
+  styled.root.appendChild(overlay);
+  let unregister = () => {};
+  let disposeRadix = () => {};
+  let disposed = false;
+  return {
+    host,
+    shadow,
+    overlay,
+    activate(close) {
+      document.body.style.setProperty('overflow', 'hidden');
+      document.body.appendChild(host);
+      disposeRadix = installRadixDialogCompatibility(host);
+      shadow.addEventListener('keydown', onKeydown);
+      overlay.addEventListener('pointerdown', onBackdrop);
+      unregister = setActiveVariantModal({ close });
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      unregister();
+      shadow.removeEventListener('keydown', onKeydown);
+      overlay.removeEventListener('pointerdown', onBackdrop);
+      disposeRadix();
+      styled.dispose();
+      host.remove();
+      if (previousOverflow)
+        document.body.style.setProperty('overflow', previousOverflow, previousOverflowPriority);
+      else document.body.style.removeProperty('overflow');
+      if (previousFocus?.isConnected) previousFocus.focus();
+    },
+  };
+}

--- a/src/widget/flows/modal-view.ts
+++ b/src/widget/flows/modal-view.ts
@@ -1,0 +1,150 @@
+import type { SubmissionResult } from '../variants/public-types';
+import type { FlowDefinition } from './definition';
+import type { FlowRoute } from './runtime';
+import type { ScreenshotScreen } from './public-types';
+
+export function prepareDialog(surface: HTMLElement, instanceId: string, size: string): HTMLElement {
+  const title = surface.querySelector<HTMLElement>('.bdv-title');
+  const titleId = `${instanceId}-title`;
+  if (title) title.id = titleId;
+  surface.setAttribute('role', 'dialog');
+  surface.setAttribute('aria-modal', 'true');
+  surface.setAttribute('aria-labelledby', titleId);
+  surface.tabIndex = -1;
+  surface.dataset.size = size;
+  return surface;
+}
+
+export function addNavigation(
+  surface: HTMLElement,
+  route: FlowRoute,
+  onBack: () => void,
+  onAdvance: () => void,
+  onClose: () => void
+): void {
+  const screen = route.screen!;
+  const close = button('×', 'bdv-close');
+  close.setAttribute('aria-label', 'Close');
+  close.addEventListener('click', onClose, { once: true });
+  surface.prepend(close);
+  const progress = document.createElement('p');
+  progress.className = 'bdf-progress';
+  progress.textContent = `Step ${route.position} of ${route.total}`;
+  surface.querySelector('.bdv-header')?.prepend(progress);
+  const actions = document.createElement('div');
+  actions.className = 'bdv-actions';
+  if (route.canGoBack) {
+    const back = button(
+      screen.type === 'message' ? 'Back' : (screen.backLabel ?? 'Back'),
+      'bdv-cancel bdf-back'
+    );
+    back.addEventListener('click', onBack);
+    actions.appendChild(back);
+  }
+  const label = screen.continueLabel ?? (route.hasNext ? 'Continue' : 'Submit');
+  const next = button(label, 'bdv-submit');
+  next.addEventListener('click', onAdvance);
+  actions.appendChild(next);
+  surface.appendChild(actions);
+}
+
+export function createScreenshotPrompt(screen: Readonly<ScreenshotScreen>): HTMLElement {
+  const surface = createStatusSurface(
+    screen.title ?? 'Add a screenshot',
+    screen.description ??
+      (screen.mode === 'required'
+        ? 'A screenshot is required before submitting.'
+        : 'Include a screenshot to help explain your feedback.')
+  );
+  if (screen.mode === 'optional') {
+    const row = document.createElement('label');
+    row.className = 'bdf-checkbox';
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.checked = true;
+    input.dataset.screenshot = '';
+    row.append(input, document.createTextNode('Include a screenshot'));
+    surface.appendChild(row);
+  }
+  return surface;
+}
+
+export function createStatusSurface(titleText: string, message: string): HTMLElement {
+  const surface = document.createElement('section');
+  surface.className = 'bdv-surface';
+  const header = document.createElement('div');
+  header.className = 'bdv-header';
+  const title = document.createElement('h2');
+  title.className = 'bdv-title';
+  title.textContent = titleText;
+  const description = document.createElement('p');
+  description.className = 'bdv-description';
+  description.textContent = message;
+  header.append(title, description);
+  surface.appendChild(header);
+  return surface;
+}
+
+export function createErrorSurface(
+  message: string,
+  cancelLabel: string,
+  retry: () => void,
+  close: () => void
+): HTMLElement {
+  const surface = createStatusSurface('Submission failed', message);
+  const actions = document.createElement('div');
+  actions.className = 'bdv-actions';
+  const retryButton = button('Try again', 'bdv-submit');
+  retryButton.addEventListener('click', retry);
+  const cancel = button(cancelLabel, 'bdv-cancel');
+  cancel.addEventListener('click', close);
+  actions.append(retryButton, cancel);
+  surface.appendChild(actions);
+  return surface;
+}
+
+export function createSuccessSurface(
+  definition: FlowDefinition,
+  submission: SubmissionResult,
+  close: () => void
+): HTMLElement {
+  const surface = createStatusSurface(
+    definition.config.content?.successTitle ?? 'Thanks for your feedback!',
+    definition.config.content?.successMessage ?? 'Your response was submitted.'
+  );
+  if (submission.isPublic) {
+    const link = document.createElement('a');
+    link.className = 'bdv-success-link';
+    link.href = submission.issueUrl;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = 'View GitHub Issue';
+    surface.appendChild(link);
+  }
+  const done = button('Done', 'bdv-submit');
+  done.addEventListener('click', close);
+  surface.appendChild(done);
+  return surface;
+}
+
+export function firstFocusable(root: HTMLElement): HTMLElement | null {
+  return root.querySelector<HTMLElement>(
+    'input:not(:disabled), textarea:not(:disabled), button:not(:disabled), a[href]'
+  );
+}
+
+export function focusable(root: HTMLElement): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'button:not(:disabled), input:not(:disabled), textarea:not(:disabled), a[href], [tabindex]:not([tabindex="-1"])'
+    )
+  ).filter(element => !element.hidden && element.getAttribute('aria-hidden') !== 'true');
+}
+
+function button(label: string, className: string): HTMLButtonElement {
+  const value = document.createElement('button');
+  value.type = 'button';
+  value.className = className;
+  value.textContent = label;
+  return value;
+}

--- a/src/widget/flows/modal-view.ts
+++ b/src/widget/flows/modal-view.ts
@@ -133,6 +133,13 @@ export function firstFocusable(root: HTMLElement): HTMLElement | null {
   );
 }
 
+export function deepActiveElement(): HTMLElement | null {
+  let active: Element | null = document.activeElement;
+  while (active instanceof HTMLElement && active.shadowRoot?.activeElement)
+    active = active.shadowRoot.activeElement;
+  return active instanceof HTMLElement ? active : null;
+}
+
 export function focusable(root: HTMLElement): HTMLElement[] {
   return Array.from(
     root.querySelectorAll<HTMLElement>(

--- a/src/widget/flows/modal.ts
+++ b/src/widget/flows/modal.ts
@@ -158,12 +158,17 @@ class FlowModalController {
 
   private async back(screen: NonNullable<ReturnType<FlowRuntime['current']>>): Promise<void> {
     if (this.busy) return;
+    this.busy = true;
     if (screen.type === 'form') {
       const values = await this.currentForm?.snapshot();
-      if (values === null || this.closed) return;
+      if (values === null || this.closed) {
+        this.busy = false;
+        return;
+      }
       if (values) this.runtime.setFormAnswers(screen.form, values);
     }
     this.runtime.back();
+    this.busy = false;
     this.render();
   }
 

--- a/src/widget/flows/modal.ts
+++ b/src/widget/flows/modal.ts
@@ -1,0 +1,311 @@
+import { createRuntimeId } from '../variants/form';
+import { closeActiveVariantModal } from '../variants/modal-coordinator';
+import type { SubmissionResult } from '../variants/public-types';
+import type { FlowDefinition } from './definition';
+import { normalizeFlowOpenOptions } from './field-validation';
+import { createFlowFormScreen, type FlowFormController } from './form-screen';
+import { createMessageScreen } from './message-screen';
+import { createFlowModalState, type FlowModalState } from './modal-state';
+import {
+  addNavigation,
+  createErrorSurface,
+  createScreenshotPrompt,
+  createStatusSurface,
+  createSuccessSurface,
+  firstFocusable,
+  focusable,
+  prepareDialog,
+} from './modal-view';
+import type { FlowOpenOptions, FlowOutcome, OpenedFlow, ScreenshotScreen } from './public-types';
+import { FlowRuntime, type CaptureEvidence } from './runtime';
+import { createStyledFlowRoot } from './styles';
+
+export interface FlowModalPorts {
+  preflight(): Promise<{ status: 'installed' | 'not_installed' | 'unreachable'; appName?: string }>;
+  capture(
+    screen: Readonly<ScreenshotScreen>,
+    include: boolean
+  ): Promise<CaptureEvidence & { returnToForm: boolean }>;
+  submit(runtime: FlowRuntime): Promise<SubmissionResult>;
+}
+
+export function openFlowModal(
+  definition: FlowDefinition,
+  options: FlowOpenOptions | undefined,
+  ports: FlowModalPorts
+): OpenedFlow {
+  const normalized = normalizeFlowOpenOptions(definition, options);
+  closeActiveVariantModal();
+  return new FlowModalController(definition, normalized, ports).open();
+}
+
+class FlowModalController {
+  private readonly instanceId: string;
+  private readonly previousFocus: HTMLElement | null;
+  private readonly runtime: FlowRuntime;
+  private readonly result: Promise<FlowOutcome>;
+  private resolveOutcome!: (outcome: FlowOutcome) => void;
+  private readonly state: FlowModalState;
+  private currentForm: FlowFormController | null = null;
+  private settled = false;
+  private closed = false;
+  private busy = false;
+  private routePreviewVersion = 0;
+
+  constructor(
+    private readonly definition: FlowDefinition,
+    normalized: ReturnType<typeof normalizeFlowOpenOptions>,
+    private readonly ports: FlowModalPorts
+  ) {
+    this.instanceId = createRuntimeId(definition.flowId);
+    this.previousFocus = deepActiveElement();
+    this.runtime = new FlowRuntime(definition, normalized.context, normalized.initialAnswers);
+    this.result = new Promise(resolve => {
+      this.resolveOutcome = resolve;
+    });
+    this.state = createFlowModalState(
+      definition.flowId,
+      this.instanceId,
+      shadow => createStyledFlowRoot(shadow, definition.config),
+      event => this.onKeydown(event),
+      event => this.onBackdrop(event)
+    );
+  }
+
+  open(): OpenedFlow {
+    const opened = Object.freeze({
+      instanceId: this.instanceId,
+      result: this.result,
+      close: () => this.close(),
+    });
+    this.state.activate(opened.close);
+    const checking = createStatusSurface('Preparing feedback', 'Checking installation…');
+    checking.setAttribute('aria-busy', 'true');
+    this.show(checking);
+    void this.preflight();
+    return opened;
+  }
+
+  private async preflight(): Promise<void> {
+    try {
+      const preflight = await this.ports.preflight();
+      if (this.closed) return;
+      if (preflight.status === 'installed') this.render();
+      else {
+        const message =
+          preflight.status === 'not_installed'
+            ? `Install the ${preflight.appName ?? 'BugDrop'} GitHub App to continue.`
+            : 'BugDrop could not reach the feedback service.';
+        this.renderError(message, () => this.close());
+      }
+    } catch {
+      if (!this.closed)
+        this.renderError('BugDrop could not reach the feedback service.', () => this.close());
+    }
+  }
+
+  private render(): void {
+    this.disposeForm();
+    const route = this.runtime.route();
+    const screen = route.screen;
+    if (!screen) {
+      void this.finish();
+      return;
+    }
+    let surface: HTMLElement;
+    if (screen.type === 'message') surface = createMessageScreen(screen);
+    else if (screen.type === 'form') {
+      const form = this.definition.config.forms.find(candidate => candidate.id === screen.form)!;
+      this.currentForm = createFlowFormScreen(form, this.instanceId, this.runtime.answers);
+      surface = this.currentForm.element;
+    } else surface = createScreenshotPrompt(screen);
+    prepareDialog(surface, this.instanceId, this.definition.config.presentation.size ?? 'default');
+    addNavigation(
+      surface,
+      route,
+      () => void this.back(screen),
+      () => void this.advance(screen, surface),
+      () => this.close()
+    );
+    if (screen.type === 'form') {
+      const preview = () => void this.previewFormRoute(screen.form, surface);
+      surface.addEventListener('input', preview);
+      surface.addEventListener('change', preview);
+    }
+    this.show(surface);
+  }
+
+  private async previewFormRoute(formId: string, surface: HTMLElement): Promise<void> {
+    const version = ++this.routePreviewVersion;
+    const values = await this.currentForm?.snapshot();
+    if (!values || version !== this.routePreviewVersion || !surface.isConnected || this.closed)
+      return;
+    this.runtime.setFormAnswers(formId, values);
+    const route = this.runtime.route();
+    const screen = route.screen;
+    if (!screen) return;
+    const progress = surface.querySelector<HTMLElement>('.bdf-progress');
+    if (progress) progress.textContent = `Step ${route.position} of ${route.total}`;
+    const next = surface.querySelector<HTMLButtonElement>('.bdv-submit');
+    if (next) next.textContent = screen.continueLabel ?? (route.hasNext ? 'Continue' : 'Submit');
+  }
+
+  private async back(screen: NonNullable<ReturnType<FlowRuntime['current']>>): Promise<void> {
+    if (this.busy) return;
+    if (screen.type === 'form') {
+      const values = await this.currentForm?.snapshot();
+      if (values === null || this.closed) return;
+      if (values) this.runtime.setFormAnswers(screen.form, values);
+    }
+    this.runtime.back();
+    this.render();
+  }
+
+  private async advance(
+    screen: NonNullable<ReturnType<FlowRuntime['current']>>,
+    surface: HTMLElement
+  ): Promise<void> {
+    if (this.busy) return;
+    if (screen.type === 'form') {
+      const values = await this.currentForm?.collect();
+      if (!values || this.closed) return;
+      this.runtime.setFormAnswers(screen.form, values);
+    }
+    if (screen.type === 'screenshot') {
+      await this.capture(screen, surface);
+      return;
+    }
+    if (!this.runtime.next()) await this.finish();
+    else this.render();
+  }
+
+  private async capture(screen: Readonly<ScreenshotScreen>, surface: HTMLElement): Promise<void> {
+    const include =
+      screen.mode !== 'optional' ||
+      Boolean(surface.querySelector<HTMLInputElement>('[data-screenshot]')?.checked);
+    this.busy = true;
+    this.state.host.hidden = true;
+    try {
+      const capture = await this.ports.capture(screen, include);
+      if (this.closed) return;
+      if (capture.returnToForm) this.runtime.back();
+      else {
+        this.runtime.capture = capture;
+        if (!this.runtime.next()) {
+          this.busy = false;
+          await this.finish();
+          return;
+        }
+      }
+    } finally {
+      this.busy = false;
+      this.state.host.hidden = false;
+    }
+    if (!this.closed) this.render();
+  }
+
+  private async finish(): Promise<void> {
+    if (this.busy || this.closed) return;
+    this.busy = true;
+    const status = createStatusSurface('Submitting feedback', 'Submitting…');
+    status.setAttribute('aria-busy', 'true');
+    this.show(status);
+    try {
+      const submission = await this.ports.submit(this.runtime);
+      if (this.closed) return;
+      this.settle({ status: 'submitted', result: submission });
+      this.busy = false;
+      this.show(createSuccessSurface(this.definition, submission, () => this.close(false)));
+    } catch (error) {
+      if (this.closed) return;
+      this.busy = false;
+      this.renderError(
+        error instanceof Error ? error.message : 'Failed to submit feedback',
+        () => void this.finish()
+      );
+    }
+  }
+
+  private renderError(message: string, retry: () => void): void {
+    this.show(
+      createErrorSurface(
+        message,
+        this.definition.config.content?.cancelLabel ?? 'Cancel',
+        retry,
+        () => this.close()
+      )
+    );
+  }
+
+  private show(surface: HTMLElement): void {
+    prepareDialog(surface, this.instanceId, this.definition.config.presentation.size ?? 'default');
+    this.state.overlay.replaceChildren(surface);
+    queueMicrotask(() => (firstFocusable(surface) ?? surface).focus());
+  }
+
+  private close(settleClosed = true): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (settleClosed) this.settle({ status: 'closed' });
+    this.disposeForm();
+    this.state.dispose();
+    if (this.previousFocus?.isConnected) this.previousFocus.focus();
+  }
+
+  private settle(outcome: FlowOutcome): void {
+    if (this.settled) return;
+    this.settled = true;
+    this.resolveOutcome(outcome);
+  }
+
+  private disposeForm(): void {
+    this.routePreviewVersion += 1;
+    this.currentForm?.dispose();
+    this.currentForm = null;
+  }
+
+  private onKeydown(event: Event): void {
+    if (!(event instanceof KeyboardEvent)) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.close();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const elements = focusable(this.state.overlay);
+    if (!elements.length) {
+      event.preventDefault();
+      this.state.overlay.querySelector<HTMLElement>('[role="dialog"]')?.focus();
+      return;
+    }
+    const first = elements[0]!;
+    const last = elements.at(-1)!;
+    const active = this.state.shadow.activeElement;
+    if (event.shiftKey && (active === first || !this.state.overlay.contains(active))) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  private onBackdrop(event: PointerEvent): void {
+    if (event.target === this.state.overlay) this.close();
+  }
+}
+
+function deepActiveElement(): HTMLElement | null {
+  let active: Element | null = document.activeElement;
+  while (active instanceof HTMLElement && active.shadowRoot?.activeElement)
+    active = active.shadowRoot.activeElement;
+  return active instanceof HTMLElement ? active : null;
+}
+
+export function createBusyOpenedFlow(flowId: string): OpenedFlow {
+  return Object.freeze({
+    instanceId: createRuntimeId(flowId),
+    result: Promise.resolve<FlowOutcome>({ status: 'busy' }),
+    close() {},
+  });
+}

--- a/src/widget/flows/modal.ts
+++ b/src/widget/flows/modal.ts
@@ -12,6 +12,7 @@ import {
   createScreenshotPrompt,
   createStatusSurface,
   createSuccessSurface,
+  deepActiveElement,
   firstFocusable,
   focusable,
   prepareDialog,
@@ -19,16 +20,15 @@ import {
 import type { FlowOpenOptions, FlowOutcome, OpenedFlow, ScreenshotScreen } from './public-types';
 import { FlowRuntime, type CaptureEvidence } from './runtime';
 import { createStyledFlowRoot } from './styles';
-
 export interface FlowModalPorts {
   preflight(): Promise<{ status: 'installed' | 'not_installed' | 'unreachable'; appName?: string }>;
   capture(
     screen: Readonly<ScreenshotScreen>,
-    include: boolean
+    include: boolean,
+    signal: AbortSignal
   ): Promise<CaptureEvidence & { returnToForm: boolean }>;
   submit(runtime: FlowRuntime): Promise<SubmissionResult>;
 }
-
 export function openFlowModal(
   definition: FlowDefinition,
   options: FlowOpenOptions | undefined,
@@ -38,7 +38,6 @@ export function openFlowModal(
   closeActiveVariantModal();
   return new FlowModalController(definition, normalized, ports).open();
 }
-
 class FlowModalController {
   private readonly instanceId: string;
   private readonly previousFocus: HTMLElement | null;
@@ -51,6 +50,8 @@ class FlowModalController {
   private closed = false;
   private busy = false;
   private routePreviewVersion = 0;
+  private preflightVersion = 0;
+  private captureAbortController: AbortController | null = null;
 
   constructor(
     private readonly definition: FlowDefinition,
@@ -87,9 +88,10 @@ class FlowModalController {
   }
 
   private async preflight(): Promise<void> {
+    const version = ++this.preflightVersion;
     try {
       const preflight = await this.ports.preflight();
-      if (this.closed) return;
+      if (this.closed || version !== this.preflightVersion) return;
       if (preflight.status === 'installed') this.render();
       else {
         const message =
@@ -99,7 +101,7 @@ class FlowModalController {
         this.renderError(message, () => void this.preflight());
       }
     } catch {
-      if (!this.closed)
+      if (!this.closed && version === this.preflightVersion)
         this.renderError(
           'BugDrop could not reach the feedback service.',
           () => void this.preflight()
@@ -188,8 +190,10 @@ class FlowModalController {
       Boolean(surface.querySelector<HTMLInputElement>('[data-screenshot]')?.checked);
     this.busy = true;
     this.state.host.hidden = true;
+    const abortController = new AbortController();
+    this.captureAbortController = abortController;
     try {
-      const capture = await this.ports.capture(screen, include);
+      const capture = await this.ports.capture(screen, include, abortController.signal);
       if (this.closed) return;
       if (capture.returnToForm) this.runtime.back();
       else {
@@ -201,6 +205,7 @@ class FlowModalController {
         }
       }
     } finally {
+      if (this.captureAbortController === abortController) this.captureAbortController = null;
       this.busy = false;
       this.state.host.hidden = false;
     }
@@ -249,6 +254,9 @@ class FlowModalController {
   private close(settleClosed = true): void {
     if (this.closed) return;
     this.closed = true;
+    this.preflightVersion += 1;
+    this.captureAbortController?.abort();
+    this.captureAbortController = null;
     if (settleClosed) this.settle({ status: 'closed' });
     this.disposeForm();
     this.state.dispose();
@@ -296,13 +304,6 @@ class FlowModalController {
   private onBackdrop(event: PointerEvent): void {
     if (event.target === this.state.overlay) this.close();
   }
-}
-
-function deepActiveElement(): HTMLElement | null {
-  let active: Element | null = document.activeElement;
-  while (active instanceof HTMLElement && active.shadowRoot?.activeElement)
-    active = active.shadowRoot.activeElement;
-  return active instanceof HTMLElement ? active : null;
 }
 
 export function createBusyOpenedFlow(flowId: string): OpenedFlow {

--- a/src/widget/flows/modal.ts
+++ b/src/widget/flows/modal.ts
@@ -96,11 +96,14 @@ class FlowModalController {
           preflight.status === 'not_installed'
             ? `Install the ${preflight.appName ?? 'BugDrop'} GitHub App to continue.`
             : 'BugDrop could not reach the feedback service.';
-        this.renderError(message, () => this.close());
+        this.renderError(message, () => void this.preflight());
       }
     } catch {
       if (!this.closed)
-        this.renderError('BugDrop could not reach the feedback service.', () => this.close());
+        this.renderError(
+          'BugDrop could not reach the feedback service.',
+          () => void this.preflight()
+        );
     }
   }
 

--- a/src/widget/flows/modal.ts
+++ b/src/widget/flows/modal.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { createRuntimeId } from '../variants/form';
 import { closeActiveVariantModal } from '../variants/modal-coordinator';
 import type { SubmissionResult } from '../variants/public-types';
@@ -171,17 +172,27 @@ class FlowModalController {
     surface: HTMLElement
   ): Promise<void> {
     if (this.busy) return;
+    this.busy = true;
     if (screen.type === 'form') {
       const values = await this.currentForm?.collect();
-      if (!values || this.closed) return;
+      if (!values || this.closed) {
+        this.busy = false;
+        return;
+      }
       this.runtime.setFormAnswers(screen.form, values);
     }
     if (screen.type === 'screenshot') {
+      this.busy = false;
       await this.capture(screen, surface);
       return;
     }
-    if (!this.runtime.next()) await this.finish();
-    else this.render();
+    if (!this.runtime.next()) {
+      this.busy = false;
+      await this.finish();
+    } else {
+      this.busy = false;
+      this.render();
+    }
   }
 
   private async capture(screen: Readonly<ScreenshotScreen>, surface: HTMLElement): Promise<void> {
@@ -304,12 +315,4 @@ class FlowModalController {
   private onBackdrop(event: PointerEvent): void {
     if (event.target === this.state.overlay) this.close();
   }
-}
-
-export function createBusyOpenedFlow(flowId: string): OpenedFlow {
-  return Object.freeze({
-    instanceId: createRuntimeId(flowId),
-    result: Promise.resolve<FlowOutcome>({ status: 'busy' }),
-    close() {},
-  });
 }

--- a/src/widget/flows/public-types.d.ts
+++ b/src/widget/flows/public-types.d.ts
@@ -1,0 +1,135 @@
+import type {
+  SubmissionResult,
+  VariantContext,
+  VariantField,
+  VariantTheme,
+} from '../variants/public-types';
+
+export interface CheckboxField {
+  id: string;
+  type: 'checkbox';
+  label: string;
+  helpText?: string;
+  required?: boolean;
+  initialValue?: boolean;
+  layout?: { span?: 1 | 2 };
+}
+
+export interface AttachmentsField {
+  id: string;
+  type: 'attachments';
+  label: string;
+  helpText?: string;
+  required?: boolean;
+  maxFiles?: number;
+  maxFileSize?: number;
+  accept?: string[];
+  layout?: { span?: 1 | 2 };
+}
+
+export type FlowField = VariantField | CheckboxField | AttachmentsField;
+export type FlowScalar = string | number | boolean | null;
+
+export type FlowCondition =
+  | { answer: string; equals: FlowScalar }
+  | { context: string; equals: FlowScalar }
+  | { all: FlowCondition[] }
+  | { any: FlowCondition[] };
+
+export interface FlowForm {
+  id: string;
+  title: string;
+  description?: string;
+  fields: FlowField[];
+}
+
+interface BaseScreen {
+  id: string;
+  when?: FlowCondition;
+}
+
+export interface MessageScreen extends BaseScreen {
+  type: 'message';
+  title: string;
+  description?: string;
+  continueLabel?: string;
+}
+
+export interface FormScreen extends BaseScreen {
+  type: 'form';
+  form: string;
+  continueLabel?: string;
+  backLabel?: string;
+}
+
+export interface ScreenshotScreen extends BaseScreen {
+  type: 'screenshot';
+  title?: string;
+  description?: string;
+  mode: 'optional' | 'auto' | 'required';
+  continueLabel?: string;
+  backLabel?: string;
+}
+
+export type FlowScreen = MessageScreen | FormScreen | ScreenshotScreen;
+
+export type FlowIssueSection =
+  | {
+      heading: string;
+      answer: string;
+      format?: 'text' | 'quote' | 'stars' | 'choice' | 'code';
+      omitWhenEmpty?: boolean;
+    }
+  | {
+      heading: string;
+      context: string;
+      format?: 'text' | 'code';
+      omitWhenEmpty?: boolean;
+    };
+
+export interface FlowConfig {
+  configVersion: 1;
+  id: string;
+  presentation: { kind: 'modal'; size?: 'compact' | 'default' | 'wide'; columns?: 1 | 2 };
+  appearance?: {
+    theme?: VariantTheme;
+    accentColor?: string;
+    density?: 'compact' | 'comfortable';
+  };
+  content?: {
+    successTitle?: string;
+    successMessage?: string;
+    cancelLabel?: string;
+  };
+  forms: FlowForm[];
+  screens: FlowScreen[];
+  issue: {
+    classification?: 'bug' | 'feature' | 'question';
+    title: string;
+    sections?: FlowIssueSection[];
+  };
+  evidence?: {
+    attachments?: string;
+    sendConsoleLogs?: string;
+    submitter?: { name?: string; email?: string };
+  };
+}
+
+export interface FlowOpenOptions {
+  context?: VariantContext;
+  initialAnswers?: Record<string, unknown>;
+}
+
+export type FlowOutcome =
+  { status: 'submitted'; result: SubmissionResult } | { status: 'closed' } | { status: 'busy' };
+
+export interface OpenedFlow {
+  readonly instanceId: string;
+  readonly result: Promise<FlowOutcome>;
+  close(): void;
+}
+
+export interface FlowHandle {
+  readonly id: string;
+  open(options?: FlowOpenOptions): OpenedFlow;
+}

--- a/src/widget/flows/runtime.ts
+++ b/src/widget/flows/runtime.ts
@@ -1,0 +1,135 @@
+import { evaluateCondition } from './conditions';
+import type { FlowDefinition } from './definition';
+import type { FlowScalar, FlowScreen } from './public-types';
+
+export interface CaptureEvidence {
+  screenshot: string | null;
+  elementSelector: string | null;
+  fullElementSelector: string | null;
+}
+
+export interface FlowRoute {
+  readonly screen: Readonly<FlowScreen> | undefined;
+  readonly position: number;
+  readonly total: number;
+  readonly canGoBack: boolean;
+  readonly hasNext: boolean;
+}
+
+export class FlowRuntime {
+  readonly answers: Record<string, unknown>;
+  capture: CaptureEvidence | null = null;
+  private currentId: string;
+
+  constructor(
+    readonly definition: FlowDefinition,
+    readonly context: Readonly<Record<string, FlowScalar>>,
+    initialAnswers: Record<string, unknown> = {}
+  ) {
+    this.answers = { ...initialAnswers };
+    this.reconcileInitiallyHidden();
+    this.currentId = this.visibleScreens()[0]?.id ?? '';
+  }
+
+  current(): Readonly<FlowScreen> | undefined {
+    return this.route().screen;
+  }
+
+  route(): FlowRoute {
+    const visible = this.visibleScreens();
+    const found = visible.findIndex(screen => screen.id === this.currentId);
+    const index = found >= 0 ? found : 0;
+    return Object.freeze({
+      screen: visible[index],
+      position: visible.length === 0 ? 0 : index + 1,
+      total: visible.length,
+      canGoBack: index > 0,
+      hasNext: index >= 0 && index < visible.length - 1,
+    });
+  }
+
+  setFormAnswers(formId: string, values: Record<string, unknown>): void {
+    const previouslyVisible = new Set(this.visibleScreens().map(screen => screen.id));
+    const paths = this.definition.screenAnswerPaths.get(
+      this.definition.screens.find(screen => screen.type === 'form' && screen.form === formId)!.id
+    )!;
+    for (const path of paths) {
+      const fieldId = path.slice(formId.length + 1);
+      this.answers[path] = values[fieldId];
+    }
+    this.reconcileNewlyHidden(previouslyVisible);
+  }
+
+  next(): boolean {
+    const route = this.route();
+    const visible = this.visibleScreens();
+    if (route.hasNext) {
+      this.currentId = visible[route.position]!.id;
+      return true;
+    }
+    return false;
+  }
+
+  back(): boolean {
+    const route = this.route();
+    const visible = this.visibleScreens();
+    if (route.canGoBack) {
+      this.currentId = visible[route.position - 2]!.id;
+      return true;
+    }
+    return false;
+  }
+
+  hasNext(): boolean {
+    return this.route().hasNext;
+  }
+
+  private visibleScreens(): readonly Readonly<FlowScreen>[] {
+    return this.definition.screens.filter(screen =>
+      evaluateCondition(screen.when, this.answers, this.context)
+    );
+  }
+
+  private reconcileInitiallyHidden(): void {
+    for (const screen of this.definition.screens) {
+      if (evaluateCondition(screen.when, this.answers, this.context)) continue;
+      this.clearScreenState(screen);
+    }
+  }
+
+  private reconcileNewlyHidden(previouslyVisible: ReadonlySet<string>): void {
+    let visible = new Set(this.visibleScreens().map(screen => screen.id));
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const screen of this.definition.screens) {
+        if (!previouslyVisible.has(screen.id) || visible.has(screen.id)) continue;
+        changed = this.clearScreenState(screen) || changed;
+      }
+      if (changed) visible = new Set(this.visibleScreens().map(screen => screen.id));
+    }
+    if (!visible.has(this.currentId)) this.currentId = this.nearestVisibleId(visible);
+  }
+
+  private clearScreenState(screen: Readonly<FlowScreen>): boolean {
+    let changed = false;
+    for (const path of this.definition.screenAnswerPaths.get(screen.id) ?? []) {
+      if (Object.prototype.hasOwnProperty.call(this.answers, path)) changed = true;
+      delete this.answers[path];
+    }
+    if (screen.type === 'screenshot' && this.capture !== null) {
+      this.capture = null;
+      changed = true;
+    }
+    return changed;
+  }
+
+  private nearestVisibleId(visible: ReadonlySet<string>): string {
+    const oldIndex = this.definition.screens.findIndex(screen => screen.id === this.currentId);
+    for (let index = oldIndex; index >= 0; index -= 1) {
+      const candidate = this.definition.screens[index];
+      if (candidate && visible.has(candidate.id)) return candidate.id;
+    }
+    return this.visibleScreens()[0]?.id ?? '';
+  }
+}

--- a/src/widget/flows/styles.ts
+++ b/src/widget/flows/styles.ts
@@ -1,0 +1,33 @@
+import { createStyledVariantRoot } from '../variants/styles';
+import type { VariantConfig } from '../variants/public-types';
+import type { FlowConfig } from './public-types';
+
+export function createStyledFlowRoot(shadow: ShadowRoot, config: Readonly<FlowConfig>) {
+  const adapter: Readonly<VariantConfig> = {
+    id: config.id,
+    presentation: config.presentation,
+    appearance: config.appearance,
+    content: { title: config.id },
+    fields: [{ id: 'placeholder', type: 'shortText', label: 'Placeholder' }],
+    issue: { title: config.id },
+  };
+  const styled = createStyledVariantRoot(shadow, adapter, 'modal');
+  const extra = document.createElement('style');
+  extra.textContent = `
+    .bdf-progress { margin: 0 0 12px; color: var(--bdv-text-muted); font-size: .8rem; }
+    .bdf-message { min-height: 180px; display: grid; align-content: center; }
+    .bdf-attachment { display: grid; gap: 7px; }
+    .bdf-checkbox { display: flex; min-height: 44px; align-items: center; gap: 10px; }
+    .bdf-checkbox input { width: 20px; height: 20px; accent-color: var(--bdv-accent); }
+    .bdf-file-list { margin: 0; padding-left: 20px; color: var(--bdv-text-muted); }
+    .bdf-back { order: -1; }
+  `;
+  shadow.prepend(extra);
+  return {
+    root: styled.root,
+    dispose() {
+      extra.remove();
+      styled.dispose();
+    },
+  };
+}

--- a/src/widget/flows/submission.ts
+++ b/src/widget/flows/submission.ts
@@ -1,0 +1,102 @@
+import { getAuthHeaders, type BugDropAuthTokenProvider } from '../auth-token';
+import { getConsoleLogSnapshot } from '../console-logs';
+import { getDomNodeCount, isFullPageDisabled } from '../screenshot';
+import type { SubmissionResult } from '../variants/public-types';
+import type { CaptureEvidence } from './runtime';
+import type { FlowConfig, FlowScalar } from './public-types';
+import { compileFlowIssueDraft } from './issue-draft';
+
+export interface FlowTransportConfig {
+  repo: string;
+  apiUrl: string;
+  authTokenProvider?: BugDropAuthTokenProvider;
+}
+
+export async function submitFlow(
+  transport: FlowTransportConfig,
+  config: Readonly<FlowConfig>,
+  answers: Readonly<Record<string, unknown>>,
+  context: Readonly<Record<string, FlowScalar>>,
+  capture: CaptureEvidence | null
+): Promise<SubmissionResult> {
+  const issue = compileFlowIssueDraft(config, answers, context);
+  const attachmentsPath = config.evidence?.attachments;
+  const logsPath = config.evidence?.sendConsoleLogs;
+  const namePath = config.evidence?.submitter?.name;
+  const emailPath = config.evidence?.submitter?.email;
+  const submitter =
+    namePath || emailPath
+      ? { name: readString(answers[namePath ?? '']), email: readString(answers[emailPath ?? '']) }
+      : undefined;
+  const response = await fetch(`${transport.apiUrl}/feedback`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await getAuthHeaders(transport.authTokenProvider)),
+    },
+    body: JSON.stringify({
+      repo: transport.repo,
+      title: issue.title,
+      description: issue.description,
+      category: issue.category,
+      screenshot: capture?.screenshot ?? null,
+      attachments: attachmentsPath ? (answers[attachmentsPath] ?? []) : [],
+      consoleLogs: logsPath && answers[logsPath] === true ? getConsoleLogSnapshot() : undefined,
+      submitter: submitter && (submitter.name || submitter.email) ? submitter : undefined,
+      metadata: collectMetadata(capture),
+    }),
+  });
+  if (response.status === 429) throw new Error('Too many submissions. Please try again later.');
+  const result = (await response.json()) as Record<string, unknown>;
+  if (!response.ok || result.success !== true)
+    throw new Error(typeof result.error === 'string' ? result.error : 'Failed to submit feedback');
+  if (
+    !Number.isInteger(result.issueNumber) ||
+    (result.issueNumber as number) <= 0 ||
+    typeof result.issueUrl !== 'string' ||
+    typeof result.isPublic !== 'boolean' ||
+    !isCanonicalIssueUrl(result.issueUrl, transport.repo, result.issueNumber as number)
+  )
+    throw new Error('BugDrop received an invalid Issue result');
+  return {
+    issueNumber: result.issueNumber as number,
+    issueUrl: result.issueUrl,
+    isPublic: result.isPublic,
+  };
+}
+
+function isCanonicalIssueUrl(value: string, repo: string, issueNumber: number): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.origin === 'https://github.com' &&
+      url.pathname === `/${repo}/issues/${issueNumber}` &&
+      !url.search &&
+      !url.hash
+    );
+  } catch {
+    return false;
+  }
+}
+
+function collectMetadata(capture: CaptureEvidence | null) {
+  const url = new URL(window.location.href);
+  url.search = '';
+  url.hash = '';
+  return {
+    url: url.toString(),
+    userAgent: navigator.userAgent,
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    timestamp: new Date().toISOString(),
+    elementSelector: capture?.elementSelector ?? null,
+    fullElementSelector: capture?.fullElementSelector ?? null,
+    domNodeCount: getDomNodeCount(),
+    fullPageDisabled: isFullPageDisabled(),
+    devicePixelRatio: window.devicePixelRatio,
+    language: navigator.language,
+  };
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}

--- a/src/widget/flows/submission.ts
+++ b/src/widget/flows/submission.ts
@@ -10,6 +10,7 @@ export interface FlowTransportConfig {
   repo: string;
   apiUrl: string;
   authTokenProvider?: BugDropAuthTokenProvider;
+  categoryLabels?: Partial<Record<'bug' | 'feature' | 'question', string | string[]>>;
 }
 
 export async function submitFlow(
@@ -39,6 +40,7 @@ export async function submitFlow(
       title: issue.title,
       description: issue.description,
       category: issue.category,
+      categoryLabels: transport.categoryLabels,
       screenshot: capture?.screenshot ?? null,
       attachments: attachmentsPath ? (answers[attachmentsPath] ?? []) : [],
       consoleLogs: logsPath && answers[logsPath] === true ? getConsoleLogSnapshot() : undefined,
@@ -62,6 +64,10 @@ export async function submitFlow(
     issueNumber: result.issueNumber as number,
     issueUrl: result.issueUrl,
     isPublic: result.isPublic,
+    ...(Array.isArray(result.labelMappingWarnings) &&
+    result.labelMappingWarnings.every(value => typeof value === 'string')
+      ? { labelMappingWarnings: result.labelMappingWarnings as string[] }
+      : {}),
   };
 }
 

--- a/src/widget/flows/submission.ts
+++ b/src/widget/flows/submission.ts
@@ -76,7 +76,7 @@ function isCanonicalIssueUrl(value: string, repo: string, issueNumber: number): 
     const url = new URL(value);
     return (
       url.origin === 'https://github.com' &&
-      url.pathname === `/${repo}/issues/${issueNumber}` &&
+      url.pathname.toLowerCase() === `/${repo}/issues/${issueNumber}`.toLowerCase() &&
       !url.search &&
       !url.hash
     );

--- a/src/widget/flows/validate-config.ts
+++ b/src/widget/flows/validate-config.ts
@@ -1,0 +1,307 @@
+import { countConditionNodes } from './conditions';
+import { validateFlowFieldConfig, validateFlowShell } from './field-validation';
+import type {
+  FlowCondition,
+  FlowConfig,
+  FlowField,
+  FlowIssueSection,
+  FlowScreen,
+} from './public-types';
+const ID = /^[a-z][a-z0-9_-]{0,63}$/;
+const PATH = /^([a-z][a-z0-9_-]{0,63})\.([a-z][a-z0-9_-]{0,63})$/;
+const TOP_KEYS = new Set([
+  'configVersion',
+  'id',
+  'presentation',
+  'appearance',
+  'content',
+  'forms',
+  'screens',
+  'issue',
+  'evidence',
+]);
+const BASE_FIELD_KEYS = ['id', 'type', 'label', 'helpText', 'required', 'layout'];
+const FIELD_KEYS: Record<FlowField['type'], Set<string>> = {
+  shortText: new Set([...BASE_FIELD_KEYS, 'placeholder', 'minLength', 'maxLength']),
+  longText: new Set([...BASE_FIELD_KEYS, 'placeholder', 'rows', 'minLength', 'maxLength']),
+  rating: new Set([...BASE_FIELD_KEYS, 'scale', 'icon', 'lowLabel', 'highLabel']),
+  singleChoice: new Set([...BASE_FIELD_KEYS, 'options', 'display']),
+  checkbox: new Set([...BASE_FIELD_KEYS, 'initialValue']),
+  attachments: new Set([...BASE_FIELD_KEYS, 'maxFiles', 'maxFileSize', 'accept']),
+};
+export function validateAndFreezeFlowConfig(input: FlowConfig): Readonly<FlowConfig> {
+  if (!object(input)) fail('config must be an object');
+  only(input, TOP_KEYS, 'config');
+  if (input.configVersion !== 1) fail('configVersion must be 1');
+  validId(input.id, 'id');
+  validateFlowShell(input);
+  if (!Array.isArray(input.forms) || input.forms.length === 0 || input.forms.length > 12) {
+    fail('forms must contain 1-12 entries');
+  }
+  if (!Array.isArray(input.screens) || input.screens.length === 0 || input.screens.length > 20) {
+    fail('screens must contain 1-20 entries');
+  }
+
+  const answerFields = new Map<string, FlowField>();
+  const forms = new Map<string, FlowConfig['forms'][number]>();
+  for (const form of input.forms) validateForm(form, forms, answerFields);
+  const referencedForms = new Set<string>();
+  const earlierAnswers = new Set<string>();
+  let screenshots = 0;
+  const screenIds = new Set<string>();
+  for (const screen of input.screens) {
+    validateScreen(screen, screenIds, forms, earlierAnswers);
+    if (screen.type === 'form') {
+      if (referencedForms.has(screen.form)) fail(`form ${screen.form} may be referenced only once`);
+      referencedForms.add(screen.form);
+      for (const field of forms.get(screen.form)!.fields)
+        earlierAnswers.add(`${screen.form}.${field.id}`);
+    }
+    if (screen.type === 'screenshot' && ++screenshots > 1)
+      fail('only one screenshot screen is supported');
+  }
+  for (const formId of forms.keys())
+    if (!referencedForms.has(formId)) fail(`form ${formId} is unused`);
+  validateIssue(input.issue, answerFields);
+  validateEvidence(input.evidence, answerFields);
+  return deepFreeze(structuredClone(input));
+}
+
+function validateForm(
+  form: FlowConfig['forms'][number],
+  forms: Map<string, FlowConfig['forms'][number]>,
+  answerFields: Map<string, FlowField>
+) {
+  if (!object(form)) fail('form must be an object');
+  only(form, new Set(['id', 'title', 'description', 'fields']), 'form');
+  validId(form.id, 'form id');
+  if (forms.has(form.id)) fail(`duplicate form id ${form.id}`);
+  text(form.title, 'form title', 500);
+  optionalText(form.description, 'form description', 2_000);
+  if (!Array.isArray(form.fields) || form.fields.length === 0 || form.fields.length > 20)
+    fail('form fields must contain 1-20 entries');
+  const ids = new Set<string>();
+  for (const field of form.fields) {
+    if (!object(field) || typeof field.type !== 'string' || !(field.type in FIELD_KEYS))
+      fail('field type is unsupported');
+    only(field, FIELD_KEYS[field.type as FlowField['type']], 'field');
+    validId(field.id, 'field id');
+    if (ids.has(field.id)) fail(`duplicate field id ${field.id}`);
+    ids.add(field.id);
+    text(field.label, 'field label', 500);
+    optionalText(field.helpText, 'field helpText', 1_000);
+    if (field.required !== undefined && typeof field.required !== 'boolean')
+      fail('field required must be boolean');
+    validateFlowFieldConfig(field as FlowField);
+    answerFields.set(`${form.id}.${field.id}`, field as FlowField);
+  }
+  forms.set(form.id, form);
+}
+
+function validateScreen(
+  screen: FlowScreen,
+  ids: Set<string>,
+  forms: Map<string, FlowConfig['forms'][number]>,
+  earlier: Set<string>
+) {
+  if (!object(screen)) fail('screen must be an object');
+  validId(screen.id, 'screen id');
+  if (ids.has(screen.id)) fail(`duplicate screen id ${screen.id}`);
+  ids.add(screen.id);
+  if (!['message', 'form', 'screenshot'].includes(screen.type)) fail('screen type is unsupported');
+  const keys =
+    screen.type === 'message'
+      ? new Set(['id', 'type', 'when', 'title', 'description', 'continueLabel'])
+      : screen.type === 'form'
+        ? new Set(['id', 'type', 'when', 'form', 'continueLabel', 'backLabel'])
+        : new Set([
+            'id',
+            'type',
+            'when',
+            'title',
+            'description',
+            'mode',
+            'continueLabel',
+            'backLabel',
+          ]);
+  only(screen, keys, 'screen');
+  if (Object.prototype.hasOwnProperty.call(screen, 'when'))
+    validateCondition(screen.when as FlowCondition, earlier);
+  if (screen.type === 'message') {
+    text(screen.title, 'message title', 500);
+    optionalText(screen.description, 'message description', 2_000);
+  }
+  if (screen.type === 'form' && !forms.has(screen.form))
+    fail(`screen references unknown form ${screen.form}`);
+  if (screen.type === 'screenshot' && !['optional', 'auto', 'required'].includes(screen.mode))
+    fail('screenshot mode is invalid');
+  if (screen.type === 'screenshot') {
+    optionalText(screen.title, 'screenshot title', 500);
+    optionalText(screen.description, 'screenshot description', 2_000);
+  }
+  optionalText(screen.continueLabel, 'screen continueLabel', 120);
+  if (screen.type !== 'message') optionalText(screen.backLabel, 'screen backLabel', 120);
+}
+
+function validateCondition(condition: FlowCondition, earlier: Set<string>) {
+  if (!object(condition)) fail('condition must be an object');
+  countConditionNodes(condition);
+  if ('answer' in condition) {
+    only(condition, new Set(['answer', 'equals']), 'answer condition');
+    if (!earlier.has(condition.answer))
+      fail(`condition answer must reference an earlier field: ${condition.answer}`);
+    scalar(condition.equals, 'condition equals');
+    return;
+  }
+  if ('context' in condition) {
+    only(condition, new Set(['context', 'equals']), 'context condition');
+    validId(condition.context, 'condition context');
+    scalar(condition.equals, 'condition equals');
+    return;
+  }
+  const key = 'all' in condition ? 'all' : 'any' in condition ? 'any' : null;
+  if (!key) fail('condition must contain answer, context, all, or any');
+  only(condition, new Set([key]), 'condition group');
+  const children =
+    key === 'all'
+      ? (condition as Extract<FlowCondition, { all: FlowCondition[] }>).all
+      : (condition as Extract<FlowCondition, { any: FlowCondition[] }>).any;
+  if (!Array.isArray(children) || children.length < 1 || children.length > 8)
+    fail(`condition ${key} must contain 1-8 entries`);
+  for (const child of children) validateCondition(child, earlier);
+}
+
+function validateIssue(issue: FlowConfig['issue'], answers: Map<string, FlowField>) {
+  if (!object(issue)) fail('issue must be an object');
+  only(issue, new Set(['classification', 'title', 'sections']), 'issue');
+  text(issue.title, 'issue title', 2_000);
+  if (
+    issue.classification !== undefined &&
+    !['bug', 'feature', 'question'].includes(issue.classification)
+  )
+    fail('issue classification is invalid');
+  validateIssueTitleTemplate(issue.title, answers);
+  if (issue.sections !== undefined) {
+    if (!Array.isArray(issue.sections) || issue.sections.length > 20)
+      fail('issue sections are invalid');
+    const headings = new Set<string>();
+    for (const section of issue.sections) validateSection(section, answers, headings);
+  }
+}
+
+function validateSection(
+  section: FlowIssueSection,
+  answers: Map<string, FlowField>,
+  headings: Set<string>
+) {
+  if (!object(section)) fail('issue section must be an object');
+  if ('answer' in section) {
+    only(section, new Set(['heading', 'answer', 'format', 'omitWhenEmpty']), 'issue section');
+    validateScalarAnswer(section.answer, answers, 'issue section');
+  } else {
+    only(section, new Set(['heading', 'context', 'format', 'omitWhenEmpty']), 'issue section');
+    validId(section.context, 'issue context');
+  }
+  text(section.heading, 'issue section heading', 120);
+  const heading = section.heading.trim().toLowerCase();
+  if (headings.has(heading)) fail(`duplicate issue section heading ${section.heading}`);
+  headings.add(heading);
+  if (section.omitWhenEmpty !== undefined && typeof section.omitWhenEmpty !== 'boolean')
+    fail('issue section omitWhenEmpty must be boolean');
+  const format = section.format ?? 'text';
+  if ('answer' in section) {
+    if (!['text', 'quote', 'stars', 'choice', 'code'].includes(format))
+      fail('issue answer format is invalid');
+    const field = answers.get(section.answer)!;
+    if (format === 'stars' && field.type !== 'rating') fail('stars format requires a rating field');
+    if (format === 'choice' && field.type !== 'singleChoice')
+      fail('choice format requires a singleChoice field');
+  } else if (!['text', 'code'].includes(format)) fail('issue context format is invalid');
+}
+
+function validateEvidence(evidence: FlowConfig['evidence'], answers: Map<string, FlowField>) {
+  if (evidence === undefined) return;
+  if (!object(evidence)) fail('evidence must be an object');
+  only(evidence, new Set(['attachments', 'sendConsoleLogs', 'submitter']), 'evidence');
+  typedPath(evidence.attachments, 'attachments', answers, 'attachments');
+  typedPath(evidence.sendConsoleLogs, 'checkbox', answers, 'sendConsoleLogs');
+  if (evidence.submitter !== undefined) {
+    if (!object(evidence.submitter)) fail('evidence submitter must be an object');
+    only(evidence.submitter, new Set(['name', 'email']), 'evidence submitter');
+    if (!evidence.submitter.name && !evidence.submitter.email)
+      fail('evidence submitter must map name or email');
+    if (evidence.submitter.name)
+      validateScalarAnswer(evidence.submitter.name, answers, 'submitter name');
+    if (evidence.submitter.email)
+      validateScalarAnswer(evidence.submitter.email, answers, 'submitter email');
+  }
+}
+function typedPath(
+  path: string | undefined,
+  type: FlowField['type'],
+  answers: Map<string, FlowField>,
+  label: string
+) {
+  if (path !== undefined && answers.get(path)?.type !== type)
+    fail(`${label} must reference a ${type} field`);
+}
+function validateScalarAnswer(path: string, answers: Map<string, FlowField>, label: string) {
+  if (!PATH.test(path) || !answers.has(path) || answers.get(path)?.type === 'attachments')
+    fail(`${label} references an unknown scalar answer: ${path}`);
+}
+function validateIssueTitleTemplate(template: string, answers: Map<string, FlowField>) {
+  let cursor = 0;
+  for (const match of template.matchAll(/{{\s*([^{}]+?)\s*}}/g)) {
+    const index = match.index!;
+    const before = template.slice(cursor, index);
+    if (before.includes('{{') || before.includes('}}') || before.endsWith('{'))
+      fail('issue title template is malformed');
+    validateScalarAnswer(match[1]!.trim(), answers, 'issue title');
+    cursor = index + match[0].length;
+    if (template[cursor] === '}') fail('issue title template is malformed');
+  }
+  const after = template.slice(cursor);
+  if (after.includes('{{') || after.includes('}}')) fail('issue title template is malformed');
+}
+function only(value: object, keys: Set<string>, label: string) {
+  for (const key of Object.keys(value))
+    if (!keys.has(key)) fail(`${label} contains unknown key ${key}`);
+}
+function validId(value: unknown, label: string) {
+  if (typeof value !== 'string' || !ID.test(value) || value === 'legacy')
+    fail(`${label} is invalid`);
+}
+function text(value: unknown, label: string, maximum: number) {
+  if (
+    typeof value !== 'string' ||
+    value.trim().length === 0 ||
+    value.length > maximum ||
+    [...value].some(character => {
+      const code = character.charCodeAt(0);
+      return code < 32 && code !== 9 && code !== 10 && code !== 13;
+    })
+  )
+    fail(`${label} is invalid`);
+}
+function optionalText(value: unknown, label: string, maximum: number) {
+  if (value !== undefined) text(value, label, maximum);
+}
+function scalar(value: unknown, label: string) {
+  if (
+    (value !== null && !['string', 'number', 'boolean'].includes(typeof value)) ||
+    (typeof value === 'number' && !Number.isFinite(value))
+  )
+    fail(`${label} must be scalar`);
+}
+function object(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+function fail(message: string): never {
+  throw new TypeError(`BugDrop flow ${message}`);
+}
+function deepFreeze<T>(value: T): Readonly<T> {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}

--- a/src/widget/flows/validate-config.ts
+++ b/src/widget/flows/validate-config.ts
@@ -59,6 +59,7 @@ export function validateAndFreezeFlowConfig(input: FlowConfig): Readonly<FlowCon
   const forms = new Map<string, FlowConfig['forms'][number]>();
   for (const form of input.forms) validateForm(form, forms, answerFields);
   const referencedForms = new Set<string>();
+  const guaranteedRequiredAnswers = new Set<string>();
   const earlierAnswers = new Map<string, FlowField>();
   let screenshots = 0;
   const screenIds = new Set<string>();
@@ -69,6 +70,9 @@ export function validateAndFreezeFlowConfig(input: FlowConfig): Readonly<FlowCon
       referencedForms.add(screen.form);
       for (const field of forms.get(screen.form)!.fields)
         earlierAnswers.set(`${screen.form}.${field.id}`, field);
+      if (screen.when === undefined)
+        for (const field of forms.get(screen.form)!.fields)
+          if (field.required) guaranteedRequiredAnswers.add(`${screen.form}.${field.id}`);
     }
     if (screen.type === 'screenshot' && ++screenshots > 1)
       fail('only one screenshot screen is supported');
@@ -77,7 +81,7 @@ export function validateAndFreezeFlowConfig(input: FlowConfig): Readonly<FlowCon
     if (!referencedForms.has(formId)) fail(`form ${formId} is unused`);
   if (input.screens.every(screen => screen.when !== undefined))
     fail('at least one screen must be unconditional');
-  validateIssue(input.issue, answerFields);
+  validateIssue(input.issue, answerFields, guaranteedRequiredAnswers);
   validateEvidence(input.evidence, answerFields);
   return deepFreeze(structuredClone(input));
 }
@@ -187,7 +191,11 @@ function validateCondition(condition: FlowCondition, earlier: Map<string, FlowFi
   for (const child of children) validateCondition(child, earlier);
 }
 
-function validateIssue(issue: FlowConfig['issue'], answers: Map<string, FlowField>) {
+function validateIssue(
+  issue: FlowConfig['issue'],
+  answers: Map<string, FlowField>,
+  guaranteedRequiredAnswers: ReadonlySet<string>
+) {
   if (!object(issue)) fail('issue must be an object');
   only(issue, new Set(['classification', 'title', 'sections']), 'issue');
   text(issue.title, 'issue title', 2_000);
@@ -196,7 +204,7 @@ function validateIssue(issue: FlowConfig['issue'], answers: Map<string, FlowFiel
     !['bug', 'feature', 'question'].includes(issue.classification)
   )
     fail('issue classification is invalid');
-  validateIssueTitleTemplate(issue.title, answers);
+  validateIssueTitleTemplate(issue.title, answers, guaranteedRequiredAnswers);
   if (issue.sections !== undefined) {
     if (!Array.isArray(issue.sections) || issue.sections.length > 20)
       fail('issue sections are invalid');
@@ -270,7 +278,11 @@ function validateTextAnswer(path: string, answers: Map<string, FlowField>, label
   if (!PATH.test(path) || (type !== 'shortText' && type !== 'longText'))
     fail(`${label} must reference a text field`);
 }
-function validateIssueTitleTemplate(template: string, answers: Map<string, FlowField>) {
+function validateIssueTitleTemplate(
+  template: string,
+  answers: Map<string, FlowField>,
+  guaranteedRequiredAnswers: ReadonlySet<string>
+) {
   let cursor = 0;
   let hasRequiredSource = false;
   let literal = '';
@@ -282,7 +294,7 @@ function validateIssueTitleTemplate(template: string, answers: Map<string, FlowF
       fail('issue title template is malformed');
     const path = match[1]!.trim();
     validateScalarAnswer(path, answers, 'issue title');
-    hasRequiredSource ||= answers.get(path)?.required === true;
+    hasRequiredSource ||= guaranteedRequiredAnswers.has(path);
     cursor = index + match[0].length;
     if (template[cursor] === '}') fail('issue title template is malformed');
   }

--- a/src/widget/flows/validate-config.ts
+++ b/src/widget/flows/validate-config.ts
@@ -272,15 +272,23 @@ function validateTextAnswer(path: string, answers: Map<string, FlowField>, label
 }
 function validateIssueTitleTemplate(template: string, answers: Map<string, FlowField>) {
   let cursor = 0;
+  let hasRequiredSource = false;
+  let literal = '';
   for (const match of template.matchAll(/{{\s*([^{}]+?)\s*}}/g)) {
     const index = match.index!;
     const before = template.slice(cursor, index);
+    literal += before;
     if (before.includes('{{') || before.includes('}}') || before.endsWith('{'))
       fail('issue title template is malformed');
-    validateScalarAnswer(match[1]!.trim(), answers, 'issue title');
+    const path = match[1]!.trim();
+    validateScalarAnswer(path, answers, 'issue title');
+    hasRequiredSource ||= answers.get(path)?.required === true;
     cursor = index + match[0].length;
     if (template[cursor] === '}') fail('issue title template is malformed');
   }
   const after = template.slice(cursor);
   if (after.includes('{{') || after.includes('}}')) fail('issue title template is malformed');
+  literal += after;
+  if (!literal.trim() && !hasRequiredSource)
+    fail('issue title must contain text or reference a required answer');
 }

--- a/src/widget/flows/validate-config.ts
+++ b/src/widget/flows/validate-config.ts
@@ -247,9 +247,9 @@ function validateEvidence(evidence: FlowConfig['evidence'], answers: Map<string,
     if (!evidence.submitter.name && !evidence.submitter.email)
       fail('evidence submitter must map name or email');
     if (evidence.submitter.name)
-      validateScalarAnswer(evidence.submitter.name, answers, 'submitter name');
+      validateTextAnswer(evidence.submitter.name, answers, 'submitter name');
     if (evidence.submitter.email)
-      validateScalarAnswer(evidence.submitter.email, answers, 'submitter email');
+      validateTextAnswer(evidence.submitter.email, answers, 'submitter email');
   }
 }
 function typedPath(
@@ -264,6 +264,11 @@ function typedPath(
 function validateScalarAnswer(path: string, answers: Map<string, FlowField>, label: string) {
   if (!PATH.test(path) || !answers.has(path) || answers.get(path)?.type === 'attachments')
     fail(`${label} references an unknown scalar answer: ${path}`);
+}
+function validateTextAnswer(path: string, answers: Map<string, FlowField>, label: string) {
+  const type = answers.get(path)?.type;
+  if (!PATH.test(path) || (type !== 'shortText' && type !== 'longText'))
+    fail(`${label} must reference a text field`);
 }
 function validateIssueTitleTemplate(template: string, answers: Map<string, FlowField>) {
   let cursor = 0;

--- a/src/widget/flows/validate-config.ts
+++ b/src/widget/flows/validate-config.ts
@@ -1,5 +1,9 @@
 import { countConditionNodes } from './conditions';
-import { validateFlowFieldConfig, validateFlowShell } from './field-validation';
+import {
+  validateFlowConditionValue,
+  validateFlowFieldConfig,
+  validateFlowShell,
+} from './field-validation';
 import type {
   FlowCondition,
   FlowConfig,
@@ -7,7 +11,16 @@ import type {
   FlowIssueSection,
   FlowScreen,
 } from './public-types';
-const ID = /^[a-z][a-z0-9_-]{0,63}$/;
+import {
+  deepFreeze,
+  fail,
+  object,
+  only,
+  optionalText,
+  scalar,
+  text,
+  validId,
+} from './validation-utils';
 const PATH = /^([a-z][a-z0-9_-]{0,63})\.([a-z][a-z0-9_-]{0,63})$/;
 const TOP_KEYS = new Set([
   'configVersion',
@@ -46,7 +59,7 @@ export function validateAndFreezeFlowConfig(input: FlowConfig): Readonly<FlowCon
   const forms = new Map<string, FlowConfig['forms'][number]>();
   for (const form of input.forms) validateForm(form, forms, answerFields);
   const referencedForms = new Set<string>();
-  const earlierAnswers = new Set<string>();
+  const earlierAnswers = new Map<string, FlowField>();
   let screenshots = 0;
   const screenIds = new Set<string>();
   for (const screen of input.screens) {
@@ -55,13 +68,15 @@ export function validateAndFreezeFlowConfig(input: FlowConfig): Readonly<FlowCon
       if (referencedForms.has(screen.form)) fail(`form ${screen.form} may be referenced only once`);
       referencedForms.add(screen.form);
       for (const field of forms.get(screen.form)!.fields)
-        earlierAnswers.add(`${screen.form}.${field.id}`);
+        earlierAnswers.set(`${screen.form}.${field.id}`, field);
     }
     if (screen.type === 'screenshot' && ++screenshots > 1)
       fail('only one screenshot screen is supported');
   }
   for (const formId of forms.keys())
     if (!referencedForms.has(formId)) fail(`form ${formId} is unused`);
+  if (input.screens.every(screen => screen.when !== undefined))
+    fail('at least one screen must be unconditional');
   validateIssue(input.issue, answerFields);
   validateEvidence(input.evidence, answerFields);
   return deepFreeze(structuredClone(input));
@@ -102,7 +117,7 @@ function validateScreen(
   screen: FlowScreen,
   ids: Set<string>,
   forms: Map<string, FlowConfig['forms'][number]>,
-  earlier: Set<string>
+  earlier: Map<string, FlowField>
 ) {
   if (!object(screen)) fail('screen must be an object');
   validId(screen.id, 'screen id');
@@ -143,14 +158,15 @@ function validateScreen(
   if (screen.type !== 'message') optionalText(screen.backLabel, 'screen backLabel', 120);
 }
 
-function validateCondition(condition: FlowCondition, earlier: Set<string>) {
+function validateCondition(condition: FlowCondition, earlier: Map<string, FlowField>) {
   if (!object(condition)) fail('condition must be an object');
   countConditionNodes(condition);
   if ('answer' in condition) {
     only(condition, new Set(['answer', 'equals']), 'answer condition');
-    if (!earlier.has(condition.answer))
-      fail(`condition answer must reference an earlier field: ${condition.answer}`);
+    const field = earlier.get(condition.answer);
+    if (!field) fail(`condition answer must reference an earlier field: ${condition.answer}`);
     scalar(condition.equals, 'condition equals');
+    validateFlowConditionValue(field, condition.equals);
     return;
   }
   if ('context' in condition) {
@@ -262,46 +278,4 @@ function validateIssueTitleTemplate(template: string, answers: Map<string, FlowF
   }
   const after = template.slice(cursor);
   if (after.includes('{{') || after.includes('}}')) fail('issue title template is malformed');
-}
-function only(value: object, keys: Set<string>, label: string) {
-  for (const key of Object.keys(value))
-    if (!keys.has(key)) fail(`${label} contains unknown key ${key}`);
-}
-function validId(value: unknown, label: string) {
-  if (typeof value !== 'string' || !ID.test(value) || value === 'legacy')
-    fail(`${label} is invalid`);
-}
-function text(value: unknown, label: string, maximum: number) {
-  if (
-    typeof value !== 'string' ||
-    value.trim().length === 0 ||
-    value.length > maximum ||
-    [...value].some(character => {
-      const code = character.charCodeAt(0);
-      return code < 32 && code !== 9 && code !== 10 && code !== 13;
-    })
-  )
-    fail(`${label} is invalid`);
-}
-function optionalText(value: unknown, label: string, maximum: number) {
-  if (value !== undefined) text(value, label, maximum);
-}
-function scalar(value: unknown, label: string) {
-  if (
-    (value !== null && !['string', 'number', 'boolean'].includes(typeof value)) ||
-    (typeof value === 'number' && !Number.isFinite(value))
-  )
-    fail(`${label} must be scalar`);
-}
-function object(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-function fail(message: string): never {
-  throw new TypeError(`BugDrop flow ${message}`);
-}
-function deepFreeze<T>(value: T): Readonly<T> {
-  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
-  Object.freeze(value);
-  for (const child of Object.values(value)) deepFreeze(child);
-  return value;
 }

--- a/src/widget/flows/validation-utils.ts
+++ b/src/widget/flows/validation-utils.ts
@@ -1,0 +1,51 @@
+const ID = /^[a-z][a-z0-9_-]{0,63}$/;
+
+export function only(value: object, keys: Set<string>, label: string): void {
+  for (const key of Object.keys(value))
+    if (!keys.has(key)) fail(`${label} contains unknown key ${key}`);
+}
+
+export function validId(value: unknown, label: string): void {
+  if (typeof value !== 'string' || !ID.test(value) || value === 'legacy')
+    fail(`${label} is invalid`);
+}
+
+export function text(value: unknown, label: string, maximum: number): void {
+  if (
+    typeof value !== 'string' ||
+    value.trim().length === 0 ||
+    value.length > maximum ||
+    [...value].some(character => {
+      const code = character.charCodeAt(0);
+      return code < 32 && code !== 9 && code !== 10 && code !== 13;
+    })
+  )
+    fail(`${label} is invalid`);
+}
+
+export function optionalText(value: unknown, label: string, maximum: number): void {
+  if (value !== undefined) text(value, label, maximum);
+}
+
+export function scalar(value: unknown, label: string): void {
+  if (
+    (value !== null && !['string', 'number', 'boolean'].includes(typeof value)) ||
+    (typeof value === 'number' && !Number.isFinite(value))
+  )
+    fail(`${label} must be scalar`);
+}
+
+export function object(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function fail(message: string): never {
+  throw new TypeError(`BugDrop flow ${message}`);
+}
+
+export function deepFreeze<T>(value: T): Readonly<T> {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -37,6 +37,7 @@ import type { BugDropPublicAPI } from './variants/public-types';
 import { createVariantManager, type VariantManager } from './variants/manager';
 import { runDefaultJourney } from './default-flow/runtime';
 import { normalizeDefaultDefinition } from './default-flow/definition';
+import { createFlowManager, type FlowManager } from './flows/manager';
 
 declare const __BUGDROP_ENABLE_TEST_HOOKS__: boolean;
 declare const __BUGDROP_DEFAULT_FLOW_RUNTIME__: 'fixed' | 'private';
@@ -892,6 +893,7 @@ function exposeBugDropAPI(root: HTMLElement, config: WidgetConfig) {
   // state needed — keeps per-init isolation if multi-instance is ever added.
   let currentMode: ThemeMode = config.theme;
   let variantManager: VariantManager | undefined;
+  let flowManager: FlowManager | undefined;
 
   window.BugDrop = {
     // Open the feedback modal programmatically
@@ -985,6 +987,30 @@ function exposeBugDropAPI(root: HTMLElement, config: WidgetConfig) {
         { isLegacyModalOpen: () => _isModalOpen }
       );
       return variantManager.register(variantConfig);
+    },
+
+    registerFlow: flowConfig => {
+      flowManager ??= createFlowManager(
+        {
+          repo: config.repo,
+          apiUrl: config.apiUrl,
+          authTokenProvider: config.authTokenProvider,
+        },
+        {
+          preflight: () => checkInstallation(config),
+          capture: async (screen, includeScreenshot) => {
+            const result = await runScreenshotCaptureFlow(
+              root,
+              { ...config, screenshotMode: screen.mode },
+              includeScreenshot,
+              () => {}
+            );
+            return result;
+          },
+        },
+        { isLegacyModalOpen: () => _isModalOpen }
+      );
+      return flowManager.register(flowConfig);
     },
   };
 

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -995,15 +995,17 @@ function exposeBugDropAPI(root: HTMLElement, config: WidgetConfig) {
           repo: config.repo,
           apiUrl: config.apiUrl,
           authTokenProvider: config.authTokenProvider,
+          categoryLabels: config.categoryLabels,
         },
         {
           preflight: () => checkInstallation(config),
-          capture: async (screen, includeScreenshot) => {
+          capture: async (screen, includeScreenshot, signal) => {
             const result = await runScreenshotCaptureFlow(
               root,
               { ...config, screenshotMode: screen.mode },
               includeScreenshot,
-              () => {}
+              () => {},
+              signal
             );
             return result;
           },

--- a/src/widget/picker.ts
+++ b/src/widget/picker.ts
@@ -124,16 +124,24 @@ function removePickerListeners(listeners: PickerListeners): void {
   document.removeEventListener('mousemove', listeners.onMouseMove, true);
 }
 
-export function createElementPicker(style?: PickerStyle): Promise<Element | null> {
+export function createElementPicker(
+  style?: PickerStyle,
+  signal?: AbortSignal
+): Promise<Element | null> {
   return new Promise(resolve => {
     // Small delay to ensure any modal has been removed from the DOM
     setTimeout(() => {
-      startPicker(resolve, style);
+      if (signal?.aborted) resolve(null);
+      else startPicker(resolve, style, signal);
     }, 50);
   });
 }
 
-function startPicker(resolve: (element: Element | null) => void, style?: PickerStyle): void {
+function startPicker(
+  resolve: (element: Element | null) => void,
+  style?: PickerStyle,
+  signal?: AbortSignal
+): void {
   const { accent, fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder } =
     resolvePickerStyle(style);
 
@@ -204,6 +212,8 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
     cleanup(keepClickBlocker);
     resolve(element);
   }
+
+  const onAbort = () => finish(null);
 
   function onPointerDown(e: PointerEvent) {
     if (activePointerId !== null || !e.isPrimary) return;
@@ -302,6 +312,7 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
     document.removeEventListener('keydown', onKeyDown);
     removePagePointerBlockers();
     cancelButton?.removeEventListener('click', onCancelClick);
+    signal?.removeEventListener('abort', onAbort);
     overlay.remove();
     highlight.remove();
     tooltip.remove();
@@ -336,6 +347,7 @@ function startPicker(resolve: (element: Element | null) => void, style?: PickerS
   document.addEventListener('click', onClick, true);
   document.addEventListener('keydown', onKeyDown);
   cancelButton?.addEventListener('click', onCancelClick);
+  signal?.addEventListener('abort', onAbort, { once: true });
 }
 
 function createCancelButton(accent: string): HTMLButtonElement {

--- a/src/widget/public-api.d.ts
+++ b/src/widget/public-api.d.ts
@@ -22,6 +22,24 @@ export type {
   VariantTheme,
 } from './variants/public-types';
 
+export type {
+  AttachmentsField,
+  CheckboxField,
+  FlowCondition,
+  FlowConfig,
+  FlowField,
+  FlowForm,
+  FlowHandle,
+  FlowIssueSection,
+  FlowOpenOptions,
+  FlowOutcome,
+  FlowScreen,
+  FormScreen,
+  MessageScreen,
+  OpenedFlow,
+  ScreenshotScreen,
+} from './flows/public-types';
+
 import type { BugDropPublicAPI } from './variants/public-types';
 
 declare global {

--- a/src/widget/variants/public-types.d.ts
+++ b/src/widget/variants/public-types.d.ts
@@ -138,4 +138,7 @@ export interface BugDropPublicAPI {
   isButtonVisible(): boolean;
   setTheme(mode: VariantTheme): void;
   registerVariant(config: VariantConfig): VariantHandle;
+  registerFlow(
+    config: import('../flows/public-types').FlowConfig
+  ): import('../flows/public-types').FlowHandle;
 }

--- a/src/widget/variants/styles.ts
+++ b/src/widget/variants/styles.ts
@@ -201,8 +201,10 @@ const VARIANT_CSS = `
   .bdv-cancel:disabled { cursor: wait; opacity: .65; }
   .bdv-overlay {
     display: grid;
-    min-height: 100%;
-    place-items: center;
+    height: 100%;
+    min-height: 0;
+    align-items: safe center;
+    justify-items: center;
     overflow: auto;
     padding: max(20px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right))
       max(20px, env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left));

--- a/test/captureCancellation.test.ts
+++ b/test/captureCancellation.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { abortableCapture } from '../src/widget/capture-cancellation';
+import { capturePromiseWithLoading } from '../src/widget/capture-loading';
+
+describe('flow capture cancellation', () => {
+  it('does not cancel capture UI created after the aborted operation is closed', async () => {
+    document.body.replaceChildren();
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const controller = new AbortController();
+    const neverSettles = new Promise<string>(() => {});
+    const result = abortableCapture(root, neverSettles, controller.signal, 'cancelled');
+
+    controller.abort();
+    await expect(result).resolves.toBe('cancelled');
+
+    const nextOverlay = document.createElement('div');
+    nextOverlay.className = 'bd-overlay';
+    const close = document.createElement('button');
+    close.className = 'bd-close';
+    nextOverlay.appendChild(close);
+    root.appendChild(nextOverlay);
+    await Promise.resolve();
+
+    expect(nextOverlay.isConnected).toBe(true);
+  });
+
+  it('does not render a late capture failure after cancellation', async () => {
+    document.body.replaceChildren();
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const controller = new AbortController();
+    let rejectCapture!: (error: Error) => void;
+    const capture = new Promise<string>((_, reject) => {
+      rejectCapture = reject;
+    });
+    const result = capturePromiseWithLoading(root, capture, {
+      showLoading: false,
+      signal: controller.signal,
+    });
+
+    controller.abort();
+    await expect(result).resolves.toEqual({ kind: 'cancelled' });
+    rejectCapture(new Error('late failure'));
+    await Promise.resolve();
+
+    expect(root.querySelector('.bd-overlay')).toBeNull();
+  });
+});

--- a/test/captureLoading.test.ts
+++ b/test/captureLoading.test.ts
@@ -35,6 +35,7 @@ afterEach(() => {
   vi.doUnmock('../src/widget/screenshot');
   vi.resetModules();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('capture loading timing', () => {
@@ -76,6 +77,27 @@ describe('capture loading timing', () => {
     await captureAreaWithLoading(root, new DOMRect(0, 0, 100, 100));
 
     expect(events).toEqual(['loading:append', 'capture:start']);
+  });
+
+  it('does not start capture when aborted during the loading paint', async () => {
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const capture = vi.fn(async () => successfulCapture);
+    const controller = new AbortController();
+    const root = document.createElement('div');
+    const { capturePromiseWithLoading } = await import('../src/widget/capture-loading');
+
+    const result = capturePromiseWithLoading(root, capture, { signal: controller.signal });
+    controller.abort();
+    frames.shift()?.(0);
+    await Promise.resolve();
+    frames.shift()?.(0);
+
+    await expect(result).resolves.toEqual({ kind: 'cancelled' });
+    expect(capture).not.toHaveBeenCalled();
   });
 
   it('returns to the picker from capture failures instead of retrying internally', async () => {

--- a/test/defaultFlowBuild.test.ts
+++ b/test/defaultFlowBuild.test.ts
@@ -90,7 +90,7 @@ describe('internal default-flow build selector', () => {
     for (const source of [fixedSource, privateSource]) {
       expect(source).not.toContain('__bugdropDefaultFlowRuntime');
       expect(source).not.toContain('__bugdropMockToPng');
-      expect(source).not.toContain('registerFlow');
+      expect(source).toContain('registerFlow');
       expect(source).not.toContain('FlowConfig');
     }
     expect(fixedSource).not.toContain('bugdrop-default@1');

--- a/test/flowConditions.test.ts
+++ b/test/flowConditions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { countConditionNodes, evaluateCondition } from '../src/widget/flows/conditions';
+import type { FlowCondition } from '../src/widget/flows/public-types';
+
+describe('flow conditions', () => {
+  it('matches only present exact scalar answers and immutable context', () => {
+    expect(evaluateCondition({ answer: 'a.b', equals: false }, { 'a.b': false }, {})).toBe(true);
+    expect(evaluateCondition({ answer: 'missing.value', equals: null }, {}, {})).toBe(false);
+    expect(
+      evaluateCondition(
+        {
+          all: [
+            { context: 'surface', equals: 'billing' },
+            { answer: 'a.b', equals: 2 },
+          ],
+        },
+        { 'a.b': 2 },
+        { surface: 'billing' }
+      )
+    ).toBe(true);
+  });
+  it('bounds condition depth and size', () => {
+    const deep: FlowCondition = {
+      all: [{ all: [{ all: [{ all: [{ answer: 'a.b', equals: true }] }] }] }],
+    };
+    expect(() => countConditionNodes(deep)).toThrow('depth');
+  });
+});

--- a/test/flowConfig.test.ts
+++ b/test/flowConfig.test.ts
@@ -176,6 +176,15 @@ describe('FlowConfig validation', () => {
     );
   });
 
+  it('rejects an Issue title sourced only from an optional answer', () => {
+    const config = flowConfig();
+    const summary = config.forms[0]!.fields.find(field => field.id === 'summary')!;
+    summary.required = false;
+    expect(() => validateAndFreezeFlowConfig(config)).toThrow(
+      'issue title must contain text or reference a required answer'
+    );
+  });
+
   it('rejects answer conditions outside the referenced field domain', () => {
     const unknownChoice = flowConfig();
     unknownChoice.screens[2]!.when = { answer: 'triage.kind', equals: 'other' };

--- a/test/flowConfig.test.ts
+++ b/test/flowConfig.test.ts
@@ -94,6 +94,16 @@ describe('FlowConfig validation', () => {
     ],
     ['dangling evidence', { ...flowConfig(), evidence: { attachments: 'triage.summary' } }],
     [
+      'all conditional screens',
+      {
+        ...flowConfig(),
+        screens: flowConfig().screens.map(screen => ({
+          ...screen,
+          when: { context: 'show', equals: true },
+        })),
+      },
+    ],
+    [
       'two screenshots',
       {
         ...flowConfig(),
@@ -147,6 +157,21 @@ describe('FlowConfig validation', () => {
     const classification = flowConfig();
     classification.issue.classification = 'feedback' as never;
     expect(() => validateAndFreezeFlowConfig(classification)).toThrow('classification');
+  });
+
+  it('rejects answer conditions outside the referenced field domain', () => {
+    const unknownChoice = flowConfig();
+    unknownChoice.screens[2]!.when = { answer: 'triage.kind', equals: 'other' };
+    expect(() => validateAndFreezeFlowConfig(unknownChoice)).toThrow('valid value');
+
+    const wrongScalar = flowConfig();
+    wrongScalar.forms[0]!.fields[0] = {
+      id: 'kind',
+      type: 'rating',
+      label: 'Rating',
+    };
+    wrongScalar.screens[2]!.when = { answer: 'triage.kind', equals: '1' };
+    expect(() => validateAndFreezeFlowConfig(wrongScalar)).toThrow('valid value');
   });
 
   it.each([null, false, 0, ''])('rejects an explicitly defined malformed condition: %j', when => {

--- a/test/flowConfig.test.ts
+++ b/test/flowConfig.test.ts
@@ -168,6 +168,14 @@ describe('FlowConfig validation', () => {
     expect(() => validateAndFreezeFlowConfig(classification)).toThrow('classification');
   });
 
+  it('requires submitter mappings to reference text fields', () => {
+    const config = flowConfig();
+    config.evidence = { ...config.evidence, submitter: { name: 'detail.logs' } };
+    expect(() => validateAndFreezeFlowConfig(config)).toThrow(
+      'submitter name must reference a text'
+    );
+  });
+
   it('rejects answer conditions outside the referenced field domain', () => {
     const unknownChoice = flowConfig();
     unknownChoice.screens[2]!.when = { answer: 'triage.kind', equals: 'other' };

--- a/test/flowConfig.test.ts
+++ b/test/flowConfig.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import type { FlowConfig } from '../src/widget/flows/public-types';
+import { validateAndFreezeFlowConfig } from '../src/widget/flows/validate-config';
+
+export function flowConfig(): FlowConfig {
+  return {
+    configVersion: 1,
+    id: 'product-triage',
+    presentation: { kind: 'modal' },
+    forms: [
+      {
+        id: 'triage',
+        title: 'Tell us what happened',
+        fields: [
+          {
+            id: 'kind',
+            type: 'singleChoice',
+            label: 'Type',
+            options: [
+              { value: 'bug', label: 'Bug' },
+              { value: 'idea', label: 'Idea' },
+            ],
+          },
+          { id: 'summary', type: 'shortText', label: 'Summary', required: true },
+        ],
+      },
+      {
+        id: 'detail',
+        title: 'Add details',
+        fields: [
+          { id: 'description', type: 'longText', label: 'Details' },
+          { id: 'logs', type: 'checkbox', label: 'Send logs' },
+          { id: 'files', type: 'attachments', label: 'Files' },
+        ],
+      },
+    ],
+    screens: [
+      { id: 'intro', type: 'message', title: 'Help us improve' },
+      { id: 'triage-step', type: 'form', form: 'triage' },
+      {
+        id: 'detail-step',
+        type: 'form',
+        form: 'detail',
+        when: { answer: 'triage.kind', equals: 'bug' },
+      },
+      {
+        id: 'evidence',
+        type: 'screenshot',
+        mode: 'optional',
+        when: { answer: 'triage.kind', equals: 'bug' },
+      },
+    ],
+    issue: {
+      classification: 'bug',
+      title: '{{triage.summary}}',
+      sections: [{ heading: 'Details', answer: 'detail.description', omitWhenEmpty: true }],
+    },
+    evidence: { attachments: 'detail.files', sendConsoleLogs: 'detail.logs' },
+  };
+}
+
+describe('FlowConfig validation', () => {
+  it('clones and deeply freezes a complete V1 config', () => {
+    const source = flowConfig();
+    const frozen = validateAndFreezeFlowConfig(source);
+    source.forms[0]!.title = 'Changed';
+    expect(frozen.forms[0]!.title).toBe('Tell us what happened');
+    expect(Object.isFrozen(frozen.screens)).toBe(true);
+  });
+  it.each([
+    ['unknown version', { ...flowConfig(), configVersion: 2 }],
+    ['unknown key', { ...flowConfig(), graph: [] }],
+    [
+      'forward condition',
+      {
+        ...flowConfig(),
+        screens: [
+          {
+            id: 'early',
+            type: 'message',
+            title: 'Early',
+            when: { answer: 'triage.kind', equals: 'bug' },
+          },
+          ...flowConfig().screens.slice(1),
+        ],
+      },
+    ],
+    [
+      'repeated form',
+      {
+        ...flowConfig(),
+        screens: [...flowConfig().screens, { id: 'again', type: 'form', form: 'triage' }],
+      },
+    ],
+    ['dangling evidence', { ...flowConfig(), evidence: { attachments: 'triage.summary' } }],
+    [
+      'two screenshots',
+      {
+        ...flowConfig(),
+        screens: [...flowConfig().screens, { id: 'second-shot', type: 'screenshot', mode: 'auto' }],
+      },
+    ],
+  ])('rejects %s synchronously', (_name, invalid) =>
+    expect(() => validateAndFreezeFlowConfig(invalid as FlowConfig)).toThrow(TypeError)
+  );
+
+  it.each([
+    [
+      'text bounds',
+      { id: 'summary', type: 'shortText', label: 'Summary', minLength: 5, maxLength: 2 },
+    ],
+    ['long text rows', { id: 'summary', type: 'longText', label: 'Summary', rows: 0 }],
+    ['rating scale', { id: 'summary', type: 'rating', label: 'Summary', scale: 6 }],
+    ['rating icon', { id: 'summary', type: 'rating', label: 'Summary', icon: 'heart' }],
+    [
+      'choice display',
+      {
+        id: 'summary',
+        type: 'singleChoice',
+        label: 'Summary',
+        display: 'menu',
+        options: [
+          { value: 'a', label: 'A' },
+          { value: 'b', label: 'B' },
+        ],
+      },
+    ],
+    ['layout', { id: 'summary', type: 'shortText', label: 'Summary', layout: { span: 3 } }],
+  ])('rejects invalid inherited %s options', (_name, field) => {
+    const config = flowConfig();
+    config.forms[0]!.fields[1] = field as never;
+    expect(() => validateAndFreezeFlowConfig(config)).toThrow(TypeError);
+  });
+
+  it('rejects invalid section formats, omit flags, finite conditions, and feedback classification', () => {
+    const format = flowConfig();
+    format.issue.sections = [{ heading: 'Summary', answer: 'triage.summary', format: 'stars' }];
+    expect(() => validateAndFreezeFlowConfig(format)).toThrow('stars');
+    const omit = flowConfig();
+    omit.issue.sections = [
+      { heading: 'Summary', answer: 'triage.summary', omitWhenEmpty: 'yes' as never },
+    ];
+    expect(() => validateAndFreezeFlowConfig(omit)).toThrow('omitWhenEmpty');
+    const condition = flowConfig();
+    condition.screens[2]!.when = { answer: 'triage.kind', equals: Number.NaN };
+    expect(() => validateAndFreezeFlowConfig(condition)).toThrow('scalar');
+    const classification = flowConfig();
+    classification.issue.classification = 'feedback' as never;
+    expect(() => validateAndFreezeFlowConfig(classification)).toThrow('classification');
+  });
+
+  it.each([null, false, 0, ''])('rejects an explicitly defined malformed condition: %j', when => {
+    const config = flowConfig();
+    config.screens[2]!.when = when as never;
+    expect(() => validateAndFreezeFlowConfig(config)).toThrow('condition must be an object');
+  });
+
+  it.each([
+    '{{triage.summary',
+    'triage.summary}}',
+    '{{{triage.summary}}}',
+    '{{triage.summary}}}',
+    '{{triage.summary}}{{',
+  ])('rejects malformed issue title template delimiters: %s', title => {
+    const config = flowConfig();
+    config.issue.title = title;
+    expect(() => validateAndFreezeFlowConfig(config)).toThrow('template is malformed');
+  });
+});

--- a/test/flowConfig.test.ts
+++ b/test/flowConfig.test.ts
@@ -123,6 +123,15 @@ describe('FlowConfig validation', () => {
     ['rating scale', { id: 'summary', type: 'rating', label: 'Summary', scale: 6 }],
     ['rating icon', { id: 'summary', type: 'rating', label: 'Summary', icon: 'heart' }],
     [
+      'attachment accept type',
+      {
+        id: 'summary',
+        type: 'attachments',
+        label: 'Summary',
+        accept: ['application/zip'],
+      },
+    ],
+    [
       'choice display',
       {
         id: 'summary',

--- a/test/flowConfig.test.ts
+++ b/test/flowConfig.test.ts
@@ -185,6 +185,16 @@ describe('FlowConfig validation', () => {
     );
   });
 
+  it('rejects an Issue title sourced only from a conditional required answer', () => {
+    const config = flowConfig();
+    config.issue.title = '{{detail.description}}';
+    const description = config.forms[1]!.fields.find(field => field.id === 'description')!;
+    description.required = true;
+    expect(() => validateAndFreezeFlowConfig(config)).toThrow(
+      'issue title must contain text or reference a required answer'
+    );
+  });
+
   it('rejects answer conditions outside the referenced field domain', () => {
     const unknownChoice = flowConfig();
     unknownChoice.screens[2]!.when = { answer: 'triage.kind', equals: 'other' };

--- a/test/flowDefinition.test.ts
+++ b/test/flowDefinition.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeFlowDefinition } from '../src/widget/flows/definition';
+import { validateAndFreezeFlowConfig } from '../src/widget/flows/validate-config';
+import { flowConfig } from './flowConfig.test';
+
+describe('flow definition', () => {
+  it('compiles stable identities and namespaced screen answer ownership', () => {
+    const definition = normalizeFlowDefinition(validateAndFreezeFlowConfig(flowConfig()));
+    expect(definition.compiler).toBe('bugdrop-flow@1');
+    expect(definition.screenAnswerPaths.get('triage-step')).toEqual([
+      'triage.kind',
+      'triage.summary',
+    ]);
+  });
+});

--- a/test/flowFormScreen.test.ts
+++ b/test/flowFormScreen.test.ts
@@ -76,6 +76,46 @@ describe('flow form screen', () => {
     expect(controller.element.textContent).toContain('unsupported file type');
   });
 
+  it('does not let an older file read overwrite a newer selection', async () => {
+    const readers: Array<{ file?: File; resolve(): void }> = [];
+    class ControlledReader {
+      result: string | ArrayBuffer | null = null;
+      private load: (() => void) | null = null;
+      addEventListener(type: string, listener: () => void) {
+        if (type === 'load') this.load = listener;
+      }
+      readAsDataURL(file: File) {
+        const entry = {
+          file,
+          resolve: () => {
+            this.result = `data:${file.type};base64,QQ==`;
+            this.load?.();
+          },
+        };
+        readers.push(entry);
+      }
+    }
+    vi.stubGlobal('FileReader', ControlledReader);
+    const controller = createFlowFormScreen(form, 'instance', { 'details.agree': true });
+    const input = controller.element.querySelector<HTMLInputElement>('#instance-files')!;
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      value: [new File(['a'], 'old.png', { type: 'image/png' })],
+    });
+    input.dispatchEvent(new Event('change'));
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      value: [new File(['b'], 'new.png', { type: 'image/png' })],
+    });
+    input.dispatchEvent(new Event('change'));
+    readers[1]!.resolve();
+    await Promise.resolve();
+    readers[0]!.resolve();
+    await Promise.resolve();
+    await expect(controller.collect()).resolves.toMatchObject({ files: [{ name: 'new.png' }] });
+    vi.unstubAllGlobals();
+  });
+
   it('snapshots the last valid attachment after a read failure without accepting it forward', async () => {
     const previous = {
       name: 'previous.txt',

--- a/test/flowFormScreen.test.ts
+++ b/test/flowFormScreen.test.ts
@@ -55,13 +55,25 @@ describe('flow form screen', () => {
     const controller = createFlowFormScreen(fileForm, 'instance', { 'details.agree': true });
     const input = controller.element.querySelector<HTMLInputElement>('#instance-files')!;
     Object.defineProperty(input, 'files', {
-      value: [new File(['too large'], 'large.txt', { type: 'text/plain' })],
+      value: [new File(['too large'], 'large.png', { type: 'image/png' })],
     });
     input.dispatchEvent(new Event('change'));
     await expect(controller.collect()).resolves.toBeNull();
     expect(input.getAttribute('aria-invalid')).toBe('true');
     expect(controller.element.textContent).toContain('too large');
     vi.restoreAllMocks();
+  });
+
+  it('rejects unsupported selected attachment types before reading them', async () => {
+    const controller = createFlowFormScreen(form, 'instance', { 'details.agree': true });
+    const input = controller.element.querySelector<HTMLInputElement>('#instance-files')!;
+    Object.defineProperty(input, 'files', {
+      value: [new File(['archive'], 'archive.zip', { type: 'application/zip' })],
+    });
+    input.dispatchEvent(new Event('change'));
+    await expect(controller.collect()).resolves.toBeNull();
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    expect(controller.element.textContent).toContain('unsupported file type');
   });
 
   it('snapshots the last valid attachment after a read failure without accepting it forward', async () => {
@@ -83,7 +95,7 @@ describe('flow form screen', () => {
     });
     const input = controller.element.querySelector<HTMLInputElement>('#instance-files')!;
     Object.defineProperty(input, 'files', {
-      value: [new File(['too large'], 'large.txt', { type: 'text/plain' })],
+      value: [new File(['too large'], 'large.png', { type: 'image/png' })],
     });
     input.dispatchEvent(new Event('change'));
 

--- a/test/flowFormScreen.test.ts
+++ b/test/flowFormScreen.test.ts
@@ -116,6 +116,61 @@ describe('flow form screen', () => {
     vi.unstubAllGlobals();
   });
 
+  it('waits for a replacement selection made while collection is pending', async () => {
+    const readers: Array<{ file?: File; resolve(): void }> = [];
+    class ControlledReader {
+      result: string | ArrayBuffer | null = null;
+      private load: (() => void) | null = null;
+      addEventListener(type: string, listener: () => void) {
+        if (type === 'load') this.load = listener;
+      }
+      readAsDataURL(file: File) {
+        readers.push({
+          file,
+          resolve: () => {
+            this.result = `data:${file.type};base64,QQ==`;
+            this.load?.();
+          },
+        });
+      }
+    }
+    vi.stubGlobal('FileReader', ControlledReader);
+    const previous = {
+      name: 'previous.png',
+      type: 'image/png',
+      size: 1,
+      dataUrl: 'data:image/png;base64,QQ==',
+    };
+    const controller = createFlowFormScreen(form, 'instance', {
+      'details.agree': true,
+      'details.files': [previous],
+    });
+    const input = controller.element.querySelector<HTMLInputElement>('#instance-files')!;
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      value: [new File(['a'], 'a.png', { type: 'image/png' })],
+    });
+    input.dispatchEvent(new Event('change'));
+    let settled = false;
+    const collected = controller.collect().then(value => {
+      settled = true;
+      return value;
+    });
+    await Promise.resolve();
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      value: [new File(['b'], 'b.png', { type: 'image/png' })],
+    });
+    input.dispatchEvent(new Event('change'));
+    readers[0]!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    readers[1]!.resolve();
+    await expect(collected).resolves.toMatchObject({ files: [{ name: 'b.png' }] });
+    vi.unstubAllGlobals();
+  });
+
   it('snapshots the last valid attachment after a read failure without accepting it forward', async () => {
     const previous = {
       name: 'previous.txt',

--- a/test/flowFormScreen.test.ts
+++ b/test/flowFormScreen.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { createFlowFormScreen } from '../src/widget/flows/form-screen';
+import type { FlowForm } from '../src/widget/flows/public-types';
+
+const form: FlowForm = {
+  id: 'details',
+  title: 'Details',
+  fields: [
+    { id: 'first', type: 'shortText', label: 'First', layout: { span: 2 } },
+    { id: 'agree', type: 'checkbox', label: 'Agree', helpText: 'Required consent', required: true },
+    { id: 'last', type: 'longText', label: 'Last' },
+    {
+      id: 'files',
+      type: 'attachments',
+      label: 'Files',
+      helpText: 'Attach evidence',
+      required: true,
+    },
+  ],
+};
+
+describe('flow form screen', () => {
+  it('preserves declared order, layout, help relationships, and snapshots without required validation', async () => {
+    const controller = createFlowFormScreen(form, 'instance', {
+      'details.first': 'One',
+      'details.last': 'Three',
+    });
+    const fields = [...controller.element.querySelectorAll<HTMLElement>('[data-bugdrop-field]')];
+    expect(fields.map(field => field.dataset.bugdropField)).toEqual([
+      'first',
+      'agree',
+      'last',
+      'files',
+    ]);
+    expect(fields[0]?.dataset.span).toBe('2');
+    const checkbox = controller.element.querySelector<HTMLInputElement>('#instance-agree')!;
+    expect(checkbox.getAttribute('aria-describedby')).toContain('instance-agree-help');
+    await expect(controller.snapshot()).resolves.toMatchObject({
+      first: 'One',
+      agree: false,
+      last: 'Three',
+      files: [],
+    });
+    expect(checkbox.getAttribute('aria-invalid')).toBeNull();
+  });
+
+  it('waits for file reads and exposes accessible read errors', async () => {
+    const fileForm: FlowForm = {
+      ...form,
+      fields: form.fields.map(field =>
+        field.id === 'files' ? { ...field, maxFileSize: 1 } : field
+      ),
+    };
+    const controller = createFlowFormScreen(fileForm, 'instance', { 'details.agree': true });
+    const input = controller.element.querySelector<HTMLInputElement>('#instance-files')!;
+    Object.defineProperty(input, 'files', {
+      value: [new File(['too large'], 'large.txt', { type: 'text/plain' })],
+    });
+    input.dispatchEvent(new Event('change'));
+    await expect(controller.collect()).resolves.toBeNull();
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    expect(controller.element.textContent).toContain('too large');
+    vi.restoreAllMocks();
+  });
+
+  it('snapshots the last valid attachment after a read failure without accepting it forward', async () => {
+    const previous = {
+      name: 'previous.txt',
+      type: 'text/plain',
+      size: 1,
+      dataUrl: 'data:text/plain;base64,eA==',
+    };
+    const fileForm: FlowForm = {
+      ...form,
+      fields: form.fields.map(field =>
+        field.id === 'files' ? { ...field, maxFileSize: 1 } : field
+      ),
+    };
+    const controller = createFlowFormScreen(fileForm, 'instance', {
+      'details.agree': true,
+      'details.files': [previous],
+    });
+    const input = controller.element.querySelector<HTMLInputElement>('#instance-files')!;
+    Object.defineProperty(input, 'files', {
+      value: [new File(['too large'], 'large.txt', { type: 'text/plain' })],
+    });
+    input.dispatchEvent(new Event('change'));
+
+    await expect(controller.collect()).resolves.toBeNull();
+    await expect(controller.snapshot()).resolves.toMatchObject({ files: [previous] });
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+  });
+});

--- a/test/flowIssueDraft.test.ts
+++ b/test/flowIssueDraft.test.ts
@@ -45,4 +45,17 @@ describe('flow Issue mapping', () => {
     const draft = compileFlowIssueDraft(flowConfig(), { 'triage.summary': 'x'.repeat(500) }, {});
     expect(draft.title).toHaveLength(256);
   });
+
+  it('keeps embedded backticks inside configured code spans', () => {
+    const config = flowConfig();
+    config.issue.sections = [{ heading: 'Build', context: 'build', format: 'code' }];
+
+    expect(
+      compileFlowIssueDraft(
+        config,
+        { 'triage.summary': 'Build report' },
+        { build: 'build `alpha`' }
+      ).description
+    ).toBe('## Build\n\n`` build `alpha` ``');
+  });
 });

--- a/test/flowIssueDraft.test.ts
+++ b/test/flowIssueDraft.test.ts
@@ -40,4 +40,9 @@ describe('flow Issue mapping', () => {
       'cannot be empty'
     );
   });
+
+  it('bounds compiled Issue titles to the receiver contract', () => {
+    const draft = compileFlowIssueDraft(flowConfig(), { 'triage.summary': 'x'.repeat(500) }, {});
+    expect(draft.title).toHaveLength(256);
+  });
 });

--- a/test/flowIssueDraft.test.ts
+++ b/test/flowIssueDraft.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { compileFlowIssueDraft } from '../src/widget/flows/issue-draft';
+import { flowConfig } from './flowConfig.test';
+
+describe('flow Issue mapping', () => {
+  it('maps namespaced answers and context without HTML execution', () => {
+    const config = flowConfig();
+    config.issue.sections = [
+      { heading: 'Details', answer: 'detail.description', format: 'quote' },
+      { heading: 'Surface', context: 'surface', format: 'code' },
+    ];
+    expect(
+      compileFlowIssueDraft(
+        config,
+        { 'triage.summary': ' Broken ', 'detail.description': '<script>no</script>' },
+        { surface: 'billing' }
+      )
+    ).toEqual({
+      title: 'Broken',
+      category: 'bug',
+      description: '## Details\n\n> <script>no</script>\n\n## Surface\n\n`billing`',
+    });
+  });
+
+  it('uses configured rating scales and choice labels and rejects empty compiled titles', () => {
+    const config = flowConfig();
+    config.forms[0]!.fields.push({ id: 'score', type: 'rating', label: 'Score', scale: 10 });
+    config.issue.sections = [
+      { heading: 'Type', answer: 'triage.kind', format: 'choice' },
+      { heading: 'Score', answer: 'triage.score', format: 'stars' },
+    ];
+    expect(
+      compileFlowIssueDraft(
+        config,
+        { 'triage.summary': 'Rated', 'triage.kind': 'idea', 'triage.score': 7 },
+        {}
+      ).description
+    ).toContain('Idea\n\n## Score\n\n★★★★★★★☆☆☆ (7/10)');
+    expect(() => compileFlowIssueDraft(config, { 'triage.summary': '   ' }, {})).toThrow(
+      'cannot be empty'
+    );
+  });
+});

--- a/test/flowManager.test.ts
+++ b/test/flowManager.test.ts
@@ -102,6 +102,35 @@ describe('flow manager and modal', () => {
     expect(host.shadowRoot?.querySelector('.bdv-title')?.textContent).toBe('Help us improve');
     opened.close();
   });
+  it('ignores a stale preflight failure after a newer retry succeeds', async () => {
+    const resolvers: Array<(value: { status: 'unreachable' | 'installed' }) => void> = [];
+    const preflight = vi.fn(
+      () =>
+        new Promise<{ status: 'unreachable' | 'installed' }>(resolve => {
+          resolvers.push(resolve);
+        })
+    );
+    const opened = createFlowManager(
+      { repo: 'owner/repo', apiUrl: '/api' },
+      { ...ports, preflight }
+    )
+      .register(flowConfig())
+      .open();
+    resolvers[0]!({ status: 'unreachable' });
+    await Promise.resolve();
+    const host = document.querySelector<HTMLElement>('[data-bugdrop-flow="product-triage"]')!;
+    const retry = host.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-submit');
+    retry?.click();
+    retry?.click();
+    expect(preflight).toHaveBeenCalledTimes(3);
+    resolvers[2]!({ status: 'installed' });
+    await Promise.resolve();
+    expect(host.shadowRoot?.querySelector('.bdv-title')?.textContent).toBe('Help us improve');
+    resolvers[1]!({ status: 'unreachable' });
+    await Promise.resolve();
+    expect(host.shadowRoot?.querySelector('.bdv-title')?.textContent).toBe('Help us improve');
+    opened.close();
+  });
   it('opens accessibly, restores focus and closes idempotently', async () => {
     const trigger = document.createElement('button');
     document.body.appendChild(trigger);

--- a/test/flowManager.test.ts
+++ b/test/flowManager.test.ts
@@ -46,8 +46,61 @@ describe('flow manager and modal', () => {
     expect(() => handle.open({ initialAnswers: { 'triage.kind': 'invalid' } })).toThrow(
       'configured choice'
     );
+    expect(() =>
+      handle.open({
+        initialAnswers: {
+          'detail.files': [
+            {
+              name: 'archive.zip',
+              type: 'application/zip',
+              size: 8,
+              dataUrl: 'data:application/zip;base64,UEsDBAo=',
+            },
+          ],
+        },
+      })
+    ).toThrow('attachment type');
+    expect(() =>
+      handle.open({
+        initialAnswers: {
+          'detail.files': [
+            {
+              name: 'image.png',
+              type: 'image/png',
+              size: 1,
+              dataUrl: 'data:text/plain;base64,QQ==',
+            },
+          ],
+        },
+      })
+    ).toThrow('dataUrl');
     expect(preflight).not.toHaveBeenCalled();
     expect(document.body.childElementCount).toBe(0);
+  });
+  it('retries installation preflight without closing the opened flow', async () => {
+    const preflight = vi
+      .fn<() => Promise<{ status: 'unreachable' | 'installed' }>>()
+      .mockResolvedValueOnce({ status: 'unreachable' })
+      .mockResolvedValueOnce({ status: 'installed' });
+    const opened = createFlowManager(
+      { repo: 'owner/repo', apiUrl: '/api' },
+      { ...ports, preflight }
+    )
+      .register(flowConfig())
+      .open();
+    await Promise.resolve();
+    await Promise.resolve();
+    const host = document.querySelector<HTMLElement>('[data-bugdrop-flow="product-triage"]')!;
+    expect(host.shadowRoot?.querySelector('.bdv-description')?.textContent).toContain(
+      'could not reach'
+    );
+    host.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-submit')?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(preflight).toHaveBeenCalledTimes(2);
+    expect(host.isConnected).toBe(true);
+    expect(host.shadowRoot?.querySelector('.bdv-title')?.textContent).toBe('Help us improve');
+    opened.close();
   });
   it('opens accessibly, restores focus and closes idempotently', async () => {
     const trigger = document.createElement('button');

--- a/test/flowManager.test.ts
+++ b/test/flowManager.test.ts
@@ -74,6 +74,27 @@ describe('flow manager and modal', () => {
         },
       })
     ).toThrow('dataUrl');
+    const pngOnly = flowConfig();
+    const attachments = pngOnly.forms[1]!.fields.find(field => field.id === 'files');
+    if (attachments?.type === 'attachments') attachments.accept = ['image/png'];
+    const pngHandle = createFlowManager(
+      { repo: 'owner/repo', apiUrl: '/api' },
+      { ...ports, preflight }
+    ).register(pngOnly);
+    expect(() =>
+      pngHandle.open({
+        initialAnswers: {
+          'detail.files': [
+            {
+              name: 'document.pdf',
+              type: 'application/pdf',
+              size: 1,
+              dataUrl: 'data:application/pdf;base64,QQ==',
+            },
+          ],
+        },
+      })
+    ).toThrow('disallowed attachment type');
     expect(preflight).not.toHaveBeenCalled();
     expect(document.body.childElementCount).toBe(0);
   });
@@ -129,6 +150,48 @@ describe('flow manager and modal', () => {
     resolvers[1]!({ status: 'unreachable' });
     await Promise.resolve();
     expect(host.shadowRoot?.querySelector('.bdv-title')?.textContent).toBe('Help us improve');
+    opened.close();
+  });
+  it('ignores a second form advance while async collection is in progress', async () => {
+    const config = flowConfig();
+    config.forms = [
+      {
+        id: 'first',
+        title: 'First form',
+        fields: [{ id: 'value', type: 'shortText', label: 'First', required: true }],
+      },
+      {
+        id: 'second',
+        title: 'Second form',
+        fields: [{ id: 'value', type: 'shortText', label: 'Second', required: true }],
+      },
+    ];
+    config.screens = [
+      { id: 'first-screen', type: 'form', form: 'first' },
+      { id: 'second-screen', type: 'form', form: 'second' },
+    ];
+    config.issue.title = '{{first.value}}';
+    config.issue.sections = [{ heading: 'Second', answer: 'second.value' }];
+    config.evidence = undefined;
+    const submit = vi.fn(async () => ({ issueNumber: 1, issueUrl: '', isPublic: false }));
+    const opened = createFlowManager({ repo: 'owner/repo', apiUrl: '/api' }, { ...ports, submit })
+      .register(config)
+      .open();
+    await Promise.resolve();
+    const host = document.querySelector<HTMLElement>('[data-bugdrop-flow]')!;
+    host.shadowRoot?.querySelector<HTMLInputElement>('input')?.setAttribute('value', 'First');
+    const firstInput = host.shadowRoot?.querySelector<HTMLInputElement>('input');
+    if (firstInput) firstInput.value = 'First';
+    const advance = host.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-submit');
+    advance?.click();
+    advance?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(
+      host.shadowRoot?.querySelector<HTMLInputElement>('input')?.getAttribute('aria-label')
+    ).toBe(null);
+    expect(host.shadowRoot?.querySelector('.bdv-label')?.textContent).toContain('Second');
+    expect(submit).not.toHaveBeenCalled();
     opened.close();
   });
   it('opens accessibly, restores focus and closes idempotently', async () => {

--- a/test/flowManager.test.ts
+++ b/test/flowManager.test.ts
@@ -116,6 +116,20 @@ describe('flow manager and modal', () => {
         },
       })
     ).toThrow('attachment size');
+    expect(() =>
+      pngHandle.open({
+        initialAnswers: {
+          'detail.files': [
+            {
+              name: 'image.png',
+              type: 'image/png',
+              size: 1,
+              dataUrl: 'data:image/png;base64,A',
+            },
+          ],
+        },
+      })
+    ).toThrow('dataUrl');
     expect(preflight).not.toHaveBeenCalled();
     expect(document.body.childElementCount).toBe(0);
   });

--- a/test/flowManager.test.ts
+++ b/test/flowManager.test.ts
@@ -194,6 +194,35 @@ describe('flow manager and modal', () => {
     expect(submit).not.toHaveBeenCalled();
     opened.close();
   });
+  it('ignores a second Back action while form snapshotting is in progress', async () => {
+    const config = flowConfig();
+    config.forms.push({
+      id: 'final',
+      title: 'Final form',
+      fields: [{ id: 'note', type: 'shortText', label: 'Final note' }],
+    });
+    config.screens = [
+      { id: 'first', type: 'form', form: 'triage' },
+      { id: 'second', type: 'form', form: 'detail' },
+      { id: 'third', type: 'form', form: 'final' },
+    ];
+    const opened = createFlowManager({ repo: 'owner/repo', apiUrl: '/api' }, ports)
+      .register(config)
+      .open({ initialAnswers: { 'triage.summary': 'Title' } });
+    await Promise.resolve();
+    const host = document.querySelector<HTMLElement>('[data-bugdrop-flow]')!;
+    host.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-submit')?.click();
+    await Promise.resolve();
+    host.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-submit')?.click();
+    await Promise.resolve();
+    const back = host.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-back');
+    back?.click();
+    back?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(host.shadowRoot?.querySelector('.bdv-title')?.textContent).toBe('Add details');
+    opened.close();
+  });
   it('opens accessibly, restores focus and closes idempotently', async () => {
     const trigger = document.createElement('button');
     document.body.appendChild(trigger);

--- a/test/flowManager.test.ts
+++ b/test/flowManager.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFlowManager } from '../src/widget/flows/manager';
+import { flowConfig } from './flowConfig.test';
+
+describe('flow manager and modal', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    vi.stubGlobal('crypto', { randomUUID: () => 'runtime-id' });
+  });
+  afterEach(() => vi.unstubAllGlobals());
+  const ports = {
+    preflight: async () => ({ status: 'installed' as const }),
+    capture: async () => ({
+      screenshot: null,
+      elementSelector: null,
+      fullElementSelector: null,
+      returnToForm: false,
+    }),
+  };
+  it('validates synchronously before DOM/network effects and rejects duplicates', () => {
+    const manager = createFlowManager({ repo: 'owner/repo', apiUrl: '/api' }, ports);
+    const invalid = { ...flowConfig(), configVersion: 2 };
+    expect(() => manager.register(invalid as never)).toThrow(TypeError);
+    expect(document.body.childElementCount).toBe(0);
+    manager.register(flowConfig());
+    expect(() => manager.register(flowConfig())).toThrow('already registered');
+  });
+  it('returns busy while the legacy modal owns the surface', async () => {
+    const opened = createFlowManager({ repo: 'owner/repo', apiUrl: '/api' }, ports, {
+      isLegacyModalOpen: () => true,
+    })
+      .register(flowConfig())
+      .open();
+    await expect(opened.result).resolves.toEqual({ status: 'busy' });
+    expect(document.body.childElementCount).toBe(0);
+  });
+  it('rejects malformed context and initial answers before DOM or preflight effects', () => {
+    const preflight = vi.fn(ports.preflight);
+    const handle = createFlowManager(
+      { repo: 'owner/repo', apiUrl: '/api' },
+      { ...ports, preflight }
+    ).register(flowConfig());
+    expect(() => handle.open({ context: { unknown: true } })).toThrow('unknown key');
+    expect(() => handle.open({ initialAnswers: { nope: true } })).toThrow('unknown key');
+    expect(() => handle.open({ initialAnswers: { 'triage.kind': 'invalid' } })).toThrow(
+      'configured choice'
+    );
+    expect(preflight).not.toHaveBeenCalled();
+    expect(document.body.childElementCount).toBe(0);
+  });
+  it('opens accessibly, restores focus and closes idempotently', async () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+    const opened = createFlowManager({ repo: 'owner/repo', apiUrl: '/api' }, ports)
+      .register(flowConfig())
+      .open();
+    await Promise.resolve();
+    await Promise.resolve();
+    const host = document.querySelector<HTMLElement>('[data-bugdrop-flow="product-triage"]');
+    expect(host?.shadowRoot?.querySelector('[role="dialog"]')?.getAttribute('aria-modal')).toBe(
+      'true'
+    );
+    const dialog = host?.shadowRoot?.querySelector('[role="dialog"]');
+    expect(dialog?.getAttribute('aria-labelledby')).toBeTruthy();
+    opened.close();
+    opened.close();
+    await expect(opened.result).resolves.toEqual({ status: 'closed' });
+    expect(document.activeElement).toBe(trigger);
+  });
+});

--- a/test/flowManager.test.ts
+++ b/test/flowManager.test.ts
@@ -95,6 +95,27 @@ describe('flow manager and modal', () => {
         },
       })
     ).toThrow('disallowed attachment type');
+    const oneByte = flowConfig();
+    const oneByteAttachments = oneByte.forms[1]!.fields.find(field => field.id === 'files');
+    if (oneByteAttachments?.type === 'attachments') oneByteAttachments.maxFileSize = 1;
+    const oneByteHandle = createFlowManager(
+      { repo: 'owner/repo', apiUrl: '/api' },
+      { ...ports, preflight }
+    ).register(oneByte);
+    expect(() =>
+      oneByteHandle.open({
+        initialAnswers: {
+          'detail.files': [
+            {
+              name: 'document.pdf',
+              type: 'application/pdf',
+              size: 1,
+              dataUrl: 'data:application/pdf;base64,JVBERi0=',
+            },
+          ],
+        },
+      })
+    ).toThrow('attachment size');
     expect(preflight).not.toHaveBeenCalled();
     expect(document.body.childElementCount).toBe(0);
   });

--- a/test/flowModal.test.ts
+++ b/test/flowModal.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { normalizeFlowDefinition } from '../src/widget/flows/definition';
+import { openFlowModal } from '../src/widget/flows/modal';
+import { addNavigation, createStatusSurface } from '../src/widget/flows/modal-view';
+import type { FlowRoute } from '../src/widget/flows/runtime';
+import { validateAndFreezeFlowConfig } from '../src/widget/flows/validate-config';
+import { flowConfig } from './flowConfig.test';
+
+describe('flow modal runtime states', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    vi.stubGlobal('crypto', { randomUUID: () => 'runtime-id' });
+  });
+  it('keeps named dialog ownership through preflight, submission, and success and restores overflow priority', async () => {
+    document.body.style.setProperty('overflow', 'clip', 'important');
+    const value = {
+      issueNumber: 1,
+      issueUrl: 'https://github.com/owner/repo/issues/1',
+      isPublic: false,
+    };
+    let resolveSubmit!: (result: typeof value) => void;
+    const submit = new Promise<typeof value>(resolve => {
+      resolveSubmit = resolve;
+    });
+    const opened = openFlowModal(
+      normalizeFlowDefinition(validateAndFreezeFlowConfig(flowConfig())),
+      { initialAnswers: { 'triage.kind': 'idea', 'triage.summary': 'Idea' } },
+      {
+        preflight: async () => ({ status: 'installed' }),
+        capture: async () => ({
+          screenshot: null,
+          elementSelector: null,
+          fullElementSelector: null,
+          returnToForm: false,
+        }),
+        submit: () => submit,
+      }
+    );
+    await Promise.resolve();
+    const host = document.querySelector<HTMLElement>('[data-bugdrop-flow]')!;
+    const dialog = () => host.shadowRoot?.querySelector<HTMLElement>('[role="dialog"]');
+    expect(dialog()?.getAttribute('aria-labelledby')).toBeTruthy();
+    host.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-submit')?.click();
+    await Promise.resolve();
+    host.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-submit')?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(dialog()?.getAttribute('aria-busy')).toBe('true');
+    resolveSubmit(value);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(dialog()?.getAttribute('aria-labelledby')).toBeTruthy();
+    opened.close();
+    expect(document.body.style.getPropertyValue('overflow')).toBe('clip');
+    expect(document.body.style.getPropertyPriority('overflow')).toBe('important');
+  });
+
+  it('allows a new modal owner to close a flow while it is submitting', async () => {
+    const definition = normalizeFlowDefinition(validateAndFreezeFlowConfig(flowConfig()));
+    const never = new Promise<never>(() => {});
+    const first = openFlowModal(
+      definition,
+      { initialAnswers: { 'triage.kind': 'idea', 'triage.summary': 'Idea' } },
+      {
+        preflight: async () => ({ status: 'installed' }),
+        capture: async () => ({
+          screenshot: null,
+          elementSelector: null,
+          fullElementSelector: null,
+          returnToForm: false,
+        }),
+        submit: () => never,
+      }
+    );
+    await Promise.resolve();
+    const firstHost = document.querySelector<HTMLElement>('[data-bugdrop-flow]')!;
+    firstHost.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-submit')?.click();
+    await Promise.resolve();
+    firstHost.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-submit')?.click();
+    await Promise.resolve();
+    openFlowModal(definition, undefined, {
+      preflight: async () => ({ status: 'installed' }),
+      capture: async () => ({
+        screenshot: null,
+        elementSelector: null,
+        fullElementSelector: null,
+        returnToForm: false,
+      }),
+      submit: async () => ({
+        issueNumber: 1,
+        issueUrl: 'https://github.com/owner/repo/issues/1',
+        isPublic: false,
+      }),
+    });
+    await expect(first.result).resolves.toEqual({ status: 'closed' });
+    expect(firstHost.isConnected).toBe(false);
+    expect(document.querySelectorAll('[data-bugdrop-flow]')).toHaveLength(1);
+  });
+
+  it('restores focus to the active control inside a host shadow root', async () => {
+    const host = document.createElement('div');
+    const shadow = host.attachShadow({ mode: 'open' });
+    const trigger = document.createElement('button');
+    shadow.appendChild(trigger);
+    document.body.appendChild(host);
+    trigger.focus();
+
+    const opened = openFlowModal(
+      normalizeFlowDefinition(validateAndFreezeFlowConfig(flowConfig())),
+      undefined,
+      {
+        preflight: () => new Promise(() => {}),
+        capture: async () => ({
+          screenshot: null,
+          elementSelector: null,
+          fullElementSelector: null,
+          returnToForm: false,
+        }),
+        submit: async () => ({
+          issueNumber: 1,
+          issueUrl: 'https://github.com/owner/repo/issues/1',
+          isPublic: false,
+        }),
+      }
+    );
+    await Promise.resolve();
+    opened.close();
+
+    expect(shadow.activeElement).toBe(trigger);
+  });
+
+  it('uses visible-route defaults for terminal, non-terminal, and overridden action copy', () => {
+    const cases: Array<[FlowRoute, string]> = [
+      [
+        {
+          screen: { id: 'terminal-message', type: 'message', title: 'Terminal' },
+          position: 1,
+          total: 1,
+          canGoBack: false,
+          hasNext: false,
+        },
+        'Submit',
+      ],
+      [
+        {
+          screen: { id: 'early-message', type: 'message', title: 'Early' },
+          position: 1,
+          total: 2,
+          canGoBack: false,
+          hasNext: true,
+        },
+        'Continue',
+      ],
+      [
+        {
+          screen: {
+            id: 'custom-message',
+            type: 'message',
+            title: 'Custom',
+            continueLabel: 'Send now',
+          },
+          position: 1,
+          total: 2,
+          canGoBack: false,
+          hasNext: true,
+        },
+        'Send now',
+      ],
+    ];
+
+    for (const [route, expected] of cases) {
+      const surface = createStatusSurface('Title', 'Description');
+      addNavigation(surface, route, vi.fn(), vi.fn(), vi.fn());
+      expect(surface.querySelector<HTMLButtonElement>('.bdv-submit')?.textContent).toBe(expected);
+    }
+  });
+});

--- a/test/flowPublicTypes.test.ts
+++ b/test/flowPublicTypes.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import type { BugDropPublicAPI, FlowConfig, FlowHandle } from '../src/widget/public-api';
+import { flowConfig } from './flowConfig.test';
+
+describe('published FlowConfig declarations', () => {
+  it('exports additive registration types', () => {
+    expectTypeOf<BugDropPublicAPI['registerFlow']>().parameter(0).toEqualTypeOf<FlowConfig>();
+    expectTypeOf<ReturnType<BugDropPublicAPI['registerFlow']>>().toEqualTypeOf<FlowHandle>();
+    expect(flowConfig().configVersion).toBe(1);
+  });
+  it('resolves FlowConfig from an actual packed package', () => {
+    const temporaryRoot = mkdtempSync(join(tmpdir(), 'bugdrop-flow-types-'));
+    try {
+      const [{ filename }] = JSON.parse(
+        execFileSync(
+          'npm',
+          ['pack', '--ignore-scripts', '--pack-destination', temporaryRoot, '--json'],
+          { cwd: process.cwd(), encoding: 'utf8' }
+        )
+      ) as Array<{ filename: string }>;
+      const packageRoot = join(temporaryRoot, 'node_modules', 'bugdrop');
+      mkdirSync(packageRoot, { recursive: true });
+      execFileSync('tar', [
+        '-xzf',
+        join(temporaryRoot, filename),
+        '--strip-components=1',
+        '-C',
+        packageRoot,
+      ]);
+      writeFileSync(
+        join(temporaryRoot, 'consumer.ts'),
+        [
+          "import type { BugDropPublicAPI, FlowConfig, FlowHandle } from 'bugdrop';",
+          'declare const api: BugDropPublicAPI;',
+          `const config = ${JSON.stringify(flowConfig())} satisfies FlowConfig;`,
+          'const handle: FlowHandle = api.registerFlow(config);',
+          'void handle.open({ context: { surface: "billing" } });',
+        ].join('\n')
+      );
+      execFileSync(
+        resolve('node_modules/.bin/tsc'),
+        [
+          '--noEmit',
+          '--strict',
+          '--module',
+          'ESNext',
+          '--moduleResolution',
+          'Bundler',
+          '--target',
+          'ES2022',
+          join(temporaryRoot, 'consumer.ts'),
+        ],
+        { cwd: temporaryRoot, stdio: 'pipe' }
+      );
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/test/flowRuntime.test.ts
+++ b/test/flowRuntime.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeFlowDefinition } from '../src/widget/flows/definition';
+import { FlowRuntime } from '../src/widget/flows/runtime';
+import { validateAndFreezeFlowConfig } from '../src/widget/flows/validate-config';
+import { flowConfig } from './flowConfig.test';
+
+describe('flow runtime', () => {
+  it('navigates visible screens, retains Back answers, and clears newly hidden answers/evidence', () => {
+    const runtime = new FlowRuntime(
+      normalizeFlowDefinition(validateAndFreezeFlowConfig(flowConfig())),
+      {}
+    );
+    expect(runtime.current()?.id).toBe('intro');
+    runtime.next();
+    runtime.setFormAnswers('triage', { kind: 'bug', summary: 'Broken' });
+    runtime.next();
+    expect(runtime.current()?.id).toBe('detail-step');
+    runtime.setFormAnswers('detail', { description: 'Steps', logs: true, files: [] });
+    runtime.next();
+    runtime.capture = {
+      screenshot: 'data:image/png;base64,x',
+      elementSelector: null,
+      fullElementSelector: null,
+    };
+    runtime.back();
+    runtime.back();
+    runtime.setFormAnswers('triage', { kind: 'idea', summary: 'Better' });
+    expect(runtime.answers['detail.description']).toBeUndefined();
+    expect(runtime.capture).toBeNull();
+    expect(runtime.current()?.id).toBe('triage-step');
+  });
+
+  it('uses visible routes and removes initially hidden answers before Issue compilation', () => {
+    const config = flowConfig();
+    const runtime = new FlowRuntime(
+      normalizeFlowDefinition(validateAndFreezeFlowConfig(config)),
+      {},
+      {
+        'triage.kind': 'idea',
+        'triage.summary': 'Idea',
+        'detail.description': 'must disappear',
+      }
+    );
+    expect(runtime.answers['detail.description']).toBeUndefined();
+    runtime.next();
+    expect(runtime.route()).toMatchObject({
+      position: 2,
+      total: 2,
+      canGoBack: true,
+      hasNext: false,
+    });
+  });
+
+  it('does not clear still-visible form state during Back snapshots', () => {
+    const runtime = new FlowRuntime(
+      normalizeFlowDefinition(validateAndFreezeFlowConfig(flowConfig())),
+      {}
+    );
+    runtime.next();
+    runtime.setFormAnswers('triage', { kind: 'bug', summary: 'Broken' });
+    runtime.next();
+    runtime.setFormAnswers('detail', { description: 'Retained', logs: false, files: [] });
+    runtime.back();
+    expect(runtime.answers['detail.description']).toBe('Retained');
+    expect(runtime.current()?.id).toBe('triage-step');
+  });
+});

--- a/test/flowSubmission.test.ts
+++ b/test/flowSubmission.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { submitFlow } from '../src/widget/flows/submission';
+import { flowConfig } from './flowConfig.test';
+
+describe('flow legacy submission', () => {
+  afterEach(() => vi.unstubAllGlobals());
+  it('carries mapped screenshot, attachments, logs, and submitter through the legacy recipe', async () => {
+    const config = flowConfig();
+    config.forms[0]!.fields.push({ id: 'name', type: 'shortText', label: 'Name' });
+    config.evidence = { ...config.evidence, submitter: { name: 'triage.name' } };
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            success: true,
+            issueNumber: 9,
+            issueUrl: 'https://github.com/owner/repo/issues/9',
+            isPublic: false,
+          }),
+          { status: 200 }
+        )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('crypto', { randomUUID: () => 'id' });
+    await submitFlow(
+      { repo: 'owner/repo', apiUrl: '/api' },
+      config,
+      {
+        'triage.summary': 'Crash',
+        'triage.name': 'Ada',
+        'detail.description': 'Steps',
+        'detail.logs': false,
+        'detail.files': [{ name: 'trace.txt' }],
+      },
+      {},
+      {
+        screenshot: 'data:image/png;base64,x',
+        elementSelector: '#save',
+        fullElementSelector: 'html body #save',
+      }
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string);
+    expect(body).toMatchObject({
+      repo: 'owner/repo',
+      title: 'Crash',
+      category: 'bug',
+      screenshot: 'data:image/png;base64,x',
+      attachments: [{ name: 'trace.txt' }],
+      submitter: { name: 'Ada' },
+      metadata: { elementSelector: '#save' },
+    });
+    expect(body.kind).toBeUndefined();
+  });
+  it('keeps retryable failures explicit', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ error: 'Nope' }), { status: 500 }))
+    );
+    await expect(
+      submitFlow(
+        { repo: 'owner/repo', apiUrl: '/api' },
+        flowConfig(),
+        { 'triage.summary': 'Crash' },
+        {},
+        null
+      )
+    ).rejects.toThrow('Nope');
+  });
+
+  it.each([
+    [0, 'https://github.com/owner/repo/issues/0'],
+    [9, 'https://example.com/owner/repo/issues/9'],
+    [9, 'https://github.com/other/repo/issues/9'],
+    [9, 'https://github.com/owner/repo/issues/10'],
+  ])('rejects non-canonical legacy Issue results', async (issueNumber, issueUrl) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ success: true, issueNumber, issueUrl, isPublic: false }))
+      )
+    );
+    await expect(
+      submitFlow(
+        { repo: 'owner/repo', apiUrl: '/api' },
+        flowConfig(),
+        { 'triage.summary': 'Crash' },
+        {},
+        null
+      )
+    ).rejects.toThrow('invalid Issue result');
+  });
+});

--- a/test/flowSubmission.test.ts
+++ b/test/flowSubmission.test.ts
@@ -17,6 +17,7 @@ describe('flow legacy submission', () => {
             issueNumber: 9,
             issueUrl: 'https://github.com/owner/repo/issues/9',
             isPublic: false,
+            labelMappingWarnings: ['Skipped an invalid label'],
           }),
           { status: 200 }
         )
@@ -24,7 +25,11 @@ describe('flow legacy submission', () => {
     vi.stubGlobal('fetch', fetchMock);
     vi.stubGlobal('crypto', { randomUUID: () => 'id' });
     await submitFlow(
-      { repo: 'owner/repo', apiUrl: '/api' },
+      {
+        repo: 'owner/repo',
+        apiUrl: '/api',
+        categoryLabels: { bug: ['defect', 'needs-triage'] },
+      },
       config,
       {
         'triage.summary': 'Crash',
@@ -45,12 +50,22 @@ describe('flow legacy submission', () => {
       repo: 'owner/repo',
       title: 'Crash',
       category: 'bug',
+      categoryLabels: { bug: ['defect', 'needs-triage'] },
       screenshot: 'data:image/png;base64,x',
       attachments: [{ name: 'trace.txt' }],
       submitter: { name: 'Ada' },
       metadata: { elementSelector: '#save' },
     });
     expect(body.kind).toBeUndefined();
+    await expect(
+      submitFlow(
+        { repo: 'owner/repo', apiUrl: '/api' },
+        config,
+        { 'triage.summary': 'Crash' },
+        {},
+        null
+      )
+    ).resolves.toMatchObject({ labelMappingWarnings: ['Skipped an invalid label'] });
   });
   it('keeps retryable failures explicit', async () => {
     vi.stubGlobal(

--- a/test/flowSubmission.test.ts
+++ b/test/flowSubmission.test.ts
@@ -83,6 +83,33 @@ describe('flow legacy submission', () => {
     ).rejects.toThrow('Nope');
   });
 
+  it('accepts canonical GitHub Issue URLs when repository casing differs', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              success: true,
+              issueNumber: 37,
+              issueUrl: 'https://github.com/owner/repo/issues/37',
+              isPublic: true,
+            })
+          )
+      )
+    );
+
+    await expect(
+      submitFlow(
+        { repo: 'Owner/Repo', apiUrl: '/api' },
+        flowConfig(),
+        { 'triage.summary': 'Crash' },
+        {},
+        null
+      )
+    ).resolves.toMatchObject({ issueNumber: 37 });
+  });
+
   it.each([
     [0, 'https://github.com/owner/repo/issues/0'],
     [9, 'https://example.com/owner/repo/issues/9'],


### PR DESCRIPTION
## Summary

- adds the public `window.BugDrop.registerFlow` FlowConfig V1 API
- composes validated message, form, conditional, and screenshot screens
- submits through the established feedback payload while preserving the default BugDrop flow
- adds backwards-compatibility, accessibility, cancellation, concurrency, and browser coverage

## Compatibility

The existing default widget and `registerVariant` behavior remain unchanged. The new flow runtime is additive and the default-shaped example is reconstructed with the new primitives.

## Verification

- `npm run validate`: 88 files, 1,344 tests passed
- full Playwright suite: 317 passed across Chromium plus Radix compatibility coverage in Chromium, Firefox, and WebKit
- PR review toolkit run against `32ee17fbbf3f1dce617ac06042c25c5707dd8d94`; accepted findings resolved and independently rechecked
- hardened Issue URL validation, Markdown code rendering, capture cancellation, attachment interleavings, and attachment validation

## Related

The website lab PR pins the exact built widget from commit `b307db46d895ae141f34befbc8cfcd107b155bc9`: https://github.com/mean-weasel/bugdrop-web/pull/71