### PR TITLE
feat: adopt flow engine for default feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,7 @@ jobs:
           echo "BUGDROP_CANARY_RESULT_FILE=test-results/issue-canary-result.json" >> "$GITHUB_ENV"
           echo "BUGDROP_CANARY_ATTEMPT_FILE=$RUNNER_TEMP/bugdrop-canary-attempt-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
           echo "EXACT_WIDGET_FIXTURE_PATH=$RUNNER_TEMP/bugdrop-exact-preview-widget-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.js" >> "$GITHUB_ENV"
+          echo "EXACT_CLASSIC_WIDGET_FIXTURE_PATH=$RUNNER_TEMP/bugdrop-exact-preview-classic-widget-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.js" >> "$GITHUB_ENV"
           echo "EXPECTED_WORKER_SHA=${GITHUB_SHA}" >> "$GITHUB_ENV"
           echo "EXPECTED_WIDGET_ORIGIN=https://bugdrop-preview.neonwatty.workers.dev" >> "$GITHUB_ENV"
           echo "LIVE_TARGET=preview" >> "$GITHUB_ENV"
@@ -402,11 +403,23 @@ jobs:
         env:
           BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
 
+      - name: Build classic preview widget
+        run: |
+          CLASSIC_OUTPUT="$RUNNER_TEMP/classic-preview-widget"
+          BUGDROP_DEFAULT_FLOW_RUNTIME=fixed node scripts/build-widget.js \
+            --mode development \
+            --source-dir . \
+            --output-dir "$CLASSIC_OUTPUT" \
+            --development-id "merge-group-${GITHUB_SHA}-classic"
+
       - name: Build all
         run: BUGDROP_BUILD_MODE=development BUGDROP_DEVELOPMENT_ID="merge-group-${GITHUB_SHA}" make build-all
 
-      - name: Record expected preview widget hash
-        run: echo "EXPECTED_WIDGET_SHA256=$(shasum -a 256 public/widget.js | awk '{print $1}')" >> "$GITHUB_ENV"
+      - name: Record expected preview widget hashes
+        run: |
+          cp "$RUNNER_TEMP/classic-preview-widget/widget.js" public/widget.classic.js
+          echo "EXPECTED_WIDGET_SHA256=$(shasum -a 256 public/widget.js | awk '{print $1}')" >> "$GITHUB_ENV"
+          echo "EXPECTED_CLASSIC_WIDGET_SHA256=$(shasum -a 256 public/widget.classic.js | awk '{print $1}')" >> "$GITHUB_ENV"
 
       - name: Deploy to preview
         run: npx wrangler deploy --env preview --var "BUILD_SHA:$GITHUB_SHA"
@@ -456,6 +469,30 @@ jobs:
           echo "Preview widget did not serve expected asset $EXPECTED_WIDGET_SHA256"
           exit 1
 
+      - name: Wait for exact classic preview widget asset
+        run: |
+          WIDGET_URL="$EXPECTED_WIDGET_ORIGIN/widget.classic.js"
+          CANDIDATE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH.candidate"
+          mkdir -p "$(dirname "$EXACT_CLASSIC_WIDGET_FIXTURE_PATH")"
+          echo "Waiting for $WIDGET_URL to serve $EXPECTED_CLASSIC_WIDGET_SHA256..."
+          for i in $(seq 1 30); do
+            if ! curl -sSf "$WIDGET_URL" -o "$CANDIDATE_PATH"; then
+              echo "Attempt $i/30 could not download the classic preview widget; waiting 5s..."
+              sleep 5
+              continue
+            fi
+            ACTUAL_SHA="$(shasum -a 256 "$CANDIDATE_PATH" | awk '{print $1}')"
+            if [ "$ACTUAL_SHA" = "$EXPECTED_CLASSIC_WIDGET_SHA256" ]; then
+              mv "$CANDIDATE_PATH" "$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"
+              echo "Classic preview widget asset matched after $((i * 5))s"
+              exit 0
+            fi
+            echo "Attempt $i/30 served $ACTUAL_SHA; waiting 5s..."
+            sleep 5
+          done
+          echo "Classic preview widget did not serve expected asset $EXPECTED_CLASSIC_WIDGET_SHA256"
+          exit 1
+
       - name: Verify fixed preview venue
         run: |
           BYPASS_ARGS=()
@@ -470,28 +507,48 @@ jobs:
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
-      - name: Run live E2E tests
-        run: npx playwright test --project=chromium-live --workers=1 --retries=0
+      - name: Run classic live E2E tests
+        run: >-
+          EXACT_WIDGET_FIXTURE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"
+          EXPECTED_WIDGET_SHA256="$EXPECTED_CLASSIC_WIDGET_SHA256"
+          npx playwright test --project=chromium-live --workers=1 --retries=0
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
-      - name: Run live Radix E2E tests
-        run: make test-live-radix
+      - name: Run composable FlowConfig live E2E tests
+        run: npx playwright test --project=chromium-flow-live --workers=1 --retries=0
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
-      - name: Run Chromium live cross-browser smoke
-        run: make test-live-cross-browser BROWSER=chromium
+      - name: Run classic live Radix E2E tests
+        run: >-
+          EXACT_WIDGET_FIXTURE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"
+          EXPECTED_WIDGET_SHA256="$EXPECTED_CLASSIC_WIDGET_SHA256"
+          make test-live-radix
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
-      - name: Run Firefox live cross-browser smoke
-        run: make test-live-cross-browser BROWSER=firefox
+      - name: Run classic Chromium live cross-browser smoke
+        run: >-
+          EXACT_WIDGET_FIXTURE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"
+          EXPECTED_WIDGET_SHA256="$EXPECTED_CLASSIC_WIDGET_SHA256"
+          make test-live-cross-browser BROWSER=chromium
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
-      - name: Run WebKit live cross-browser smoke
-        run: make test-live-cross-browser BROWSER=webkit
+      - name: Run classic Firefox live cross-browser smoke
+        run: >-
+          EXACT_WIDGET_FIXTURE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"
+          EXPECTED_WIDGET_SHA256="$EXPECTED_CLASSIC_WIDGET_SHA256"
+          make test-live-cross-browser BROWSER=firefox
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Run classic WebKit live cross-browser smoke
+        run: >-
+          EXACT_WIDGET_FIXTURE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"
+          EXPECTED_WIDGET_SHA256="$EXPECTED_CLASSIC_WIDGET_SHA256"
+          make test-live-cross-browser BROWSER=webkit
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
@@ -499,7 +556,9 @@ jobs:
         run: |
           mkdir -p "$(dirname "$BUGDROP_CANARY_ATTEMPT_FILE")"
           : > "$BUGDROP_CANARY_ATTEMPT_FILE"
-          npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --workers=1 --retries=0
+          EXACT_WIDGET_FIXTURE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH" \
+          EXPECTED_WIDGET_SHA256="$EXPECTED_CLASSIC_WIDGET_SHA256" \
+            npx playwright test e2e/widget.issue-canary.spec.ts --project=chromium-issue-canary --workers=1 --retries=0
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Build outputs
 dist/
 public/widget.js
+public/widget.classic.js
 public/widget.v*.js
 public/versions.json
 

--- a/e2e/default-flow-compatibility.spec.ts
+++ b/e2e/default-flow-compatibility.spec.ts
@@ -27,12 +27,10 @@ function host(page: Page) {
 }
 
 async function prepareContext(context: BrowserContext, runner: Runner, captureHook?: string) {
-  if (runner === 'private') {
-    await context.addInitScript(() => {
-      (window as unknown as { __bugdropDefaultFlowRuntime?: string }).__bugdropDefaultFlowRuntime =
-        'private';
-    });
-  }
+  await context.addInitScript(selected => {
+    (window as unknown as { __bugdropDefaultFlowRuntime?: string }).__bugdropDefaultFlowRuntime =
+      selected;
+  }, runner);
   if (captureHook) await context.addInitScript({ content: captureHook });
 }
 
@@ -83,9 +81,9 @@ async function expectPairedJourney(
   captureHook?: string
 ): Promise<JourneyResult> {
   const fixed = await runJourney(browser, 'fixed', journey, captureHook);
-  const privateRuntime = await runJourney(browser, 'private', journey, captureHook);
-  expect(privateRuntime.trace).toEqual(fixed.trace);
-  expect(privateRuntime.requests).toEqual(fixed.requests);
+  const flowRuntime = await runJourney(browser, 'private', journey, captureHook);
+  expect(flowRuntime.trace).toEqual(fixed.trace);
+  expect(flowRuntime.requests).toEqual(fixed.requests);
   return fixed;
 }
 

--- a/e2e/public-flow.flow-live.spec.ts
+++ b/e2e/public-flow.flow-live.spec.ts
@@ -1,0 +1,142 @@
+import { expect, type Page } from '@playwright/test';
+import {
+  assertExactPreviewWidgetResponse,
+  test,
+  waitForPreviewWidgetResponse,
+} from './live-preview-widget';
+
+const expectedWidgetOrigin = process.env.EXPECTED_WIDGET_ORIGIN;
+const expectedWidgetSha256 = process.env.EXPECTED_WIDGET_SHA256;
+const venuePath = process.env.LIVE_VENUE_PATH || '/';
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+
+if (bypassSecret) {
+  test.beforeEach(async ({ context }) => {
+    await context.route('**/*.vercel.app/**', route =>
+      route.continue({
+        headers: {
+          ...route.request().headers(),
+          'x-vercel-protection-bypass': bypassSecret,
+        },
+      })
+    );
+  });
+}
+
+async function loadFlowWidget(page: Page): Promise<void> {
+  const response = expectedWidgetOrigin
+    ? waitForPreviewWidgetResponse(page, expectedWidgetOrigin)
+    : undefined;
+  await page.goto(venuePath);
+  await expect
+    .poll(() => page.evaluate(() => typeof window.BugDrop?.registerFlow))
+    .toBe('function');
+  if (response && expectedWidgetSha256) {
+    await assertExactPreviewWidgetResponse(await response, expectedWidgetSha256);
+  }
+}
+
+test('runs a conditional multi-screen FlowConfig through the exact preview widget', async ({
+  page,
+}) => {
+  await page.route('**/api/check/**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ installed: true, appName: 'neonwatty-bugdrop' }),
+    })
+  );
+  const submissions: Array<Record<string, unknown>> = [];
+  await page.route('**/api/feedback', route => {
+    submissions.push(route.request().postDataJSON() as Record<string, unknown>);
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        issueNumber: 902,
+        issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/902',
+        isPublic: false,
+      }),
+    });
+  });
+
+  await loadFlowWidget(page);
+  await page.evaluate(() => {
+    window
+      .BugDrop!.registerFlow({
+        configVersion: 1,
+        id: 'merge-queue-composable-flow',
+        presentation: { kind: 'modal' },
+        forms: [
+          {
+            id: 'triage',
+            title: 'Classify your feedback',
+            fields: [
+              {
+                id: 'kind',
+                type: 'singleChoice',
+                label: 'Type',
+                required: true,
+                options: [
+                  { value: 'bug', label: 'Bug' },
+                  { value: 'idea', label: 'Idea' },
+                ],
+              },
+              { id: 'summary', type: 'shortText', label: 'Summary', required: true },
+            ],
+          },
+          {
+            id: 'detail',
+            title: 'Describe the bug',
+            fields: [{ id: 'description', type: 'longText', label: 'Steps', required: true }],
+          },
+        ],
+        screens: [
+          { id: 'intro', type: 'message', title: 'Help us improve' },
+          { id: 'triage-screen', type: 'form', form: 'triage' },
+          {
+            id: 'detail-screen',
+            type: 'form',
+            form: 'detail',
+            when: { answer: 'triage.kind', equals: 'bug' },
+          },
+          {
+            id: 'screenshot',
+            type: 'screenshot',
+            mode: 'optional',
+            when: { answer: 'triage.kind', equals: 'bug' },
+          },
+        ],
+        issue: {
+          classification: 'bug',
+          title: '{{triage.summary}}',
+          sections: [{ heading: 'Steps', answer: 'detail.description' }],
+        },
+      })
+      .open();
+  });
+
+  const host = page.locator('body > [data-bugdrop-flow="merge-queue-composable-flow"]');
+  await expect(host.getByRole('heading', { name: 'Help us improve' })).toBeVisible();
+  await host.getByRole('button', { name: 'Continue' }).click();
+  await host.getByLabel('Bug').click();
+  await host.getByLabel('Summary').fill('Preview flow failure');
+  await host.getByRole('button', { name: 'Continue' }).click();
+  await host.getByLabel('Steps').fill('Open the preview and submit');
+  await host.getByRole('button', { name: 'Continue' }).click();
+  await host.getByLabel('Include a screenshot', { exact: true }).uncheck();
+  await host.getByRole('button', { name: 'Submit' }).click();
+  await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+
+  expect(submissions).toHaveLength(1);
+  expect(submissions[0]).toMatchObject({
+    repo: 'mean-weasel/bugdrop-widget-test',
+    title: 'Preview flow failure',
+    description: '## Steps\n\nOpen the preview and submit',
+    category: 'bug',
+    screenshot: null,
+    attachments: [],
+  });
+  expect(submissions[0]?.kind).toBeUndefined();
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8787';
 const issueCanaryProject = 'chromium-issue-canary';
 const liveProjects = [
   'chromium-live',
+  'chromium-flow-live',
   'chromium-live-radix',
   'chromium-cross-browser-live',
   'firefox-cross-browser-live',
@@ -63,7 +64,7 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
       testIgnore: [
-        /.*\.(?:live|live-radix|cross-browser-live|issue-canary|radix)\.spec\.ts$/,
+        /.*\.(?:live|flow-live|live-radix|cross-browser-live|issue-canary|radix)\.spec\.ts$/,
         /default-flow-production\.spec\.ts$/,
       ],
     },
@@ -89,6 +90,15 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
       },
       testMatch: liveTestMatch(/.*\.live\.spec\.ts/),
+      timeout: 60_000,
+    },
+    {
+      name: 'chromium-flow-live',
+      fullyParallel: false,
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+      testMatch: liveTestMatch(/.*\.flow-live\.spec\.ts/),
       timeout: 60_000,
     },
     {

--- a/scripts/build-widget.js
+++ b/scripts/build-widget.js
@@ -2,7 +2,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { readFile, readdir, realpath, writeFile } from 'node:fs/promises';
+import { lstat, readFile, readdir, realpath, writeFile } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -18,11 +18,8 @@ import { loadRetentionInput } from './release/retention.mjs';
 const CONTROLLER_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const FIXED_DEFAULT_BASELINE_ROOT = join(CONTROLLER_ROOT, 'scripts/default-flow-fixed-baseline');
 const FIXED_DEFAULT_BASELINE_MANIFEST = join(FIXED_DEFAULT_BASELINE_ROOT, 'manifest.json');
-const FIXED_DEFAULT_BASELINE_PATHS = new Map([
-  ['src/widget/index.ts', 'src/widget/index.ts.txt'],
-  ['src/widget/default-flow/definition.ts', 'src/widget/default-flow/definition.ts.txt'],
-  ['src/widget/default-flow/runtime.ts', 'src/widget/default-flow/runtime.ts.txt'],
-]);
+const FIXED_DEFAULT_BASELINE_ENTRY = 'src/widget/index.ts';
+const FIXED_DEFAULT_BASELINE_FILE_COUNT = 70;
 const VALUE_OPTIONS = new Set([
   'mode',
   'source-dir',
@@ -128,14 +125,12 @@ async function treeDigest(root) {
 }
 
 async function controllerIdentity() {
+  const fixedBaselineFiles = await listSourceFiles(FIXED_DEFAULT_BASELINE_ROOT);
   const paths = [
     fileURLToPath(import.meta.url),
     join(CONTROLLER_ROOT, 'scripts/release/canonical-json.mjs'),
     join(CONTROLLER_ROOT, 'scripts/release/static-assets.mjs'),
-    FIXED_DEFAULT_BASELINE_MANIFEST,
-    ...Array.from(FIXED_DEFAULT_BASELINE_PATHS.values(), path =>
-      join(FIXED_DEFAULT_BASELINE_ROOT, path)
-    ),
+    ...fixedBaselineFiles.map(path => join(FIXED_DEFAULT_BASELINE_ROOT, path)),
   ];
   const hash = createHash('sha256');
   for (const path of paths) {
@@ -182,7 +177,7 @@ async function loadFixedDefaultBaseline(sourceDir) {
     manifest.schema !== 'bugdrop.default-flow-fixed-baseline/v1' ||
     manifest.sourceCommit !== 'bb0f1b50a37867f8351b99f7e712a960836deb3f' ||
     !Array.isArray(manifest.files) ||
-    manifest.files.length !== 3
+    manifest.files.length !== FIXED_DEFAULT_BASELINE_FILE_COUNT
   ) {
     throw new Error('Fixed default baseline manifest identity is invalid');
   }
@@ -209,7 +204,11 @@ async function loadFixedDefaultBaseline(sourceDir) {
     }
     candidatePaths.add(candidatePath);
     assetPaths.add(assetPath);
-    if (FIXED_DEFAULT_BASELINE_PATHS.get(candidatePath) !== assetPath) {
+    if (
+      (candidatePath !== 'src/defaults.ts' && !candidatePath.startsWith('src/widget/')) ||
+      !candidatePath.endsWith('.ts') ||
+      assetPath !== `${candidatePath}.txt`
+    ) {
       throw new Error('Fixed default baseline manifest path identity is invalid');
     }
     const candidateFile = resolveInside(physicalSourceDir, candidatePath, 'candidate path');
@@ -227,10 +226,33 @@ async function loadFixedDefaultBaseline(sourceDir) {
     }
     baseline.set(candidateFile, bytes.toString('utf8'));
   }
-  if (candidatePaths.size !== FIXED_DEFAULT_BASELINE_PATHS.size) {
+  if (
+    candidatePaths.size !== FIXED_DEFAULT_BASELINE_FILE_COUNT ||
+    !candidatePaths.has(FIXED_DEFAULT_BASELINE_ENTRY)
+  ) {
     throw new Error('Fixed default baseline manifest is incomplete');
   }
-  return baseline;
+  const entry = resolveInside(physicalSourceDir, FIXED_DEFAULT_BASELINE_ENTRY, 'candidate entry');
+  let entryStat;
+  try {
+    entryStat = await lstat(entry);
+  } catch {
+    throw new Error(`Fixed default baseline candidate is missing: ${FIXED_DEFAULT_BASELINE_ENTRY}`);
+  }
+  if (!entryStat.isFile() || entryStat.isSymbolicLink()) {
+    throw new Error(
+      `Fixed default baseline candidate must be a regular file: ${FIXED_DEFAULT_BASELINE_ENTRY}`
+    );
+  }
+  return { entry, modules: baseline };
+}
+
+function resolveFixedDefaultImport(modules, importer, specifier) {
+  const unresolved = resolve(dirname(importer), specifier);
+  for (const path of [unresolved, `${unresolved}.ts`, join(unresolved, 'index.ts')]) {
+    if (modules.has(path)) return path;
+  }
+  throw new Error(`Fixed default baseline import is missing: ${specifier} from ${importer}`);
 }
 
 function git(sourceDir, args) {
@@ -253,6 +275,7 @@ async function bundleCandidate({ sourceDir, version, enableTestHooks, defaultFlo
   const entry = join(sourceDir, 'src/widget/index.ts');
   const fixedBaseline =
     defaultFlowRuntime === 'fixed' ? await loadFixedDefaultBaseline(sourceDir) : undefined;
+  const loadedFixedBaseline = new Set();
   const result = await build({
     absWorkingDir: sourceDir,
     bundle: true,
@@ -261,7 +284,7 @@ async function bundleCandidate({ sourceDir, version, enableTestHooks, defaultFlo
       __BUGDROP_DEFAULT_FLOW_RUNTIME__: JSON.stringify(defaultFlowRuntime),
       __BUGDROP_VERSION__: JSON.stringify(version),
     },
-    entryPoints: [entry],
+    entryPoints: [fixedBaseline?.entry ?? entry],
     format: 'iife',
     logLevel: 'silent',
     minify: true,
@@ -272,9 +295,25 @@ async function bundleCandidate({ sourceDir, version, enableTestHooks, defaultFlo
             {
               name: 'fixed-default-baseline',
               setup(build) {
+                build.onResolve({ filter: /.*/ }, args => {
+                  if (!fixedBaseline.modules.has(args.importer) || !args.path.startsWith('.')) {
+                    return undefined;
+                  }
+                  return {
+                    path: resolveFixedDefaultImport(
+                      fixedBaseline.modules,
+                      args.importer,
+                      args.path
+                    ),
+                  };
+                });
                 build.onLoad({ filter: /\.[cm]?[jt]sx?$/ }, args => {
-                  const contents = fixedBaseline.get(resolve(args.path));
+                  const contents = fixedBaseline.modules.get(args.path);
                   if (contents === undefined) return undefined;
+                  if (loadedFixedBaseline.has(args.path)) {
+                    throw new Error(`Fixed default baseline loaded more than once: ${args.path}`);
+                  }
+                  loadedFixedBaseline.add(args.path);
                   return { contents, loader: 'ts', resolveDir: dirname(args.path) };
                 });
               },
@@ -283,6 +322,13 @@ async function bundleCandidate({ sourceDir, version, enableTestHooks, defaultFlo
         : [],
     write: false,
   });
+  if (fixedBaseline && loadedFixedBaseline.size !== fixedBaseline.modules.size) {
+    const missing = Array.from(fixedBaseline.modules.keys())
+      .filter(path => !loadedFixedBaseline.has(path))
+      .map(path => normalized(relative(sourceDir, path)))
+      .sort();
+    throw new Error(`Fixed default baseline substitution is incomplete: ${missing.join(', ')}`);
+  }
   if (result.outputFiles.length !== 1) throw new Error('Expected exactly one widget bundle output');
   const bytes = Buffer.from(result.outputFiles[0].contents);
   if (!enableTestHooks && bytes.includes('__bugdropMockToPng')) {

--- a/scripts/build-widget.js
+++ b/scripts/build-widget.js
@@ -2,8 +2,8 @@
 
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { readFile, readdir, writeFile } from 'node:fs/promises';
-import { basename, dirname, join, relative, resolve, sep } from 'node:path';
+import { readFile, readdir, realpath, writeFile } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { build, version as esbuildVersion } from 'esbuild';
@@ -16,11 +16,12 @@ import { canonicalize } from './release/canonical-json.mjs';
 import { loadRetentionInput } from './release/retention.mjs';
 
 const CONTROLLER_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const FIXED_DEFAULT_BASELINE_SHA = 'bb0f1b50a37867f8351b99f7e712a960836deb3f';
-const FIXED_DEFAULT_BASELINE_FILES = new Set([
-  'src/widget/index.ts',
-  'src/widget/default-flow/definition.ts',
-  'src/widget/default-flow/runtime.ts',
+const FIXED_DEFAULT_BASELINE_ROOT = join(CONTROLLER_ROOT, 'scripts/default-flow-fixed-baseline');
+const FIXED_DEFAULT_BASELINE_MANIFEST = join(FIXED_DEFAULT_BASELINE_ROOT, 'manifest.json');
+const FIXED_DEFAULT_BASELINE_PATHS = new Map([
+  ['src/widget/index.ts', 'src/widget/index.ts.txt'],
+  ['src/widget/default-flow/definition.ts', 'src/widget/default-flow/definition.ts.txt'],
+  ['src/widget/default-flow/runtime.ts', 'src/widget/default-flow/runtime.ts.txt'],
 ]);
 const VALUE_OPTIONS = new Set([
   'mode',
@@ -131,6 +132,10 @@ async function controllerIdentity() {
     fileURLToPath(import.meta.url),
     join(CONTROLLER_ROOT, 'scripts/release/canonical-json.mjs'),
     join(CONTROLLER_ROOT, 'scripts/release/static-assets.mjs'),
+    FIXED_DEFAULT_BASELINE_MANIFEST,
+    ...Array.from(FIXED_DEFAULT_BASELINE_PATHS.values(), path =>
+      join(FIXED_DEFAULT_BASELINE_ROOT, path)
+    ),
   ];
   const hash = createHash('sha256');
   for (const path of paths) {
@@ -140,6 +145,92 @@ async function controllerIdentity() {
     hash.update('\0');
   }
   return `sha256:${hash.digest('hex')}`;
+}
+
+function isPlainObject(value) {
+  return value !== null && !Array.isArray(value) && typeof value === 'object';
+}
+
+function resolveInside(root, path, label) {
+  if (typeof path !== 'string' || path.length === 0 || path.includes('\\') || isAbsolute(path)) {
+    throw new Error(`Fixed default baseline ${label} is invalid`);
+  }
+  const resolved = resolve(root, path);
+  const fromRoot = relative(root, resolved);
+  if (
+    fromRoot === '' ||
+    fromRoot === '..' ||
+    fromRoot.startsWith(`..${sep}`) ||
+    isAbsolute(fromRoot)
+  ) {
+    throw new Error(`Fixed default baseline ${label} escapes its root`);
+  }
+  return resolved;
+}
+
+async function loadFixedDefaultBaseline(sourceDir) {
+  const physicalSourceDir = await realpath(sourceDir);
+  const physicalBaselineRoot = await realpath(FIXED_DEFAULT_BASELINE_ROOT);
+  let manifest;
+  try {
+    manifest = JSON.parse(await readFile(FIXED_DEFAULT_BASELINE_MANIFEST, 'utf8'));
+  } catch {
+    throw new Error('Fixed default baseline manifest is missing or malformed');
+  }
+  if (
+    !isPlainObject(manifest) ||
+    manifest.schema !== 'bugdrop.default-flow-fixed-baseline/v1' ||
+    manifest.sourceCommit !== 'bb0f1b50a37867f8351b99f7e712a960836deb3f' ||
+    !Array.isArray(manifest.files) ||
+    manifest.files.length !== 3
+  ) {
+    throw new Error('Fixed default baseline manifest identity is invalid');
+  }
+  const candidatePaths = new Set();
+  const assetPaths = new Set();
+  const baseline = new Map();
+  for (const file of manifest.files) {
+    if (
+      !isPlainObject(file) ||
+      !Number.isSafeInteger(file.length) ||
+      file.length <= 0 ||
+      typeof file.sha256 !== 'string' ||
+      !/^[a-f0-9]{64}$/.test(file.sha256)
+    ) {
+      throw new Error('Fixed default baseline manifest entry is invalid');
+    }
+    if (typeof file.candidatePath !== 'string' || typeof file.assetPath !== 'string') {
+      throw new Error('Fixed default baseline manifest entry is invalid');
+    }
+    const candidatePath = normalized(file.candidatePath);
+    const assetPath = normalized(file.assetPath);
+    if (candidatePaths.has(candidatePath) || assetPaths.has(assetPath)) {
+      throw new Error('Fixed default baseline manifest contains a duplicate path');
+    }
+    candidatePaths.add(candidatePath);
+    assetPaths.add(assetPath);
+    if (FIXED_DEFAULT_BASELINE_PATHS.get(candidatePath) !== assetPath) {
+      throw new Error('Fixed default baseline manifest path identity is invalid');
+    }
+    const candidateFile = resolveInside(physicalSourceDir, candidatePath, 'candidate path');
+    const declaredAssetFile = resolveInside(physicalBaselineRoot, assetPath, 'asset path');
+    let bytes;
+    try {
+      const assetFile = await realpath(declaredAssetFile);
+      resolveInside(physicalBaselineRoot, relative(physicalBaselineRoot, assetFile), 'asset path');
+      bytes = await readFile(assetFile);
+    } catch {
+      throw new Error(`Fixed default baseline asset is missing: ${assetPath}`);
+    }
+    if (bytes.length !== file.length || sha256(bytes) !== file.sha256) {
+      throw new Error(`Fixed default baseline asset integrity failed: ${assetPath}`);
+    }
+    baseline.set(candidateFile, bytes.toString('utf8'));
+  }
+  if (candidatePaths.size !== FIXED_DEFAULT_BASELINE_PATHS.size) {
+    throw new Error('Fixed default baseline manifest is incomplete');
+  }
+  return baseline;
 }
 
 function git(sourceDir, args) {
@@ -160,6 +251,8 @@ function repositoryFromRemote(remote) {
 
 async function bundleCandidate({ sourceDir, version, enableTestHooks, defaultFlowRuntime }) {
   const entry = join(sourceDir, 'src/widget/index.ts');
+  const fixedBaseline =
+    defaultFlowRuntime === 'fixed' ? await loadFixedDefaultBaseline(sourceDir) : undefined;
   const result = await build({
     absWorkingDir: sourceDir,
     bundle: true,
@@ -180,14 +273,9 @@ async function bundleCandidate({ sourceDir, version, enableTestHooks, defaultFlo
               name: 'fixed-default-baseline',
               setup(build) {
                 build.onLoad({ filter: /\.[cm]?[jt]sx?$/ }, args => {
-                  const path = normalized(relative(sourceDir, args.path));
-                  if (!FIXED_DEFAULT_BASELINE_FILES.has(path)) return undefined;
-                  const contents = execFileSync(
-                    'git',
-                    ['-C', CONTROLLER_ROOT, 'show', `${FIXED_DEFAULT_BASELINE_SHA}:${path}`],
-                    { encoding: 'utf8' }
-                  );
-                  return { contents, loader: 'ts' };
+                  const contents = fixedBaseline.get(resolve(args.path));
+                  if (contents === undefined) return undefined;
+                  return { contents, loader: 'ts', resolveDir: dirname(args.path) };
                 });
               },
             },
@@ -271,18 +359,11 @@ async function main() {
   if (!version) throw new Error('Release mode requires --version or BUGDROP_VERSION');
   if (!timestamp) throw new Error('Release mode requires --timestamp or BUGDROP_RELEASE_TIMESTAMP');
 
-  const targetSha = option(
-    options,
-    'target-sha',
-    'BUGDROP_TARGET_SHA',
-    git(sourceDir, ['rev-parse', 'HEAD'])
-  );
-  const repository = option(
-    options,
-    'repository',
-    'BUGDROP_REPOSITORY',
-    repositoryFromRemote(git(sourceDir, ['remote', 'get-url', 'origin']))
-  );
+  const targetSha =
+    option(options, 'target-sha', 'BUGDROP_TARGET_SHA') ?? git(sourceDir, ['rev-parse', 'HEAD']);
+  const repository =
+    option(options, 'repository', 'BUGDROP_REPOSITORY') ??
+    repositoryFromRemote(git(sourceDir, ['remote', 'get-url', 'origin']));
   const retention = await loadRetentionPlan(
     option(options, 'retention-plan', 'BUGDROP_RETENTION_PLAN'),
     option(options, 'request-plan', 'BUGDROP_REQUEST_PLAN')

--- a/scripts/build-widget.js
+++ b/scripts/build-widget.js
@@ -16,6 +16,12 @@ import { canonicalize } from './release/canonical-json.mjs';
 import { loadRetentionInput } from './release/retention.mjs';
 
 const CONTROLLER_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const FIXED_DEFAULT_BASELINE_SHA = 'bb0f1b50a37867f8351b99f7e712a960836deb3f';
+const FIXED_DEFAULT_BASELINE_FILES = new Set([
+  'src/widget/index.ts',
+  'src/widget/default-flow/definition.ts',
+  'src/widget/default-flow/runtime.ts',
+]);
 const VALUE_OPTIONS = new Set([
   'mode',
   'source-dir',
@@ -47,7 +53,7 @@ Common options:
   --source-dir PATH           Candidate checkout (default: repository root)
   --output-dir PATH           Clean output tree (default: <source>/public)
   --development-id ID         Visible identity for development output
-  --default-flow-runtime ID   Internal default controller: fixed (default) or private
+  --default-flow-runtime ID   Internal default controller: private (default) or fixed rollback
 
 Release options:
   --version MAJOR.MINOR.PATCH  Required planned stable version
@@ -167,6 +173,26 @@ async function bundleCandidate({ sourceDir, version, enableTestHooks, defaultFlo
     logLevel: 'silent',
     minify: true,
     outfile: 'widget.js',
+    plugins:
+      defaultFlowRuntime === 'fixed'
+        ? [
+            {
+              name: 'fixed-default-baseline',
+              setup(build) {
+                build.onLoad({ filter: /\.[cm]?[jt]sx?$/ }, args => {
+                  const path = normalized(relative(sourceDir, args.path));
+                  if (!FIXED_DEFAULT_BASELINE_FILES.has(path)) return undefined;
+                  const contents = execFileSync(
+                    'git',
+                    ['-C', CONTROLLER_ROOT, 'show', `${FIXED_DEFAULT_BASELINE_SHA}:${path}`],
+                    { encoding: 'utf8' }
+                  );
+                  return { contents, loader: 'ts' };
+                });
+              },
+            },
+          ]
+        : [],
     write: false,
   });
   if (result.outputFiles.length !== 1) throw new Error('Expected exactly one widget bundle output');
@@ -215,10 +241,10 @@ async function main() {
     options,
     'default-flow-runtime',
     'BUGDROP_DEFAULT_FLOW_RUNTIME',
-    'fixed'
+    'private'
   );
   if (defaultFlowRuntime !== 'fixed' && defaultFlowRuntime !== 'private') {
-    throw new Error('Unsupported default flow runtime: expected fixed or private');
+    throw new Error('Unsupported default flow runtime: expected private or fixed');
   }
 
   if (mode === 'development') {

--- a/scripts/default-flow-fixed-baseline/manifest.json
+++ b/scripts/default-flow-fixed-baseline/manifest.json
@@ -3,10 +3,88 @@
   "sourceCommit": "bb0f1b50a37867f8351b99f7e712a960836deb3f",
   "files": [
     {
-      "candidatePath": "src/widget/index.ts",
-      "assetPath": "src/widget/index.ts.txt",
-      "length": 65201,
-      "sha256": "e43e2d05611dfd5b9bab77f14ee0be3ad8a8cc1f587f37a57ad519d6189e399d"
+      "candidatePath": "src/defaults.ts",
+      "assetPath": "src/defaults.ts.txt",
+      "length": 681,
+      "sha256": "2754b3a0be5c4b38edb99d0d12874bfd4c523ffcc1a74e6569b3730c87360d46"
+    },
+    {
+      "candidatePath": "src/widget/annotation-flow.ts",
+      "assetPath": "src/widget/annotation-flow.ts.txt",
+      "length": 4128,
+      "sha256": "904d37d0e3ed847c0b9f83615f4d780a7d5d09113bbdd9e0e29bee4726e84a02"
+    },
+    {
+      "candidatePath": "src/widget/annotator.ts",
+      "assetPath": "src/widget/annotator.ts.txt",
+      "length": 7756,
+      "sha256": "42db5583e3f6c08e6668a3f44906f539a259f8a584fb5a198b9c69cbe7243604"
+    },
+    {
+      "candidatePath": "src/widget/area-picker.ts",
+      "assetPath": "src/widget/area-picker.ts.txt",
+      "length": 8189,
+      "sha256": "a3b442e2caab7163aa821e728d29f757c6be73049e0e1b891ee724006e6eeedf"
+    },
+    {
+      "candidatePath": "src/widget/auth-token.ts",
+      "assetPath": "src/widget/auth-token.ts.txt",
+      "length": 994,
+      "sha256": "266ebcd0b16cd1e3cb66ae072163aa83ebd78c2ea9cbaa922cd8206d37ddcaa4"
+    },
+    {
+      "candidatePath": "src/widget/capture-cancellation.ts",
+      "assetPath": "src/widget/capture-cancellation.ts.txt",
+      "length": 1203,
+      "sha256": "0fad003ef3ce3a209f4f7c573b8404c3f0967693c994df24efee969a40570700"
+    },
+    {
+      "candidatePath": "src/widget/capture-flow-result.ts",
+      "assetPath": "src/widget/capture-flow-result.ts.txt",
+      "length": 675,
+      "sha256": "a2cb43d6e29ecab5ead93c798c006b9a3263f2c179bc7adc521ee315a8f08bda"
+    },
+    {
+      "candidatePath": "src/widget/capture-flow-style.ts",
+      "assetPath": "src/widget/capture-flow-style.ts.txt",
+      "length": 391,
+      "sha256": "bff9f38bc0313a2a7b3bc3078a4767c6d49e8865c861c6f4b585b5bb086e4b43"
+    },
+    {
+      "candidatePath": "src/widget/capture-flow.ts",
+      "assetPath": "src/widget/capture-flow.ts.txt",
+      "length": 10680,
+      "sha256": "794cedcd8dce02320f354c5fe49f1c4dd84a0768334932472d78ae6842057874"
+    },
+    {
+      "candidatePath": "src/widget/capture-loading.ts",
+      "assetPath": "src/widget/capture-loading.ts.txt",
+      "length": 7034,
+      "sha256": "22aa30f620bd634ccb38b65f9b8f449a40535cf2762c46c8e96152262606abde"
+    },
+    {
+      "candidatePath": "src/widget/capture-timeout.ts",
+      "assetPath": "src/widget/capture-timeout.ts.txt",
+      "length": 632,
+      "sha256": "4e6b4e1b9176414c3767ef589f1e31c6c6f1b6c8d332c5e7e4970443e8b6b04d"
+    },
+    {
+      "candidatePath": "src/widget/console-log-redaction.ts",
+      "assetPath": "src/widget/console-log-redaction.ts.txt",
+      "length": 1251,
+      "sha256": "7a1c02640ba76f20d6767a3e3c466bb6cb640afa75eb9b9cd45e15e75b4ba5b2"
+    },
+    {
+      "candidatePath": "src/widget/console-logs.ts",
+      "assetPath": "src/widget/console-logs.ts.txt",
+      "length": 2818,
+      "sha256": "5eab48f97daf4cb7cca24e03bec7808c115f684e089603e6dd6f968141c49e51"
+    },
+    {
+      "candidatePath": "src/widget/crop-screenshot.ts",
+      "assetPath": "src/widget/crop-screenshot.ts.txt",
+      "length": 968,
+      "sha256": "648c8160fa92333624550c70909606c7a899f84a205e10b26013abe6ee6f2145"
     },
     {
       "candidatePath": "src/widget/default-flow/definition.ts",
@@ -19,6 +97,330 @@
       "assetPath": "src/widget/default-flow/runtime.ts.txt",
       "length": 2005,
       "sha256": "720b00d490edccee7a2be55eac3487f1638f73dc1de86b59e98f5f9a87a88048"
+    },
+    {
+      "candidatePath": "src/widget/element-context.ts",
+      "assetPath": "src/widget/element-context.ts.txt",
+      "length": 1984,
+      "sha256": "c50f6e934a84a9d2a1ccace08de9ba1f2b8e3a72751cec1233d2e41833d4c6ee"
+    },
+    {
+      "candidatePath": "src/widget/flows/busy-opened-flow.ts",
+      "assetPath": "src/widget/flows/busy-opened-flow.ts.txt",
+      "length": 335,
+      "sha256": "683de1998e5eaca388eeee88964bd87b0c18a654f5c102a7ebf86a7b0a7bfb21"
+    },
+    {
+      "candidatePath": "src/widget/flows/conditions.ts",
+      "assetPath": "src/widget/flows/conditions.ts.txt",
+      "length": 1555,
+      "sha256": "3bd5b1fe9c233a0e775d1b385fb61fbbedf79e47e9aed33d5282474ca45f0c17"
+    },
+    {
+      "candidatePath": "src/widget/flows/definition.ts",
+      "assetPath": "src/widget/flows/definition.ts.txt",
+      "length": 1871,
+      "sha256": "4337e9d9d43d2c8b4259efb03ea34ff807af21acf4e4b1aebd329e0fcb0cb990"
+    },
+    {
+      "candidatePath": "src/widget/flows/extra-fields.ts",
+      "assetPath": "src/widget/flows/extra-fields.ts.txt",
+      "length": 7568,
+      "sha256": "9483eccc99c68007ad03ca176ec4c8ce82d5558c9def84a75df2873182f1bb29"
+    },
+    {
+      "candidatePath": "src/widget/flows/field-validation.ts",
+      "assetPath": "src/widget/flows/field-validation.ts.txt",
+      "length": 13437,
+      "sha256": "55b2a42b88e681cb18f00212f8faa7afeae6d86e6595c5d86900ac5945c1100b"
+    },
+    {
+      "candidatePath": "src/widget/flows/form-screen.ts",
+      "assetPath": "src/widget/flows/form-screen.ts.txt",
+      "length": 4605,
+      "sha256": "f9651f906aa0499474915534d35423431afee24c7c36ba964fcea2a5ec3975ec"
+    },
+    {
+      "candidatePath": "src/widget/flows/issue-draft.ts",
+      "assetPath": "src/widget/flows/issue-draft.ts.txt",
+      "length": 3313,
+      "sha256": "7178b90d6d2a06923e669bdc3a1025211e9218f13b1fbf47e8dc10c20a374a69"
+    },
+    {
+      "candidatePath": "src/widget/flows/manager.ts",
+      "assetPath": "src/widget/flows/manager.ts.txt",
+      "length": 1787,
+      "sha256": "90182c2b0f57df4ef47529fe22e8eeadc3d2ce0d41101d244df446fa2fa89d1d"
+    },
+    {
+      "candidatePath": "src/widget/flows/message-screen.ts",
+      "assetPath": "src/widget/flows/message-screen.ts.txt",
+      "length": 737,
+      "sha256": "53ece3a438fdda55b35516aaecaf3cd0b0f0e7d33262f898708590fd7463bcf7"
+    },
+    {
+      "candidatePath": "src/widget/flows/modal-state.ts",
+      "assetPath": "src/widget/flows/modal-state.ts.txt",
+      "length": 2331,
+      "sha256": "94d9998ae95d3be4cdcd528a104e3acd339712659334474020080c474a679d67"
+    },
+    {
+      "candidatePath": "src/widget/flows/modal-view.ts",
+      "assetPath": "src/widget/flows/modal-view.ts.txt",
+      "length": 5566,
+      "sha256": "b4d9aa31492b5ce170d568b14f1fb00745b5a94fbd739082ccfff6bc791fef28"
+    },
+    {
+      "candidatePath": "src/widget/flows/modal.ts",
+      "assetPath": "src/widget/flows/modal.ts.txt",
+      "length": 11113,
+      "sha256": "3bd47e6a79143772eb32f2104fe06f82b074d4396c095f98ca4cfbb3774b67b0"
+    },
+    {
+      "candidatePath": "src/widget/flows/runtime.ts",
+      "assetPath": "src/widget/flows/runtime.ts.txt",
+      "length": 4366,
+      "sha256": "80395312242217a0dc941aa0ddd482982f9ab18549f38ce3f251e0312d6d515f"
+    },
+    {
+      "candidatePath": "src/widget/flows/styles.ts",
+      "assetPath": "src/widget/flows/styles.ts.txt",
+      "length": 1338,
+      "sha256": "020a40c9636a42ae1fd722d5fb47078b78cdd872cd5d0040b1be7ee698d213f2"
+    },
+    {
+      "candidatePath": "src/widget/flows/submission.ts",
+      "assetPath": "src/widget/flows/submission.ts.txt",
+      "length": 4237,
+      "sha256": "3fc883d3c6e4bc9475fb1441b2596d3579559b5eb6b74f0f88d587319a987680"
+    },
+    {
+      "candidatePath": "src/widget/flows/validate-config.ts",
+      "assetPath": "src/widget/flows/validate-config.ts.txt",
+      "length": 13013,
+      "sha256": "d1d620542d2b91e0a5ddcb122523ba1457754147c5e5ef155a753ca9825f5088"
+    },
+    {
+      "candidatePath": "src/widget/flows/validation-utils.ts",
+      "assetPath": "src/widget/flows/validation-utils.ts.txt",
+      "length": 1676,
+      "sha256": "8a770b0a4168343bb278eeab02a5eabef5d0b79c30c4b4237dd0cb888156f781"
+    },
+    {
+      "candidatePath": "src/widget/i18n.ts",
+      "assetPath": "src/widget/i18n.ts.txt",
+      "length": 4537,
+      "sha256": "3bb0a11c292d9ad1e183982febdc20cd6d93afc2ebc1daed33a5897bc4ff9a95"
+    },
+    {
+      "candidatePath": "src/widget/index.ts",
+      "assetPath": "src/widget/index.ts.txt",
+      "length": 65201,
+      "sha256": "e43e2d05611dfd5b9bab77f14ee0be3ad8a8cc1f587f37a57ad519d6189e399d"
+    },
+    {
+      "candidatePath": "src/widget/locales/de.ts",
+      "assetPath": "src/widget/locales/de.ts.txt",
+      "length": 7962,
+      "sha256": "89899522354bb8f0265fbcb4ef4c0af948b8a68a2ee2664b0840703d51db5033"
+    },
+    {
+      "candidatePath": "src/widget/locales/en.ts",
+      "assetPath": "src/widget/locales/en.ts.txt",
+      "length": 6541,
+      "sha256": "3d771c616433b4e7fa6be50af5a1a2cf0293cb43bf0e1f53beff80ed64c690a5"
+    },
+    {
+      "candidatePath": "src/widget/locales/nl.ts",
+      "assetPath": "src/widget/locales/nl.ts.txt",
+      "length": 7506,
+      "sha256": "2e62c3ade5abc5bbf7c83e906a2f1979dd3f6f22da55ab1d4b1615c6cd341349"
+    },
+    {
+      "candidatePath": "src/widget/locales/pl.ts",
+      "assetPath": "src/widget/locales/pl.ts.txt",
+      "length": 7775,
+      "sha256": "0c49438383047f134707291f2ca21df15dd8146f908060a9eb614567b32edeaa"
+    },
+    {
+      "candidatePath": "src/widget/mask.ts",
+      "assetPath": "src/widget/mask.ts.txt",
+      "length": 8747,
+      "sha256": "73a5dc69bdd5f1b425777949a6670ffa43cf49a2ae7d0da9d866e3278ab998fb"
+    },
+    {
+      "candidatePath": "src/widget/owned-roots.ts",
+      "assetPath": "src/widget/owned-roots.ts.txt",
+      "length": 1145,
+      "sha256": "c974ec75c0f43dfbb4cd6b028597c952ce3616ba76eb4767cd3132a2a94cdb3b"
+    },
+    {
+      "candidatePath": "src/widget/picker-style.ts",
+      "assetPath": "src/widget/picker-style.ts.txt",
+      "length": 1450,
+      "sha256": "40f472be64e0ececa0b9135fa2720aca6f2077cf05e5637613f6d3d50578114b"
+    },
+    {
+      "candidatePath": "src/widget/picker-target.ts",
+      "assetPath": "src/widget/picker-target.ts.txt",
+      "length": 2666,
+      "sha256": "81ea4b06ff2a29f5aca4162fa8ae3c93e1d0844a4a6ef982f50954d26b024055"
+    },
+    {
+      "candidatePath": "src/widget/picker.ts",
+      "assetPath": "src/widget/picker.ts.txt",
+      "length": 12108,
+      "sha256": "d247d7872ef3c6086e35f2562b616e1f440b6fc82eeb0e34ec1cadd1edafc66d"
+    },
+    {
+      "candidatePath": "src/widget/radix-compat.ts",
+      "assetPath": "src/widget/radix-compat.ts.txt",
+      "length": 3333,
+      "sha256": "465cc3a8103f6b1c948187eac3e9011b31ef42c86945a44f84a77b670416d606"
+    },
+    {
+      "candidatePath": "src/widget/sanitize.ts",
+      "assetPath": "src/widget/sanitize.ts.txt",
+      "length": 2859,
+      "sha256": "849562ec60eb225dc55b576181ac4908576a1c93915a6091048d8de4a624cd9b"
+    },
+    {
+      "candidatePath": "src/widget/screenshot-options.ts",
+      "assetPath": "src/widget/screenshot-options.ts.txt",
+      "length": 4267,
+      "sha256": "cd3cb462b9ece8aa55b55b6dc9787eded20aa3a8a80df4358b6a0ec5ef307bc3"
+    },
+    {
+      "candidatePath": "src/widget/screenshot.ts",
+      "assetPath": "src/widget/screenshot.ts.txt",
+      "length": 11179,
+      "sha256": "1ecb7cc9ebd46069b9c4cf65829149f59d23736ace4f910460cc39dbe8dea794"
+    },
+    {
+      "candidatePath": "src/widget/selector-metadata.ts",
+      "assetPath": "src/widget/selector-metadata.ts.txt",
+      "length": 5850,
+      "sha256": "c3aab8a2768c4250ad2feaa5496a649ce9dfda560c71844dc43bfbbb52411a47"
+    },
+    {
+      "candidatePath": "src/widget/theme.ts",
+      "assetPath": "src/widget/theme.ts.txt",
+      "length": 5497,
+      "sha256": "285c1dba4b02e70d25a9ed3b34c271f8e2f3a6575b934eaad9a6cfcc7801bed3"
+    },
+    {
+      "candidatePath": "src/widget/ui.ts",
+      "assetPath": "src/widget/ui.ts.txt",
+      "length": 41275,
+      "sha256": "d3fbb7afac3c61f312d904808a314cf795b52b4fd9487900605f027a6e65750c"
+    },
+    {
+      "candidatePath": "src/widget/variants/answer-validation.ts",
+      "assetPath": "src/widget/variants/answer-validation.ts.txt",
+      "length": 3070,
+      "sha256": "900b53269fe2271c0d06a4b37006b5dc6fbf31b402828345aec9922c3dc7cae4"
+    },
+    {
+      "candidatePath": "src/widget/variants/fields/index.ts",
+      "assetPath": "src/widget/variants/fields/index.ts.txt",
+      "length": 742,
+      "sha256": "d2d07c30ece0839186550170b78d1332fa6c41f567fdd284479be32519b67a24"
+    },
+    {
+      "candidatePath": "src/widget/variants/fields/long-text.ts",
+      "assetPath": "src/widget/variants/fields/long-text.ts.txt",
+      "length": 872,
+      "sha256": "d1c382128cb37a1272de2f978027b6d9cd6d90c115e31ee4e720480abdcfc586"
+    },
+    {
+      "candidatePath": "src/widget/variants/fields/rating.ts",
+      "assetPath": "src/widget/variants/fields/rating.ts.txt",
+      "length": 4033,
+      "sha256": "9f98d4744c9f6ee792b6dbaf0e913959f39bbcea90641501c57ae235cb6c574c"
+    },
+    {
+      "candidatePath": "src/widget/variants/fields/shared.ts",
+      "assetPath": "src/widget/variants/fields/shared.ts.txt",
+      "length": 2594,
+      "sha256": "f84f2bdd0c2f19c715fb510d24bda22eb9c39017f55df52963cb2caa30bb3fd0"
+    },
+    {
+      "candidatePath": "src/widget/variants/fields/short-text.ts",
+      "assetPath": "src/widget/variants/fields/short-text.ts.txt",
+      "length": 839,
+      "sha256": "c6f9aafc202f8820839121c0edcf8295e805ee3000ae97452ef506c80d6663d9"
+    },
+    {
+      "candidatePath": "src/widget/variants/fields/single-choice.ts",
+      "assetPath": "src/widget/variants/fields/single-choice.ts.txt",
+      "length": 1866,
+      "sha256": "0f2cf87bf0e496ba977a322d85c53dc776e9c96769c86b01888f8bb09b1450f9"
+    },
+    {
+      "candidatePath": "src/widget/variants/flow-definition.ts",
+      "assetPath": "src/widget/variants/flow-definition.ts.txt",
+      "length": 704,
+      "sha256": "a2b9a2b5e23ef6691f60fdb0e7e37b84ee417ec88249f5ffbfb6cbdeab97a9df"
+    },
+    {
+      "candidatePath": "src/widget/variants/form.ts",
+      "assetPath": "src/widget/variants/form.ts.txt",
+      "length": 8232,
+      "sha256": "dff38ed231ee67c412498a81bbb40cb404f52f336840e2d47b1c5cbc4b907e2b"
+    },
+    {
+      "candidatePath": "src/widget/variants/issue-draft.ts",
+      "assetPath": "src/widget/variants/issue-draft.ts.txt",
+      "length": 3771,
+      "sha256": "df347c04cfea6bdfe6b5c2092bb1009daa4f5f9a05c939881cbf4f694f602eae"
+    },
+    {
+      "candidatePath": "src/widget/variants/manager.ts",
+      "assetPath": "src/widget/variants/manager.ts.txt",
+      "length": 2373,
+      "sha256": "2bba40259098b139f1f86b5bca7dd790219af2fe8027ebe34ff12409aa95a6e3"
+    },
+    {
+      "candidatePath": "src/widget/variants/modal-coordinator.ts",
+      "assetPath": "src/widget/variants/modal-coordinator.ts.txt",
+      "length": 395,
+      "sha256": "244b8be9b9d8dffd62c1df50f6b122e4bd5eb6672cf6f8549aa66bc48dea6db1"
+    },
+    {
+      "candidatePath": "src/widget/variants/presentations/inline.ts",
+      "assetPath": "src/widget/variants/presentations/inline.ts.txt",
+      "length": 2030,
+      "sha256": "98829ee1e8f930b19bf7584b01f762344a50534faf3fb338cef23dcfad015108"
+    },
+    {
+      "candidatePath": "src/widget/variants/presentations/modal.ts",
+      "assetPath": "src/widget/variants/presentations/modal.ts.txt",
+      "length": 5906,
+      "sha256": "d9a04357492d227b59ffd24a8cc7ec8400442beb82d1013a66d14292b3eaf274"
+    },
+    {
+      "candidatePath": "src/widget/variants/styles.ts",
+      "assetPath": "src/widget/variants/styles.ts.txt",
+      "length": 7895,
+      "sha256": "5a649246e64f4dc0faa01bdf12c4a9432930f1ed10e2ee19ebe4834ba54c9c91"
+    },
+    {
+      "candidatePath": "src/widget/variants/submission.ts",
+      "assetPath": "src/widget/variants/submission.ts.txt",
+      "length": 4276,
+      "sha256": "23d2a4c6a995c115cbf2725fb50b2003ecde0c2db1ce1d0d868051209186adf4"
+    },
+    {
+      "candidatePath": "src/widget/variants/validate-config.ts",
+      "assetPath": "src/widget/variants/validate-config.ts.txt",
+      "length": 14775,
+      "sha256": "c088f0dd045eddb0b4e0296f6c340bb2b131425e30dcdf447c37ec5929926b83"
+    },
+    {
+      "candidatePath": "src/widget/viewport-capture.ts",
+      "assetPath": "src/widget/viewport-capture.ts.txt",
+      "length": 7029,
+      "sha256": "621db242edb002d0fc723b1d7fa9263e702f31ac892c0c1840ab8b94ee5e57c0"
     }
   ]
 }

--- a/scripts/default-flow-fixed-baseline/manifest.json
+++ b/scripts/default-flow-fixed-baseline/manifest.json
@@ -1,0 +1,24 @@
+{
+  "schema": "bugdrop.default-flow-fixed-baseline/v1",
+  "sourceCommit": "bb0f1b50a37867f8351b99f7e712a960836deb3f",
+  "files": [
+    {
+      "candidatePath": "src/widget/index.ts",
+      "assetPath": "src/widget/index.ts.txt",
+      "length": 65201,
+      "sha256": "e43e2d05611dfd5b9bab77f14ee0be3ad8a8cc1f587f37a57ad519d6189e399d"
+    },
+    {
+      "candidatePath": "src/widget/default-flow/definition.ts",
+      "assetPath": "src/widget/default-flow/definition.ts.txt",
+      "length": 4412,
+      "sha256": "387d8e624be87f5961a34941e5b406c9c8fc4556439cff4470b84712717d20e1"
+    },
+    {
+      "candidatePath": "src/widget/default-flow/runtime.ts",
+      "assetPath": "src/widget/default-flow/runtime.ts.txt",
+      "length": 2005,
+      "sha256": "720b00d490edccee7a2be55eac3487f1638f73dc1de86b59e98f5f9a87a88048"
+    }
+  ]
+}

--- a/scripts/default-flow-fixed-baseline/src/defaults.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/defaults.ts.txt
@@ -1,0 +1,16 @@
+export const DEFAULT_ACCENT_COLOR = '#14b8a6';
+export const DEFAULT_SELECTED_ELEMENT_CONTEXT_MAX_VIEWPORT_AREA_MULTIPLIER = 0;
+export const DEFAULT_SELECTED_ELEMENT_CONTEXT_MIN_PADDING_PX = 80;
+export const DEFAULT_SELECTED_ELEMENT_SCREENSHOT_PIXEL_RATIO = 1;
+
+export function resolveAccentColor(accentColor?: string | null): string {
+  return accentColor || DEFAULT_ACCENT_COLOR;
+}
+
+export function getAccentHoverColor(accentColor: string): string {
+  return `color-mix(in srgb, ${accentColor} 85%, black)`;
+}
+
+export function resolveSelectedElementContextMaxArea(value?: number | null): number {
+  return value ?? DEFAULT_SELECTED_ELEMENT_CONTEXT_MAX_VIEWPORT_AREA_MULTIPLIER;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/annotation-flow.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/annotation-flow.ts.txt
@@ -1,0 +1,108 @@
+import { createAnnotator, type Tool } from './annotator';
+import { createModal, redactionNoteHtml } from './ui';
+import { escapeWidgetText, t } from './i18n';
+
+export function showAnnotationStep(
+  root: HTMLElement,
+  screenshot: string,
+  redactionCount = 0,
+  opts?: {
+    redactionUnavailable?: boolean;
+    redactionLimitations?: boolean;
+    selectedElementCapture?: boolean;
+  }
+): Promise<string | 'retake' | 'cancel'> {
+  return new Promise(resolve => {
+    const redactionMessages: string[] = [];
+    if (opts?.redactionUnavailable) {
+      redactionMessages.push(t().viewportRedactionUnavailableNote);
+    } else {
+      if (redactionCount > 0) {
+        redactionMessages.push(t().redactionCountNote(redactionCount));
+      }
+      if (opts?.redactionLimitations) {
+        redactionMessages.push(t().redactionLimitationsNote);
+      }
+    }
+    const redactionNote = redactionMessages.length
+      ? redactionNoteHtml(redactionMessages.join(' '))
+      : '';
+    const configLinkHtml =
+      '<a href="https://bugdrop.dev/docs/configuration#select-element-screenshots" target="_blank" rel="noopener noreferrer">data-element-context-max-area</a>';
+    const selectedElementNote = opts?.selectedElementCapture
+      ? `
+        <p class="bd-selected-element-note" style="margin: -4px 0 12px; color: var(--bd-text-secondary); font-size: 13px;">
+          ${t().selectedElementNote(configLinkHtml)}
+        </p>
+      `
+      : '';
+    const modal = createModal(
+      root,
+      t().reviewScreenshotTitle,
+      `
+        ${redactionNote}
+        <p style="margin: 0 0 12px; color: var(--bd-text-secondary); font-size: 13px;">
+          ${escapeWidgetText(t().annotationInstruction)}
+        </p>
+        ${selectedElementNote}
+        <div class="bd-tools">
+          <button class="bd-tool active" data-tool="draw">✏️ ${escapeWidgetText(t().toolDraw)}</button>
+          <button class="bd-tool" data-tool="arrow">➡️ ${escapeWidgetText(t().toolArrow)}</button>
+          <button class="bd-tool" data-tool="rect">▢ ${escapeWidgetText(t().toolRectangle)}</button>
+          <button class="bd-tool" data-tool="redact">${escapeWidgetText(t().toolRedact)}</button>
+          <button class="bd-tool" data-action="undo">↶ ${escapeWidgetText(t().undo)}</button>
+        </div>
+        <div id="annotation-canvas" class="bd-annotation-stage"></div>
+        <div class="bd-actions">
+          <button class="bd-btn bd-btn-secondary" data-action="retake">${escapeWidgetText(t().retake)}</button>
+          <button class="bd-btn bd-btn-primary" data-action="done">${escapeWidgetText(t().submitFeedback)}</button>
+        </div>
+      `,
+      false,
+      'bd-modal--annotator'
+    );
+
+    const canvasContainer = modal.querySelector('#annotation-canvas') as HTMLElement;
+    const annotator = createAnnotator(canvasContainer, screenshot);
+
+    const toolButtons = modal.querySelectorAll('[data-tool]');
+    toolButtons.forEach(btn => {
+      btn.addEventListener('click', e => {
+        const target = e.currentTarget as HTMLElement;
+        const tool = target.dataset.tool;
+
+        if (tool) {
+          toolButtons.forEach(b => b.classList.remove('active'));
+          target.classList.add('active');
+          annotator.setTool(tool as Tool);
+        }
+      });
+    });
+
+    const undoBtn = modal.querySelector('[data-action="undo"]') as HTMLElement | null;
+    undoBtn?.addEventListener('click', () => annotator.undo());
+
+    const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
+    const retakeBtn = modal.querySelector('[data-action="retake"]') as HTMLElement;
+    const doneBtn = modal.querySelector('[data-action="done"]') as HTMLElement;
+
+    closeBtn?.addEventListener('click', () => {
+      annotator.destroy();
+      modal.remove();
+      resolve('cancel');
+    });
+
+    retakeBtn?.addEventListener('click', () => {
+      annotator.destroy();
+      modal.remove();
+      resolve('retake');
+    });
+
+    doneBtn?.addEventListener('click', () => {
+      const annotated = annotator.getImageData();
+      annotator.destroy();
+      modal.remove();
+      resolve(annotated);
+    });
+  });
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/annotator.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/annotator.ts.txt
@@ -1,0 +1,285 @@
+export type Tool = 'draw' | 'arrow' | 'rect' | 'redact';
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+const ANNOTATION_COLOR = '#ff0000';
+const REDACTION_COLOR = '#000000';
+const VISIBLE_ANNOTATION_LINE_WIDTH = 5.5;
+const ARROW_HEAD_ANGLE = Math.PI / 7;
+const MIN_ANNOTATION_DISTANCE = 2;
+const MIN_REDACTION_SIZE = 4;
+const REDACTION_PADDING = 1;
+
+export function createAnnotator(
+  container: HTMLElement,
+  imageData: string
+): {
+  setTool: (tool: Tool) => void;
+  undo: () => void;
+  getImageData: () => string;
+  destroy: () => void;
+} {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d')!;
+
+  let currentTool: Tool = 'draw';
+  let isDrawing = false;
+  let points: Point[] = [];
+  let draftBase: ImageData | null = null;
+  let hasDrawnStroke = false;
+  const history: ImageData[] = [];
+
+  // Load image
+  const img = new Image();
+  img.onload = () => {
+    // Keep full resolution in canvas, scale display via CSS
+    canvas.width = img.width;
+    canvas.height = img.height;
+    canvas.style.maxWidth = '100%';
+    canvas.style.height = 'auto';
+    canvas.style.cursor = 'crosshair';
+
+    ctx.drawImage(img, 0, 0);
+
+    // Commit the unannotated screenshot as the undo floor.
+    commitState();
+  };
+  img.src = imageData;
+
+  container.appendChild(canvas);
+
+  function commitState() {
+    history.push(ctx.getImageData(0, 0, canvas.width, canvas.height));
+  }
+
+  function restoreState(state: ImageData) {
+    ctx.putImageData(state, 0, 0);
+  }
+
+  function getLatestState() {
+    return history[history.length - 1] ?? null;
+  }
+
+  function getDistance(from: Point, to: Point) {
+    return Math.hypot(to.x - from.x, to.y - from.y);
+  }
+
+  function resetDraft() {
+    window.removeEventListener('mouseup', handleMouseUp);
+    isDrawing = false;
+    points = [];
+    draftBase = null;
+    hasDrawnStroke = false;
+  }
+
+  function cancelDraft() {
+    if (draftBase) restoreState(draftBase);
+    resetDraft();
+  }
+
+  function getCanvasPoint(e: MouseEvent): Point {
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = img.width / rect.width;
+    const scaleY = img.height / rect.height;
+    const x = (e.clientX - rect.left) * scaleX;
+    const y = (e.clientY - rect.top) * scaleY;
+    return {
+      x: Math.max(0, Math.min(canvas.width, x)),
+      y: Math.max(0, Math.min(canvas.height, y)),
+    };
+  }
+
+  function getLineWidth() {
+    const rect = canvas.getBoundingClientRect();
+    const scale = Math.max(canvas.width / rect.width, canvas.height / rect.height, 1);
+    return Math.round(VISIBLE_ANNOTATION_LINE_WIDTH * scale);
+  }
+
+  function drawLine(from: Point, to: Point) {
+    const lineWidth = getLineWidth();
+
+    ctx.beginPath();
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
+    ctx.strokeStyle = ANNOTATION_COLOR;
+    ctx.lineWidth = lineWidth;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.stroke();
+  }
+
+  function drawArrow(from: Point, to: Point) {
+    // Line
+    drawLine(from, to);
+
+    // Arrowhead
+    const angle = Math.atan2(to.y - from.y, to.x - from.x);
+    const headLength = getLineWidth() * 5;
+
+    ctx.beginPath();
+    ctx.moveTo(to.x, to.y);
+    ctx.lineTo(
+      to.x - headLength * Math.cos(angle - ARROW_HEAD_ANGLE),
+      to.y - headLength * Math.sin(angle - ARROW_HEAD_ANGLE)
+    );
+    ctx.lineTo(
+      to.x - headLength * Math.cos(angle + ARROW_HEAD_ANGLE),
+      to.y - headLength * Math.sin(angle + ARROW_HEAD_ANGLE)
+    );
+    ctx.closePath();
+    ctx.fillStyle = ANNOTATION_COLOR;
+    ctx.fill();
+  }
+
+  function drawRect(from: Point, to: Point) {
+    ctx.strokeStyle = ANNOTATION_COLOR;
+    ctx.lineWidth = getLineWidth();
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.strokeRect(from.x, from.y, to.x - from.x, to.y - from.y);
+  }
+
+  function getRectBounds(from: Point, to: Point) {
+    const x = Math.min(from.x, to.x);
+    const y = Math.min(from.y, to.y);
+    const width = Math.abs(to.x - from.x);
+    const height = Math.abs(to.y - from.y);
+    return { x, y, width, height };
+  }
+
+  function getRedactionBounds(from: Point, to: Point) {
+    const { x, y, width, height } = getRectBounds(from, to);
+    const left = Math.max(0, Math.floor(x) - REDACTION_PADDING);
+    const top = Math.max(0, Math.floor(y) - REDACTION_PADDING);
+    const right = Math.min(canvas.width, Math.ceil(x + width) + REDACTION_PADDING);
+    const bottom = Math.min(canvas.height, Math.ceil(y + height) + REDACTION_PADDING);
+    return {
+      x: left,
+      y: top,
+      width: Math.max(0, right - left),
+      height: Math.max(0, bottom - top),
+    };
+  }
+
+  function isMeaningfulRedaction(from: Point, to: Point) {
+    const { width, height } = getRedactionBounds(from, to);
+    return width >= MIN_REDACTION_SIZE && height >= MIN_REDACTION_SIZE;
+  }
+
+  function drawRedaction(from: Point, to: Point) {
+    const { x, y, width, height } = getRedactionBounds(from, to);
+    ctx.fillStyle = REDACTION_COLOR;
+    ctx.fillRect(x, y, width, height);
+  }
+
+  function handleMouseDown(e: MouseEvent) {
+    const base = getLatestState();
+    if (!base) return;
+
+    isDrawing = true;
+    points = [getCanvasPoint(e)];
+    draftBase = base;
+    hasDrawnStroke = false;
+    window.addEventListener('mouseup', handleMouseUp);
+  }
+
+  function handleMouseMove(e: MouseEvent) {
+    if (!isDrawing || !draftBase) return;
+
+    const point = getCanvasPoint(e);
+
+    if (currentTool === 'draw') {
+      drawLine(points[points.length - 1], point);
+      points.push(point);
+      hasDrawnStroke = hasDrawnStroke || getDistance(points[0], point) >= MIN_ANNOTATION_DISTANCE;
+    } else {
+      // Preview for shape-like tools.
+      restoreState(draftBase);
+
+      if (currentTool === 'arrow') {
+        drawArrow(points[0], point);
+      } else if (currentTool === 'rect') {
+        drawRect(points[0], point);
+      } else if (currentTool === 'redact') {
+        drawRedaction(points[0], point);
+      }
+    }
+  }
+
+  function handleMouseUp(e: MouseEvent) {
+    if (!isDrawing || !draftBase) {
+      resetDraft();
+      return;
+    }
+
+    const point = getCanvasPoint(e);
+    const start = points[0];
+    const isMeaningfulAnnotation =
+      currentTool === 'redact'
+        ? isMeaningfulRedaction(start, point)
+        : hasDrawnStroke || getDistance(start, point) >= MIN_ANNOTATION_DISTANCE;
+
+    if (!isMeaningfulAnnotation) {
+      restoreState(draftBase);
+      resetDraft();
+      return;
+    }
+
+    if (currentTool === 'arrow') {
+      restoreState(draftBase);
+      drawArrow(start, point);
+    } else if (currentTool === 'rect') {
+      restoreState(draftBase);
+      drawRect(start, point);
+    } else if (currentTool === 'redact') {
+      restoreState(draftBase);
+      drawRedaction(start, point);
+    } else if (currentTool === 'draw' && !hasDrawnStroke) {
+      drawLine(start, point);
+    }
+
+    commitState();
+    resetDraft();
+  }
+
+  // Event handlers
+  canvas.addEventListener('mousedown', handleMouseDown);
+  canvas.addEventListener('mousemove', handleMouseMove);
+  canvas.addEventListener('mouseup', handleMouseUp);
+
+  return {
+    setTool(tool: Tool) {
+      cancelDraft();
+      currentTool = tool;
+    },
+
+    undo() {
+      if (draftBase) {
+        cancelDraft();
+        return;
+      }
+
+      if (history.length <= 1) return;
+
+      resetDraft();
+      history.pop();
+      const previousState = getLatestState();
+      if (previousState) restoreState(previousState);
+    },
+
+    getImageData(): string {
+      return canvas.toDataURL('image/png');
+    },
+
+    destroy() {
+      resetDraft();
+      canvas.removeEventListener('mousedown', handleMouseDown);
+      canvas.removeEventListener('mousemove', handleMouseMove);
+      canvas.removeEventListener('mouseup', handleMouseUp);
+      canvas.remove();
+    },
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/area-picker.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/area-picker.ts.txt
@@ -1,0 +1,270 @@
+import type { PickerStyle } from './picker';
+import { resolvePickerStyle } from './picker';
+import { t } from './i18n';
+
+const MIN_SELECTION_SIZE = 10;
+type ResolvedAreaPickerStyle = ReturnType<typeof resolvePickerStyle>;
+
+export function createAreaPicker(
+  style?: PickerStyle,
+  opts?: { redactionsAvailable?: boolean },
+  signal?: AbortSignal
+): Promise<DOMRect | null> {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      if (signal?.aborted) resolve(null);
+      else startAreaPicker(resolve, style, opts, signal);
+    }, 50);
+  });
+}
+
+function startAreaPicker(
+  resolve: (rect: DOMRect | null) => void,
+  style?: PickerStyle,
+  opts?: { redactionsAvailable?: boolean },
+  signal?: AbortSignal
+): void {
+  const { accent, fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder } =
+    resolvePickerStyle(style);
+
+  const overlay = createOverlay();
+  document.body.appendChild(overlay);
+
+  const selectionBorder = createSelectionBorder({ accent, bw, radius });
+  document.body.appendChild(selectionBorder);
+
+  const instruction = opts?.redactionsAvailable
+    ? t().areaPickerRedactionInstruction
+    : t().areaPickerInstruction;
+  const showInlineCancel = usesCoarsePointer();
+  const tooltip = createTooltip(
+    { accent, fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder },
+    instruction,
+    showInlineCancel
+  );
+  document.body.appendChild(tooltip);
+  const cancelButton = tooltip.querySelector<HTMLButtonElement>('#bugdrop-area-picker-cancel');
+
+  let startX = 0;
+  let startY = 0;
+  let isDragging = false;
+  let activePointerId: number | null = null;
+
+  function updateSelection(x1: number, y1: number, x2: number, y2: number) {
+    const left = Math.min(x1, x2);
+    const top = Math.min(y1, y2);
+    const width = Math.abs(x2 - x1);
+    const height = Math.abs(y2 - y1);
+
+    selectionBorder.style.left = `${left}px`;
+    selectionBorder.style.top = `${top}px`;
+    selectionBorder.style.width = `${width}px`;
+    selectionBorder.style.height = `${height}px`;
+    selectionBorder.style.display = 'block';
+
+    // Cut a clear window in the overlay using clip-path
+    const right = left + width;
+    const bottom = top + height;
+    overlay.style.clipPath = `polygon(
+      0% 0%, 0% 100%, ${left}px 100%, ${left}px ${top}px,
+      ${right}px ${top}px, ${right}px ${bottom}px,
+      ${left}px ${bottom}px, ${left}px 100%, 100% 100%, 100% 0%
+    )`;
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (activePointerId !== null || !e.isPrimary) return;
+    e.preventDefault();
+    startX = e.clientX;
+    startY = e.clientY;
+    isDragging = true;
+    activePointerId = e.pointerId;
+    overlay.setPointerCapture?.(e.pointerId);
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!isDragging || e.pointerId !== activePointerId) return;
+    e.preventDefault();
+    updateSelection(startX, startY, e.clientX, e.clientY);
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (!isDragging || e.pointerId !== activePointerId) return;
+    e.preventDefault();
+    isDragging = false;
+    activePointerId = null;
+    overlay.releasePointerCapture?.(e.pointerId);
+
+    const width = Math.abs(e.clientX - startX);
+    const height = Math.abs(e.clientY - startY);
+
+    if (width < MIN_SELECTION_SIZE || height < MIN_SELECTION_SIZE) {
+      // Too small — reset and let user try again
+      selectionBorder.style.display = 'none';
+      overlay.style.clipPath = '';
+      return;
+    }
+
+    const left = Math.min(startX, e.clientX) + window.scrollX;
+    const top = Math.min(startY, e.clientY) + window.scrollY;
+
+    cleanup();
+    resolve(new DOMRect(left, top, width, height));
+  }
+
+  function onPointerCancel(e: PointerEvent) {
+    if (e.pointerId !== activePointerId) return;
+    isDragging = false;
+    activePointerId = null;
+    selectionBorder.style.display = 'none';
+    overlay.style.clipPath = '';
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      cleanup();
+      resolve(null);
+    }
+  }
+
+  function onCancelClick() {
+    cleanup();
+    resolve(null);
+  }
+
+  const onAbort = () => {
+    cleanup();
+    resolve(null);
+  };
+
+  function cleanup() {
+    overlay.removeEventListener('pointerdown', onPointerDown);
+    document.removeEventListener('pointermove', onPointerMove);
+    document.removeEventListener('pointerup', onPointerUp);
+    document.removeEventListener('pointercancel', onPointerCancel);
+    document.removeEventListener('keydown', onKeyDown);
+    cancelButton?.removeEventListener('click', onCancelClick);
+    signal?.removeEventListener('abort', onAbort);
+    overlay.remove();
+    selectionBorder.remove();
+    tooltip.remove();
+  }
+
+  overlay.addEventListener('pointerdown', onPointerDown);
+  document.addEventListener('pointermove', onPointerMove);
+  document.addEventListener('pointerup', onPointerUp);
+  document.addEventListener('pointercancel', onPointerCancel);
+  document.addEventListener('keydown', onKeyDown);
+  cancelButton?.addEventListener('click', onCancelClick);
+  signal?.addEventListener('abort', onAbort, { once: true });
+}
+
+function createOverlay(): HTMLDivElement {
+  const overlay = document.createElement('div');
+  overlay.id = 'bugdrop-area-picker-overlay';
+  overlay.style.cssText = `
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 2147483646;
+    cursor: crosshair;
+    touch-action: none;
+    user-select: none;
+  `;
+  return overlay;
+}
+
+function createSelectionBorder(
+  style: Pick<ResolvedAreaPickerStyle, 'accent' | 'bw' | 'radius'>
+): HTMLDivElement {
+  const selectionBorder = document.createElement('div');
+  selectionBorder.id = 'bugdrop-area-picker-selection';
+  selectionBorder.style.cssText = `
+    position: fixed;
+    border: ${style.bw}px solid ${style.accent};
+    box-shadow: 0 0 0 4px color-mix(in srgb, ${style.accent} 30%, transparent);
+    border-radius: ${style.radius};
+    z-index: 2147483647;
+    pointer-events: none;
+    display: none;
+  `;
+  return selectionBorder;
+}
+
+function createTooltip(
+  style: Pick<
+    ResolvedAreaPickerStyle,
+    'accent' | 'fontFamily' | 'radius' | 'bw' | 'tooltipBg' | 'tooltipText' | 'tooltipBorder'
+  >,
+  text: string,
+  showInlineCancel: boolean
+): HTMLDivElement {
+  const tooltip = document.createElement('div');
+  tooltip.id = 'bugdrop-area-picker-tooltip';
+  tooltip.style.cssText = `
+    position: fixed;
+    top: calc(env(safe-area-inset-top, 0px) + 20px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: ${style.tooltipBg};
+    color: ${style.tooltipText};
+    padding: 14px 28px;
+    border-radius: ${style.radius};
+    font-family: ${style.fontFamily};
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.5;
+    max-width: min(420px, calc(100vw - 40px));
+    box-sizing: border-box;
+    text-align: center;
+    z-index: 2147483647;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border: ${style.bw}px solid ${style.tooltipBorder};
+    pointer-events: none;
+  `;
+  if (showInlineCancel) {
+    const cancelButton = document.createElement('button');
+    cancelButton.id = 'bugdrop-area-picker-cancel';
+    cancelButton.type = 'button';
+    cancelButton.textContent = t().cancel;
+    cancelButton.style.cssText = `
+      align-items: center;
+      appearance: none;
+      background: transparent;
+      border: 0;
+      color: ${style.accent};
+      cursor: pointer;
+      display: inline-flex;
+      font: inherit;
+      font-weight: 700;
+      justify-content: center;
+      margin: -10px -12px;
+      min-height: 44px;
+      min-width: 44px;
+      padding: 10px 12px;
+      pointer-events: auto;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+      touch-action: manipulation;
+      white-space: nowrap;
+      width: auto;
+    `;
+    tooltip.append(text, ' (', cancelButton, ')');
+  } else {
+    tooltip.textContent = `${text} (${t().escToCancel})`;
+  }
+  return tooltip;
+}
+
+function usesCoarsePointer(): boolean {
+  const hasTouchPoints = navigator.maxTouchPoints > 0;
+  if (!window.matchMedia) return hasTouchPoints;
+
+  return (
+    window.matchMedia('(hover: none), (pointer: coarse), (any-pointer: coarse)').matches ||
+    hasTouchPoints
+  );
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/auth-token.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/auth-token.ts.txt
@@ -1,0 +1,31 @@
+export type BugDropAuthTokenProvider = () => string | Promise<string> | null | undefined;
+
+type GlobalWithTokenProviders = Window & Record<string, unknown>;
+
+export function resolveAuthTokenProvider(
+  providerName: string | undefined,
+  globalObject: GlobalWithTokenProviders = window as unknown as GlobalWithTokenProviders
+): BugDropAuthTokenProvider | undefined {
+  if (!providerName) return undefined;
+
+  const provider = globalObject[providerName];
+  if (typeof provider !== 'function') {
+    console.warn(`[BugDrop] data-auth-token-provider "${providerName}" must reference a function.`);
+    return undefined;
+  }
+
+  return provider as BugDropAuthTokenProvider;
+}
+
+export async function getAuthHeaders(
+  tokenProvider: BugDropAuthTokenProvider | undefined
+): Promise<Record<string, string>> {
+  if (!tokenProvider) return {};
+
+  const token = await tokenProvider();
+  if (!token) return {};
+
+  return {
+    Authorization: token.startsWith('Bearer ') ? token : `Bearer ${token}`,
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/capture-cancellation.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/capture-cancellation.ts.txt
@@ -1,0 +1,42 @@
+export function abortableCapture<T>(
+  root: HTMLElement,
+  operation: Promise<T>,
+  signal: AbortSignal,
+  cancelledValue: T
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    let aborted = false;
+    const cleanup = () => {
+      signal.removeEventListener('abort', abort);
+    };
+    const abort = () => {
+      if (aborted) return;
+      aborted = true;
+      cancelCaptureUi(root);
+      cleanup();
+      resolve(cancelledValue);
+    };
+    signal.addEventListener('abort', abort, { once: true });
+    if (signal.aborted) abort();
+    operation.then(
+      value => {
+        cleanup();
+        if (!aborted) resolve(value);
+      },
+      error => {
+        cleanup();
+        if (!aborted) reject(error);
+      }
+    );
+  });
+}
+
+function cancelCaptureUi(root: HTMLElement): void {
+  const overlays = Array.from(root.querySelectorAll('.bd-overlay')) as HTMLElement[];
+  for (const overlay of overlays) {
+    (overlay.querySelector('.bd-close') as HTMLButtonElement | null)?.click();
+    overlay.remove();
+  }
+  document.querySelector<HTMLButtonElement>('#bugdrop-element-picker-cancel')?.click();
+  document.querySelector<HTMLButtonElement>('#bugdrop-area-picker-cancel')?.click();
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/capture-flow-result.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/capture-flow-result.ts.txt
@@ -1,0 +1,22 @@
+import type { CaptureFlowResult } from './capture-flow';
+import type { EmptyCaptureReason } from './capture-flow';
+
+export function emptyCaptureResult(): CaptureFlowResult {
+  return {
+    screenshot: null,
+    ...emptyElementMetadata(),
+    returnToForm: false,
+  };
+}
+
+export function emptyElementMetadata() {
+  return { elementSelector: null, fullElementSelector: null };
+}
+
+export function shouldRememberComplexScreenshotSkip(reason: EmptyCaptureReason): boolean {
+  return reason === 'explicit-skip' || reason === 'capture-failure-skip';
+}
+
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled screenshot choice: ${JSON.stringify(value)}`);
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/capture-flow-style.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/capture-flow-style.ts.txt
@@ -1,0 +1,14 @@
+import type { CaptureFlowConfig } from './capture-flow';
+
+export function getCapturePickerStyle(config: CaptureFlowConfig) {
+  return {
+    accentColor: config.accentColor,
+    font: config.font,
+    radius: config.radius,
+    borderWidth: config.borderWidth,
+    bgColor: config.bgColor,
+    textColor: config.textColor,
+    borderColor: config.borderColor,
+    theme: config.theme,
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/capture-flow.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/capture-flow.ts.txt
@@ -1,0 +1,339 @@
+/* eslint-disable max-lines */
+import { createAreaPicker } from './area-picker';
+import { showAnnotationStep } from './annotation-flow';
+import {
+  captureAreaWithLoading,
+  capturePromiseWithLoading,
+  captureWithLoading,
+} from './capture-loading';
+import { getElementContextCaptureTarget } from './element-context';
+import { createElementPicker } from './picker';
+import { getElementSelector, getFullElementSelector } from './selector-metadata';
+import { getRedactionCount, isFullPageDisabled } from './screenshot';
+import { showScreenshotOptions, type ScreenshotChoice } from './screenshot-options';
+import { DEFAULT_SELECTED_ELEMENT_SCREENSHOT_PIXEL_RATIO } from '../defaults';
+import { abortableCapture } from './capture-cancellation';
+import {
+  assertNever,
+  emptyCaptureResult,
+  emptyElementMetadata,
+  shouldRememberComplexScreenshotSkip,
+} from './capture-flow-result';
+import { getCapturePickerStyle } from './capture-flow-style';
+
+export interface CaptureFlowConfig {
+  screenshotMode: 'optional' | 'auto' | 'required';
+  screenshotScale?: number;
+  elementContextMaxArea?: number;
+  accentColor?: string;
+  font?: string;
+  radius?: string;
+  borderWidth?: string;
+  bgColor?: string;
+  textColor?: string;
+  borderColor?: string;
+  theme: 'light' | 'dark' | 'auto';
+}
+
+export interface CaptureFlowResult {
+  screenshot: string | null;
+  elementSelector: string | null;
+  fullElementSelector: string | null;
+  returnToForm: boolean;
+}
+
+export type EmptyCaptureReason =
+  'none' | 'explicit-skip' | 'capture-failure-skip' | 'selection-cancelled';
+
+type ElementMetadata = Pick<CaptureFlowResult, 'elementSelector' | 'fullElementSelector'>;
+type ChosenCaptureResult =
+  | ({
+      kind: 'captured';
+      screenshot: string;
+      redactionCount: number;
+      redactionUnavailable: boolean;
+      redactionLimitations: boolean;
+    } & ElementMetadata)
+  | { kind: 'returnToForm' }
+  | { kind: 'chooseAgain' }
+  | ({
+      kind: 'empty';
+      reason: EmptyCaptureReason;
+    } & ElementMetadata);
+
+export async function runScreenshotCaptureFlow(
+  root: HTMLElement,
+  config: CaptureFlowConfig,
+  includeScreenshot: boolean,
+  onComplexScreenshotSkipped: () => void,
+  signal?: AbortSignal
+): Promise<CaptureFlowResult> {
+  if (signal?.aborted) return { ...emptyCaptureResult(), returnToForm: true };
+  const operation = runScreenshotCaptureFlowInternal(
+    root,
+    config,
+    includeScreenshot,
+    onComplexScreenshotSkipped,
+    signal
+  );
+  return signal
+    ? abortableCapture(root, operation, signal, { ...emptyCaptureResult(), returnToForm: true })
+    : operation;
+}
+
+async function runScreenshotCaptureFlowInternal(
+  root: HTMLElement,
+  config: CaptureFlowConfig,
+  includeScreenshot: boolean,
+  onComplexScreenshotSkipped: () => void,
+  signal?: AbortSignal
+): Promise<CaptureFlowResult> {
+  if (config.screenshotMode === 'auto') return captureAutomaticScreenshot(root, config, signal);
+
+  if (!includeScreenshot) return emptyCaptureResult();
+
+  const screenshotRequired = config.screenshotMode === 'required';
+  while (true) {
+    const result = await captureChosenScreenshot(root, config, screenshotRequired, signal);
+    if (signal?.aborted) return { ...emptyCaptureResult(), returnToForm: true };
+    if (result.kind === 'returnToForm') {
+      return { ...emptyCaptureResult(), returnToForm: true };
+    }
+    if (result.kind === 'chooseAgain') continue;
+
+    if (result.kind === 'empty') {
+      if (!screenshotRequired && shouldRememberComplexScreenshotSkip(result.reason)) {
+        onComplexScreenshotSkipped();
+      }
+      if (screenshotRequired) continue;
+      return {
+        screenshot: null,
+        elementSelector: result.elementSelector,
+        fullElementSelector: result.fullElementSelector,
+        returnToForm: false,
+      };
+    }
+
+    const annotatedScreenshot = await showAnnotationStep(
+      root,
+      result.screenshot,
+      result.redactionCount,
+      {
+        redactionUnavailable: result.redactionUnavailable,
+        ...(result.redactionLimitations ? { redactionLimitations: true } : {}),
+        ...(result.elementSelector ? { selectedElementCapture: true } : {}),
+      }
+    );
+    if (signal?.aborted) return { ...emptyCaptureResult(), returnToForm: true };
+
+    if (annotatedScreenshot === 'retake') continue;
+    if (annotatedScreenshot === 'cancel') {
+      return { ...emptyCaptureResult(), returnToForm: true };
+    }
+
+    return {
+      screenshot: annotatedScreenshot,
+      elementSelector: result.elementSelector,
+      fullElementSelector: result.fullElementSelector,
+      returnToForm: false,
+    };
+  }
+}
+
+async function captureAutomaticScreenshot(
+  root: HTMLElement,
+  config: CaptureFlowConfig,
+  signal?: AbortSignal
+): Promise<CaptureFlowResult> {
+  if (isFullPageDisabled()) {
+    return emptyCaptureResult();
+  }
+
+  const result = await captureWithLoading(root, undefined, config.screenshotScale, {
+    allowChooseAgain: false,
+    signal,
+  });
+  if (result.kind === 'cancelled') {
+    return { ...emptyCaptureResult(), returnToForm: true };
+  }
+
+  return {
+    screenshot: result.kind === 'ok' ? result.dataUrl : null,
+    elementSelector: null,
+    fullElementSelector: null,
+    returnToForm: false,
+  };
+}
+
+export { shouldRememberComplexScreenshotSkip } from './capture-flow-result';
+
+async function captureChosenScreenshot(
+  root: HTMLElement,
+  config: CaptureFlowConfig,
+  screenshotRequired: boolean,
+  signal?: AbortSignal
+): Promise<ChosenCaptureResult> {
+  const screenshotChoice = await showScreenshotOptions(root, {
+    allowSkip: !screenshotRequired,
+  });
+
+  switch (screenshotChoice.kind) {
+    case 'cancel':
+      return { kind: 'returnToForm' };
+    case 'skip':
+      return emptyChosenCaptureResult('explicit-skip');
+    case 'viewport':
+      return captureFromViewportChoice(root, screenshotChoice, screenshotRequired, signal);
+    case 'capture':
+      return captureFromFullPageChoice(root, config, screenshotRequired, signal);
+    case 'element':
+      return captureFromElementChoice(root, config, screenshotRequired, signal);
+    case 'area':
+      return captureFromAreaChoice(root, config, screenshotRequired, signal);
+    default:
+      return assertNever(screenshotChoice);
+  }
+}
+
+async function captureFromViewportChoice(
+  root: HTMLElement,
+  choice: Extract<ScreenshotChoice, { kind: 'viewport' }>,
+  screenshotRequired: boolean,
+  signal?: AbortSignal
+): Promise<ChosenCaptureResult> {
+  const result = await capturePromiseWithLoading(root, choice.capture, {
+    allowSkip: !screenshotRequired,
+    showLoading: false,
+    signal,
+  });
+  if (result.kind === 'cancelled') return { kind: 'returnToForm' };
+  if (result.kind === 'choose-again') return { kind: 'chooseAgain' };
+  if (result.kind === 'skipped') {
+    return emptyChosenCaptureResult('capture-failure-skip');
+  }
+  return {
+    kind: 'captured',
+    screenshot: result.dataUrl,
+    elementSelector: null,
+    fullElementSelector: null,
+    redactionCount: 0,
+    redactionUnavailable: true,
+    redactionLimitations: false,
+  };
+}
+
+async function captureFromFullPageChoice(
+  root: HTMLElement,
+  config: CaptureFlowConfig,
+  screenshotRequired: boolean,
+  signal?: AbortSignal
+): Promise<ChosenCaptureResult> {
+  const result = await captureWithLoading(root, undefined, config.screenshotScale, {
+    allowSkip: !screenshotRequired,
+    signal,
+  });
+  if (result.kind === 'cancelled') return { kind: 'returnToForm' };
+  if (result.kind === 'choose-again') return { kind: 'chooseAgain' };
+  if (result.kind === 'skipped') {
+    return emptyChosenCaptureResult('capture-failure-skip');
+  }
+  return {
+    kind: 'captured',
+    screenshot: result.dataUrl,
+    elementSelector: null,
+    fullElementSelector: null,
+    redactionCount: result.redaction?.count ?? 0,
+    redactionUnavailable: false,
+    redactionLimitations: result.redaction?.hasLimitations ?? false,
+  };
+}
+
+async function captureFromElementChoice(
+  root: HTMLElement,
+  config: CaptureFlowConfig,
+  screenshotRequired: boolean,
+  signal?: AbortSignal
+): Promise<ChosenCaptureResult> {
+  const element = await createElementPicker(getCapturePickerStyle(config), signal);
+  if (!element) {
+    return emptyChosenCaptureResult('selection-cancelled');
+  }
+
+  const elementMetadata = {
+    elementSelector: getElementSelector(element),
+    fullElementSelector: getFullElementSelector(element),
+  };
+  const captureTarget = getElementContextCaptureTarget(element, {
+    maxViewportAreaMultiplier: config.elementContextMaxArea,
+  });
+  const result = await captureWithLoading(root, captureTarget, config.screenshotScale, {
+    allowSkip: !screenshotRequired,
+    captureOptions: {
+      highlightElement: element,
+      highlightStyle: {
+        accentColor: config.accentColor,
+        radius: config.radius,
+        borderWidth: config.borderWidth,
+      },
+      pixelRatio: DEFAULT_SELECTED_ELEMENT_SCREENSHOT_PIXEL_RATIO,
+    },
+    signal,
+  });
+  if (result.kind === 'cancelled') return { kind: 'returnToForm' };
+  if (result.kind === 'choose-again') return { kind: 'chooseAgain' };
+  if (result.kind === 'skipped') {
+    return emptyChosenCaptureResult('capture-failure-skip', elementMetadata);
+  }
+  return {
+    kind: 'captured',
+    screenshot: result.dataUrl,
+    ...elementMetadata,
+    redactionCount: result.redaction?.count ?? 0,
+    redactionUnavailable: false,
+    redactionLimitations: result.redaction?.hasLimitations ?? false,
+  };
+}
+
+async function captureFromAreaChoice(
+  root: HTMLElement,
+  config: CaptureFlowConfig,
+  screenshotRequired: boolean,
+  signal?: AbortSignal
+): Promise<ChosenCaptureResult> {
+  const rect = await createAreaPicker(
+    getCapturePickerStyle(config),
+    {
+      redactionsAvailable: getRedactionCount() > 0,
+    },
+    signal
+  );
+  if (!rect) {
+    return emptyChosenCaptureResult('selection-cancelled');
+  }
+
+  const result = await captureAreaWithLoading(root, rect, config.screenshotScale, {
+    allowSkip: !screenshotRequired,
+    signal,
+  });
+  if (result.kind === 'cancelled') return { kind: 'returnToForm' };
+  if (result.kind === 'choose-again') return { kind: 'chooseAgain' };
+  if (result.kind === 'skipped') {
+    return emptyChosenCaptureResult('capture-failure-skip');
+  }
+  return {
+    kind: 'captured',
+    screenshot: result.dataUrl,
+    elementSelector: null,
+    fullElementSelector: null,
+    redactionCount: result.redaction?.count ?? 0,
+    redactionUnavailable: false,
+    redactionLimitations: result.redaction?.hasLimitations ?? false,
+  };
+}
+
+function emptyChosenCaptureResult(
+  reason: EmptyCaptureReason,
+  metadata: ElementMetadata = emptyElementMetadata()
+): ChosenCaptureResult {
+  return { kind: 'empty', reason, ...metadata };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/capture-loading.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/capture-loading.ts.txt
@@ -1,0 +1,212 @@
+import { MaskApplicationError } from './mask';
+import {
+  captureAreaScreenshot,
+  captureScreenshot,
+  type CapturedScreenshot,
+  type CaptureScreenshotOptions,
+} from './screenshot';
+import { createModal } from './ui';
+import { escapeWidgetText, t } from './i18n';
+
+export type CaptureWithLoadingResult =
+  | { kind: 'ok'; dataUrl: string; redaction?: CapturedScreenshot['redaction'] }
+  | { kind: 'choose-again' }
+  | { kind: 'skipped' }
+  | { kind: 'cancelled' };
+
+type CapturePayload = string | CapturedScreenshot;
+type CaptureLoadingOptions = {
+  allowSkip?: boolean;
+  allowChooseAgain?: boolean;
+  showLoading?: boolean;
+  captureOptions?: CaptureScreenshotOptions;
+  signal?: AbortSignal;
+};
+type CaptureOperation = Promise<CapturePayload> | (() => Promise<CapturePayload>);
+
+export async function captureWithLoading(
+  root: HTMLElement,
+  element?: Element,
+  screenshotScale?: number,
+  opts?: CaptureLoadingOptions
+): Promise<CaptureWithLoadingResult> {
+  const startCapture = () => captureScreenshot(element, screenshotScale, opts?.captureOptions);
+  return capturePromiseWithLoading(root, startCapture, opts);
+}
+
+export async function captureAreaWithLoading(
+  root: HTMLElement,
+  rect: DOMRect,
+  screenshotScale?: number,
+  opts?: CaptureLoadingOptions
+): Promise<CaptureWithLoadingResult> {
+  const startCapture = () => captureAreaScreenshot(rect, screenshotScale, opts?.captureOptions);
+  return capturePromiseWithLoading(root, startCapture, opts);
+}
+
+export async function capturePromiseWithLoading(
+  root: HTMLElement,
+  captureOperation: CaptureOperation,
+  opts?: CaptureLoadingOptions
+): Promise<CaptureWithLoadingResult> {
+  const loadingModal =
+    opts?.showLoading === false
+      ? null
+      : createModal(
+          root,
+          t().capturingTitle,
+          `
+            <div style="display: flex; flex-direction: column; align-items: center; padding: 20px;">
+              <div class="bd-spinner bd-spinner--lg"></div>
+              <p class="bd-loading-text" style="margin-top: 12px;">${escapeWidgetText(t().capturingScreenshot)}</p>
+            </div>
+          `
+        );
+
+  try {
+    if (loadingModal) {
+      await waitForLoadingPaint();
+    }
+    if (opts?.signal?.aborted) {
+      loadingModal?.remove();
+      return { kind: 'cancelled' };
+    }
+    const capturePromise =
+      typeof captureOperation === 'function' ? captureOperation() : captureOperation;
+    const screenshot = await captureUntilAborted(capturePromise, opts?.signal);
+    loadingModal?.remove();
+    if (screenshot === null) return { kind: 'cancelled' };
+    return normalizeCaptureResult(screenshot);
+  } catch (error) {
+    loadingModal?.remove();
+    if (opts?.signal?.aborted) return { kind: 'cancelled' };
+    console.warn('[BugDrop] Screenshot capture failed:', error);
+    const allowSkip = opts?.allowSkip !== false;
+    const allowChooseAgain = opts?.allowChooseAgain !== false;
+
+    if (error instanceof MaskApplicationError) {
+      return showMaskFailureModal(root);
+    }
+
+    return new Promise(resolve => {
+      const errorModal = createModal(
+        root,
+        t().captureFailedTitle,
+        `
+          <div class="bd-error-message">
+            <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-9.5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5.5zm0 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
+            </svg>
+            <span class="bd-error-message__text">${escapeWidgetText(t().captureFailedMessage)}</span>
+          </div>
+          <div class="bd-actions">
+            ${allowSkip ? `<button class="bd-btn bd-btn-secondary" data-action="skip">${escapeWidgetText(t().skipScreenshot)}</button>` : ''}
+            ${allowChooseAgain ? `<button class="bd-btn bd-btn-primary" data-action="choose-again">${escapeWidgetText(t().chooseAnotherMethod)}</button>` : ''}
+          </div>
+        `,
+        true
+      );
+
+      const closeBtn = errorModal.querySelector('.bd-close') as HTMLElement;
+      const skipBtn = errorModal.querySelector('[data-action="skip"]') as HTMLElement;
+      const chooseAgainBtn = errorModal.querySelector(
+        '[data-action="choose-again"]'
+      ) as HTMLElement;
+
+      closeBtn?.addEventListener('click', () => {
+        errorModal.remove();
+        resolve({ kind: 'cancelled' });
+      });
+
+      skipBtn?.addEventListener('click', () => {
+        errorModal.remove();
+        resolve({ kind: 'skipped' });
+      });
+
+      chooseAgainBtn?.addEventListener('click', () => {
+        errorModal.remove();
+        resolve({ kind: 'choose-again' });
+      });
+    });
+  }
+}
+
+function captureUntilAborted(
+  capture: Promise<CapturePayload>,
+  signal: AbortSignal | undefined
+): Promise<CapturePayload | null> {
+  if (!signal) return capture;
+  if (signal.aborted) return Promise.resolve(null);
+  return new Promise((resolve, reject) => {
+    const abort = () => resolve(null);
+    signal.addEventListener('abort', abort, { once: true });
+    capture.then(
+      value => {
+        signal.removeEventListener('abort', abort);
+        resolve(value);
+      },
+      error => {
+        signal.removeEventListener('abort', abort);
+        reject(error);
+      }
+    );
+  });
+}
+
+function waitForLoadingPaint(): Promise<void> {
+  if (typeof requestAnimationFrame !== 'function') {
+    return new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  return new Promise(resolve => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}
+
+function showMaskFailureModal(root: HTMLElement): Promise<CaptureWithLoadingResult> {
+  return new Promise(resolve => {
+    const modal = createModal(
+      root,
+      t().maskFailureTitle,
+      `
+        <div class="bd-error-message">
+          <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-9.5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5.5zm0 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
+          </svg>
+          <span class="bd-error-message__text">${escapeWidgetText(t().maskFailureMessage)}</span>
+        </div>
+        <div class="bd-actions">
+          <button class="bd-btn bd-btn-primary" data-action="skip">${escapeWidgetText(t().continueWithoutScreenshot)}</button>
+        </div>
+      `,
+      true
+    );
+
+    const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
+    const skipBtn = modal.querySelector('[data-action="skip"]') as HTMLElement;
+
+    closeBtn?.addEventListener('click', () => {
+      modal.remove();
+      resolve({ kind: 'cancelled' });
+    });
+
+    skipBtn?.addEventListener('click', () => {
+      modal.remove();
+      resolve({ kind: 'skipped' });
+    });
+  });
+}
+
+function normalizeCaptureResult(capture: CapturePayload): CaptureWithLoadingResult {
+  if (typeof capture === 'string') {
+    return { kind: 'ok', dataUrl: capture };
+  }
+
+  return {
+    kind: 'ok',
+    dataUrl: capture.dataUrl,
+    redaction: capture.redaction,
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/capture-timeout.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/capture-timeout.ts.txt
@@ -1,0 +1,22 @@
+import { t } from './i18n';
+
+const CAPTURE_TIMEOUT_MS = 15_000;
+
+export function withCaptureTimeout<T>(
+  capturePromise: Promise<T>,
+  onTimeout?: () => void
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      try {
+        onTimeout?.();
+      } catch {
+        // Cancellation is best-effort; it must not replace the stable timeout result.
+      }
+      reject(new Error(t().captureTimeout));
+    }, CAPTURE_TIMEOUT_MS);
+  });
+
+  return Promise.race([capturePromise, timeoutPromise]).finally(() => clearTimeout(timer!));
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/console-log-redaction.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/console-log-redaction.ts.txt
@@ -1,0 +1,29 @@
+const SECRET_KEY_PATTERN = String.raw`(?:"|')?\b(?:password|passwd|pwd|token|api[_-]?key|secret|authorization|auth|cookie)\b(?:"|')?`;
+const QUOTED_SECRET_PATTERN = new RegExp(
+  String.raw`(${SECRET_KEY_PATTERN}\s*[:=]\s*)(["'])(?!Bearer\b)(?:\\[\s\S]|(?!\2)[^\\])*?\2`,
+  'gi'
+);
+const UNTERMINATED_QUOTED_SECRET_PATTERN = new RegExp(
+  String.raw`(${SECRET_KEY_PATTERN}\s*[:=]\s*)(["'])(?!Bearer\b)(?:\\[^\r\n]|(?!\2)[^\\\r\n])*(?=\r?\n|$)`,
+  'gi'
+);
+const STRUCTURED_SECRET_PATTERN = new RegExp(
+  String.raw`(${SECRET_KEY_PATTERN}\s*[:=]\s*)(?:\[[^\]\r\n]*\]|\{[^\}\r\n]*\})`,
+  'gi'
+);
+const UNQUOTED_SECRET_PATTERN = new RegExp(
+  String.raw`(${SECRET_KEY_PATTERN}\s*[:=]\s*)(?!Bearer\b)[^"',\s}&]+`,
+  'gi'
+);
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const LONG_SECRET_PATTERN = /\b[A-Za-z0-9+/_=-]{32,}\b/g;
+
+export function redactConsoleLogMessage(value: string): string {
+  return value
+    .replace(BEARER_PATTERN, 'Bearer [redacted]')
+    .replace(STRUCTURED_SECRET_PATTERN, '$1[redacted]')
+    .replace(QUOTED_SECRET_PATTERN, '$1$2[redacted]$2')
+    .replace(UNTERMINATED_QUOTED_SECRET_PATTERN, '$1$2[redacted]')
+    .replace(UNQUOTED_SECRET_PATTERN, '$1[redacted]')
+    .replace(LONG_SECRET_PATTERN, '[redacted]');
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/console-logs.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/console-logs.ts.txt
@@ -1,0 +1,108 @@
+import { redactConsoleLogMessage } from './console-log-redaction';
+
+type ConsoleLogLevel = 'log' | 'info' | 'warn' | 'error';
+
+export interface ConsoleLogEntry {
+  level: ConsoleLogLevel;
+  message: string;
+  timestamp: string;
+  sourceUrl?: string;
+  lineNumber?: number;
+  columnNumber?: number;
+}
+
+const MAX_ENTRIES = 50;
+const MAX_MESSAGE_LENGTH = 1000;
+
+const capturedLogs: ConsoleLogEntry[] = [];
+let hasStarted = false;
+
+export function startConsoleLogCapture(): void {
+  if (hasStarted || typeof window === 'undefined' || typeof console === 'undefined') return;
+  hasStarted = true;
+
+  patchConsoleMethod('log');
+  patchConsoleMethod('info');
+  patchConsoleMethod('warn');
+  patchConsoleMethod('error');
+
+  window.addEventListener('error', event => {
+    addLog({
+      level: 'error',
+      message: event.message || 'Unhandled error',
+      timestamp: new Date().toISOString(),
+      sourceUrl: event.filename || undefined,
+      lineNumber: event.lineno || undefined,
+      columnNumber: event.colno || undefined,
+    });
+  });
+
+  window.addEventListener('unhandledrejection', event => {
+    addLog({
+      level: 'error',
+      message: `Unhandled promise rejection: ${formatConsoleValue(event.reason)}`,
+      timestamp: new Date().toISOString(),
+    });
+  });
+}
+
+export function getConsoleLogSnapshot(): ConsoleLogEntry[] {
+  return capturedLogs.map(entry => ({ ...entry }));
+}
+
+function patchConsoleMethod(level: ConsoleLogLevel): void {
+  const original = console[level];
+  if (typeof original !== 'function') return;
+
+  console[level] = (...args: unknown[]) => {
+    addLog({
+      level,
+      message: args.map(formatConsoleValue).join(' '),
+      timestamp: new Date().toISOString(),
+      ...getConsoleSource(),
+    });
+    original.apply(console, args);
+  };
+}
+
+function addLog(entry: ConsoleLogEntry): void {
+  capturedLogs.push({
+    ...entry,
+    message: redactConsoleLogMessage(entry.message).slice(0, MAX_MESSAGE_LENGTH),
+  });
+  while (capturedLogs.length > MAX_ENTRIES) {
+    capturedLogs.shift();
+  }
+}
+
+function formatConsoleValue(value: unknown): string {
+  if (value instanceof Error) {
+    return value.stack || value.message;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function getConsoleSource(): Pick<ConsoleLogEntry, 'sourceUrl' | 'lineNumber' | 'columnNumber'> {
+  const stack = new Error().stack;
+  if (!stack) return {};
+
+  for (const line of stack.split('\n').slice(2)) {
+    if (line.includes('console-logs')) continue;
+    const match = line.match(/\(?((?:https?:|file:|\/)[^():]+):(\d+):(\d+)\)?$/);
+    if (!match) continue;
+    return {
+      sourceUrl: match[1],
+      lineNumber: Number(match[2]),
+      columnNumber: Number(match[3]),
+    };
+  }
+
+  return {};
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/crop-screenshot.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/crop-screenshot.ts.txt
@@ -1,0 +1,38 @@
+export async function cropScreenshot(
+  imageDataUrl: string,
+  rect: DOMRect,
+  pixelRatio: number
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      const cropW = Math.round(rect.width * pixelRatio);
+      const cropH = Math.round(rect.height * pixelRatio);
+      canvas.width = cropW;
+      canvas.height = cropH;
+
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        reject(new Error('Failed to get canvas context'));
+        return;
+      }
+
+      ctx.drawImage(
+        img,
+        Math.round(rect.x * pixelRatio),
+        Math.round(rect.y * pixelRatio),
+        cropW,
+        cropH,
+        0,
+        0,
+        cropW,
+        cropH
+      );
+
+      resolve(canvas.toDataURL('image/png'));
+    };
+    img.onerror = () => reject(new Error('Failed to load image for cropping'));
+    img.src = imageDataUrl;
+  });
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/default-flow/definition.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/default-flow/definition.ts.txt
@@ -1,0 +1,142 @@
+import type { BugDropAuthTokenProvider } from '../auth-token';
+import type { IssueLinkVisibility } from '../ui';
+
+export const DEFAULT_DEFINITION_ID = 'bugdrop-default@1' as const;
+
+type DefaultWelcomePolicy = 'once' | 'always' | 'never';
+type DefaultScreenshotMode = 'optional' | 'auto' | 'required';
+type DefaultCategory = 'bug' | 'feature' | 'question';
+type DefaultCategoryLabels = Partial<Record<DefaultCategory, string | readonly string[]>>;
+
+export interface DefaultDefinitionInput {
+  repo: string;
+  apiUrl: string;
+  authTokenProvider?: BugDropAuthTokenProvider;
+  welcome: DefaultWelcomePolicy;
+  screenshotMode: DefaultScreenshotMode;
+  skipWelcome: boolean;
+  hasSeenWelcome: boolean;
+  showName: boolean;
+  requireName: boolean;
+  showEmail: boolean;
+  requireEmail: boolean;
+  sendConsoleLogs: boolean;
+  screenshotScale?: number;
+  elementContextMaxArea?: number;
+  accentColor?: string;
+  categoryLabels?: DefaultCategoryLabels;
+  issueLinkVisibility: IssueLinkVisibility;
+}
+
+export interface DefaultDefinition {
+  readonly id: typeof DEFAULT_DEFINITION_ID;
+  readonly steps: readonly [
+    Readonly<{ kind: 'welcome'; enabled: boolean; remember: boolean }>,
+    Readonly<{
+      kind: 'details';
+      repo: string;
+      showName: boolean;
+      requireName: boolean;
+      showEmail: boolean;
+      requireEmail: boolean;
+      sendConsoleLogs: boolean;
+    }>,
+    Readonly<{
+      kind: 'screenshot';
+      mode: DefaultScreenshotMode;
+      repo: string;
+      screenshotScale?: number;
+      elementContextMaxArea?: number;
+      accentColor?: string;
+    }>,
+  ];
+  readonly system: Readonly<{
+    preflight: Readonly<{
+      kind: 'installation';
+      repo: string;
+      apiUrl: string;
+      authTokenProvider?: BugDropAuthTokenProvider;
+    }>;
+    submission: Readonly<{
+      kind: 'legacy-feedback';
+      repo: string;
+      apiUrl: string;
+      authTokenProvider?: BugDropAuthTokenProvider;
+      categoryLabels?: Readonly<DefaultCategoryLabels>;
+      issueLinkVisibility: IssueLinkVisibility;
+    }>;
+  }>;
+}
+
+export type DefaultWelcomeStep = DefaultDefinition['steps'][0];
+export type DefaultDetailsStep = DefaultDefinition['steps'][1];
+export type DefaultScreenshotStep = DefaultDefinition['steps'][2];
+export type DefaultPreflightRecipe = DefaultDefinition['system']['preflight'];
+export type DefaultSubmissionRecipe = DefaultDefinition['system']['submission'];
+
+function freezeCategoryLabels(
+  labels: DefaultCategoryLabels | undefined
+): Readonly<DefaultCategoryLabels> | undefined {
+  if (!labels) return undefined;
+  return Object.freeze(
+    Object.fromEntries(
+      Object.entries(labels).map(([category, value]) => [
+        category,
+        Array.isArray(value) ? Object.freeze([...value]) : value,
+      ])
+    ) as DefaultCategoryLabels
+  );
+}
+
+export function normalizeDefaultDefinition(input: DefaultDefinitionInput): DefaultDefinition {
+  const welcomeEnabled =
+    !input.skipWelcome &&
+    input.welcome !== 'never' &&
+    !(input.welcome === 'once' && input.hasSeenWelcome);
+
+  const steps = Object.freeze([
+    Object.freeze({
+      kind: 'welcome' as const,
+      enabled: welcomeEnabled,
+      remember: welcomeEnabled && input.welcome === 'once',
+    }),
+    Object.freeze({
+      kind: 'details' as const,
+      repo: input.repo,
+      showName: input.showName,
+      requireName: input.requireName,
+      showEmail: input.showEmail,
+      requireEmail: input.requireEmail,
+      sendConsoleLogs: input.sendConsoleLogs,
+    }),
+    Object.freeze({
+      kind: 'screenshot' as const,
+      mode: input.screenshotMode,
+      repo: input.repo,
+      screenshotScale: input.screenshotScale,
+      elementContextMaxArea: input.elementContextMaxArea,
+      accentColor: input.accentColor,
+    }),
+  ]) as DefaultDefinition['steps'];
+
+  return Object.freeze({
+    id: DEFAULT_DEFINITION_ID,
+    steps,
+    system: Object.freeze({
+      preflight: Object.freeze({
+        kind: 'installation' as const,
+        repo: input.repo,
+        apiUrl: input.apiUrl,
+        authTokenProvider: input.authTokenProvider,
+      }),
+      submission: Object.freeze({
+        kind: 'legacy-feedback' as const,
+        repo: input.repo,
+        apiUrl: input.apiUrl,
+        authTokenProvider: input.authTokenProvider,
+        categoryLabels: freezeCategoryLabels(input.categoryLabels),
+        issueLinkVisibility: input.issueLinkVisibility,
+      }),
+    }),
+  });
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/default-flow/runtime.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/default-flow/runtime.ts.txt
@@ -1,0 +1,55 @@
+import type {
+  DefaultDefinition,
+  DefaultDetailsStep,
+  DefaultPreflightRecipe,
+  DefaultScreenshotStep,
+  DefaultSubmissionRecipe,
+  DefaultWelcomeStep,
+} from './definition';
+
+type DefaultPreflightResult =
+  { status: 'installed' } | { status: 'not_installed' | 'unreachable'; appName?: string };
+
+export interface DefaultJourneyPorts<Details, Capture> {
+  preflight: (recipe: DefaultPreflightRecipe) => Promise<DefaultPreflightResult>;
+  showPreflightFailure: (result: Exclude<DefaultPreflightResult, { status: 'installed' }>) => void;
+  showWelcome: (step: DefaultWelcomeStep) => Promise<boolean>;
+  rememberWelcome: (step: DefaultWelcomeStep) => void;
+  showDetails: (step: DefaultDetailsStep, previous: Details | null) => Promise<Details | null>;
+  capture: (
+    step: DefaultScreenshotStep,
+    details: Details
+  ) => Promise<Capture & { returnToDetails: boolean }>;
+  submit: (recipe: DefaultSubmissionRecipe, details: Details, capture: Capture) => Promise<void>;
+}
+
+export async function runDefaultJourney<Details, Capture>(
+  definition: DefaultDefinition,
+  ports: DefaultJourneyPorts<Details, Capture>
+): Promise<'finished' | 'preflight-blocked'> {
+  const preflight = await ports.preflight(definition.system.preflight);
+  if (preflight.status !== 'installed') {
+    ports.showPreflightFailure(preflight);
+    return 'preflight-blocked';
+  }
+
+  const welcome = definition.steps[0];
+  if (welcome.enabled) {
+    if (!(await ports.showWelcome(welcome))) return 'finished';
+    if (welcome.remember) ports.rememberWelcome(welcome);
+  }
+
+  const detailsStep = definition.steps[1];
+  const screenshotStep = definition.steps[2];
+  let details: Details | null = null;
+  while (true) {
+    details = await ports.showDetails(detailsStep, details);
+    if (!details) return 'finished';
+
+    const capture = await ports.capture(screenshotStep, details);
+    if (capture.returnToDetails) continue;
+
+    await ports.submit(definition.system.submission, details, capture);
+    return 'finished';
+  }
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/element-context.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/element-context.ts.txt
@@ -1,0 +1,65 @@
+import {
+  DEFAULT_SELECTED_ELEMENT_CONTEXT_MIN_PADDING_PX,
+  resolveSelectedElementContextMaxArea,
+} from '../defaults';
+
+interface ElementContextOptions {
+  maxViewportAreaMultiplier?: number;
+}
+
+export function getElementContextCaptureTarget(
+  element: Element,
+  options: ElementContextOptions
+): Element {
+  const selectedRect = element.getBoundingClientRect();
+  if (!isUsableRect(selectedRect)) return element;
+
+  const viewportArea = Math.max(1, window.innerWidth * window.innerHeight);
+  const maxContextArea =
+    viewportArea * resolveSelectedElementContextMaxArea(options.maxViewportAreaMultiplier);
+
+  let best: Element = element;
+  let current = element.parentElement;
+
+  while (current && current !== document.body && current !== document.documentElement) {
+    const rect = current.getBoundingClientRect();
+    const area = rect.width * rect.height;
+
+    if (
+      isUsableRect(rect) &&
+      area <= maxContextArea &&
+      containsRect(rect, selectedRect) &&
+      hasUsefulContext(rect, selectedRect)
+    ) {
+      best = current;
+    }
+
+    current = current.parentElement;
+  }
+
+  return best;
+}
+
+function isUsableRect(rect: DOMRect): boolean {
+  return rect.width > 0 && rect.height > 0;
+}
+
+function containsRect(candidate: DOMRect, selected: DOMRect): boolean {
+  return (
+    candidate.left <= selected.left &&
+    candidate.top <= selected.top &&
+    candidate.right >= selected.right &&
+    candidate.bottom >= selected.bottom
+  );
+}
+
+function hasUsefulContext(candidate: DOMRect, selected: DOMRect): boolean {
+  const horizontalContext =
+    candidate.width >= selected.width + DEFAULT_SELECTED_ELEMENT_CONTEXT_MIN_PADDING_PX * 2;
+  const verticalContext =
+    candidate.height >= selected.height + DEFAULT_SELECTED_ELEMENT_CONTEXT_MIN_PADDING_PX * 2;
+  const selectedArea = selected.width * selected.height;
+  const candidateArea = candidate.width * candidate.height;
+
+  return horizontalContext || verticalContext || candidateArea >= selectedArea * 4;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/busy-opened-flow.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/busy-opened-flow.ts.txt
@@ -1,0 +1,10 @@
+import { createRuntimeId } from '../variants/form';
+import type { FlowOutcome, OpenedFlow } from './public-types';
+
+export function createBusyOpenedFlow(flowId: string): OpenedFlow {
+  return Object.freeze({
+    instanceId: createRuntimeId(flowId),
+    result: Promise.resolve<FlowOutcome>({ status: 'busy' }),
+    close() {},
+  });
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/conditions.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/conditions.ts.txt
@@ -1,0 +1,40 @@
+import type { FlowCondition, FlowScalar } from './public-types';
+
+const MAX_CONDITION_DEPTH = 4;
+const MAX_CONDITION_NODES = 32;
+
+export function evaluateCondition(
+  condition: FlowCondition | undefined,
+  answers: Readonly<Record<string, unknown>>,
+  context: Readonly<Record<string, FlowScalar>>
+): boolean {
+  if (!condition) return true;
+  if ('answer' in condition) return hasEqualValue(answers, condition.answer, condition.equals);
+  if ('context' in condition) return hasEqualValue(context, condition.context, condition.equals);
+  if ('all' in condition) {
+    return condition.all.every(child => evaluateCondition(child, answers, context));
+  }
+  return condition.any.some(child => evaluateCondition(child, answers, context));
+}
+
+function hasEqualValue(
+  values: Readonly<Record<string, unknown>>,
+  key: string,
+  expected: FlowScalar
+): boolean {
+  return Object.prototype.hasOwnProperty.call(values, key) && values[key] === expected;
+}
+
+export function countConditionNodes(condition: FlowCondition, depth = 1): number {
+  if (depth > MAX_CONDITION_DEPTH) {
+    throw new TypeError(`BugDrop flow condition depth cannot exceed ${MAX_CONDITION_DEPTH}`);
+  }
+  if ('answer' in condition || 'context' in condition) return 1;
+  const children = 'all' in condition ? condition.all : condition.any;
+  let count = 1;
+  for (const child of children) count += countConditionNodes(child, depth + 1);
+  if (count > MAX_CONDITION_NODES) {
+    throw new TypeError(`BugDrop flow conditions cannot exceed ${MAX_CONDITION_NODES} nodes`);
+  }
+  return count;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/definition.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/definition.ts.txt
@@ -1,0 +1,52 @@
+import type { FlowConfig, FlowField, FlowScreen } from './public-types';
+
+export interface FlowDefinition {
+  readonly compiler: 'bugdrop-flow@1';
+  readonly flowId: string;
+  readonly config: Readonly<FlowConfig>;
+  readonly fields: ReadonlyMap<string, Readonly<FlowField>>;
+  readonly contextKeys: ReadonlySet<string>;
+  readonly screenAnswerPaths: ReadonlyMap<string, readonly string[]>;
+  readonly screens: readonly Readonly<FlowScreen>[];
+}
+
+export function normalizeFlowDefinition(config: Readonly<FlowConfig>): FlowDefinition {
+  const fields = new Map<string, Readonly<FlowField>>();
+  for (const form of config.forms) {
+    for (const field of form.fields) fields.set(`${form.id}.${field.id}`, field);
+  }
+  const screenAnswerPaths = new Map<string, readonly string[]>();
+  const contextKeys = new Set<string>();
+  for (const screen of config.screens) {
+    collectConditionContextKeys(screen.when, contextKeys);
+    screenAnswerPaths.set(
+      screen.id,
+      screen.type === 'form'
+        ? config.forms
+            .find(form => form.id === screen.form)!
+            .fields.map(field => `${screen.form}.${field.id}`)
+        : []
+    );
+  }
+  for (const section of config.issue.sections ?? []) {
+    if ('context' in section) contextKeys.add(section.context);
+  }
+  return Object.freeze({
+    compiler: 'bugdrop-flow@1' as const,
+    flowId: config.id,
+    config,
+    fields,
+    contextKeys,
+    screenAnswerPaths,
+    screens: config.screens,
+  });
+}
+
+function collectConditionContextKeys(condition: FlowScreen['when'], keys: Set<string>): void {
+  if (!condition) return;
+  if ('context' in condition) keys.add(condition.context);
+  else if ('all' in condition)
+    condition.all.forEach(child => collectConditionContextKeys(child, keys));
+  else if ('any' in condition)
+    condition.any.forEach(child => collectConditionContextKeys(child, keys));
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/extra-fields.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/extra-fields.ts.txt
@@ -1,0 +1,227 @@
+import { isAllowedFlowAttachmentType, type FlowAttachment } from './field-validation';
+import type { AttachmentsField, CheckboxField } from './public-types';
+
+export interface ExtraFieldController {
+  readonly id: string;
+  readonly required: boolean;
+  readonly element: HTMLElement;
+  read(validate: boolean): Promise<{ ok: true; value: unknown } | { ok: false }>;
+  setRequiredError(show: boolean): void;
+  focus(): void;
+  dispose(): void;
+}
+
+export function createCheckboxController(
+  field: Readonly<CheckboxField>,
+  formId: string,
+  instanceId: string,
+  answers: Readonly<Record<string, unknown>>
+): ExtraFieldController {
+  const scaffold = createScaffold(field, instanceId);
+  const input = document.createElement('input');
+  input.type = 'checkbox';
+  input.id = scaffold.controlId;
+  input.checked =
+    typeof answers[`${formId}.${field.id}`] === 'boolean'
+      ? Boolean(answers[`${formId}.${field.id}`])
+      : Boolean(field.initialValue);
+  input.setAttribute('aria-required', String(field.required ?? false));
+  if (scaffold.describedBy) input.setAttribute('aria-describedby', scaffold.describedBy);
+  scaffold.wrapper.classList.add('bdf-checkbox');
+  scaffold.wrapper.insertBefore(input, scaffold.label);
+  return {
+    id: field.id,
+    required: Boolean(field.required),
+    element: scaffold.wrapper,
+    read: async () => ({ ok: true, value: input.checked }),
+    setRequiredError(show) {
+      scaffold.setError(input, show ? 'This checkbox is required.' : null);
+    },
+    focus: () => input.focus(),
+    dispose() {},
+  };
+}
+
+export function createAttachmentsController(
+  field: Readonly<AttachmentsField>,
+  formId: string,
+  instanceId: string,
+  answers: Readonly<Record<string, unknown>>
+): ExtraFieldController {
+  const scaffold = createScaffold(field, instanceId);
+  scaffold.wrapper.classList.add('bdf-attachment');
+  const input = document.createElement('input');
+  input.className = 'bdv-input';
+  input.type = 'file';
+  input.id = scaffold.controlId;
+  input.multiple = (field.maxFiles ?? 5) > 1;
+  input.setAttribute('aria-required', String(field.required ?? false));
+  if (field.accept) input.accept = field.accept.join(',');
+  if (scaffold.describedBy) input.setAttribute('aria-describedby', scaffold.describedBy);
+  const list = document.createElement('ul');
+  list.className = 'bdf-file-list';
+  list.setAttribute('aria-live', 'polite');
+  scaffold.wrapper.insertBefore(input, scaffold.error);
+  scaffold.wrapper.insertBefore(list, scaffold.error);
+  const initialValue = answers[`${formId}.${field.id}`];
+  let values = Array.isArray(initialValue) ? ([...initialValue] as FlowAttachment[]) : [];
+  let readFailed = false;
+  let pending: Promise<void> = Promise.resolve();
+  let readVersion = 0;
+  renderNames(
+    list,
+    values.map(value => value.name)
+  );
+  const onChange = () => {
+    const version = ++readVersion;
+    readFailed = false;
+    scaffold.setError(input, null);
+    const files = Array.from(input.files ?? []);
+    pending = readFiles(files, field)
+      .then(next => {
+        if (version !== readVersion) return;
+        values = next;
+        renderNames(
+          list,
+          next.map(value => value.name)
+        );
+      })
+      .catch(error => {
+        if (version !== readVersion) return;
+        readFailed = true;
+        scaffold.setError(
+          input,
+          error instanceof Error ? error.message : 'Could not read the selected attachment.'
+        );
+      });
+  };
+  input.addEventListener('change', onChange);
+  return {
+    id: field.id,
+    required: Boolean(field.required),
+    element: scaffold.wrapper,
+    async read(validate) {
+      while (true) {
+        const currentRead = pending;
+        await currentRead;
+        if (currentRead === pending) break;
+      }
+      return readFailed && validate ? { ok: false } : { ok: true, value: values };
+    },
+    setRequiredError(show) {
+      if (!readFailed) scaffold.setError(input, show ? 'Select at least one attachment.' : null);
+    },
+    focus: () => input.focus(),
+    dispose: () => {
+      readVersion += 1;
+      input.removeEventListener('change', onChange);
+    },
+  };
+}
+
+interface ExtraScaffold {
+  wrapper: HTMLDivElement;
+  label: HTMLLabelElement;
+  error: HTMLDivElement;
+  controlId: string;
+  describedBy: string | null;
+  setError(target: HTMLElement, message: string | null): void;
+}
+
+function createScaffold(
+  field: Readonly<CheckboxField | AttachmentsField>,
+  instanceId: string
+): ExtraScaffold {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'bdv-field';
+  wrapper.dataset.bugdropField = field.id;
+  wrapper.dataset.span = String(field.layout?.span ?? 1);
+  const controlId = `${instanceId}-${field.id}`;
+  const label = document.createElement('label');
+  label.className = 'bdv-label';
+  label.htmlFor = controlId;
+  label.textContent = field.label;
+  if (field.required) {
+    const required = document.createElement('span');
+    required.className = 'bdv-required';
+    required.textContent = ' *';
+    required.setAttribute('aria-hidden', 'true');
+    label.appendChild(required);
+  }
+  wrapper.appendChild(label);
+  const describedBy: string[] = [];
+  if (field.helpText) {
+    const help = document.createElement('div');
+    help.className = 'bdv-help';
+    help.id = `${controlId}-help`;
+    help.textContent = field.helpText;
+    wrapper.appendChild(help);
+    describedBy.push(help.id);
+  }
+  const error = document.createElement('div');
+  error.className = 'bdv-error';
+  error.id = `${controlId}-error`;
+  error.hidden = true;
+  error.setAttribute('aria-live', 'polite');
+  wrapper.appendChild(error);
+  describedBy.push(error.id);
+  return {
+    wrapper,
+    label,
+    error,
+    controlId,
+    describedBy: describedBy.join(' ') || null,
+    setError(target, message) {
+      error.textContent = message ?? '';
+      error.hidden = !message;
+      if (message) target.setAttribute('aria-invalid', 'true');
+      else target.removeAttribute('aria-invalid');
+    },
+  };
+}
+
+async function readFiles(
+  files: File[],
+  field: Readonly<AttachmentsField>
+): Promise<FlowAttachment[]> {
+  if (files.length > (field.maxFiles ?? 5))
+    throw new TypeError(`Select at most ${field.maxFiles ?? 5} attachments.`);
+  return Promise.all(
+    files.map(file => readAttachment(file, field.maxFileSize ?? 5 * 1024 * 1024, field.accept))
+  );
+}
+
+async function readAttachment(
+  file: File,
+  maxSize: number,
+  accept: ReadonlyArray<string> | undefined
+): Promise<FlowAttachment> {
+  if (!isAllowedFlowAttachmentType(file.type))
+    throw new TypeError(`${file.name} has an unsupported file type.`);
+  if (accept && !accept.includes(file.type))
+    throw new TypeError(`${file.name} is not an accepted file type.`);
+  if (file.size > maxSize) throw new TypeError(`${file.name} is too large.`);
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', () =>
+      typeof reader.result === 'string'
+        ? resolve(reader.result)
+        : reject(new Error('Could not read the selected attachment.'))
+    );
+    reader.addEventListener('error', () =>
+      reject(new Error('Could not read the selected attachment.'))
+    );
+    reader.readAsDataURL(file);
+  });
+  return { name: file.name, type: file.type, size: file.size, dataUrl };
+}
+
+function renderNames(list: HTMLUListElement, names: string[]): void {
+  list.replaceChildren(
+    ...names.map(name => {
+      const item = document.createElement('li');
+      item.textContent = name;
+      return item;
+    })
+  );
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/field-validation.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/field-validation.ts.txt
@@ -1,0 +1,318 @@
+import type { FlowDefinition } from './definition';
+import type {
+  AttachmentsField,
+  FlowField,
+  FlowConfig,
+  FlowOpenOptions,
+  FlowScalar,
+} from './public-types';
+
+export interface FlowAttachment {
+  name: string;
+  type: string;
+  size: number;
+  dataUrl: string;
+}
+
+const ALLOWED_ATTACHMENT_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'video/mp4',
+  'video/webm',
+  'video/quicktime',
+]);
+
+export function isAllowedFlowAttachmentType(value: string): boolean {
+  return ALLOWED_ATTACHMENT_TYPES.has(value);
+}
+
+export interface NormalizedFlowOpenOptions {
+  context: Readonly<Record<string, FlowScalar>>;
+  initialAnswers: Record<string, unknown>;
+}
+
+export function normalizeFlowOpenOptions(
+  definition: FlowDefinition,
+  options: FlowOpenOptions | undefined
+): NormalizedFlowOpenOptions {
+  const declaredOptions = options;
+  if (options !== undefined && !isObject(options)) fail('open options must be an object');
+  assertOnlyKeys(options ?? {}, new Set(['context', 'initialAnswers']), 'open options');
+  return {
+    context: Object.freeze(normalizeContext(definition, declaredOptions?.context)),
+    initialAnswers: normalizeInitialAnswers(definition, declaredOptions?.initialAnswers),
+  };
+}
+
+export function validateFlowFieldConfig(field: FlowField): void {
+  validateLayout(field);
+  if (field.type === 'shortText' || field.type === 'longText') validateTextField(field);
+  else if (field.type === 'rating') validateRatingField(field);
+  else if (field.type === 'singleChoice') validateChoiceField(field);
+  else if (field.type === 'checkbox') validateCheckboxField(field);
+  else validateAttachmentsField(field);
+}
+
+export function validateFlowConditionValue(field: FlowField, value: FlowScalar): void {
+  if (field.type === 'rating') {
+    const scale = field.scale ?? 5;
+    if (!Number.isInteger(value) || (value as number) < 1 || (value as number) > scale)
+      fail(`condition equals is not a valid value for field ${field.id}`);
+    return;
+  }
+  if (field.type === 'singleChoice') {
+    if (typeof value !== 'string' || !field.options.some(option => option.value === value))
+      fail(`condition equals is not a valid value for field ${field.id}`);
+    return;
+  }
+  if (field.type === 'checkbox') {
+    if (typeof value !== 'boolean')
+      fail(`condition equals is not a valid value for field ${field.id}`);
+    return;
+  }
+  if (field.type === 'attachments')
+    fail(`condition answer cannot reference attachments field ${field.id}`);
+  if (typeof value !== 'string' || value !== value.trim())
+    fail(`condition equals is not a valid value for field ${field.id}`);
+  const minimum = field.minLength ?? 0;
+  const maximum = field.maxLength ?? (field.type === 'shortText' ? 500 : 5_000);
+  if (value.length < minimum || value.length > maximum)
+    fail(`condition equals is not a valid value for field ${field.id}`);
+}
+
+export function validateFlowShell(config: FlowConfig): void {
+  const { presentation, appearance, content } = config;
+  if (!isObject(presentation)) fail('presentation must be an object');
+  assertOnlyKeys(presentation, new Set(['kind', 'size', 'columns']), 'presentation');
+  if (presentation.kind !== 'modal') fail('presentation kind must be modal');
+  if (
+    presentation.size !== undefined &&
+    !['compact', 'default', 'wide'].includes(presentation.size)
+  )
+    fail('modal size is invalid');
+  if (
+    presentation.columns !== undefined &&
+    presentation.columns !== 1 &&
+    presentation.columns !== 2
+  )
+    fail('presentation columns must be 1 or 2');
+  if (appearance !== undefined) {
+    if (!isObject(appearance)) fail('appearance must be an object');
+    assertOnlyKeys(appearance, new Set(['theme', 'accentColor', 'density']), 'appearance');
+    if (appearance.theme !== undefined && !['light', 'dark', 'auto'].includes(appearance.theme))
+      fail('appearance theme is invalid');
+    optionalCopy(appearance.accentColor, 'appearance accentColor', 120);
+    if (
+      appearance.density !== undefined &&
+      !['compact', 'comfortable'].includes(appearance.density)
+    )
+      fail('appearance density is invalid');
+  }
+  if (content !== undefined) {
+    if (!isObject(content)) fail('content must be an object');
+    assertOnlyKeys(content, new Set(['successTitle', 'successMessage', 'cancelLabel']), 'content');
+    optionalCopy(content.successTitle, 'successTitle', 500);
+    optionalCopy(content.successMessage, 'successMessage', 2_000);
+    optionalCopy(content.cancelLabel, 'cancelLabel', 120);
+  }
+}
+
+function normalizeFlowFieldValue(field: Readonly<FlowField>, raw: unknown): unknown {
+  if (field.type === 'shortText' || field.type === 'longText') {
+    if (typeof raw !== 'string') fail(`initial answer ${field.id} must be text`);
+    const minimum = field.minLength ?? 0;
+    const maximum = field.maxLength ?? (field.type === 'shortText' ? 500 : 5_000);
+    const value = raw.trim();
+    if (value.length < minimum || value.length > maximum)
+      fail(`initial answer ${field.id} has invalid length`);
+    return value;
+  }
+  if (field.type === 'rating') {
+    const scale = field.scale ?? 5;
+    if (!Number.isInteger(raw) || (raw as number) < 1 || (raw as number) > scale)
+      fail(`initial answer ${field.id} must be a rating from 1-${scale}`);
+    return raw;
+  }
+  if (field.type === 'singleChoice') {
+    if (typeof raw !== 'string' || !field.options.some(option => option.value === raw))
+      fail(`initial answer ${field.id} must be a configured choice`);
+    return raw;
+  }
+  if (field.type === 'checkbox') {
+    if (typeof raw !== 'boolean') fail(`initial answer ${field.id} must be boolean`);
+    return raw;
+  }
+  return normalizeAttachments(field, raw);
+}
+
+function normalizeContext(
+  definition: FlowDefinition,
+  raw: FlowOpenOptions['context']
+): Record<string, FlowScalar> {
+  if (raw !== undefined && !isObject(raw)) fail('context must be an object');
+  const context = raw ?? {};
+  const unknown = Object.keys(context).find(key => !definition.contextKeys.has(key));
+  if (unknown) fail(`context contains unknown key ${unknown}`);
+  const output: Record<string, FlowScalar> = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (!isScalar(value) || (typeof value === 'number' && !Number.isFinite(value)))
+      fail(`context ${key} must be a finite scalar`);
+    output[key] = value;
+  }
+  return output;
+}
+
+function normalizeInitialAnswers(
+  definition: FlowDefinition,
+  raw: FlowOpenOptions['initialAnswers']
+): Record<string, unknown> {
+  if (raw !== undefined && !isObject(raw)) fail('initialAnswers must be an object');
+  const answers = raw ?? {};
+  const unknown = Object.keys(answers).find(key => !definition.fields.has(key));
+  if (unknown) fail(`initialAnswers contains unknown key ${unknown}`);
+  return Object.fromEntries(
+    Object.entries(answers).map(([path, value]) => [
+      path,
+      normalizeFlowFieldValue(definition.fields.get(path)!, value),
+    ])
+  );
+}
+
+function validateLayout(field: FlowField): void {
+  if (field.layout === undefined) return;
+  if (!isObject(field.layout)) fail(`field ${field.id} layout must be an object`);
+  assertOnlyKeys(field.layout, new Set(['span']), `field ${field.id} layout`);
+  if (field.layout.span !== undefined && field.layout.span !== 1 && field.layout.span !== 2)
+    fail(`field ${field.id} layout span must be 1 or 2`);
+}
+
+function validateTextField(field: Extract<FlowField, { type: 'shortText' | 'longText' }>): void {
+  optionalCopy(field.placeholder, `field ${field.id} placeholder`, 500);
+  const minimum = field.minLength ?? 0;
+  const maximum = field.maxLength ?? (field.type === 'shortText' ? 500 : 5_000);
+  if (!boundedInteger(minimum, 0, 5_000) || !boundedInteger(maximum, 1, 5_000) || minimum > maximum)
+    fail(`field ${field.id} has invalid text bounds`);
+  if (field.type === 'longText' && field.rows !== undefined && !boundedInteger(field.rows, 1, 50))
+    fail(`field ${field.id} rows must be 1-50`);
+}
+
+function validateRatingField(field: Extract<FlowField, { type: 'rating' }>): void {
+  if (field.scale !== undefined && field.scale !== 5 && field.scale !== 10)
+    fail(`field ${field.id} rating scale must be 5 or 10`);
+  if (field.icon !== undefined && field.icon !== 'star' && field.icon !== 'number')
+    fail(`field ${field.id} rating icon is invalid`);
+  optionalCopy(field.lowLabel, `field ${field.id} lowLabel`, 500);
+  optionalCopy(field.highLabel, `field ${field.id} highLabel`, 500);
+}
+
+function validateChoiceField(field: Extract<FlowField, { type: 'singleChoice' }>): void {
+  if (!Array.isArray(field.options) || field.options.length < 2 || field.options.length > 50)
+    fail(`field ${field.id} requires 2-50 choices`);
+  if (field.display !== undefined && !['radio', 'cards', 'buttons'].includes(field.display))
+    fail(`field ${field.id} choice display is invalid`);
+  const values = new Set<string>();
+  for (const option of field.options) {
+    if (!isObject(option)) fail(`field ${field.id} has an invalid choice`);
+    assertOnlyKeys(option, new Set(['value', 'label', 'description']), `field ${field.id} choice`);
+    requiredCopy(option.value, `field ${field.id} choice value`, 120);
+    requiredCopy(option.label, `field ${field.id} choice label`, 500);
+    optionalCopy(option.description, `field ${field.id} choice description`, 1_000);
+    if (values.has(option.value)) fail(`field ${field.id} has duplicate choices`);
+    values.add(option.value);
+  }
+}
+
+function validateCheckboxField(field: Extract<FlowField, { type: 'checkbox' }>): void {
+  if (field.initialValue !== undefined && typeof field.initialValue !== 'boolean')
+    fail(`field ${field.id} initialValue must be boolean`);
+}
+
+function validateAttachmentsField(field: AttachmentsField): void {
+  if (field.maxFiles !== undefined && !boundedInteger(field.maxFiles, 1, 5))
+    fail(`field ${field.id} maxFiles must be 1-5`);
+  if (field.maxFileSize !== undefined && !boundedInteger(field.maxFileSize, 1, 5 * 1024 * 1024))
+    fail(`field ${field.id} maxFileSize is invalid`);
+  if (
+    field.accept !== undefined &&
+    (!Array.isArray(field.accept) ||
+      field.accept.length === 0 ||
+      field.accept.length > 20 ||
+      field.accept.some(
+        value =>
+          typeof value !== 'string' ||
+          !value.trim() ||
+          value.length > 120 ||
+          !isAllowedFlowAttachmentType(value)
+      ))
+  )
+    fail(`field ${field.id} accept is invalid`);
+}
+
+function normalizeAttachments(field: AttachmentsField, raw: unknown): FlowAttachment[] {
+  if (!Array.isArray(raw) || raw.length > (field.maxFiles ?? 5))
+    fail(`initial answer ${field.id} has too many attachments`);
+  return raw.map(value => {
+    if (!isObject(value)) fail(`initial answer ${field.id} has an invalid attachment`);
+    assertOnlyKeys(value, new Set(['name', 'type', 'size', 'dataUrl']), 'attachment');
+    requiredCopy(value.name, 'attachment name', 500);
+    if (typeof value.type !== 'string' || !isAllowedFlowAttachmentType(value.type))
+      fail('attachment type is invalid');
+    if (field.accept && !field.accept.includes(value.type))
+      fail(`initial answer ${field.id} has a disallowed attachment type`);
+    if (!boundedInteger(value.size, 0, field.maxFileSize ?? 5 * 1024 * 1024))
+      fail('attachment size is invalid');
+    if (
+      typeof value.dataUrl !== 'string' ||
+      !new RegExp(`^data:${escapeRegex(value.type)};base64,[A-Za-z0-9+/]+={0,2}$`).test(
+        value.dataUrl
+      )
+    )
+      fail('attachment dataUrl is invalid');
+    const encoded = value.dataUrl.slice(value.dataUrl.indexOf(',') + 1);
+    if (encoded.length % 4 !== 0) fail('attachment dataUrl is invalid');
+    const decodedSize = atob(encoded).length;
+    if (decodedSize > (field.maxFileSize ?? 5 * 1024 * 1024)) fail('attachment size is invalid');
+    return { name: value.name, type: value.type, size: value.size, dataUrl: value.dataUrl };
+  });
+}
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function requiredCopy(value: unknown, label: string, maximum: number): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    !value.trim() ||
+    value.length > maximum ||
+    hasControlChars(value)
+  )
+    fail(`${label} is invalid`);
+}
+function optionalCopy(value: unknown, label: string, maximum: number): void {
+  if (value !== undefined) requiredCopy(value, label, maximum);
+}
+function hasControlChars(value: string): boolean {
+  return [...value].some(character => {
+    const code = character.charCodeAt(0);
+    return (code < 32 && code !== 9 && code !== 10 && code !== 13) || code === 127;
+  });
+}
+function boundedInteger(value: unknown, minimum: number, maximum: number): value is number {
+  return Number.isInteger(value) && (value as number) >= minimum && (value as number) <= maximum;
+}
+function isScalar(value: unknown): value is FlowScalar {
+  return value === null || ['string', 'number', 'boolean'].includes(typeof value);
+}
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+function assertOnlyKeys(value: object, allowed: Set<string>, label: string): void {
+  const unknown = Object.keys(value).find(key => !allowed.has(key));
+  if (unknown) fail(`${label} contains unknown key ${unknown}`);
+}
+function fail(message: string): never {
+  throw new TypeError(`BugDrop flow ${message}`);
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/form-screen.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/form-screen.ts.txt
@@ -1,0 +1,136 @@
+import { normalizeVariantAnswers, VariantAnswerError } from '../variants/answer-validation';
+import { createFieldController } from '../variants/fields';
+import type { FieldController } from '../variants/fields/types';
+import type { VariantField } from '../variants/public-types';
+import {
+  createAttachmentsController,
+  createCheckboxController,
+  type ExtraFieldController,
+} from './extra-fields';
+import type { FlowField, FlowForm } from './public-types';
+
+export interface FlowFormController {
+  readonly element: HTMLElement;
+  collect(): Promise<Record<string, unknown> | null>;
+  snapshot(): Promise<Record<string, unknown> | null>;
+  dispose(): void;
+}
+
+export function createFlowFormScreen(
+  formConfig: Readonly<FlowForm>,
+  instanceId: string,
+  answers: Readonly<Record<string, unknown>>
+): FlowFormController {
+  const section = createSurface(formConfig);
+  const fields = document.createElement('div');
+  fields.className = 'bdv-fields';
+  section.appendChild(fields);
+  const controllers = formConfig.fields.map(field =>
+    createController(field, formConfig.id, instanceId, answers)
+  );
+  for (const controller of controllers) fields.appendChild(controller.element);
+
+  const read = async (validate: boolean): Promise<Record<string, unknown> | null> => {
+    const standard = controllers.filter(isStandardController);
+    for (const controller of standard) controller.setError(null);
+    let values = Object.fromEntries(
+      standard.map(controller => [controller.field.id, controller.getValue()])
+    );
+    if (validate) {
+      try {
+        values = normalizeVariantAnswers(formConfig.fields.filter(isStandardField), values);
+      } catch (error) {
+        showStandardError(error, standard);
+        return null;
+      }
+    }
+    for (const controller of controllers.filter(isExtraController)) {
+      controller.setRequiredError(false);
+      const readResult = await controller.read(validate);
+      if (!readResult.ok) {
+        controller.focus();
+        return null;
+      }
+      if (
+        validate &&
+        controller.required &&
+        (readResult.value === false ||
+          (Array.isArray(readResult.value) && readResult.value.length === 0))
+      ) {
+        controller.setRequiredError(true);
+        controller.focus();
+        return null;
+      }
+      values[controller.id] = readResult.value;
+    }
+    return values;
+  };
+
+  return {
+    element: section,
+    collect: () => read(true),
+    snapshot: () => read(false),
+    dispose() {
+      for (const controller of controllers) controller.dispose();
+    },
+  };
+}
+
+type Controller = FieldController | ExtraFieldController;
+
+function createController(
+  field: Readonly<FlowField>,
+  formId: string,
+  instanceId: string,
+  answers: Readonly<Record<string, unknown>>
+): Controller {
+  if (field.type === 'checkbox') {
+    return createCheckboxController(field, formId, instanceId, answers);
+  }
+  if (field.type === 'attachments') {
+    return createAttachmentsController(field, formId, instanceId, answers);
+  }
+  const controller = createFieldController(field, instanceId);
+  controller.setValue(answers[`${formId}.${field.id}`] ?? '');
+  return controller;
+}
+
+function createSurface(formConfig: Readonly<FlowForm>): HTMLElement {
+  const section = document.createElement('section');
+  section.className = 'bdv-surface';
+  const header = document.createElement('div');
+  header.className = 'bdv-header';
+  const title = document.createElement('h2');
+  title.className = 'bdv-title';
+  title.textContent = formConfig.title;
+  header.appendChild(title);
+  if (formConfig.description) {
+    const description = document.createElement('p');
+    description.className = 'bdv-description';
+    description.textContent = formConfig.description;
+    header.appendChild(description);
+  }
+  section.appendChild(header);
+  return section;
+}
+
+function showStandardError(error: unknown, controllers: FieldController[]): void {
+  const target =
+    error instanceof VariantAnswerError
+      ? controllers.find(controller => controller.field.id === error.fieldId)
+      : undefined;
+  target?.setError(
+    error instanceof Error ? error.message.replace(/^Answer \S+ /, '') : 'Invalid answer'
+  );
+  target?.focus();
+}
+
+function isStandardField(field: Readonly<FlowField>): field is VariantField {
+  return field.type !== 'checkbox' && field.type !== 'attachments';
+}
+function isStandardController(controller: Controller): controller is FieldController {
+  return 'field' in controller;
+}
+function isExtraController(controller: Controller): controller is ExtraFieldController {
+  return 'read' in controller;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/issue-draft.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/issue-draft.ts.txt
@@ -1,0 +1,88 @@
+import type { FlowConfig, FlowIssueSection, FlowScalar } from './public-types';
+
+export interface FlowIssueDraft {
+  title: string;
+  description: string;
+  category: 'bug' | 'feature' | 'question';
+}
+
+export function compileFlowIssueDraft(
+  config: Readonly<FlowConfig>,
+  answers: Readonly<Record<string, unknown>>,
+  context: Readonly<Record<string, FlowScalar>>
+): FlowIssueDraft {
+  const title = interpolate(config.issue.title, answers).trim().slice(0, 256);
+  if (!title) throw new TypeError('BugDrop flow Issue title cannot be empty');
+  const sections = (config.issue.sections ?? [])
+    .map(section => compileSection(config, section, answers, context))
+    .filter((value): value is string => value !== null);
+  return {
+    title,
+    description: sections.join('\n\n'),
+    category: config.issue.classification ?? 'bug',
+  };
+}
+
+function interpolate(template: string, answers: Readonly<Record<string, unknown>>): string {
+  return template.replace(/{{\s*([^{}]+?)\s*}}/g, (_, path: string) =>
+    stringify(answers[path.trim()])
+  );
+}
+
+function compileSection(
+  config: Readonly<FlowConfig>,
+  section: FlowIssueSection,
+  answers: Readonly<Record<string, unknown>>,
+  context: Readonly<Record<string, FlowScalar>>
+): string | null {
+  const value = 'answer' in section ? answers[section.answer] : context[section.context];
+  if (section.omitWhenEmpty && (value === undefined || value === null || value === '')) return null;
+  const rendered = formatValue(config, section, value);
+  return `## ${section.heading}\n\n${rendered}`;
+}
+
+function formatValue(
+  config: Readonly<FlowConfig>,
+  section: FlowIssueSection,
+  value: unknown
+): string {
+  const format = section.format;
+  const rendered = stringify(value);
+  if (format === 'quote')
+    return rendered
+      .split('\n')
+      .map(line => `> ${line}`)
+      .join('\n');
+  if (format === 'code') return formatInlineCode(rendered);
+  if (format === 'stars' && typeof value === 'number' && 'answer' in section) {
+    const field = findField(config, section.answer);
+    const scale = field?.type === 'rating' ? (field.scale ?? 5) : 5;
+    return `${'★'.repeat(value)}${'☆'.repeat(Math.max(0, scale - value))} (${value}/${scale})`;
+  }
+  if (format === 'choice' && typeof value === 'string' && 'answer' in section) {
+    const field = findField(config, section.answer);
+    if (field?.type === 'singleChoice')
+      return field.options.find(option => option.value === value)?.label ?? rendered;
+  }
+  return rendered;
+}
+
+function formatInlineCode(value: string): string {
+  const longestRun = Math.max(0, ...[...value.matchAll(/`+/g)].map(match => match[0].length));
+  const delimiter = '`'.repeat(longestRun + 1);
+  const padding = value.startsWith('`') || value.endsWith('`') ? ' ' : '';
+  return `${delimiter}${padding}${value}${padding}${delimiter}`;
+}
+
+function findField(config: Readonly<FlowConfig>, path: string) {
+  const separator = path.indexOf('.');
+  const formId = path.slice(0, separator);
+  const fieldId = path.slice(separator + 1);
+  return config.forms.find(form => form.id === formId)?.fields.find(field => field.id === fieldId);
+}
+
+function stringify(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value.trim();
+  return String(value);
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/manager.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/manager.ts.txt
@@ -1,0 +1,47 @@
+import type { FlowConfig, FlowHandle, FlowOpenOptions } from './public-types';
+import { normalizeFlowDefinition, type FlowDefinition } from './definition';
+import { createBusyOpenedFlow } from './busy-opened-flow';
+import { openFlowModal, type FlowModalPorts } from './modal';
+import { submitFlow, type FlowTransportConfig } from './submission';
+import { validateAndFreezeFlowConfig } from './validate-config';
+import { normalizeFlowOpenOptions } from './field-validation';
+
+export interface FlowManager {
+  register(config: FlowConfig): FlowHandle;
+}
+export function createFlowManager(
+  transport: FlowTransportConfig,
+  ports: Pick<FlowModalPorts, 'preflight' | 'capture'>,
+  runtime: { isLegacyModalOpen(): boolean } = { isLegacyModalOpen: () => false }
+): FlowManager {
+  const flows = new Map<string, FlowDefinition>();
+  return {
+    register(config) {
+      const normalized = validateAndFreezeFlowConfig(config);
+      if (flows.has(normalized.id))
+        throw new TypeError(`BugDrop flow is already registered: ${normalized.id}`);
+      const definition = normalizeFlowDefinition(normalized);
+      flows.set(normalized.id, definition);
+      return Object.freeze({
+        id: normalized.id,
+        open(options?: FlowOpenOptions) {
+          if (runtime.isLegacyModalOpen()) {
+            normalizeFlowOpenOptions(definition, options);
+            return createBusyOpenedFlow(normalized.id);
+          }
+          return openFlowModal(definition, options, {
+            ...ports,
+            submit: flowRuntime =>
+              submitFlow(
+                transport,
+                normalized,
+                flowRuntime.answers,
+                flowRuntime.context,
+                flowRuntime.capture
+              ),
+          });
+        },
+      });
+    },
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/message-screen.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/message-screen.ts.txt
@@ -1,0 +1,20 @@
+import type { MessageScreen } from './public-types';
+
+export function createMessageScreen(screen: Readonly<MessageScreen>): HTMLElement {
+  const section = document.createElement('section');
+  section.className = 'bdv-surface bdf-message';
+  const header = document.createElement('div');
+  header.className = 'bdv-header';
+  const title = document.createElement('h2');
+  title.className = 'bdv-title';
+  title.textContent = screen.title;
+  header.appendChild(title);
+  if (screen.description) {
+    const description = document.createElement('p');
+    description.className = 'bdv-description';
+    description.textContent = screen.description;
+    header.appendChild(description);
+  }
+  section.appendChild(header);
+  return section;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/modal-state.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/modal-state.ts.txt
@@ -1,0 +1,63 @@
+import { installRadixDialogCompatibility } from '../radix-compat';
+import { setActiveVariantModal } from '../variants/modal-coordinator';
+
+export interface FlowModalState {
+  readonly host: HTMLElement;
+  readonly shadow: ShadowRoot;
+  readonly overlay: HTMLElement;
+  activate(close: () => void): void;
+  dispose(): void;
+}
+
+export function createFlowModalState(
+  flowId: string,
+  instanceId: string,
+  createRoot: (shadow: ShadowRoot) => { root: HTMLElement; dispose(): void },
+  onKeydown: (event: Event) => void,
+  onBackdrop: (event: PointerEvent) => void
+): FlowModalState {
+  const previousFocus =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const previousOverflow = document.body.style.getPropertyValue('overflow');
+  const previousOverflowPriority = document.body.style.getPropertyPriority('overflow');
+  const host = document.createElement('div');
+  host.dataset.bugdropOwned = '';
+  host.dataset.bugdropFlow = flowId;
+  host.dataset.bugdropInstance = instanceId;
+  Object.assign(host.style, { position: 'fixed', inset: '0', zIndex: '2147483646' });
+  const shadow = host.attachShadow({ mode: 'open' });
+  const styled = createRoot(shadow);
+  const overlay = document.createElement('div');
+  overlay.className = 'bdv-overlay';
+  styled.root.appendChild(overlay);
+  let unregister = () => {};
+  let disposeRadix = () => {};
+  let disposed = false;
+  return {
+    host,
+    shadow,
+    overlay,
+    activate(close) {
+      document.body.style.setProperty('overflow', 'hidden');
+      document.body.appendChild(host);
+      disposeRadix = installRadixDialogCompatibility(host);
+      shadow.addEventListener('keydown', onKeydown);
+      overlay.addEventListener('pointerdown', onBackdrop);
+      unregister = setActiveVariantModal({ close });
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      unregister();
+      shadow.removeEventListener('keydown', onKeydown);
+      overlay.removeEventListener('pointerdown', onBackdrop);
+      disposeRadix();
+      styled.dispose();
+      host.remove();
+      if (previousOverflow)
+        document.body.style.setProperty('overflow', previousOverflow, previousOverflowPriority);
+      else document.body.style.removeProperty('overflow');
+      if (previousFocus?.isConnected) previousFocus.focus();
+    },
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/modal-view.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/modal-view.ts.txt
@@ -1,0 +1,157 @@
+import type { SubmissionResult } from '../variants/public-types';
+import type { FlowDefinition } from './definition';
+import type { FlowRoute } from './runtime';
+import type { ScreenshotScreen } from './public-types';
+
+export function prepareDialog(surface: HTMLElement, instanceId: string, size: string): HTMLElement {
+  const title = surface.querySelector<HTMLElement>('.bdv-title');
+  const titleId = `${instanceId}-title`;
+  if (title) title.id = titleId;
+  surface.setAttribute('role', 'dialog');
+  surface.setAttribute('aria-modal', 'true');
+  surface.setAttribute('aria-labelledby', titleId);
+  surface.tabIndex = -1;
+  surface.dataset.size = size;
+  return surface;
+}
+
+export function addNavigation(
+  surface: HTMLElement,
+  route: FlowRoute,
+  onBack: () => void,
+  onAdvance: () => void,
+  onClose: () => void
+): void {
+  const screen = route.screen!;
+  const close = button('×', 'bdv-close');
+  close.setAttribute('aria-label', 'Close');
+  close.addEventListener('click', onClose, { once: true });
+  surface.prepend(close);
+  const progress = document.createElement('p');
+  progress.className = 'bdf-progress';
+  progress.textContent = `Step ${route.position} of ${route.total}`;
+  surface.querySelector('.bdv-header')?.prepend(progress);
+  const actions = document.createElement('div');
+  actions.className = 'bdv-actions';
+  if (route.canGoBack) {
+    const back = button(
+      screen.type === 'message' ? 'Back' : (screen.backLabel ?? 'Back'),
+      'bdv-cancel bdf-back'
+    );
+    back.addEventListener('click', onBack);
+    actions.appendChild(back);
+  }
+  const label = screen.continueLabel ?? (route.hasNext ? 'Continue' : 'Submit');
+  const next = button(label, 'bdv-submit');
+  next.addEventListener('click', onAdvance);
+  actions.appendChild(next);
+  surface.appendChild(actions);
+}
+
+export function createScreenshotPrompt(screen: Readonly<ScreenshotScreen>): HTMLElement {
+  const surface = createStatusSurface(
+    screen.title ?? 'Add a screenshot',
+    screen.description ??
+      (screen.mode === 'required'
+        ? 'A screenshot is required before submitting.'
+        : 'Include a screenshot to help explain your feedback.')
+  );
+  if (screen.mode === 'optional') {
+    const row = document.createElement('label');
+    row.className = 'bdf-checkbox';
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.checked = true;
+    input.dataset.screenshot = '';
+    row.append(input, document.createTextNode('Include a screenshot'));
+    surface.appendChild(row);
+  }
+  return surface;
+}
+
+export function createStatusSurface(titleText: string, message: string): HTMLElement {
+  const surface = document.createElement('section');
+  surface.className = 'bdv-surface';
+  const header = document.createElement('div');
+  header.className = 'bdv-header';
+  const title = document.createElement('h2');
+  title.className = 'bdv-title';
+  title.textContent = titleText;
+  const description = document.createElement('p');
+  description.className = 'bdv-description';
+  description.textContent = message;
+  header.append(title, description);
+  surface.appendChild(header);
+  return surface;
+}
+
+export function createErrorSurface(
+  message: string,
+  cancelLabel: string,
+  retry: () => void,
+  close: () => void
+): HTMLElement {
+  const surface = createStatusSurface('Submission failed', message);
+  const actions = document.createElement('div');
+  actions.className = 'bdv-actions';
+  const retryButton = button('Try again', 'bdv-submit');
+  retryButton.addEventListener('click', retry);
+  const cancel = button(cancelLabel, 'bdv-cancel');
+  cancel.addEventListener('click', close);
+  actions.append(retryButton, cancel);
+  surface.appendChild(actions);
+  return surface;
+}
+
+export function createSuccessSurface(
+  definition: FlowDefinition,
+  submission: SubmissionResult,
+  close: () => void
+): HTMLElement {
+  const surface = createStatusSurface(
+    definition.config.content?.successTitle ?? 'Thanks for your feedback!',
+    definition.config.content?.successMessage ?? 'Your response was submitted.'
+  );
+  if (submission.isPublic) {
+    const link = document.createElement('a');
+    link.className = 'bdv-success-link';
+    link.href = submission.issueUrl;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = 'View GitHub Issue';
+    surface.appendChild(link);
+  }
+  const done = button('Done', 'bdv-submit');
+  done.addEventListener('click', close);
+  surface.appendChild(done);
+  return surface;
+}
+
+export function firstFocusable(root: HTMLElement): HTMLElement | null {
+  return root.querySelector<HTMLElement>(
+    'input:not(:disabled), textarea:not(:disabled), button:not(:disabled), a[href]'
+  );
+}
+
+export function deepActiveElement(): HTMLElement | null {
+  let active: Element | null = document.activeElement;
+  while (active instanceof HTMLElement && active.shadowRoot?.activeElement)
+    active = active.shadowRoot.activeElement;
+  return active instanceof HTMLElement ? active : null;
+}
+
+export function focusable(root: HTMLElement): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'button:not(:disabled), input:not(:disabled), textarea:not(:disabled), a[href], [tabindex]:not([tabindex="-1"])'
+    )
+  ).filter(element => !element.hidden && element.getAttribute('aria-hidden') !== 'true');
+}
+
+function button(label: string, className: string): HTMLButtonElement {
+  const value = document.createElement('button');
+  value.type = 'button';
+  value.className = className;
+  value.textContent = label;
+  return value;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/modal.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/modal.ts.txt
@@ -1,0 +1,323 @@
+/* eslint-disable max-lines */
+import { createRuntimeId } from '../variants/form';
+import { closeActiveVariantModal } from '../variants/modal-coordinator';
+import type { SubmissionResult } from '../variants/public-types';
+import type { FlowDefinition } from './definition';
+import { normalizeFlowOpenOptions } from './field-validation';
+import { createFlowFormScreen, type FlowFormController } from './form-screen';
+import { createMessageScreen } from './message-screen';
+import { createFlowModalState, type FlowModalState } from './modal-state';
+import {
+  addNavigation,
+  createErrorSurface,
+  createScreenshotPrompt,
+  createStatusSurface,
+  createSuccessSurface,
+  deepActiveElement,
+  firstFocusable,
+  focusable,
+  prepareDialog,
+} from './modal-view';
+import type { FlowOpenOptions, FlowOutcome, OpenedFlow, ScreenshotScreen } from './public-types';
+import { FlowRuntime, type CaptureEvidence } from './runtime';
+import { createStyledFlowRoot } from './styles';
+export interface FlowModalPorts {
+  preflight(): Promise<{ status: 'installed' | 'not_installed' | 'unreachable'; appName?: string }>;
+  capture(
+    screen: Readonly<ScreenshotScreen>,
+    include: boolean,
+    signal: AbortSignal
+  ): Promise<CaptureEvidence & { returnToForm: boolean }>;
+  submit(runtime: FlowRuntime): Promise<SubmissionResult>;
+}
+export function openFlowModal(
+  definition: FlowDefinition,
+  options: FlowOpenOptions | undefined,
+  ports: FlowModalPorts
+): OpenedFlow {
+  const normalized = normalizeFlowOpenOptions(definition, options);
+  closeActiveVariantModal();
+  return new FlowModalController(definition, normalized, ports).open();
+}
+class FlowModalController {
+  private readonly instanceId: string;
+  private readonly previousFocus: HTMLElement | null;
+  private readonly runtime: FlowRuntime;
+  private readonly result: Promise<FlowOutcome>;
+  private resolveOutcome!: (outcome: FlowOutcome) => void;
+  private readonly state: FlowModalState;
+  private currentForm: FlowFormController | null = null;
+  private settled = false;
+  private closed = false;
+  private busy = false;
+  private routePreviewVersion = 0;
+  private preflightVersion = 0;
+  private captureAbortController: AbortController | null = null;
+
+  constructor(
+    private readonly definition: FlowDefinition,
+    normalized: ReturnType<typeof normalizeFlowOpenOptions>,
+    private readonly ports: FlowModalPorts
+  ) {
+    this.instanceId = createRuntimeId(definition.flowId);
+    this.previousFocus = deepActiveElement();
+    this.runtime = new FlowRuntime(definition, normalized.context, normalized.initialAnswers);
+    this.result = new Promise(resolve => {
+      this.resolveOutcome = resolve;
+    });
+    this.state = createFlowModalState(
+      definition.flowId,
+      this.instanceId,
+      shadow => createStyledFlowRoot(shadow, definition.config),
+      event => this.onKeydown(event),
+      event => this.onBackdrop(event)
+    );
+  }
+
+  open(): OpenedFlow {
+    const opened = Object.freeze({
+      instanceId: this.instanceId,
+      result: this.result,
+      close: () => this.close(),
+    });
+    this.state.activate(opened.close);
+    const checking = createStatusSurface('Preparing feedback', 'Checking installation…');
+    checking.setAttribute('aria-busy', 'true');
+    this.show(checking);
+    void this.preflight();
+    return opened;
+  }
+
+  private async preflight(): Promise<void> {
+    const version = ++this.preflightVersion;
+    try {
+      const preflight = await this.ports.preflight();
+      if (this.closed || version !== this.preflightVersion) return;
+      if (preflight.status === 'installed') this.render();
+      else {
+        const message =
+          preflight.status === 'not_installed'
+            ? `Install the ${preflight.appName ?? 'BugDrop'} GitHub App to continue.`
+            : 'BugDrop could not reach the feedback service.';
+        this.renderError(message, () => void this.preflight());
+      }
+    } catch {
+      if (!this.closed && version === this.preflightVersion)
+        this.renderError(
+          'BugDrop could not reach the feedback service.',
+          () => void this.preflight()
+        );
+    }
+  }
+
+  private render(): void {
+    this.disposeForm();
+    const route = this.runtime.route();
+    const screen = route.screen;
+    if (!screen) {
+      void this.finish();
+      return;
+    }
+    let surface: HTMLElement;
+    if (screen.type === 'message') surface = createMessageScreen(screen);
+    else if (screen.type === 'form') {
+      const form = this.definition.config.forms.find(candidate => candidate.id === screen.form)!;
+      this.currentForm = createFlowFormScreen(form, this.instanceId, this.runtime.answers);
+      surface = this.currentForm.element;
+    } else surface = createScreenshotPrompt(screen);
+    prepareDialog(surface, this.instanceId, this.definition.config.presentation.size ?? 'default');
+    addNavigation(
+      surface,
+      route,
+      () => void this.back(screen),
+      () => void this.advance(screen, surface),
+      () => this.close()
+    );
+    if (screen.type === 'form') {
+      const preview = () => void this.previewFormRoute(screen.form, surface);
+      surface.addEventListener('input', preview);
+      surface.addEventListener('change', preview);
+    }
+    this.show(surface);
+  }
+
+  private async previewFormRoute(formId: string, surface: HTMLElement): Promise<void> {
+    const version = ++this.routePreviewVersion;
+    const values = await this.currentForm?.snapshot();
+    if (!values || version !== this.routePreviewVersion || !surface.isConnected || this.closed)
+      return;
+    this.runtime.setFormAnswers(formId, values);
+    const route = this.runtime.route();
+    const screen = route.screen;
+    if (!screen) return;
+    const progress = surface.querySelector<HTMLElement>('.bdf-progress');
+    if (progress) progress.textContent = `Step ${route.position} of ${route.total}`;
+    const next = surface.querySelector<HTMLButtonElement>('.bdv-submit');
+    if (next) next.textContent = screen.continueLabel ?? (route.hasNext ? 'Continue' : 'Submit');
+  }
+
+  private async back(screen: NonNullable<ReturnType<FlowRuntime['current']>>): Promise<void> {
+    if (this.busy) return;
+    this.busy = true;
+    if (screen.type === 'form') {
+      const values = await this.currentForm?.snapshot();
+      if (values === null || this.closed) {
+        this.busy = false;
+        return;
+      }
+      if (values) this.runtime.setFormAnswers(screen.form, values);
+    }
+    this.runtime.back();
+    this.busy = false;
+    this.render();
+  }
+
+  private async advance(
+    screen: NonNullable<ReturnType<FlowRuntime['current']>>,
+    surface: HTMLElement
+  ): Promise<void> {
+    if (this.busy) return;
+    this.busy = true;
+    if (screen.type === 'form') {
+      const values = await this.currentForm?.collect();
+      if (!values || this.closed) {
+        this.busy = false;
+        return;
+      }
+      this.runtime.setFormAnswers(screen.form, values);
+    }
+    if (screen.type === 'screenshot') {
+      this.busy = false;
+      await this.capture(screen, surface);
+      return;
+    }
+    if (!this.runtime.next()) {
+      this.busy = false;
+      await this.finish();
+    } else {
+      this.busy = false;
+      this.render();
+    }
+  }
+
+  private async capture(screen: Readonly<ScreenshotScreen>, surface: HTMLElement): Promise<void> {
+    const include =
+      screen.mode !== 'optional' ||
+      Boolean(surface.querySelector<HTMLInputElement>('[data-screenshot]')?.checked);
+    this.busy = true;
+    this.state.host.hidden = true;
+    const abortController = new AbortController();
+    this.captureAbortController = abortController;
+    try {
+      const capture = await this.ports.capture(screen, include, abortController.signal);
+      if (this.closed) return;
+      if (capture.returnToForm) this.runtime.back();
+      else {
+        this.runtime.capture = capture;
+        if (!this.runtime.next()) {
+          this.busy = false;
+          await this.finish();
+          return;
+        }
+      }
+    } finally {
+      if (this.captureAbortController === abortController) this.captureAbortController = null;
+      this.busy = false;
+      this.state.host.hidden = false;
+    }
+    if (!this.closed) this.render();
+  }
+
+  private async finish(): Promise<void> {
+    if (this.busy || this.closed) return;
+    this.busy = true;
+    const status = createStatusSurface('Submitting feedback', 'Submitting…');
+    status.setAttribute('aria-busy', 'true');
+    this.show(status);
+    try {
+      const submission = await this.ports.submit(this.runtime);
+      if (this.closed) return;
+      this.settle({ status: 'submitted', result: submission });
+      this.busy = false;
+      this.show(createSuccessSurface(this.definition, submission, () => this.close(false)));
+    } catch (error) {
+      if (this.closed) return;
+      this.busy = false;
+      this.renderError(
+        error instanceof Error ? error.message : 'Failed to submit feedback',
+        () => void this.finish()
+      );
+    }
+  }
+
+  private renderError(message: string, retry: () => void): void {
+    this.show(
+      createErrorSurface(
+        message,
+        this.definition.config.content?.cancelLabel ?? 'Cancel',
+        retry,
+        () => this.close()
+      )
+    );
+  }
+
+  private show(surface: HTMLElement): void {
+    prepareDialog(surface, this.instanceId, this.definition.config.presentation.size ?? 'default');
+    this.state.overlay.replaceChildren(surface);
+    queueMicrotask(() => (firstFocusable(surface) ?? surface).focus());
+  }
+
+  private close(settleClosed = true): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.preflightVersion += 1;
+    this.captureAbortController?.abort();
+    this.captureAbortController = null;
+    if (settleClosed) this.settle({ status: 'closed' });
+    this.disposeForm();
+    this.state.dispose();
+    if (this.previousFocus?.isConnected) this.previousFocus.focus();
+  }
+
+  private settle(outcome: FlowOutcome): void {
+    if (this.settled) return;
+    this.settled = true;
+    this.resolveOutcome(outcome);
+  }
+
+  private disposeForm(): void {
+    this.routePreviewVersion += 1;
+    this.currentForm?.dispose();
+    this.currentForm = null;
+  }
+
+  private onKeydown(event: Event): void {
+    if (!(event instanceof KeyboardEvent)) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.close();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const elements = focusable(this.state.overlay);
+    if (!elements.length) {
+      event.preventDefault();
+      this.state.overlay.querySelector<HTMLElement>('[role="dialog"]')?.focus();
+      return;
+    }
+    const first = elements[0]!;
+    const last = elements.at(-1)!;
+    const active = this.state.shadow.activeElement;
+    if (event.shiftKey && (active === first || !this.state.overlay.contains(active))) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  private onBackdrop(event: PointerEvent): void {
+    if (event.target === this.state.overlay) this.close();
+  }
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/runtime.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/runtime.ts.txt
@@ -1,0 +1,135 @@
+import { evaluateCondition } from './conditions';
+import type { FlowDefinition } from './definition';
+import type { FlowScalar, FlowScreen } from './public-types';
+
+export interface CaptureEvidence {
+  screenshot: string | null;
+  elementSelector: string | null;
+  fullElementSelector: string | null;
+}
+
+export interface FlowRoute {
+  readonly screen: Readonly<FlowScreen> | undefined;
+  readonly position: number;
+  readonly total: number;
+  readonly canGoBack: boolean;
+  readonly hasNext: boolean;
+}
+
+export class FlowRuntime {
+  readonly answers: Record<string, unknown>;
+  capture: CaptureEvidence | null = null;
+  private currentId: string;
+
+  constructor(
+    readonly definition: FlowDefinition,
+    readonly context: Readonly<Record<string, FlowScalar>>,
+    initialAnswers: Record<string, unknown> = {}
+  ) {
+    this.answers = { ...initialAnswers };
+    this.reconcileInitiallyHidden();
+    this.currentId = this.visibleScreens()[0]?.id ?? '';
+  }
+
+  current(): Readonly<FlowScreen> | undefined {
+    return this.route().screen;
+  }
+
+  route(): FlowRoute {
+    const visible = this.visibleScreens();
+    const found = visible.findIndex(screen => screen.id === this.currentId);
+    const index = found >= 0 ? found : 0;
+    return Object.freeze({
+      screen: visible[index],
+      position: visible.length === 0 ? 0 : index + 1,
+      total: visible.length,
+      canGoBack: index > 0,
+      hasNext: index >= 0 && index < visible.length - 1,
+    });
+  }
+
+  setFormAnswers(formId: string, values: Record<string, unknown>): void {
+    const previouslyVisible = new Set(this.visibleScreens().map(screen => screen.id));
+    const paths = this.definition.screenAnswerPaths.get(
+      this.definition.screens.find(screen => screen.type === 'form' && screen.form === formId)!.id
+    )!;
+    for (const path of paths) {
+      const fieldId = path.slice(formId.length + 1);
+      this.answers[path] = values[fieldId];
+    }
+    this.reconcileNewlyHidden(previouslyVisible);
+  }
+
+  next(): boolean {
+    const route = this.route();
+    const visible = this.visibleScreens();
+    if (route.hasNext) {
+      this.currentId = visible[route.position]!.id;
+      return true;
+    }
+    return false;
+  }
+
+  back(): boolean {
+    const route = this.route();
+    const visible = this.visibleScreens();
+    if (route.canGoBack) {
+      this.currentId = visible[route.position - 2]!.id;
+      return true;
+    }
+    return false;
+  }
+
+  hasNext(): boolean {
+    return this.route().hasNext;
+  }
+
+  private visibleScreens(): readonly Readonly<FlowScreen>[] {
+    return this.definition.screens.filter(screen =>
+      evaluateCondition(screen.when, this.answers, this.context)
+    );
+  }
+
+  private reconcileInitiallyHidden(): void {
+    for (const screen of this.definition.screens) {
+      if (evaluateCondition(screen.when, this.answers, this.context)) continue;
+      this.clearScreenState(screen);
+    }
+  }
+
+  private reconcileNewlyHidden(previouslyVisible: ReadonlySet<string>): void {
+    let visible = new Set(this.visibleScreens().map(screen => screen.id));
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const screen of this.definition.screens) {
+        if (!previouslyVisible.has(screen.id) || visible.has(screen.id)) continue;
+        changed = this.clearScreenState(screen) || changed;
+      }
+      if (changed) visible = new Set(this.visibleScreens().map(screen => screen.id));
+    }
+    if (!visible.has(this.currentId)) this.currentId = this.nearestVisibleId(visible);
+  }
+
+  private clearScreenState(screen: Readonly<FlowScreen>): boolean {
+    let changed = false;
+    for (const path of this.definition.screenAnswerPaths.get(screen.id) ?? []) {
+      if (Object.prototype.hasOwnProperty.call(this.answers, path)) changed = true;
+      delete this.answers[path];
+    }
+    if (screen.type === 'screenshot' && this.capture !== null) {
+      this.capture = null;
+      changed = true;
+    }
+    return changed;
+  }
+
+  private nearestVisibleId(visible: ReadonlySet<string>): string {
+    const oldIndex = this.definition.screens.findIndex(screen => screen.id === this.currentId);
+    for (let index = oldIndex; index >= 0; index -= 1) {
+      const candidate = this.definition.screens[index];
+      if (candidate && visible.has(candidate.id)) return candidate.id;
+    }
+    return this.visibleScreens()[0]?.id ?? '';
+  }
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/styles.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/styles.ts.txt
@@ -1,0 +1,33 @@
+import { createStyledVariantRoot } from '../variants/styles';
+import type { VariantConfig } from '../variants/public-types';
+import type { FlowConfig } from './public-types';
+
+export function createStyledFlowRoot(shadow: ShadowRoot, config: Readonly<FlowConfig>) {
+  const adapter: Readonly<VariantConfig> = {
+    id: config.id,
+    presentation: config.presentation,
+    appearance: config.appearance,
+    content: { title: config.id },
+    fields: [{ id: 'placeholder', type: 'shortText', label: 'Placeholder' }],
+    issue: { title: config.id },
+  };
+  const styled = createStyledVariantRoot(shadow, adapter, 'modal');
+  const extra = document.createElement('style');
+  extra.textContent = `
+    .bdf-progress { margin: 0 0 12px; color: var(--bdv-text-muted); font-size: .8rem; }
+    .bdf-message { min-height: 180px; display: grid; align-content: center; }
+    .bdf-attachment { display: grid; gap: 7px; }
+    .bdf-checkbox { display: flex; min-height: 44px; align-items: center; gap: 10px; }
+    .bdf-checkbox input { width: 20px; height: 20px; accent-color: var(--bdv-accent); }
+    .bdf-file-list { margin: 0; padding-left: 20px; color: var(--bdv-text-muted); }
+    .bdf-back { order: -1; }
+  `;
+  shadow.prepend(extra);
+  return {
+    root: styled.root,
+    dispose() {
+      extra.remove();
+      styled.dispose();
+    },
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/submission.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/submission.ts.txt
@@ -1,0 +1,108 @@
+import { getAuthHeaders, type BugDropAuthTokenProvider } from '../auth-token';
+import { getConsoleLogSnapshot } from '../console-logs';
+import { getDomNodeCount, isFullPageDisabled } from '../screenshot';
+import type { SubmissionResult } from '../variants/public-types';
+import type { CaptureEvidence } from './runtime';
+import type { FlowConfig, FlowScalar } from './public-types';
+import { compileFlowIssueDraft } from './issue-draft';
+
+export interface FlowTransportConfig {
+  repo: string;
+  apiUrl: string;
+  authTokenProvider?: BugDropAuthTokenProvider;
+  categoryLabels?: Partial<Record<'bug' | 'feature' | 'question', string | string[]>>;
+}
+
+export async function submitFlow(
+  transport: FlowTransportConfig,
+  config: Readonly<FlowConfig>,
+  answers: Readonly<Record<string, unknown>>,
+  context: Readonly<Record<string, FlowScalar>>,
+  capture: CaptureEvidence | null
+): Promise<SubmissionResult> {
+  const issue = compileFlowIssueDraft(config, answers, context);
+  const attachmentsPath = config.evidence?.attachments;
+  const logsPath = config.evidence?.sendConsoleLogs;
+  const namePath = config.evidence?.submitter?.name;
+  const emailPath = config.evidence?.submitter?.email;
+  const submitter =
+    namePath || emailPath
+      ? { name: readString(answers[namePath ?? '']), email: readString(answers[emailPath ?? '']) }
+      : undefined;
+  const response = await fetch(`${transport.apiUrl}/feedback`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await getAuthHeaders(transport.authTokenProvider)),
+    },
+    body: JSON.stringify({
+      repo: transport.repo,
+      title: issue.title,
+      description: issue.description,
+      category: issue.category,
+      categoryLabels: transport.categoryLabels,
+      screenshot: capture?.screenshot ?? null,
+      attachments: attachmentsPath ? (answers[attachmentsPath] ?? []) : [],
+      consoleLogs: logsPath && answers[logsPath] === true ? getConsoleLogSnapshot() : undefined,
+      submitter: submitter && (submitter.name || submitter.email) ? submitter : undefined,
+      metadata: collectMetadata(capture),
+    }),
+  });
+  if (response.status === 429) throw new Error('Too many submissions. Please try again later.');
+  const result = (await response.json()) as Record<string, unknown>;
+  if (!response.ok || result.success !== true)
+    throw new Error(typeof result.error === 'string' ? result.error : 'Failed to submit feedback');
+  if (
+    !Number.isInteger(result.issueNumber) ||
+    (result.issueNumber as number) <= 0 ||
+    typeof result.issueUrl !== 'string' ||
+    typeof result.isPublic !== 'boolean' ||
+    !isCanonicalIssueUrl(result.issueUrl, transport.repo, result.issueNumber as number)
+  )
+    throw new Error('BugDrop received an invalid Issue result');
+  return {
+    issueNumber: result.issueNumber as number,
+    issueUrl: result.issueUrl,
+    isPublic: result.isPublic,
+    ...(Array.isArray(result.labelMappingWarnings) &&
+    result.labelMappingWarnings.every(value => typeof value === 'string')
+      ? { labelMappingWarnings: result.labelMappingWarnings as string[] }
+      : {}),
+  };
+}
+
+function isCanonicalIssueUrl(value: string, repo: string, issueNumber: number): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.origin === 'https://github.com' &&
+      url.pathname.toLowerCase() === `/${repo}/issues/${issueNumber}`.toLowerCase() &&
+      !url.search &&
+      !url.hash
+    );
+  } catch {
+    return false;
+  }
+}
+
+function collectMetadata(capture: CaptureEvidence | null) {
+  const url = new URL(window.location.href);
+  url.search = '';
+  url.hash = '';
+  return {
+    url: url.toString(),
+    userAgent: navigator.userAgent,
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    timestamp: new Date().toISOString(),
+    elementSelector: capture?.elementSelector ?? null,
+    fullElementSelector: capture?.fullElementSelector ?? null,
+    domNodeCount: getDomNodeCount(),
+    fullPageDisabled: isFullPageDisabled(),
+    devicePixelRatio: window.devicePixelRatio,
+    language: navigator.language,
+  };
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/validate-config.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/validate-config.ts.txt
@@ -1,0 +1,306 @@
+import { countConditionNodes } from './conditions';
+import {
+  validateFlowConditionValue,
+  validateFlowFieldConfig,
+  validateFlowShell,
+} from './field-validation';
+import type {
+  FlowCondition,
+  FlowConfig,
+  FlowField,
+  FlowIssueSection,
+  FlowScreen,
+} from './public-types';
+import {
+  deepFreeze,
+  fail,
+  object,
+  only,
+  optionalText,
+  scalar,
+  text,
+  validId,
+} from './validation-utils';
+const PATH = /^([a-z][a-z0-9_-]{0,63})\.([a-z][a-z0-9_-]{0,63})$/;
+const TOP_KEYS = new Set([
+  'configVersion',
+  'id',
+  'presentation',
+  'appearance',
+  'content',
+  'forms',
+  'screens',
+  'issue',
+  'evidence',
+]);
+const BASE_FIELD_KEYS = ['id', 'type', 'label', 'helpText', 'required', 'layout'];
+const FIELD_KEYS: Record<FlowField['type'], Set<string>> = {
+  shortText: new Set([...BASE_FIELD_KEYS, 'placeholder', 'minLength', 'maxLength']),
+  longText: new Set([...BASE_FIELD_KEYS, 'placeholder', 'rows', 'minLength', 'maxLength']),
+  rating: new Set([...BASE_FIELD_KEYS, 'scale', 'icon', 'lowLabel', 'highLabel']),
+  singleChoice: new Set([...BASE_FIELD_KEYS, 'options', 'display']),
+  checkbox: new Set([...BASE_FIELD_KEYS, 'initialValue']),
+  attachments: new Set([...BASE_FIELD_KEYS, 'maxFiles', 'maxFileSize', 'accept']),
+};
+export function validateAndFreezeFlowConfig(input: FlowConfig): Readonly<FlowConfig> {
+  if (!object(input)) fail('config must be an object');
+  only(input, TOP_KEYS, 'config');
+  if (input.configVersion !== 1) fail('configVersion must be 1');
+  validId(input.id, 'id');
+  validateFlowShell(input);
+  if (!Array.isArray(input.forms) || input.forms.length === 0 || input.forms.length > 12) {
+    fail('forms must contain 1-12 entries');
+  }
+  if (!Array.isArray(input.screens) || input.screens.length === 0 || input.screens.length > 20) {
+    fail('screens must contain 1-20 entries');
+  }
+
+  const answerFields = new Map<string, FlowField>();
+  const forms = new Map<string, FlowConfig['forms'][number]>();
+  for (const form of input.forms) validateForm(form, forms, answerFields);
+  const referencedForms = new Set<string>();
+  const guaranteedRequiredAnswers = new Set<string>();
+  const earlierAnswers = new Map<string, FlowField>();
+  let screenshots = 0;
+  const screenIds = new Set<string>();
+  for (const screen of input.screens) {
+    validateScreen(screen, screenIds, forms, earlierAnswers);
+    if (screen.type === 'form') {
+      if (referencedForms.has(screen.form)) fail(`form ${screen.form} may be referenced only once`);
+      referencedForms.add(screen.form);
+      for (const field of forms.get(screen.form)!.fields)
+        earlierAnswers.set(`${screen.form}.${field.id}`, field);
+      if (screen.when === undefined)
+        for (const field of forms.get(screen.form)!.fields)
+          if (field.required) guaranteedRequiredAnswers.add(`${screen.form}.${field.id}`);
+    }
+    if (screen.type === 'screenshot' && ++screenshots > 1)
+      fail('only one screenshot screen is supported');
+  }
+  for (const formId of forms.keys())
+    if (!referencedForms.has(formId)) fail(`form ${formId} is unused`);
+  if (input.screens.every(screen => screen.when !== undefined))
+    fail('at least one screen must be unconditional');
+  validateIssue(input.issue, answerFields, guaranteedRequiredAnswers);
+  validateEvidence(input.evidence, answerFields);
+  return deepFreeze(structuredClone(input));
+}
+
+function validateForm(
+  form: FlowConfig['forms'][number],
+  forms: Map<string, FlowConfig['forms'][number]>,
+  answerFields: Map<string, FlowField>
+) {
+  if (!object(form)) fail('form must be an object');
+  only(form, new Set(['id', 'title', 'description', 'fields']), 'form');
+  validId(form.id, 'form id');
+  if (forms.has(form.id)) fail(`duplicate form id ${form.id}`);
+  text(form.title, 'form title', 500);
+  optionalText(form.description, 'form description', 2_000);
+  if (!Array.isArray(form.fields) || form.fields.length === 0 || form.fields.length > 20)
+    fail('form fields must contain 1-20 entries');
+  const ids = new Set<string>();
+  for (const field of form.fields) {
+    if (!object(field) || typeof field.type !== 'string' || !(field.type in FIELD_KEYS))
+      fail('field type is unsupported');
+    only(field, FIELD_KEYS[field.type as FlowField['type']], 'field');
+    validId(field.id, 'field id');
+    if (ids.has(field.id)) fail(`duplicate field id ${field.id}`);
+    ids.add(field.id);
+    text(field.label, 'field label', 500);
+    optionalText(field.helpText, 'field helpText', 1_000);
+    if (field.required !== undefined && typeof field.required !== 'boolean')
+      fail('field required must be boolean');
+    validateFlowFieldConfig(field as FlowField);
+    answerFields.set(`${form.id}.${field.id}`, field as FlowField);
+  }
+  forms.set(form.id, form);
+}
+
+function validateScreen(
+  screen: FlowScreen,
+  ids: Set<string>,
+  forms: Map<string, FlowConfig['forms'][number]>,
+  earlier: Map<string, FlowField>
+) {
+  if (!object(screen)) fail('screen must be an object');
+  validId(screen.id, 'screen id');
+  if (ids.has(screen.id)) fail(`duplicate screen id ${screen.id}`);
+  ids.add(screen.id);
+  if (!['message', 'form', 'screenshot'].includes(screen.type)) fail('screen type is unsupported');
+  const keys =
+    screen.type === 'message'
+      ? new Set(['id', 'type', 'when', 'title', 'description', 'continueLabel'])
+      : screen.type === 'form'
+        ? new Set(['id', 'type', 'when', 'form', 'continueLabel', 'backLabel'])
+        : new Set([
+            'id',
+            'type',
+            'when',
+            'title',
+            'description',
+            'mode',
+            'continueLabel',
+            'backLabel',
+          ]);
+  only(screen, keys, 'screen');
+  if (Object.prototype.hasOwnProperty.call(screen, 'when'))
+    validateCondition(screen.when as FlowCondition, earlier);
+  if (screen.type === 'message') {
+    text(screen.title, 'message title', 500);
+    optionalText(screen.description, 'message description', 2_000);
+  }
+  if (screen.type === 'form' && !forms.has(screen.form))
+    fail(`screen references unknown form ${screen.form}`);
+  if (screen.type === 'screenshot' && !['optional', 'auto', 'required'].includes(screen.mode))
+    fail('screenshot mode is invalid');
+  if (screen.type === 'screenshot') {
+    optionalText(screen.title, 'screenshot title', 500);
+    optionalText(screen.description, 'screenshot description', 2_000);
+  }
+  optionalText(screen.continueLabel, 'screen continueLabel', 120);
+  if (screen.type !== 'message') optionalText(screen.backLabel, 'screen backLabel', 120);
+}
+
+function validateCondition(condition: FlowCondition, earlier: Map<string, FlowField>) {
+  if (!object(condition)) fail('condition must be an object');
+  countConditionNodes(condition);
+  if ('answer' in condition) {
+    only(condition, new Set(['answer', 'equals']), 'answer condition');
+    const field = earlier.get(condition.answer);
+    if (!field) fail(`condition answer must reference an earlier field: ${condition.answer}`);
+    scalar(condition.equals, 'condition equals');
+    validateFlowConditionValue(field, condition.equals);
+    return;
+  }
+  if ('context' in condition) {
+    only(condition, new Set(['context', 'equals']), 'context condition');
+    validId(condition.context, 'condition context');
+    scalar(condition.equals, 'condition equals');
+    return;
+  }
+  const key = 'all' in condition ? 'all' : 'any' in condition ? 'any' : null;
+  if (!key) fail('condition must contain answer, context, all, or any');
+  only(condition, new Set([key]), 'condition group');
+  const children =
+    key === 'all'
+      ? (condition as Extract<FlowCondition, { all: FlowCondition[] }>).all
+      : (condition as Extract<FlowCondition, { any: FlowCondition[] }>).any;
+  if (!Array.isArray(children) || children.length < 1 || children.length > 8)
+    fail(`condition ${key} must contain 1-8 entries`);
+  for (const child of children) validateCondition(child, earlier);
+}
+
+function validateIssue(
+  issue: FlowConfig['issue'],
+  answers: Map<string, FlowField>,
+  guaranteedRequiredAnswers: ReadonlySet<string>
+) {
+  if (!object(issue)) fail('issue must be an object');
+  only(issue, new Set(['classification', 'title', 'sections']), 'issue');
+  text(issue.title, 'issue title', 2_000);
+  if (
+    issue.classification !== undefined &&
+    !['bug', 'feature', 'question'].includes(issue.classification)
+  )
+    fail('issue classification is invalid');
+  validateIssueTitleTemplate(issue.title, answers, guaranteedRequiredAnswers);
+  if (issue.sections !== undefined) {
+    if (!Array.isArray(issue.sections) || issue.sections.length > 20)
+      fail('issue sections are invalid');
+    const headings = new Set<string>();
+    for (const section of issue.sections) validateSection(section, answers, headings);
+  }
+}
+
+function validateSection(
+  section: FlowIssueSection,
+  answers: Map<string, FlowField>,
+  headings: Set<string>
+) {
+  if (!object(section)) fail('issue section must be an object');
+  if ('answer' in section) {
+    only(section, new Set(['heading', 'answer', 'format', 'omitWhenEmpty']), 'issue section');
+    validateScalarAnswer(section.answer, answers, 'issue section');
+  } else {
+    only(section, new Set(['heading', 'context', 'format', 'omitWhenEmpty']), 'issue section');
+    validId(section.context, 'issue context');
+  }
+  text(section.heading, 'issue section heading', 120);
+  const heading = section.heading.trim().toLowerCase();
+  if (headings.has(heading)) fail(`duplicate issue section heading ${section.heading}`);
+  headings.add(heading);
+  if (section.omitWhenEmpty !== undefined && typeof section.omitWhenEmpty !== 'boolean')
+    fail('issue section omitWhenEmpty must be boolean');
+  const format = section.format ?? 'text';
+  if ('answer' in section) {
+    if (!['text', 'quote', 'stars', 'choice', 'code'].includes(format))
+      fail('issue answer format is invalid');
+    const field = answers.get(section.answer)!;
+    if (format === 'stars' && field.type !== 'rating') fail('stars format requires a rating field');
+    if (format === 'choice' && field.type !== 'singleChoice')
+      fail('choice format requires a singleChoice field');
+  } else if (!['text', 'code'].includes(format)) fail('issue context format is invalid');
+}
+
+function validateEvidence(evidence: FlowConfig['evidence'], answers: Map<string, FlowField>) {
+  if (evidence === undefined) return;
+  if (!object(evidence)) fail('evidence must be an object');
+  only(evidence, new Set(['attachments', 'sendConsoleLogs', 'submitter']), 'evidence');
+  typedPath(evidence.attachments, 'attachments', answers, 'attachments');
+  typedPath(evidence.sendConsoleLogs, 'checkbox', answers, 'sendConsoleLogs');
+  if (evidence.submitter !== undefined) {
+    if (!object(evidence.submitter)) fail('evidence submitter must be an object');
+    only(evidence.submitter, new Set(['name', 'email']), 'evidence submitter');
+    if (!evidence.submitter.name && !evidence.submitter.email)
+      fail('evidence submitter must map name or email');
+    if (evidence.submitter.name)
+      validateTextAnswer(evidence.submitter.name, answers, 'submitter name');
+    if (evidence.submitter.email)
+      validateTextAnswer(evidence.submitter.email, answers, 'submitter email');
+  }
+}
+function typedPath(
+  path: string | undefined,
+  type: FlowField['type'],
+  answers: Map<string, FlowField>,
+  label: string
+) {
+  if (path !== undefined && answers.get(path)?.type !== type)
+    fail(`${label} must reference a ${type} field`);
+}
+function validateScalarAnswer(path: string, answers: Map<string, FlowField>, label: string) {
+  if (!PATH.test(path) || !answers.has(path) || answers.get(path)?.type === 'attachments')
+    fail(`${label} references an unknown scalar answer: ${path}`);
+}
+function validateTextAnswer(path: string, answers: Map<string, FlowField>, label: string) {
+  const type = answers.get(path)?.type;
+  if (!PATH.test(path) || (type !== 'shortText' && type !== 'longText'))
+    fail(`${label} must reference a text field`);
+}
+function validateIssueTitleTemplate(
+  template: string,
+  answers: Map<string, FlowField>,
+  guaranteedRequiredAnswers: ReadonlySet<string>
+) {
+  let cursor = 0;
+  let hasRequiredSource = false;
+  let literal = '';
+  for (const match of template.matchAll(/{{\s*([^{}]+?)\s*}}/g)) {
+    const index = match.index!;
+    const before = template.slice(cursor, index);
+    literal += before;
+    if (before.includes('{{') || before.includes('}}') || before.endsWith('{'))
+      fail('issue title template is malformed');
+    const path = match[1]!.trim();
+    validateScalarAnswer(path, answers, 'issue title');
+    hasRequiredSource ||= guaranteedRequiredAnswers.has(path);
+    cursor = index + match[0].length;
+    if (template[cursor] === '}') fail('issue title template is malformed');
+  }
+  const after = template.slice(cursor);
+  if (after.includes('{{') || after.includes('}}')) fail('issue title template is malformed');
+  literal += after;
+  if (!literal.trim() && !hasRequiredSource)
+    fail('issue title must contain text or reference a required answer');
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/flows/validation-utils.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/flows/validation-utils.ts.txt
@@ -1,0 +1,51 @@
+const ID = /^[a-z][a-z0-9_-]{0,63}$/;
+
+export function only(value: object, keys: Set<string>, label: string): void {
+  for (const key of Object.keys(value))
+    if (!keys.has(key)) fail(`${label} contains unknown key ${key}`);
+}
+
+export function validId(value: unknown, label: string): void {
+  if (typeof value !== 'string' || !ID.test(value) || value === 'legacy')
+    fail(`${label} is invalid`);
+}
+
+export function text(value: unknown, label: string, maximum: number): void {
+  if (
+    typeof value !== 'string' ||
+    value.trim().length === 0 ||
+    value.length > maximum ||
+    [...value].some(character => {
+      const code = character.charCodeAt(0);
+      return code < 32 && code !== 9 && code !== 10 && code !== 13;
+    })
+  )
+    fail(`${label} is invalid`);
+}
+
+export function optionalText(value: unknown, label: string, maximum: number): void {
+  if (value !== undefined) text(value, label, maximum);
+}
+
+export function scalar(value: unknown, label: string): void {
+  if (
+    (value !== null && !['string', 'number', 'boolean'].includes(typeof value)) ||
+    (typeof value === 'number' && !Number.isFinite(value))
+  )
+    fail(`${label} must be scalar`);
+}
+
+export function object(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function fail(message: string): never {
+  throw new TypeError(`BugDrop flow ${message}`);
+}
+
+export function deepFreeze<T>(value: T): Readonly<T> {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/i18n.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/i18n.ts.txt
@@ -1,0 +1,146 @@
+import { de } from './locales/de';
+import { en } from './locales/en';
+import { nl } from './locales/nl';
+import { pl } from './locales/pl';
+import { escapeHtml } from './sanitize';
+
+export interface WidgetStrings {
+  // Trigger button & pull tab
+  triggerLabel: string;
+  triggerAriaLabel: string;
+  dismissButtonAriaLabel: string;
+  pullTabAriaLabel: string;
+  dragHandleTitle: string;
+  // Install prompt
+  installRequiredTitle: string;
+  connectionErrorTitle: string;
+  installRequiredMessage: string;
+  apiUnreachableMessage: string;
+  installApp: string;
+  // Welcome screen
+  welcomeTitle: string;
+  welcomeHeadline: string;
+  welcomeBodyLine1: string;
+  welcomeBodyLine2: string;
+  getStarted: string;
+  // Feedback form
+  feedbackFormTitle: string;
+  categoryLabel: string;
+  categoryBug: string;
+  categoryFeature: string;
+  categoryQuestion: string;
+  nameLabel: string;
+  namePlaceholder: string;
+  emailLabel: string;
+  emailPlaceholder: string;
+  titleLabel: string;
+  titlePlaceholder: string;
+  descriptionLabel: string;
+  descriptionPlaceholder: string;
+  screenshotAutoNote: string;
+  screenshotAutoRedactionNote: string;
+  screenshotRequiredNote: string;
+  includeScreenshotLabel: string;
+  sendConsoleLogsLabel: string;
+  // Uploads
+  uploadsAriaLabel: string;
+  uploadFilesAriaLabel: string;
+  uploadButton: string;
+  uploadTooMany: (max: number) => string;
+  uploadUnsupportedType: string;
+  uploadTooLarge: (maxSize: string) => string;
+  uploadReadError: string;
+  removeAttachmentAriaLabel: (name: string) => string;
+  // Common buttons
+  cancel: string;
+  continueButton: string;
+  submit: string;
+  // Submission
+  submittingTitle: string;
+  creatingIssue: string;
+  rateLimited: (minutes: number) => string;
+  submitFailedFallback: string;
+  networkError: string;
+  submissionFailedTitle: string;
+  tryAgain: string;
+  // Success modal
+  successTitle: string;
+  // Callers pass a trusted issue-number HTML fragment; dictionaries own surrounding text only.
+  issueCreated: (issueNumberHtml: string) => string;
+  feedbackSubmittedMessage: string;
+  viewOnGitHub: string;
+  done: string;
+  // Screenshot options
+  captureScreenshotTitle: string;
+  chooseWhatToCapture: string;
+  viewportRedactionWarning: string;
+  redactionReviewNote: string;
+  pageTooComplexViewportNote: string;
+  pageTooComplexElementNote: string;
+  fullPage: string;
+  captureViewport: string;
+  selectArea: string;
+  selectElement: string;
+  skipScreenshot: string;
+  // Element & area pickers
+  areaPickerInstruction: string;
+  areaPickerRedactionInstruction: string;
+  elementPickerInstruction: string;
+  elementPickerTouchInstruction: string;
+  escToCancel: string;
+  // Capture loading & failures
+  capturingTitle: string;
+  capturingScreenshot: string;
+  captureFailedTitle: string;
+  captureFailedMessage: string;
+  chooseAnotherMethod: string;
+  maskFailureTitle: string;
+  maskFailureMessage: string;
+  continueWithoutScreenshot: string;
+  // Annotation step
+  reviewScreenshotTitle: string;
+  viewportRedactionUnavailableNote: string;
+  redactionCountNote: (count: number) => string;
+  redactionLimitationsNote: string;
+  annotationInstruction: string;
+  // Callers pass a trusted configuration-link HTML fragment; dictionaries own surrounding text only.
+  selectedElementNote: (linkHtml: string) => string;
+  toolDraw: string;
+  toolArrow: string;
+  toolRectangle: string;
+  toolRedact: string;
+  undo: string;
+  retake: string;
+  submitFeedback: string;
+  // Capture timeout
+  captureTimeout: string;
+}
+
+const DICTIONARIES = { en, de, nl, pl } satisfies Record<string, WidgetStrings>;
+
+export type SupportedLocale = keyof typeof DICTIONARIES;
+
+// Use this for dictionary strings inserted into raw HTML templates.
+export function escapeWidgetText(value: string): string {
+  return escapeHtml(value);
+}
+
+export function resolveLocale(raw: string | undefined | null): SupportedLocale {
+  if (!raw) return 'en';
+  // Accept both BCP 47 ("nl-NL") and POSIX/Symfony ("nl_NL") region formats.
+  const base = raw.toLowerCase().split(/[-_]/)[0];
+  if (Object.prototype.hasOwnProperty.call(DICTIONARIES, base)) return base as SupportedLocale;
+  console.warn(`[BugDrop] Unsupported data-locale "${raw}"; falling back to English.`);
+  return 'en';
+}
+
+// The widget is a per-page singleton, so module-level locale state is acceptable.
+let currentStrings: WidgetStrings = en;
+
+export function setLocale(locale: SupportedLocale): void {
+  currentStrings = DICTIONARIES[locale];
+}
+
+export function t(): WidgetStrings {
+  return currentStrings;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/index.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/index.ts.txt
@@ -1,0 +1,1873 @@
+import { getDomNodeCount, getRedactionCount, isFullPageDisabled } from './screenshot';
+import { runScreenshotCaptureFlow } from './capture-flow';
+import { injectStyles, createModal, showSuccessModal, type IssueLinkVisibility } from './ui';
+import {
+  resolveTheme,
+  applyThemeClass,
+  applyCustomStyles,
+  attachSystemThemeListener,
+  isValidTheme,
+  type ThemeMode,
+} from './theme';
+import {
+  escapeHtml,
+  sanitizeCssColor,
+  sanitizeCssFontFamily,
+  sanitizeNonNegativeNumber,
+  sanitizeNonNegativePixelValue,
+  sanitizePositiveInteger,
+  sanitizeShadowPreset,
+  sanitizeUrl,
+} from './sanitize';
+import {
+  getAuthHeaders,
+  resolveAuthTokenProvider,
+  type BugDropAuthTokenProvider,
+} from './auth-token';
+import {
+  getConsoleLogSnapshot,
+  startConsoleLogCapture,
+  type ConsoleLogEntry,
+} from './console-logs';
+import { escapeWidgetText, resolveLocale, setLocale, t, type SupportedLocale } from './i18n';
+import { installRadixDialogCompatibility } from './radix-compat';
+import { closeActiveVariantModal } from './variants/modal-coordinator';
+import { resolveAccentColor } from '../defaults';
+import type { BugDropPublicAPI } from './variants/public-types';
+import { createVariantManager, type VariantManager } from './variants/manager';
+import { runDefaultJourney } from './default-flow/runtime';
+import { normalizeDefaultDefinition } from './default-flow/definition';
+import { createFlowManager, type FlowManager } from './flows/manager';
+
+declare const __BUGDROP_ENABLE_TEST_HOOKS__: boolean;
+declare const __BUGDROP_DEFAULT_FLOW_RUNTIME__: 'fixed' | 'private';
+
+type FeedbackCategory = 'bug' | 'feature' | 'question';
+type CategoryLabelConfig = Partial<Record<FeedbackCategory, string | string[]>>;
+type FeedbackAttachment = {
+  name: string;
+  type: string;
+  size: number;
+  dataUrl: string;
+};
+
+interface WidgetConfig {
+  repo: string;
+  apiUrl: string;
+  authTokenProvider?: BugDropAuthTokenProvider;
+  position: 'bottom-right' | 'bottom-left';
+  theme: 'light' | 'dark' | 'auto';
+  // Name/email field configuration
+  showName: boolean;
+  requireName: boolean;
+  showEmail: boolean;
+  requireEmail: boolean;
+  // Dismissible button configuration
+  buttonDismissible: boolean;
+  dismissDuration?: number; // Days before dismissed button reappears (undefined = forever)
+  showRestore: boolean; // Show a pull tab after dismissing (default true when dismissible)
+  // Button visibility (false = API-only mode)
+  showButton: boolean;
+  // Custom accent color (hex)
+  accentColor?: string;
+  // Custom icon URL (replaces default bug emoji), or 'none' to hide the icon
+  iconUrl?: string;
+  // Custom trigger button label text; defaults to the active locale's triggerLabel
+  label?: string;
+  // Optional mapping from built-in feedback categories to GitHub labels
+  categoryLabels?: CategoryLabelConfig;
+  // Tier 1 styling customization
+  font?: string; // 'inherit' to use host page font, or a custom font-family string
+  radius?: string; // Border radius in px (e.g., '0', '8', '16')
+  bgColor?: string; // Background color override (e.g., '#fffef0')
+  textColor?: string; // Text color override (e.g., '#1a1a1a')
+  // Tier 2 styling customization
+  borderWidth?: string; // Border width in px (e.g., '4')
+  borderColor?: string; // Border color (e.g., '#1a1a1a')
+  shadow?: string; // Shadow preset: 'none', 'soft' (default), 'hard'
+  // Welcome screen behavior
+  welcome: 'once' | 'always' | 'never';
+  // Screenshot configuration
+  screenshotMode: 'optional' | 'auto' | 'required';
+  screenshotScale?: number; // Minimum pixel ratio for captures (default: 2)
+  elementContextMaxArea?: number; // Max ancestor capture area as a viewport multiplier
+  issueLinkVisibility: IssueLinkVisibility;
+  sendConsoleLogs: boolean;
+  // UI language for widget texts
+  locale: SupportedLocale;
+}
+
+// Declare global BugDrop API
+declare global {
+  interface Window {
+    BugDrop?: BugDropPublicAPI;
+  }
+}
+
+interface FeedbackData {
+  title: string;
+  description: string;
+  category: FeedbackCategory;
+  screenshot: string | null;
+  attachments: FeedbackAttachment[];
+  elementSelector: string | null;
+  fullElementSelector: string | null;
+  selectedElementHighlightColor: string | null;
+  sendConsoleLogs: boolean;
+  name?: string;
+  email?: string;
+}
+
+// localStorage key for dismissed state
+const BUGDROP_DISMISSED_KEY = 'bugdrop_dismissed';
+const BUGDROP_TRIGGER_POSITION_PREFIX = 'bugdrop_trigger_position_';
+const BUGDROP_WELCOMED_PREFIX = 'bugdrop_welcomed_';
+const BUGDROP_COMPLEX_SCREENSHOT_SKIPPED_PREFIX = 'bugdrop_complex_screenshot_skipped_';
+const COMPLEX_SCREENSHOT_SKIP_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const TRIGGER_VIEWPORT_MARGIN_PX = 8;
+const TRIGGER_KEYBOARD_MOVE_PX = 16;
+const MAX_UPLOAD_FILES = 5;
+const MAX_UPLOAD_SIZE_BYTES = 5 * 1024 * 1024;
+const ACCEPTED_UPLOAD_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'video/mp4',
+  'video/webm',
+  'video/quicktime',
+];
+
+// Parse user agent to extract browser info
+function parseBrowser(ua: string): { name: string; version: string } {
+  // Order matters - check more specific patterns first
+  const browsers: Array<{ name: string; pattern: RegExp }> = [
+    { name: 'Edge', pattern: /Edg(?:e|A|iOS)?\/(\d+[\d.]*)/ },
+    { name: 'Opera', pattern: /(?:OPR|Opera)\/(\d+[\d.]*)/ },
+    { name: 'Chrome', pattern: /Chrome\/(\d+[\d.]*)/ },
+    { name: 'Safari', pattern: /Version\/(\d+[\d.]*).*Safari/ },
+    { name: 'Firefox', pattern: /Firefox\/(\d+[\d.]*)/ },
+  ];
+
+  for (const { name, pattern } of browsers) {
+    const match = ua.match(pattern);
+    if (match) {
+      return { name, version: match[1] || 'unknown' };
+    }
+  }
+
+  return { name: 'Unknown', version: 'unknown' };
+}
+
+// Parse user agent to extract OS info
+function parseOS(ua: string): { name: string; version: string } {
+  const osPatterns: Array<{ name: string; pattern: RegExp; versionIndex?: number }> = [
+    { name: 'iOS', pattern: /iPhone OS (\d+[_\d]*)/, versionIndex: 1 },
+    { name: 'iOS', pattern: /iPad.*OS (\d+[_\d]*)/, versionIndex: 1 },
+    { name: 'macOS', pattern: /Mac OS X (\d+[_.\d]*)/, versionIndex: 1 },
+    { name: 'Windows', pattern: /Windows NT (\d+\.\d+)/, versionIndex: 1 },
+    { name: 'Android', pattern: /Android (\d+[\d.]*)/, versionIndex: 1 },
+    { name: 'Linux', pattern: /Linux/, versionIndex: undefined },
+    { name: 'Chrome OS', pattern: /CrOS/, versionIndex: undefined },
+  ];
+
+  for (const { name, pattern, versionIndex } of osPatterns) {
+    const match = ua.match(pattern);
+    if (match) {
+      const version =
+        versionIndex !== undefined && match[versionIndex]
+          ? match[versionIndex].replace(/_/g, '.')
+          : '';
+      return { name, version };
+    }
+  }
+
+  return { name: 'Unknown', version: '' };
+}
+
+// Redact sensitive parts of URL (query params, common ID patterns)
+function redactUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    // Remove query string and hash
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    // If URL parsing fails, return as-is but try to strip query params
+    return url.split('?')[0].split('#')[0];
+  }
+}
+
+// Collect system info for feedback submission
+function getSystemInfo(): {
+  browser: { name: string; version: string };
+  os: { name: string; version: string };
+  devicePixelRatio: number;
+  language: string;
+  url: string;
+} {
+  const ua = navigator.userAgent;
+  return {
+    browser: parseBrowser(ua),
+    os: parseOS(ua),
+    devicePixelRatio: window.devicePixelRatio || 1,
+    language: navigator.language || 'unknown',
+    url: redactUrl(window.location.href),
+  };
+}
+
+// Store widget state for API access
+let _widgetRoot: HTMLElement | null = null;
+let _triggerButton: HTMLElement | null = null;
+let _pullTab: HTMLElement | null = null;
+let _isModalOpen = false;
+let _widgetConfig: WidgetConfig | null = null;
+let _triggerDragMoved = false;
+
+// Helper to check if button was dismissed
+function isButtonDismissed(dismissDuration?: number): boolean {
+  try {
+    const dismissedAt = localStorage.getItem(BUGDROP_DISMISSED_KEY);
+    if (!dismissedAt) return false;
+
+    // Legacy support: if stored value is 'true', treat as permanently dismissed
+    if (dismissedAt === 'true') return true;
+
+    const timestamp = parseInt(dismissedAt, 10);
+    if (isNaN(timestamp)) return false;
+
+    // If no duration set, dismissed forever
+    if (dismissDuration === undefined) return true;
+
+    // Check if duration has passed (duration is in days)
+    const durationMs = dismissDuration * 24 * 60 * 60 * 1000;
+    return Date.now() - timestamp < durationMs;
+  } catch {
+    // localStorage may be blocked in some contexts
+    return false;
+  }
+}
+
+// Helper to dismiss the button
+function dismissButton(): void {
+  try {
+    localStorage.setItem(BUGDROP_DISMISSED_KEY, Date.now().toString());
+  } catch {
+    // localStorage may be blocked in some contexts
+  }
+}
+
+function hasSeenWelcome(repo: string): boolean {
+  try {
+    return localStorage.getItem(BUGDROP_WELCOMED_PREFIX + repo) !== null;
+  } catch {
+    return false;
+  }
+}
+
+function markWelcomeSeen(repo: string): void {
+  try {
+    localStorage.setItem(BUGDROP_WELCOMED_PREFIX + repo, Date.now().toString());
+  } catch {
+    // localStorage may be blocked
+  }
+}
+
+function getComplexScreenshotSkipKey(repo: string): string {
+  return `${BUGDROP_COMPLEX_SCREENSHOT_SKIPPED_PREFIX}${repo}:${redactUrl(window.location.href)}`;
+}
+
+function hasSkippedComplexScreenshots(repo: string): boolean {
+  try {
+    const key = getComplexScreenshotSkipKey(repo);
+    const skippedAt = localStorage.getItem(key);
+    if (!skippedAt) return false;
+
+    const timestamp = parseInt(skippedAt, 10);
+    if (isNaN(timestamp) || Date.now() - timestamp > COMPLEX_SCREENSHOT_SKIP_TTL_MS) {
+      localStorage.removeItem(key);
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function markComplexScreenshotsSkipped(repo: string): void {
+  try {
+    localStorage.setItem(getComplexScreenshotSkipKey(repo), Date.now().toString());
+  } catch {
+    // localStorage may be blocked
+  }
+}
+
+function clearComplexScreenshotsSkipped(repo: string): void {
+  try {
+    localStorage.removeItem(getComplexScreenshotSkipKey(repo));
+  } catch {
+    // localStorage may be blocked
+  }
+}
+
+function rememberComplexScreenshotSkip(config: WidgetConfig, formResult: FeedbackFormResult): void {
+  if (!isFullPageDisabled()) return;
+  markComplexScreenshotsSkipped(config.repo);
+  formResult.includeScreenshot = false;
+}
+
+function parseCategoryLabels(rawValue: string | undefined): CategoryLabelConfig | undefined {
+  if (!rawValue) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawValue);
+  } catch (err) {
+    const detail = err instanceof Error ? `: ${err.message}` : '';
+    console.warn(
+      `[BugDrop] Invalid data-category-labels JSON${detail}. Using default GitHub labels.`
+    );
+    return undefined;
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    console.warn(
+      '[BugDrop] Invalid data-category-labels: expected a JSON object. Using default GitHub labels.'
+    );
+    return undefined;
+  }
+
+  // Validate per-category shape so misconfig surfaces in browser DevTools rather
+  // than only inside the issue body the operator may never read. The server
+  // re-validates regardless — this layer exists for operator feedback.
+  const knownCategories: FeedbackCategory[] = ['bug', 'feature', 'question'];
+  const result: CategoryLabelConfig = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!knownCategories.includes(key as FeedbackCategory)) {
+      console.warn(
+        `[BugDrop] Invalid data-category-labels: unknown category "${key}" (expected ${knownCategories.join(', ')}). Ignoring.`
+      );
+      continue;
+    }
+    if (typeof value === 'string') {
+      result[key as FeedbackCategory] = value;
+    } else if (Array.isArray(value) && value.every(v => typeof v === 'string')) {
+      result[key as FeedbackCategory] = value;
+    } else {
+      console.warn(
+        `[BugDrop] Invalid data-category-labels: value for "${key}" must be a string or string array. Ignoring.`
+      );
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+// Read config from script tag (fallback to src-based lookup for async/defer)
+const script = (document.currentScript ||
+  document.querySelector('script[src*="bugdrop"][src*="widget"]')) as HTMLScriptElement;
+if (!document.currentScript) {
+  console.warn(
+    '[BugDrop] document.currentScript is null — do not use async or defer on the BugDrop script tag.'
+  );
+}
+const rawTheme = script?.dataset.theme;
+if (rawTheme && !isValidTheme(rawTheme)) {
+  console.warn(`[BugDrop] Invalid data-theme "${rawTheme}". Expected "light", "dark", or "auto".`);
+}
+const locale = resolveLocale(script?.dataset.locale || document.documentElement.lang);
+const requireName = script?.dataset.requireName === 'true';
+const requireEmail = script?.dataset.requireEmail === 'true';
+const rawPosition = script?.dataset.position;
+if (rawPosition && rawPosition !== 'bottom-right' && rawPosition !== 'bottom-left') {
+  console.warn(
+    `[BugDrop] Invalid data-position "${rawPosition}". Expected "bottom-right" or "bottom-left".`
+  );
+}
+const rawDismissDuration = script?.dataset.dismissDuration;
+const dismissDuration = sanitizePositiveInteger(rawDismissDuration);
+if (rawDismissDuration && dismissDuration === undefined) {
+  console.warn(
+    '[BugDrop] Invalid data-dismiss-duration. Expected a positive whole number of days.'
+  );
+}
+const rawScreenshotScale = script?.dataset.screenshotScale;
+const screenshotScale = sanitizeNonNegativeNumber(rawScreenshotScale);
+if (rawScreenshotScale && screenshotScale === undefined) {
+  console.warn('[BugDrop] Invalid data-screenshot-scale. Expected a non-negative number.');
+}
+const rawElementContextMaxArea = script?.dataset.elementContextMaxArea;
+const elementContextMaxArea = sanitizeNonNegativeNumber(rawElementContextMaxArea);
+if (rawElementContextMaxArea && elementContextMaxArea === undefined) {
+  console.warn('[BugDrop] Invalid data-element-context-max-area. Expected a non-negative number.');
+}
+const rawShadow = script?.dataset.shadow;
+const shadow = sanitizeShadowPreset(rawShadow);
+if (rawShadow && !shadow) {
+  console.warn('[BugDrop] Invalid data-shadow. Expected "soft", "hard", or "none".');
+}
+const rawShowIssueLink = script?.dataset.showIssueLink;
+const issueLinkVisibility: IssueLinkVisibility =
+  rawShowIssueLink === 'always' || rawShowIssueLink === 'never' ? rawShowIssueLink : 'public';
+if (rawShowIssueLink && rawShowIssueLink !== 'public' && rawShowIssueLink !== issueLinkVisibility) {
+  console.warn(
+    `[BugDrop] Invalid data-show-issue-link "${rawShowIssueLink}". Expected "public", "always", or "never".`
+  );
+}
+const config: WidgetConfig = {
+  repo: script?.dataset.repo || '',
+  apiUrl: script?.src.replace(/\/widget(?:\.v[\d.]+)?\.js$/, '/api') || '',
+  authTokenProvider: resolveAuthTokenProvider(script?.dataset.authTokenProvider),
+  position: rawPosition === 'bottom-left' ? 'bottom-left' : 'bottom-right',
+  theme: isValidTheme(rawTheme) ? rawTheme : 'auto', // Default to auto-detection
+  // Name/email field configuration (all default to false for backwards compatibility)
+  showName: script?.dataset.showName === 'true' || requireName,
+  requireName,
+  showEmail: script?.dataset.showEmail === 'true' || requireEmail,
+  requireEmail,
+  // Dismissible button configuration
+  buttonDismissible: script?.dataset.buttonDismissible === 'true',
+  dismissDuration,
+  // Show restore pill after dismissing (default true when dismissible, unless explicitly false)
+  showRestore: script?.dataset.showRestore !== 'false',
+  // Button visibility (default true, set to false for API-only mode)
+  showButton: script?.dataset.button !== 'false',
+  // Custom accent color (e.g., "#FF6B35")
+  accentColor: sanitizeCssColor(script?.dataset.color),
+  // Custom icon URL (or 'none' to hide)
+  iconUrl: sanitizeUrl(script?.dataset.icon),
+  // Custom trigger label
+  label: script?.dataset.label || undefined,
+  categoryLabels: parseCategoryLabels(script?.dataset.categoryLabels),
+  // Tier 1 styling customization
+  font: sanitizeCssFontFamily(script?.dataset.font),
+  radius: sanitizeNonNegativePixelValue(script?.dataset.radius)?.toString(),
+  bgColor: sanitizeCssColor(script?.dataset.bg),
+  textColor: sanitizeCssColor(script?.dataset.text),
+  // Tier 2 styling customization
+  borderWidth: sanitizeNonNegativePixelValue(script?.dataset.borderWidth)?.toString(),
+  borderColor: sanitizeCssColor(script?.dataset.borderColor),
+  shadow,
+  // Welcome screen behavior (default: 'once')
+  welcome: (() => {
+    const val = script?.dataset.welcome;
+    if (val === 'false' || val === 'never') return 'never' as const;
+    if (val === 'always') return 'always' as const;
+    return 'once' as const;
+  })(),
+  // Screenshot configuration
+  screenshotMode: (() => {
+    const val = script?.dataset.screenshot;
+    if (val === 'auto' || val === 'required') return val;
+    if (val && val !== 'optional') {
+      console.warn(
+        `[BugDrop] Invalid data-screenshot "${val}". Expected "optional", "auto", or "required".`
+      );
+    }
+    return 'optional' as const;
+  })(),
+  screenshotScale,
+  elementContextMaxArea,
+  issueLinkVisibility,
+  sendConsoleLogs: script?.dataset.sendConsoleLogs === 'true',
+  locale,
+};
+
+setLocale(config.locale);
+
+startConsoleLogCapture();
+
+// Validate config
+if (!config.repo) {
+  console.error('[BugDrop] Missing data-repo attribute');
+} else if (!/^[^/]+\/[^/]+$/.test(config.repo)) {
+  console.error(
+    `[BugDrop] Invalid data-repo format "${config.repo}". Expected "owner/repo" (e.g., "octocat/hello-world").`
+  );
+} else {
+  initWidget(config);
+}
+
+// Build the trigger button label text
+function getTriggerLabel(config: WidgetConfig): string {
+  return config.label !== undefined ? config.label : t().triggerLabel;
+}
+
+function appendTriggerContent(trigger: HTMLElement, config: WidgetConfig): void {
+  if (config.position === 'bottom-left') {
+    trigger.appendChild(createTriggerDragHandle());
+  }
+
+  if (config.iconUrl !== 'none') {
+    const icon = document.createElement('span');
+    icon.className = 'bd-trigger-icon';
+
+    if (config.iconUrl) {
+      const image = document.createElement('img');
+      image.src = config.iconUrl;
+      image.alt = '';
+      const fallback = document.createElement('span');
+      fallback.textContent = '🐛';
+      fallback.style.display = 'none';
+      image.addEventListener('error', () => {
+        image.style.display = 'none';
+        fallback.style.display = '';
+      });
+      icon.append(image, fallback);
+    } else {
+      icon.textContent = '🐛';
+    }
+
+    trigger.appendChild(icon);
+  }
+
+  const label = document.createElement('span');
+  label.className = 'bd-trigger-label';
+  label.textContent = getTriggerLabel(config);
+  trigger.appendChild(label);
+
+  if (config.position !== 'bottom-left') {
+    trigger.appendChild(createTriggerDragHandle());
+  }
+}
+
+function createTriggerDragHandle(): HTMLElement {
+  const handle = document.createElement('span');
+  handle.className = 'bd-trigger-drag-handle';
+  handle.setAttribute('aria-hidden', 'true');
+  handle.title = t().dragHandleTitle;
+  handle.innerHTML = `
+    <svg viewBox="0 0 12 24" aria-hidden="true" focusable="false">
+      <circle cx="4" cy="5" r="1.5" fill="currentColor"></circle>
+      <circle cx="8" cy="5" r="1.5" fill="currentColor"></circle>
+      <circle cx="4" cy="9.5" r="1.5" fill="currentColor"></circle>
+      <circle cx="8" cy="9.5" r="1.5" fill="currentColor"></circle>
+      <circle cx="4" cy="14" r="1.5" fill="currentColor"></circle>
+      <circle cx="8" cy="14" r="1.5" fill="currentColor"></circle>
+      <circle cx="4" cy="18.5" r="1.5" fill="currentColor"></circle>
+      <circle cx="8" cy="18.5" r="1.5" fill="currentColor"></circle>
+    </svg>
+  `;
+  return handle;
+}
+
+function getTriggerClassName(config: WidgetConfig, isRestoring = false): string {
+  const classes = [
+    'bd-trigger',
+    `bd-trigger--${config.position === 'bottom-left' ? 'left' : 'right'}`,
+  ];
+  if (isRestoring) classes.push('bd-trigger--restoring');
+  return classes.join(' ');
+}
+
+function getTriggerPositionKey(config: WidgetConfig): string {
+  return `${BUGDROP_TRIGGER_POSITION_PREFIX}${config.repo}_${config.position}`;
+}
+
+function getStoredTriggerTop(config: WidgetConfig): number | null {
+  try {
+    const raw = localStorage.getItem(getTriggerPositionKey(config));
+    if (!raw) return null;
+
+    const top = Number(raw);
+    return Number.isFinite(top) ? top : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveTriggerTop(config: WidgetConfig, top: number): void {
+  try {
+    localStorage.setItem(getTriggerPositionKey(config), String(Math.round(top)));
+  } catch {
+    // localStorage may be blocked
+  }
+}
+
+function clampTriggerTop(trigger: HTMLElement, top: number): number {
+  const rect = trigger.getBoundingClientRect();
+  const maxTop = Math.max(
+    TRIGGER_VIEWPORT_MARGIN_PX,
+    window.innerHeight - rect.height - TRIGGER_VIEWPORT_MARGIN_PX
+  );
+  return Math.min(Math.max(top, TRIGGER_VIEWPORT_MARGIN_PX), maxTop);
+}
+
+function setTriggerTop(trigger: HTMLElement, top: number): number {
+  const clampedTop = clampTriggerTop(trigger, top);
+  trigger.style.top = `${clampedTop}px`;
+  trigger.style.bottom = 'auto';
+  return clampedTop;
+}
+
+function applyStoredTriggerPosition(trigger: HTMLElement, config: WidgetConfig): void {
+  const top = getStoredTriggerTop(config);
+  if (top === null) return;
+  trigger.classList.add('bd-trigger--positioned');
+  setTriggerTop(trigger, top);
+}
+
+function reclampVisibleTriggerPosition(trigger: HTMLElement, config: WidgetConfig): void {
+  if (!trigger.style.top) return;
+
+  const rect = trigger.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) return;
+
+  const renderedTop = parseFloat(trigger.style.top);
+  if (!Number.isFinite(renderedTop)) return;
+
+  const desiredTop = trigger.classList.contains('bd-trigger--dragging')
+    ? renderedTop
+    : (getStoredTriggerTop(config) ?? renderedTop);
+  setTriggerTop(trigger, desiredTop);
+}
+
+function attachTriggerViewportClamp(trigger: HTMLElement, config: WidgetConfig): void {
+  const reclamp = () => {
+    if (!trigger.isConnected) {
+      cleanup();
+      return;
+    }
+    reclampVisibleTriggerPosition(trigger, config);
+  };
+
+  const cleanup = () => {
+    window.removeEventListener('resize', reclamp);
+    window.visualViewport?.removeEventListener('resize', reclamp);
+  };
+
+  window.addEventListener('resize', reclamp);
+  window.visualViewport?.addEventListener('resize', reclamp);
+}
+
+function attachTriggerDragBehavior(trigger: HTMLElement, config: WidgetConfig): void {
+  const handle = trigger.querySelector<HTMLElement>('.bd-trigger-drag-handle');
+  if (!handle) return;
+
+  let pointerId: number | null = null;
+  let startPointerY = 0;
+  let startTop = 0;
+  let moved = false;
+
+  const endDrag = () => {
+    if (pointerId === null) return;
+    pointerId = null;
+    trigger.classList.remove('bd-trigger--dragging');
+    window.removeEventListener('pointermove', handlePointerMove);
+    window.removeEventListener('pointerup', handlePointerUp);
+    window.removeEventListener('pointercancel', handlePointerCancel);
+
+    if (moved) {
+      saveTriggerTop(config, trigger.getBoundingClientRect().top);
+      window.setTimeout(() => {
+        _triggerDragMoved = false;
+      }, 0);
+    }
+  };
+
+  function handlePointerMove(e: PointerEvent): void {
+    if (pointerId !== e.pointerId) return;
+    const nextTop = startTop + e.clientY - startPointerY;
+    if (Math.abs(e.clientY - startPointerY) > 3) {
+      moved = true;
+      _triggerDragMoved = true;
+    }
+    setTriggerTop(trigger, nextTop);
+  }
+
+  function handlePointerUp(e: PointerEvent): void {
+    if (pointerId !== e.pointerId) return;
+    endDrag();
+  }
+
+  function handlePointerCancel(e: PointerEvent): void {
+    if (pointerId !== e.pointerId) return;
+    endDrag();
+  }
+
+  handle.addEventListener('pointerdown', e => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const rect = trigger.getBoundingClientRect();
+    pointerId = e.pointerId;
+    startPointerY = e.clientY;
+    startTop = rect.top;
+    moved = false;
+    trigger.classList.add('bd-trigger--dragging');
+    handle.setPointerCapture(e.pointerId);
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointercancel', handlePointerCancel);
+  });
+
+  handle.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+  });
+}
+
+function attachTriggerKeyboardMove(trigger: HTMLElement, config: WidgetConfig): void {
+  trigger.addEventListener('keydown', e => {
+    if (e.target !== trigger) return;
+    if (!['ArrowUp', 'ArrowDown', 'Home', 'End'].includes(e.key)) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    const rect = trigger.getBoundingClientRect();
+    const maxTop = window.innerHeight - rect.height - TRIGGER_VIEWPORT_MARGIN_PX;
+    const nextTop =
+      e.key === 'ArrowUp'
+        ? rect.top - TRIGGER_KEYBOARD_MOVE_PX
+        : e.key === 'ArrowDown'
+          ? rect.top + TRIGGER_KEYBOARD_MOVE_PX
+          : e.key === 'Home'
+            ? TRIGGER_VIEWPORT_MARGIN_PX
+            : maxTop;
+
+    trigger.classList.add('bd-trigger--positioned');
+    saveTriggerTop(config, setTriggerTop(trigger, nextTop));
+  });
+}
+
+// Create the pull tab shown after dismissing the button
+function createPullTab(root: HTMLElement, config: WidgetConfig): HTMLElement {
+  const tab = document.createElement('div');
+  tab.className =
+    config.position === 'bottom-left' ? 'bd-pull-tab bd-pull-tab--left' : 'bd-pull-tab';
+  tab.innerHTML = '<span class="bd-pull-tab-chevron">‹</span>';
+  tab.setAttribute('role', 'button');
+  tab.setAttribute('tabindex', '0');
+  tab.setAttribute('aria-label', t().pullTabAriaLabel);
+
+  const handleRestore = () => {
+    // Clear dismissed state
+    try {
+      localStorage.removeItem(BUGDROP_DISMISSED_KEY);
+    } catch {
+      // localStorage may be blocked
+    }
+
+    // Remove the pull tab
+    tab.remove();
+    _pullTab = null;
+
+    // Recreate the trigger button with restore animation
+    createTriggerButton(root, config, true);
+  };
+
+  tab.addEventListener('click', handleRestore);
+  tab.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleRestore();
+    }
+  });
+
+  root.appendChild(tab);
+  _pullTab = tab;
+  return tab;
+}
+
+function initWidget(config: WidgetConfig) {
+  // Store config for API access
+  _widgetConfig = config;
+
+  // If button is not dismissible, clear any stale dismissed state from localStorage
+  // This ensures the button shows on non-dismissible pages even after visiting dismissible ones
+  if (!config.buttonDismissible) {
+    try {
+      localStorage.removeItem(BUGDROP_DISMISSED_KEY);
+    } catch {
+      // localStorage may be blocked
+    }
+  }
+
+  // Create Shadow DOM for style isolation
+  const host = document.createElement('div');
+  host.id = 'bugdrop-host';
+  host.style.pointerEvents = 'auto';
+  document.body.appendChild(host);
+
+  const shadow = host.attachShadow({ mode: 'open' });
+  installRadixDialogCompatibility(host);
+
+  // Prevent keyboard events from leaking to host page (e.g., ERPNext console shortcuts)
+  for (const eventType of ['keydown', 'keypress', 'keyup'] as const) {
+    shadow.addEventListener(eventType, (e: Event) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {
+        e.stopPropagation();
+      }
+    });
+  }
+
+  // Inject styles and create root wrapper
+  const root = injectStyles(shadow, config);
+  _widgetRoot = root;
+
+  // Determine if button should be rendered
+  const shouldShowButton =
+    config.showButton && !(config.buttonDismissible && isButtonDismissed(config.dismissDuration));
+
+  if (shouldShowButton) {
+    const trigger = document.createElement('button');
+    trigger.className = getTriggerClassName(config);
+    appendTriggerContent(trigger, config);
+    trigger.setAttribute('aria-label', t().triggerAriaLabel);
+
+    // Add close button if dismissible
+    if (config.buttonDismissible) {
+      const closeBtn = document.createElement('button');
+      closeBtn.className = 'bd-trigger-close';
+      closeBtn.textContent = '×';
+      closeBtn.setAttribute('aria-label', t().dismissButtonAriaLabel);
+      trigger.appendChild(closeBtn);
+
+      // Handle close button click
+      closeBtn.addEventListener('click', e => {
+        e.stopPropagation(); // Don't trigger the main button
+        dismissButton();
+
+        // Remove restoring class if present (to avoid animation conflicts)
+        trigger.classList.remove('bd-trigger--restoring');
+
+        // Add dismiss animation
+        trigger.classList.add('bd-trigger--dismissing');
+
+        // Wait for animation to finish before removing
+        trigger.addEventListener(
+          'animationend',
+          () => {
+            trigger.remove();
+            _triggerButton = null;
+
+            // Show pull tab if enabled
+            if (config.showRestore) {
+              createPullTab(root, config);
+            }
+          },
+          { once: true }
+        );
+      });
+    }
+
+    root.appendChild(trigger);
+    _triggerButton = trigger;
+    applyStoredTriggerPosition(trigger, config);
+    attachTriggerViewportClamp(trigger, config);
+    attachTriggerDragBehavior(trigger, config);
+    attachTriggerKeyboardMove(trigger, config);
+
+    // Handle trigger click
+    trigger.addEventListener('click', () => {
+      if (_triggerDragMoved) {
+        _triggerDragMoved = false;
+        return;
+      }
+      openFeedbackFlow(root, config);
+    });
+  } else if (
+    config.showButton &&
+    config.buttonDismissible &&
+    config.showRestore &&
+    isButtonDismissed(config.dismissDuration)
+  ) {
+    // Button was previously dismissed - show pull tab
+    createPullTab(root, config);
+  }
+
+  // Expose the BugDrop API
+  exposeBugDropAPI(root, config);
+
+  // Dispatch ready event
+  window.dispatchEvent(new CustomEvent('bugdrop:ready'));
+}
+
+// Create and expose the BugDrop JavaScript API
+function exposeBugDropAPI(root: HTMLElement, config: WidgetConfig) {
+  // Closure-captured so each widget instance has its own mode state. Read by
+  // the matchMedia listener below and mutated by setTheme. No module-level
+  // state needed — keeps per-init isolation if multi-instance is ever added.
+  let currentMode: ThemeMode = config.theme;
+  let variantManager: VariantManager | undefined;
+  let flowManager: FlowManager | undefined;
+
+  window.BugDrop = {
+    // Open the feedback modal programmatically
+    open: () => {
+      if (!_isModalOpen) {
+        openFeedbackFlow(root, config, { skipWelcome: true });
+      }
+    },
+
+    // Close the current modal
+    close: () => {
+      if (_isModalOpen) {
+        // Find and remove any open modal
+        const modal = root.querySelector('.bd-modal');
+        if (modal) {
+          modal.remove();
+        }
+        _isModalOpen = false;
+      }
+    },
+
+    // Hide the floating button
+    hide: () => {
+      if (_triggerButton) {
+        _triggerButton.style.display = 'none';
+      }
+    },
+
+    // Show the floating button (clears dismissed state when called)
+    show: () => {
+      // Clear dismissed state when explicitly called
+      try {
+        localStorage.removeItem(BUGDROP_DISMISSED_KEY);
+      } catch {
+        // localStorage may be blocked
+      }
+
+      // Remove pull tab if present
+      if (_pullTab) {
+        _pullTab.remove();
+        _pullTab = null;
+      }
+
+      if (_triggerButton) {
+        _triggerButton.style.display = '';
+        reclampVisibleTriggerPosition(_triggerButton, config);
+        window.requestAnimationFrame(() => {
+          if (_triggerButton) reclampVisibleTriggerPosition(_triggerButton, config);
+        });
+      } else if (config.showButton) {
+        // Recreate button if it was removed
+        createTriggerButton(root, config);
+      }
+    },
+
+    // Check if modal is currently open
+    isOpen: () => _isModalOpen,
+
+    // Check if floating button is visible
+    isButtonVisible: () => {
+      return _triggerButton !== null && _triggerButton.style.display !== 'none';
+    },
+
+    // Set the widget theme at runtime. Accepts 'light' | 'dark' | 'auto'.
+    // Invalid input warns and no-ops. Only toggles the root class and re-runs
+    // the custom-color inline styles — it does NOT re-inject the <style> block
+    // because the dark-mode CSS variables are already defined statically in
+    // `.bd-root.bd-dark { ... }` and get activated by the class flip alone.
+    setTheme: (mode: unknown) => {
+      if (!isValidTheme(mode)) {
+        console.warn(
+          `[BugDrop] Invalid theme ${String(mode)}. Expected 'light' | 'dark' | 'auto'.`
+        );
+        return;
+      }
+      currentMode = mode;
+      const resolved = resolveTheme(mode);
+      applyThemeClass(root, resolved);
+      applyCustomStyles(root, config, resolved);
+    },
+
+    // The sidecar is created only on the first registration. Legacy-only pages
+    // do not allocate variant maps, IDs, DOM, listeners, observers, or storage.
+    registerVariant: variantConfig => {
+      variantManager ??= createVariantManager(
+        {
+          repo: config.repo,
+          apiUrl: config.apiUrl,
+          authTokenProvider: config.authTokenProvider,
+        },
+        { isLegacyModalOpen: () => _isModalOpen }
+      );
+      return variantManager.register(variantConfig);
+    },
+
+    registerFlow: flowConfig => {
+      flowManager ??= createFlowManager(
+        {
+          repo: config.repo,
+          apiUrl: config.apiUrl,
+          authTokenProvider: config.authTokenProvider,
+          categoryLabels: config.categoryLabels,
+        },
+        {
+          preflight: () => checkInstallation(config),
+          capture: async (screen, includeScreenshot, signal) => {
+            const result = await runScreenshotCaptureFlow(
+              root,
+              { ...config, screenshotMode: screen.mode },
+              includeScreenshot,
+              () => {},
+              signal
+            );
+            return result;
+          },
+        },
+        { isLegacyModalOpen: () => _isModalOpen }
+      );
+      return flowManager.register(flowConfig);
+    },
+  };
+
+  // Fix for data-theme="auto" not following OS changes after init. One
+  // persistent listener gated by `currentMode === 'auto'` so explicit
+  // light/dark modes ignore OS changes. Cleanup fn is discarded — widgets
+  // live for the page lifetime.
+  attachSystemThemeListener(resolved => {
+    if (currentMode !== 'auto') return;
+    applyThemeClass(root, resolved);
+    applyCustomStyles(root, config, resolved);
+  });
+}
+
+// Helper to create the trigger button (used by show() API and pull tab restore)
+function createTriggerButton(root: HTMLElement, config: WidgetConfig, isRestoring = false) {
+  const trigger = document.createElement('button');
+  trigger.className = getTriggerClassName(config, isRestoring);
+  appendTriggerContent(trigger, config);
+  trigger.setAttribute('aria-label', t().triggerAriaLabel);
+
+  if (config.buttonDismissible) {
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'bd-trigger-close';
+    closeBtn.textContent = '×';
+    closeBtn.setAttribute('aria-label', t().dismissButtonAriaLabel);
+    trigger.appendChild(closeBtn);
+
+    closeBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      dismissButton();
+
+      // Remove restoring class if present (to avoid animation conflicts)
+      trigger.classList.remove('bd-trigger--restoring');
+
+      // Add dismiss animation
+      trigger.classList.add('bd-trigger--dismissing');
+
+      // Wait for animation to finish before removing
+      trigger.addEventListener(
+        'animationend',
+        () => {
+          trigger.remove();
+          _triggerButton = null;
+
+          // Show pull tab if enabled
+          if (config.showRestore) {
+            createPullTab(root, config);
+          }
+        },
+        { once: true }
+      );
+    });
+  }
+
+  root.appendChild(trigger);
+  _triggerButton = trigger;
+  applyStoredTriggerPosition(trigger, config);
+  attachTriggerViewportClamp(trigger, config);
+  attachTriggerDragBehavior(trigger, config);
+  attachTriggerKeyboardMove(trigger, config);
+
+  trigger.addEventListener('click', () => {
+    if (_triggerDragMoved) {
+      _triggerDragMoved = false;
+      return;
+    }
+    openFeedbackFlow(root, config);
+  });
+}
+
+async function openFeedbackFlow(
+  root: HTMLElement,
+  config: WidgetConfig,
+  opts?: { skipWelcome?: boolean }
+) {
+  if (_isModalOpen) {
+    return;
+  }
+
+  closeActiveVariantModal();
+
+  // Mark modal as open
+  _isModalOpen = true;
+
+  if (
+    __BUGDROP_DEFAULT_FLOW_RUNTIME__ === 'private' ||
+    (__BUGDROP_ENABLE_TEST_HOOKS__ && shouldUsePrivateDefaultJourney())
+  ) {
+    const outcome = await runPrivateDefaultJourney(root, config, opts);
+    if (outcome === 'preflight-blocked') return;
+  } else {
+    // Check if app is installed
+    const { status: installStatus, appName } = await checkInstallation(config);
+    if (installStatus === 'not_installed') {
+      showInstallPrompt(root, config, undefined, appName);
+      return;
+    }
+    if (installStatus === 'unreachable') {
+      showInstallPrompt(root, config, t().apiUnreachableMessage, appName);
+      return;
+    }
+
+    await runFixedDefaultJourney(root, config, opts);
+  }
+
+  // Flow complete
+  _isModalOpen = false;
+}
+
+function shouldUsePrivateDefaultJourney(): boolean {
+  return (
+    (window as unknown as { __bugdropDefaultFlowRuntime?: unknown }).__bugdropDefaultFlowRuntime ===
+    'private'
+  );
+}
+
+async function runFixedDefaultJourney(
+  root: HTMLElement,
+  config: WidgetConfig,
+  opts?: { skipWelcome?: boolean }
+) {
+  // Step 1: Welcome screen (conditional)
+  const skipWelcome =
+    opts?.skipWelcome ||
+    config.welcome === 'never' ||
+    (config.welcome === 'once' && hasSeenWelcome(config.repo));
+
+  if (!skipWelcome) {
+    const continueFlow = await showWelcomeScreen(root);
+    if (!continueFlow) {
+      _isModalOpen = false;
+      return;
+    }
+    if (config.welcome === 'once') {
+      markWelcomeSeen(config.repo);
+    }
+  }
+
+  let formResult: FeedbackFormResult | null = null;
+  while (true) {
+    // Step 2: Feedback form (with optional screenshot checkbox)
+    formResult = await showFeedbackFormWithScreenshotOption(root, config, formResult);
+    if (!formResult) {
+      // User cancelled
+      _isModalOpen = false;
+      return;
+    }
+
+    const submittedFormResult = formResult;
+    const screenshotResult = await runScreenshotCaptureFlow(
+      root,
+      config,
+      submittedFormResult.includeScreenshot,
+      () => rememberComplexScreenshotSkip(config, submittedFormResult)
+    );
+
+    if (screenshotResult.returnToForm) continue;
+
+    // Submit
+    await submitFeedback(root, config, {
+      title: formResult.title,
+      description: formResult.description,
+      category: formResult.category,
+      name: formResult.name,
+      email: formResult.email,
+      screenshot: screenshotResult.screenshot,
+      attachments: formResult.attachments,
+      elementSelector: screenshotResult.elementSelector,
+      fullElementSelector: screenshotResult.fullElementSelector,
+      selectedElementHighlightColor: screenshotResult.elementSelector
+        ? resolveAccentColor(config.accentColor)
+        : null,
+      sendConsoleLogs: formResult.sendConsoleLogs,
+    });
+    break;
+  }
+}
+
+async function runPrivateDefaultJourney(
+  root: HTMLElement,
+  config: WidgetConfig,
+  opts?: { skipWelcome?: boolean }
+) {
+  const definition = normalizeDefaultDefinition({
+    repo: config.repo,
+    apiUrl: config.apiUrl,
+    authTokenProvider: config.authTokenProvider,
+    welcome: config.welcome,
+    screenshotMode: config.screenshotMode,
+    skipWelcome: Boolean(opts?.skipWelcome),
+    hasSeenWelcome: hasSeenWelcome(config.repo),
+    showName: config.showName,
+    requireName: config.requireName,
+    showEmail: config.showEmail,
+    requireEmail: config.requireEmail,
+    sendConsoleLogs: config.sendConsoleLogs,
+    screenshotScale: config.screenshotScale,
+    elementContextMaxArea: config.elementContextMaxArea,
+    accentColor: config.accentColor,
+    categoryLabels: config.categoryLabels,
+    issueLinkVisibility: config.issueLinkVisibility,
+  });
+
+  return runDefaultJourney<
+    FeedbackFormResult,
+    Awaited<ReturnType<typeof runScreenshotCaptureFlow>>
+  >(definition, {
+    preflight: recipe =>
+      checkInstallation({
+        ...config,
+        repo: recipe.repo,
+        apiUrl: recipe.apiUrl,
+        authTokenProvider: recipe.authTokenProvider,
+      }),
+    showPreflightFailure: result =>
+      showInstallPrompt(
+        root,
+        config,
+        result.status === 'unreachable' ? t().apiUnreachableMessage : undefined,
+        result.appName
+      ),
+    showWelcome: () => showWelcomeScreen(root),
+    rememberWelcome: () => markWelcomeSeen(definition.steps[1].repo),
+    showDetails: (step, previous) =>
+      showFeedbackFormWithScreenshotOption(
+        root,
+        {
+          ...config,
+          repo: step.repo,
+          showName: step.showName,
+          requireName: step.requireName,
+          showEmail: step.showEmail,
+          requireEmail: step.requireEmail,
+          sendConsoleLogs: step.sendConsoleLogs,
+          screenshotMode: definition.steps[2].mode,
+        },
+        previous
+      ),
+    capture: async (step, details) => {
+      const captureConfig: WidgetConfig = {
+        ...config,
+        repo: step.repo,
+        screenshotMode: step.mode,
+        screenshotScale: step.screenshotScale,
+        elementContextMaxArea: step.elementContextMaxArea,
+        accentColor: step.accentColor,
+      };
+      const result = await runScreenshotCaptureFlow(
+        root,
+        captureConfig,
+        details.includeScreenshot,
+        () => rememberComplexScreenshotSkip(captureConfig, details)
+      );
+      return { ...result, returnToDetails: result.returnToForm };
+    },
+    submit: (recipe, details, capture) =>
+      submitFeedback(
+        root,
+        {
+          ...config,
+          repo: recipe.repo,
+          apiUrl: recipe.apiUrl,
+          authTokenProvider: recipe.authTokenProvider,
+          categoryLabels: recipe.categoryLabels as CategoryLabelConfig | undefined,
+          issueLinkVisibility: recipe.issueLinkVisibility,
+        },
+        {
+          title: details.title,
+          description: details.description,
+          category: details.category,
+          name: details.name,
+          email: details.email,
+          screenshot: capture.screenshot,
+          attachments: details.attachments,
+          elementSelector: capture.elementSelector,
+          fullElementSelector: capture.fullElementSelector,
+          selectedElementHighlightColor: capture.elementSelector
+            ? resolveAccentColor(config.accentColor)
+            : null,
+          sendConsoleLogs: details.sendConsoleLogs,
+        }
+      ),
+  });
+}
+
+async function checkInstallation(
+  config: WidgetConfig
+): Promise<{ status: 'installed' | 'not_installed' | 'unreachable'; appName?: string }> {
+  try {
+    const response = await fetch(`${config.apiUrl}/check/${config.repo}`, {
+      headers: await getAuthHeaders(config.authTokenProvider),
+    });
+    if (!response.ok) return { status: 'unreachable' };
+    const data = await response.json();
+    return {
+      status: data.installed === true ? 'installed' : 'not_installed',
+      appName: data.appName,
+    };
+  } catch {
+    return { status: 'unreachable' };
+  }
+}
+
+function showInstallPrompt(
+  root: HTMLElement,
+  config: WidgetConfig,
+  errorMessage?: string,
+  serverAppName?: string
+) {
+  const appName =
+    serverAppName ||
+    (config.apiUrl.includes('bugdrop.neonwatty.workers.dev')
+      ? 'neonwatty-bugdrop'
+      : config.apiUrl.replace(/https?:\/\//, '').replace(/\..*/, ''));
+  const installUrl = `https://github.com/apps/${appName}/installations/new`;
+  const message = errorMessage || t().installRequiredMessage;
+  const title = errorMessage ? t().connectionErrorTitle : t().installRequiredTitle;
+  const modal = createModal(
+    root,
+    title,
+    `
+      <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">${escapeHtml(message)}</p>
+      <div class="bd-actions">
+        <button class="bd-btn bd-btn-secondary" data-action="cancel">${escapeWidgetText(t().cancel)}</button>
+        ${!errorMessage ? `<a href="${installUrl}" target="_blank" class="bd-btn bd-btn-primary" style="text-decoration: none;">${escapeWidgetText(t().installApp)}</a>` : ''}
+      </div>
+    `,
+    true
+  );
+
+  const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
+  const cancelBtn = modal.querySelector('[data-action="cancel"]') as HTMLElement;
+
+  closeBtn?.addEventListener('click', () => {
+    modal.remove();
+    _isModalOpen = false;
+  });
+  cancelBtn?.addEventListener('click', () => {
+    modal.remove();
+    _isModalOpen = false;
+  });
+}
+
+function showWelcomeScreen(root: HTMLElement): Promise<boolean> {
+  return new Promise(resolve => {
+    const modal = createModal(
+      root,
+      t().welcomeTitle,
+      `
+        <div style="text-align: center; padding: 8px 0 16px;">
+          <div style="font-size: 3rem; margin-bottom: 12px;">💬</div>
+          <p style="margin: 0 0 12px; color: var(--bd-text-primary); font-size: 1.05rem; font-weight: 500;">
+            ${escapeWidgetText(t().welcomeHeadline)}
+          </p>
+          <p style="margin: 0 0 8px; color: var(--bd-text-secondary); font-size: 0.95rem; line-height: 1.6;">
+            ${escapeWidgetText(t().welcomeBodyLine1)}<br/>
+            ${escapeWidgetText(t().welcomeBodyLine2)}
+          </p>
+        </div>
+        <div class="bd-actions" style="justify-content: center;">
+          <button class="bd-btn bd-btn-primary" data-action="continue">${escapeWidgetText(t().getStarted)}</button>
+        </div>
+      `,
+      true
+    );
+
+    const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
+    const continueBtn = modal.querySelector('[data-action="continue"]') as HTMLElement;
+
+    closeBtn?.addEventListener('click', () => {
+      modal.remove();
+      resolve(false);
+    });
+
+    continueBtn?.addEventListener('click', () => {
+      modal.remove();
+      resolve(true);
+    });
+  });
+}
+
+interface FeedbackFormResult {
+  title: string;
+  description: string;
+  category: FeedbackCategory;
+  name?: string;
+  email?: string;
+  includeScreenshot: boolean;
+  attachments: FeedbackAttachment[];
+  sendConsoleLogs: boolean;
+}
+
+function showFeedbackFormWithScreenshotOption(
+  root: HTMLElement,
+  config: WidgetConfig,
+  initialValues?: FeedbackFormResult | null
+): Promise<FeedbackFormResult | null> {
+  return new Promise(resolve => {
+    // Build optional name field
+    const nameFieldHtml = config.showName
+      ? `
+          <div class="bd-form-group">
+            <label class="bd-label" for="name">${escapeWidgetText(t().nameLabel)}${config.requireName ? ' *' : ''}</label>
+            <input type="text" id="name" class="bd-input" ${config.requireName ? 'required' : ''} placeholder="${escapeWidgetText(t().namePlaceholder)}" value="${escapeHtml(initialValues?.name || '')}" />
+          </div>
+        `
+      : '';
+
+    // Build optional email field
+    const emailFieldHtml = config.showEmail
+      ? `
+          <div class="bd-form-group">
+            <label class="bd-label" for="email">${escapeWidgetText(t().emailLabel)}${config.requireEmail ? ' *' : ''}</label>
+            <input type="email" id="email" class="bd-input" ${config.requireEmail ? 'required' : ''} placeholder="${escapeWidgetText(t().emailPlaceholder)}" value="${escapeHtml(initialValues?.email || '')}" />
+          </div>
+        `
+      : '';
+
+    const modal = createModal(
+      root,
+      t().feedbackFormTitle,
+      `
+        <form id="feedback-form">
+          <div class="bd-form-group">
+            <label class="bd-label">${escapeWidgetText(t().categoryLabel)}</label>
+            <div class="bd-category-selector" style="display: flex; gap: 8px; margin-top: 6px;">
+              <label class="bd-category-option" style="flex: 1; display: flex; align-items: center; gap: 6px; padding: 8px 12px; border: var(--bd-border-style); border-radius: var(--bd-radius-sm); cursor: pointer; transition: all 0.15s ease;">
+                <input type="radio" name="category" value="bug" ${getCategoryChecked(initialValues, 'bug')} style="accent-color: var(--bd-primary);" />
+                <span style="font-size: 0.9rem;">🐛 ${escapeWidgetText(t().categoryBug)}</span>
+              </label>
+              <label class="bd-category-option" style="flex: 1; display: flex; align-items: center; gap: 6px; padding: 8px 12px; border: var(--bd-border-style); border-radius: var(--bd-radius-sm); cursor: pointer; transition: all 0.15s ease;">
+                <input type="radio" name="category" value="feature" ${getCategoryChecked(initialValues, 'feature')} style="accent-color: var(--bd-primary);" />
+                <span style="font-size: 0.9rem;">✨ ${escapeWidgetText(t().categoryFeature)}</span>
+              </label>
+              <label class="bd-category-option" style="flex: 1; display: flex; align-items: center; gap: 6px; padding: 8px 12px; border: var(--bd-border-style); border-radius: var(--bd-radius-sm); cursor: pointer; transition: all 0.15s ease;">
+                <input type="radio" name="category" value="question" ${getCategoryChecked(initialValues, 'question')} style="accent-color: var(--bd-primary);" />
+                <span style="font-size: 0.9rem;">❓ ${escapeWidgetText(t().categoryQuestion)}</span>
+              </label>
+            </div>
+          </div>
+          <div class="bd-form-group">
+            <label class="bd-label" for="title">${escapeWidgetText(t().titleLabel)} *</label>
+            <input type="text" id="title" class="bd-input" required placeholder="${escapeWidgetText(t().titlePlaceholder)}" value="${escapeHtml(initialValues?.title || '')}" />
+          </div>
+          <div class="bd-form-group">
+            <label class="bd-label" for="description">${escapeWidgetText(t().descriptionLabel)}</label>
+            <textarea id="description" class="bd-textarea" placeholder="${escapeWidgetText(t().descriptionPlaceholder)}">${escapeHtml(initialValues?.description || '')}</textarea>
+          </div>
+          ${nameFieldHtml}
+          ${emailFieldHtml}
+          <div class="bd-evidence-block">
+            <div class="bd-evidence-row">
+              ${getScreenshotFormControl(config, initialValues)}
+              ${getUploadFormControl()}
+            </div>
+            <input type="file" id="attachment-upload" accept="${ACCEPTED_UPLOAD_TYPES.join(',')}" multiple class="bd-upload-input" />
+            <div id="attachment-list" class="bd-upload-list" aria-live="polite">${
+              initialValues?.attachments.length ? '' : ''
+            }</div>
+            <p id="attachment-error" class="bd-field-error" hidden></p>
+            ${getConsoleLogsFormControl(config, initialValues)}
+          </div>
+          <div class="bd-actions">
+            <button type="button" class="bd-btn bd-btn-secondary" data-action="cancel">${escapeWidgetText(t().cancel)}</button>
+            <button type="submit" class="bd-btn bd-btn-primary" id="submit-btn">${config.screenshotMode === 'auto' ? escapeWidgetText(t().submit) : escapeWidgetText(t().continueButton)}</button>
+          </div>
+        </form>
+      `
+    );
+
+    const form = modal.querySelector('#feedback-form') as HTMLFormElement;
+    const nameInput = modal.querySelector('#name') as HTMLInputElement | null;
+    const emailInput = modal.querySelector('#email') as HTMLInputElement | null;
+    const titleInput = modal.querySelector('#title') as HTMLInputElement;
+    const descInput = modal.querySelector('#description') as HTMLTextAreaElement;
+    const screenshotCheckbox = modal.querySelector(
+      '#include-screenshot'
+    ) as HTMLInputElement | null;
+    const uploadInput = modal.querySelector('#attachment-upload') as HTMLInputElement;
+    const uploadButton = modal.querySelector('[data-action="choose-uploads"]') as HTMLButtonElement;
+    const uploadList = modal.querySelector('#attachment-list') as HTMLElement;
+    const uploadError = modal.querySelector('#attachment-error') as HTMLElement;
+    const consoleLogsCheckbox = modal.querySelector('#send-console-logs') as HTMLInputElement;
+    const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
+    const cancelBtn = modal.querySelector('[data-action="cancel"]') as HTMLElement;
+    let attachments = [...(initialValues?.attachments ?? [])];
+
+    const closeModal = () => {
+      modal.remove();
+      resolve(null);
+    };
+
+    closeBtn?.addEventListener('click', closeModal);
+    cancelBtn?.addEventListener('click', closeModal);
+
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+
+      // Validate required fields
+      if (!titleInput.value.trim()) {
+        titleInput.classList.add('bd-input--error');
+        titleInput.focus();
+        return;
+      }
+
+      // Validate name if required
+      if (config.requireName && nameInput && !nameInput.value.trim()) {
+        nameInput.classList.add('bd-input--error');
+        nameInput.focus();
+        return;
+      }
+
+      // Validate email if required
+      if (config.requireEmail && emailInput && !emailInput.value.trim()) {
+        emailInput.classList.add('bd-input--error');
+        emailInput.focus();
+        return;
+      }
+
+      // Get selected category
+      const categoryInput = modal.querySelector(
+        'input[name="category"]:checked'
+      ) as HTMLInputElement;
+      const category = (categoryInput?.value || 'bug') as FeedbackCategory;
+      const includeScreenshot =
+        config.screenshotMode === 'optional' ? (screenshotCheckbox?.checked ?? false) : true;
+      if (config.screenshotMode === 'optional' && includeScreenshot) {
+        clearComplexScreenshotsSkipped(config.repo);
+      }
+
+      modal.remove();
+      resolve({
+        title: titleInput.value.trim(),
+        description: descInput.value.trim(),
+        category,
+        name: nameInput?.value.trim() || undefined,
+        email: emailInput?.value.trim() || undefined,
+        includeScreenshot,
+        attachments,
+        sendConsoleLogs: consoleLogsCheckbox.checked,
+      });
+    });
+
+    // Clear error styling on input
+    titleInput.addEventListener('input', () => titleInput.classList.remove('bd-input--error'));
+    nameInput?.addEventListener('input', () => nameInput.classList.remove('bd-input--error'));
+    emailInput?.addEventListener('input', () => emailInput.classList.remove('bd-input--error'));
+
+    const rerenderUploads = () => {
+      renderUploadList(uploadList, attachments, index => {
+        attachments = attachments.filter((_, itemIndex) => itemIndex !== index);
+        rerenderUploads();
+      });
+    };
+
+    uploadButton.addEventListener('click', () => uploadInput.click());
+    uploadInput.addEventListener('change', async () => {
+      const files = Array.from(uploadInput.files ?? []);
+      uploadInput.value = '';
+      uploadError.textContent = '';
+      uploadError.hidden = true;
+
+      const remainingSlots = MAX_UPLOAD_FILES - attachments.length;
+      if (files.length > remainingSlots) {
+        showUploadError(uploadError, t().uploadTooMany(MAX_UPLOAD_FILES));
+        return;
+      }
+
+      for (const file of files) {
+        const validationError = validateUploadFile(file);
+        if (validationError) {
+          showUploadError(uploadError, validationError);
+          return;
+        }
+      }
+
+      try {
+        const nextAttachments = await Promise.all(files.map(fileToAttachment));
+        attachments = [...attachments, ...nextAttachments];
+        rerenderUploads();
+      } catch {
+        showUploadError(uploadError, t().uploadReadError);
+      }
+    });
+
+    rerenderUploads();
+  });
+}
+
+function getUploadFormControl(): string {
+  return `
+    <div class="bd-upload-group">
+      <div class="bd-upload-row" aria-label="${escapeWidgetText(t().uploadsAriaLabel)}">
+        <button type="button" class="bd-btn bd-btn-secondary bd-upload-button" data-action="choose-uploads" aria-label="${escapeWidgetText(t().uploadFilesAriaLabel)}">
+          <svg class="bd-upload-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <path d="M8 11V3" />
+            <path d="M4.5 6.5 8 3l3.5 3.5" />
+            <path d="M3 12.5h10" />
+          </svg>
+          ${escapeWidgetText(t().uploadButton)}
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+function validateUploadFile(file: File): string | null {
+  if (!ACCEPTED_UPLOAD_TYPES.includes(file.type)) {
+    return t().uploadUnsupportedType;
+  }
+  if (file.size > MAX_UPLOAD_SIZE_BYTES) {
+    return t().uploadTooLarge(formatFileSize(MAX_UPLOAD_SIZE_BYTES));
+  }
+  return null;
+}
+
+function showUploadError(target: HTMLElement, message: string) {
+  target.textContent = message;
+  target.hidden = false;
+}
+
+function renderUploadList(
+  target: HTMLElement,
+  attachments: FeedbackAttachment[],
+  onRemove: (index: number) => void
+) {
+  target.innerHTML = attachments
+    .map(
+      (attachment, index) => `
+        <div class="bd-upload-item">
+          <span class="bd-upload-item__name">${escapeHtml(attachment.name)}</span>
+          <span class="bd-upload-item__meta">${formatFileSize(attachment.size)}</span>
+          <button type="button" class="bd-upload-remove" data-index="${index}" aria-label="${escapeWidgetText(t().removeAttachmentAriaLabel(attachment.name))}">&times;</button>
+        </div>
+      `
+    )
+    .join('');
+
+  target.querySelectorAll('.bd-upload-remove').forEach(button => {
+    button.addEventListener('click', () => {
+      const index = Number((button as HTMLElement).dataset.index);
+      if (Number.isInteger(index)) onRemove(index);
+    });
+  });
+}
+
+function fileToAttachment(file: File): Promise<FeedbackAttachment> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', () => {
+      if (typeof reader.result !== 'string') {
+        reject(new Error('Could not read file.'));
+        return;
+      }
+      resolve({
+        name: file.name,
+        type: file.type,
+        size: file.size,
+        dataUrl: reader.result,
+      });
+    });
+    reader.addEventListener('error', () => reject(new Error('Could not read file.')));
+    reader.readAsDataURL(file);
+  });
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${Math.round((bytes / (1024 * 1024)) * 10) / 10} MB`;
+}
+
+function getScreenshotFormControl(
+  config: WidgetConfig,
+  initialValues?: FeedbackFormResult | null
+): string {
+  if (config.screenshotMode === 'auto') {
+    const redactionNote =
+      getRedactionCount() > 0 ? ` ${escapeWidgetText(t().screenshotAutoRedactionNote)}` : '';
+    return `
+      <p style="margin: 8px 0 0; color: var(--bd-text-secondary); font-size: 0.95rem;">
+        ${escapeWidgetText(t().screenshotAutoNote)}${redactionNote}
+      </p>
+    `;
+  }
+
+  if (config.screenshotMode === 'required') {
+    return `
+      <p style="margin: 8px 0 0; color: var(--bd-text-secondary); font-size: 0.95rem;">
+        ${escapeWidgetText(t().screenshotRequiredNote)}
+      </p>
+    `;
+  }
+
+  const includeScreenshot =
+    initialValues?.includeScreenshot ??
+    (!isFullPageDisabled() || !hasSkippedComplexScreenshots(config.repo));
+
+  return `
+    <div class="bd-screenshot-control">
+      <input type="checkbox" id="include-screenshot" ${includeScreenshot ? 'checked' : ''} class="bd-checkbox" />
+      <label for="include-screenshot" class="bd-checkbox-label">
+        ${escapeWidgetText(t().includeScreenshotLabel)}
+      </label>
+    </div>
+  `;
+}
+
+function getConsoleLogsFormControl(
+  config: WidgetConfig,
+  initialValues?: FeedbackFormResult | null
+): string {
+  const sendConsoleLogs = initialValues?.sendConsoleLogs ?? config.sendConsoleLogs;
+
+  return `
+    <div class="bd-form-group" style="display: flex; align-items: center; gap: 10px; margin-top: 8px;">
+      <input type="checkbox" id="send-console-logs" ${sendConsoleLogs ? 'checked' : ''} style="width: 18px; height: 18px; accent-color: var(--bd-primary); cursor: pointer;" />
+      <label for="send-console-logs" style="font-size: 0.95rem; color: var(--bd-text-secondary); cursor: pointer; user-select: none;">
+        ${escapeWidgetText(t().sendConsoleLogsLabel)}
+      </label>
+    </div>
+  `;
+}
+
+function getCategoryChecked(
+  initialValues: FeedbackFormResult | null | undefined,
+  category: FeedbackCategory
+): string {
+  return (initialValues?.category || 'bug') === category ? 'checked' : '';
+}
+
+async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: FeedbackData) {
+  // Show submitting modal with loading state
+  const modal = createModal(
+    root,
+    t().submittingTitle,
+    `
+      <div style="display: flex; flex-direction: column; align-items: center; padding: 20px;">
+        <div class="bd-spinner bd-spinner--lg"></div>
+        <p class="bd-loading-text" style="margin-top: 12px;">${escapeWidgetText(t().creatingIssue)}</p>
+      </div>
+    `
+  );
+
+  try {
+    // Build submitter info if provided
+    const submitter = data.name || data.email ? { name: data.name, email: data.email } : undefined;
+
+    // Collect system info
+    const systemInfo = getSystemInfo();
+    const domNodeCount = getDomNodeCount();
+    const consoleLogs: ConsoleLogEntry[] | undefined = data.sendConsoleLogs
+      ? getConsoleLogSnapshot()
+      : undefined;
+
+    const response = await fetch(`${config.apiUrl}/feedback`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(await getAuthHeaders(config.authTokenProvider)),
+      },
+      body: JSON.stringify({
+        repo: config.repo,
+        title: data.title,
+        description: data.description,
+        category: data.category,
+        categoryLabels: config.categoryLabels,
+        screenshot: data.screenshot,
+        attachments: data.attachments,
+        consoleLogs,
+        submitter,
+        metadata: {
+          url: systemInfo.url, // Redacted URL (no query params)
+          userAgent: navigator.userAgent,
+          viewport: {
+            width: window.innerWidth,
+            height: window.innerHeight,
+          },
+          timestamp: new Date().toISOString(),
+          elementSelector: data.elementSelector,
+          fullElementSelector: data.fullElementSelector,
+          selectedElementHighlightColor: data.selectedElementHighlightColor || undefined,
+          domNodeCount,
+          fullPageDisabled: isFullPageDisabled(),
+          // Parsed system info
+          browser: systemInfo.browser,
+          os: systemInfo.os,
+          devicePixelRatio: systemInfo.devicePixelRatio,
+          language: systemInfo.language,
+        },
+      }),
+    });
+
+    modal.remove();
+
+    if (response.status === 429) {
+      const retryAfter = response.headers.get('Retry-After');
+      const minutes = retryAfter ? Math.ceil(parseInt(retryAfter, 10) / 60) : 15;
+      showSubmitError(root, config, data, t().rateLimited(minutes));
+      return;
+    }
+
+    const result = await response.json();
+
+    if (result.success) {
+      await showSuccessModal(
+        root,
+        result.issueNumber,
+        result.issueUrl,
+        result.isPublic ?? false,
+        config.issueLinkVisibility
+      );
+    } else {
+      showSubmitError(root, config, data, result.error || t().submitFailedFallback);
+    }
+  } catch (_error) {
+    modal.remove();
+    showSubmitError(root, config, data, t().networkError);
+  }
+}
+
+function showSubmitError(
+  root: HTMLElement,
+  config: WidgetConfig,
+  data: FeedbackData,
+  errorMessage: string
+) {
+  const modal = createModal(
+    root,
+    t().submissionFailedTitle,
+    `
+      <div class="bd-error-message">
+        <svg class="bd-error-message__icon" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0-9.5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5.5zm0 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
+        </svg>
+        <span class="bd-error-message__text">${escapeHtml(errorMessage)}</span>
+      </div>
+      <div class="bd-actions">
+        <button class="bd-btn bd-btn-secondary" data-action="cancel">${escapeWidgetText(t().cancel)}</button>
+        <button class="bd-btn bd-btn-primary" data-action="retry">${escapeWidgetText(t().tryAgain)}</button>
+      </div>
+    `,
+    true
+  );
+
+  const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
+  const cancelBtn = modal.querySelector('[data-action="cancel"]') as HTMLElement;
+  const retryBtn = modal.querySelector('[data-action="retry"]') as HTMLElement;
+
+  closeBtn?.addEventListener('click', () => modal.remove());
+  cancelBtn?.addEventListener('click', () => modal.remove());
+
+  retryBtn?.addEventListener('click', async () => {
+    modal.remove();
+    await submitFeedback(root, config, data);
+  });
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/locales/de.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/locales/de.ts.txt
@@ -1,0 +1,135 @@
+import type { WidgetStrings } from '../i18n';
+
+export const de: WidgetStrings = {
+  // Trigger button & pull tab
+  triggerLabel: 'Feedback',
+  triggerAriaLabel: 'Fehler melden oder Feedback senden',
+  dismissButtonAriaLabel: 'Feedback-Button ausblenden',
+  pullTabAriaLabel: 'Feedback-Button anzeigen',
+  dragHandleTitle: 'Feedback-Button verschieben',
+  // Install prompt
+  installRequiredTitle: 'Installation erforderlich',
+  connectionErrorTitle: 'Verbindungsfehler',
+  installRequiredMessage:
+    'BugDrop benötigt die Installation der GitHub-App, um Issues zu erstellen.',
+  apiUnreachableMessage:
+    'Die BugDrop-API ist nicht erreichbar. Überprüfen Sie Ihre Netzwerkverbindung oder die URL des Script-Tags.',
+  installApp: 'App installieren',
+  // Welcome screen
+  welcomeTitle: 'Teilen Sie Ihr Feedback',
+  welcomeHeadline: 'Helfen Sie uns, besser zu werden, indem Sie Ihre Meinung teilen',
+  welcomeBodyLine1:
+    'Melden Sie Fehler, schlagen Sie Funktionen vor oder hinterlassen Sie Feedback.',
+  welcomeBodyLine2: 'Sie können optional kommentierte Screenshots hinzufügen.',
+  getStarted: 'Los geht’s',
+  // Feedback form
+  feedbackFormTitle: 'Feedback senden',
+  categoryLabel: 'Kategorie',
+  categoryBug: 'Fehler',
+  categoryFeature: 'Funktion',
+  categoryQuestion: 'Frage',
+  nameLabel: 'Name',
+  namePlaceholder: 'Ihr Name',
+  emailLabel: 'E-Mail',
+  emailPlaceholder: 'ihre@email.de',
+  titleLabel: 'Titel',
+  titlePlaceholder: 'Kurze Beschreibung des Problems oder Vorschlags',
+  descriptionLabel: 'Beschreibung',
+  descriptionPlaceholder: 'Geben Sie weitere Details, Schritte zur Reproduktion oder Kontext an...',
+  screenshotAutoNote:
+    'Diese Website hängt beim Absenden automatisch einen Screenshot der gesamten Seite an, ohne eine Vorschau anzuzeigen. Überprüfen Sie Ihre Seite vor dem Senden auf sensible Informationen.',
+  screenshotAutoRedactionNote:
+    'Einige von dieser Website als privat markierte Felder können auf unterstützten Seiten optisch maskiert werden, nicht markierte sensible Informationen können jedoch weiterhin enthalten sein.',
+  screenshotRequiredNote: '📸 Vor dem Absenden ist ein Screenshot erforderlich.',
+  includeScreenshotLabel: '📸 Screenshot hinzufügen',
+  sendConsoleLogsLabel: 'Konsolenprotokolle mitsenden',
+  // Uploads
+  uploadsAriaLabel: 'Uploads',
+  uploadFilesAriaLabel: 'Dateien hochladen',
+  uploadButton: 'Hochladen',
+  uploadTooMany: (max: number) =>
+    `Laden Sie bis zu ${max} Dateien hoch. Entfernen Sie eine Datei, bevor Sie eine weitere hinzufügen.`,
+  uploadUnsupportedType:
+    'Dieser Dateityp wird nicht unterstützt. Laden Sie ein Bild, ein PDF oder ein kurzes Video hoch.',
+  uploadTooLarge: (maxSize: string) =>
+    `Die Datei ist zu groß. Laden Sie Dateien bis zu ${maxSize} hoch.`,
+  uploadReadError: 'Diese Datei konnte nicht gelesen werden. Versuchen Sie es mit einer anderen.',
+  removeAttachmentAriaLabel: (name: string) => `${name} entfernen`,
+  // Common buttons
+  cancel: 'Abbrechen',
+  continueButton: 'Weiter',
+  submit: 'Absenden',
+  // Submission
+  submittingTitle: 'Wird gesendet...',
+  creatingIssue: 'Issue wird erstellt...',
+  rateLimited: (minutes: number) =>
+    `Zu viele Übermittlungen. Bitte versuchen Sie es in ${minutes} Minute${minutes === 1 ? '' : 'n'} erneut.`,
+  submitFailedFallback: 'Senden fehlgeschlagen',
+  networkError: 'Netzwerkfehler. Bitte überprüfen Sie Ihre Verbindung.',
+  submissionFailedTitle: 'Senden fehlgeschlagen',
+  tryAgain: 'Erneut versuchen',
+  // Success modal
+  successTitle: 'Feedback gesendet!',
+  issueCreated: (issueNumberHtml: string) => `Issue ${issueNumberHtml} wurde erstellt.`,
+  feedbackSubmittedMessage: 'Ihr Feedback wurde erfolgreich gesendet.',
+  viewOnGitHub: 'Auf GitHub ansehen',
+  done: 'Fertig',
+  // Screenshot options
+  captureScreenshotTitle: 'Screenshot erstellen',
+  chooseWhatToCapture: 'Wählen Sie aus, was erfasst werden soll:',
+  viewportRedactionWarning:
+    'Bei der Erfassung des sichtbaren Bereichs über den Browser können private Felder nicht automatisch maskiert werden. Wählen Sie „Element auswählen“, um die automatische Maskierung beizubehalten, oder überprüfen und verdecken Sie sensible Bereiche vor dem Senden.',
+  redactionReviewNote:
+    'Diese Website hat einige Felder zur Schwärzung markiert. Überprüfen Sie den Screenshot vor dem Senden.',
+  pageTooComplexViewportNote:
+    'Diese Seite ist zu komplex für eine vollständige Erfassung oder eine Bereichserfassung. Erfassen Sie stattdessen den sichtbaren Bereich oder wählen Sie ein bestimmtes Element aus.',
+  pageTooComplexElementNote:
+    'Diese Seite ist zu komplex für eine vollständige Erfassung oder eine Bereichserfassung. Wählen Sie stattdessen ein bestimmtes Element aus.',
+  fullPage: 'Ganze Seite',
+  captureViewport: 'Sichtbaren Bereich erfassen',
+  selectArea: 'Bereich auswählen',
+  selectElement: 'Element auswählen',
+  skipScreenshot: 'Screenshot überspringen',
+  // Element & area pickers
+  areaPickerInstruction: 'Ziehen Sie eine Auswahl um den zu erfassenden Bereich',
+  areaPickerRedactionInstruction:
+    'Ziehen Sie eine Auswahl um den zu erfassenden Bereich. Markierte private Felder können maskiert werden, wenn sie darin enthalten sind.',
+  elementPickerInstruction: 'Klicken Sie auf ein beliebiges Element, um es zu erfassen',
+  elementPickerTouchInstruction: 'Tippen Sie auf ein beliebiges Element, um es zu erfassen',
+  escToCancel: 'ESC zum Abbrechen',
+  // Capture loading & failures
+  capturingTitle: 'Wird erfasst...',
+  capturingScreenshot: 'Screenshot wird erfasst...',
+  captureFailedTitle: 'Erfassung fehlgeschlagen',
+  captureFailedMessage:
+    'Der Screenshot konnte nicht erfasst werden. Die Seite ist möglicherweise zu komplex, oder Browsereinschränkungen greifen.',
+  chooseAnotherMethod: 'Andere Methode wählen',
+  maskFailureTitle: 'Datenschutz-Maskierung fehlgeschlagen',
+  maskFailureMessage:
+    'Die automatische Schwärzung privater Felder konnte nicht angewendet werden. Zum Schutz Ihrer Daten wurde dieser Screenshot verworfen. Sie können Ihr Feedback weiterhin ohne Screenshot senden.',
+  continueWithoutScreenshot: 'Ohne Screenshot fortfahren',
+  // Annotation step
+  reviewScreenshotTitle: 'Screenshot überprüfen',
+  viewportRedactionUnavailableNote:
+    'Bei diesem über den Browser erfassten sichtbaren Bereich konnten private Felder nicht automatisch maskiert werden. Überprüfen und verdecken Sie sensible Bereiche vor dem Senden.',
+  redactionCountNote: (count: number) =>
+    count === 1
+      ? `${count} privates Element wurde zur Schwärzung in diesem Screenshot markiert. Überprüfen Sie ihn vor dem Senden.`
+      : `${count} private Elemente wurden zur Schwärzung in diesem Screenshot markiert. Überprüfen Sie ihn vor dem Senden.`,
+  redactionLimitationsNote:
+    'BugDrop hat nur die gemessenen markierten Bereiche abgedeckt. Es untersucht keine Pixel innerhalb eingebetteter oder gerenderter Inhalte wie iFrames, Canvas, Bildern, SVGs, Videos, CSS-Hintergründen oder benutzerdefinierten Steuerelementen. Stellen Sie vor dem Senden sicher, dass das schwarze Feld den sensiblen Bereich vollständig abdeckt, oder nehmen Sie den Screenshot nach Markierung eines größeren Bereichs erneut auf.',
+  annotationInstruction:
+    'Stellen Sie vor dem Senden sicher, dass keine sensiblen Informationen sichtbar sind. Verdecken Sie sensible Bereiche vor dem Absenden. Schwärzungen werden dauerhaft in das hochgeladene Bild eingebettet.',
+  selectedElementNote: (linkHtml: string) =>
+    `Benötigen Sie mehr umgebenden Kontext? Passen Sie ${linkHtml} im BugDrop-Script-Tag an.`,
+  toolDraw: 'Zeichnen',
+  toolArrow: 'Pfeil',
+  toolRectangle: 'Rechteck',
+  toolRedact: 'Schwärzen',
+  undo: 'Rückgängig',
+  retake: 'Erneut aufnehmen',
+  submitFeedback: 'Feedback senden',
+  // Capture timeout
+  captureTimeout:
+    'Zeitüberschreitung bei der Screenshot-Erfassung — die Seite ist möglicherweise zu komplex',
+};

--- a/scripts/default-flow-fixed-baseline/src/widget/locales/en.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/locales/en.ts.txt
@@ -1,0 +1,127 @@
+import type { WidgetStrings } from '../i18n';
+
+export const en: WidgetStrings = {
+  // Trigger button & pull tab
+  triggerLabel: 'Feedback',
+  triggerAriaLabel: 'Report a bug or send feedback',
+  dismissButtonAriaLabel: 'Dismiss feedback button',
+  pullTabAriaLabel: 'Show feedback button',
+  dragHandleTitle: 'Drag feedback button',
+  // Install prompt
+  installRequiredTitle: 'Install Required',
+  connectionErrorTitle: 'Connection Error',
+  installRequiredMessage: 'BugDrop requires GitHub App installation to create issues.',
+  apiUnreachableMessage:
+    'Unable to reach BugDrop API. Check your network connection or script tag URL.',
+  installApp: 'Install App',
+  // Welcome screen
+  welcomeTitle: 'Share Your Feedback',
+  welcomeHeadline: 'Help us improve by sharing your thoughts',
+  welcomeBodyLine1: 'Report bugs, suggest features, or leave feedback.',
+  welcomeBodyLine2: 'You can optionally include annotated screenshots.',
+  getStarted: 'Get Started',
+  // Feedback form
+  feedbackFormTitle: 'Send Feedback',
+  categoryLabel: 'Category',
+  categoryBug: 'Bug',
+  categoryFeature: 'Feature',
+  categoryQuestion: 'Question',
+  nameLabel: 'Name',
+  namePlaceholder: 'Your name',
+  emailLabel: 'Email',
+  emailPlaceholder: 'your@email.com',
+  titleLabel: 'Title',
+  titlePlaceholder: 'Brief description of the issue or suggestion',
+  descriptionLabel: 'Description',
+  descriptionPlaceholder: 'Provide additional details, steps to reproduce, or context...',
+  screenshotAutoNote:
+    'This site will attach a full-page screenshot when you submit without showing a preview. Review your page for sensitive information before sending.',
+  screenshotAutoRedactionNote:
+    'Some fields this site marked private may be visually masked on supported pages, but unmarked sensitive information can still be included.',
+  screenshotRequiredNote: '📸 A screenshot is required before submitting.',
+  includeScreenshotLabel: '📸 Include a screenshot',
+  sendConsoleLogsLabel: 'Send Console Logs',
+  // Uploads
+  uploadsAriaLabel: 'Uploads',
+  uploadFilesAriaLabel: 'Upload files',
+  uploadButton: 'Upload',
+  uploadTooMany: (max: number) => `Upload up to ${max} files. Remove a file before adding another.`,
+  uploadUnsupportedType: 'That file type is not supported. Upload an image, PDF, or short video.',
+  uploadTooLarge: (maxSize: string) => `File is too large. Upload files up to ${maxSize}.`,
+  uploadReadError: 'Could not read that file. Try another one.',
+  removeAttachmentAriaLabel: (name: string) => `Remove ${name}`,
+  // Common buttons
+  cancel: 'Cancel',
+  continueButton: 'Continue',
+  submit: 'Submit',
+  // Submission
+  submittingTitle: 'Submitting...',
+  creatingIssue: 'Creating issue...',
+  rateLimited: (minutes: number) =>
+    `Too many submissions. Please try again in ${minutes} minute${minutes === 1 ? '' : 's'}.`,
+  submitFailedFallback: 'Failed to submit',
+  networkError: 'Network error. Please check your connection.',
+  submissionFailedTitle: 'Submission Failed',
+  tryAgain: 'Try Again',
+  // Success modal
+  successTitle: 'Feedback Submitted!',
+  issueCreated: (issueNumberHtml: string) => `Issue ${issueNumberHtml} has been created.`,
+  feedbackSubmittedMessage: 'Your feedback has been submitted successfully.',
+  viewOnGitHub: 'View on GitHub',
+  done: 'Done',
+  // Screenshot options
+  captureScreenshotTitle: 'Capture Screenshot',
+  chooseWhatToCapture: 'Choose what to capture:',
+  viewportRedactionWarning:
+    'Browser viewport capture cannot apply automatic private-field masks. Select Element to preserve automatic masking, or review and cover sensitive areas before sending.',
+  redactionReviewNote:
+    'This site marked some fields for redaction. Review the screenshot before sending.',
+  pageTooComplexViewportNote:
+    'This page is too complex for full-page or area capture. Capture the visible viewport or select a specific element instead.',
+  pageTooComplexElementNote:
+    'This page is too complex for full-page or area capture. Select a specific element instead.',
+  fullPage: 'Full Page',
+  captureViewport: 'Capture Viewport',
+  selectArea: 'Select Area',
+  selectElement: 'Select Element',
+  skipScreenshot: 'Skip Screenshot',
+  // Element & area pickers
+  areaPickerInstruction: 'Draw a selection around the area to capture',
+  areaPickerRedactionInstruction:
+    'Draw a selection around the area to capture. Marked private fields may be masked if included.',
+  elementPickerInstruction: 'Click any element to capture it',
+  elementPickerTouchInstruction: 'Tap any element to capture it',
+  escToCancel: 'ESC to cancel',
+  // Capture loading & failures
+  capturingTitle: 'Capturing...',
+  capturingScreenshot: 'Capturing screenshot...',
+  captureFailedTitle: 'Capture Failed',
+  captureFailedMessage:
+    'Failed to capture screenshot. The page may be too complex or browser restrictions may apply.',
+  chooseAnotherMethod: 'Choose Another Method',
+  maskFailureTitle: 'Privacy masking failed',
+  maskFailureMessage:
+    'Automatic redaction of private fields could not be applied. To protect your data, this screenshot was discarded. You can still submit feedback without one.',
+  continueWithoutScreenshot: 'Continue without screenshot',
+  // Annotation step
+  reviewScreenshotTitle: 'Review Screenshot',
+  viewportRedactionUnavailableNote:
+    'This browser viewport capture could not apply automatic private-field masks. Review and cover any sensitive areas before sending.',
+  redactionCountNote: (count: number) =>
+    `${count} private ${count === 1 ? 'item was' : 'items were'} marked for redaction in this screenshot. Review before sending.`,
+  redactionLimitationsNote:
+    'BugDrop only covered the measured marked boxes. It does not inspect pixels inside embedded or rendered content such as iframes, canvas, images, SVGs, videos, CSS backgrounds, or custom controls. Confirm the black box fully covers the sensitive region before sending, or retake after marking a larger wrapper.',
+  annotationInstruction:
+    'Check that no sensitive information is visible before sending. Cover sensitive areas before submitting. Redactions are baked into the uploaded image.',
+  selectedElementNote: (linkHtml: string) =>
+    `Need more surrounding context? Adjust ${linkHtml} on the BugDrop script tag.`,
+  toolDraw: 'Draw',
+  toolArrow: 'Arrow',
+  toolRectangle: 'Rectangle',
+  toolRedact: 'Redact',
+  undo: 'Undo',
+  retake: 'Retake',
+  submitFeedback: 'Submit Feedback',
+  // Capture timeout
+  captureTimeout: 'Screenshot capture timed out — the page may be too complex',
+};

--- a/scripts/default-flow-fixed-baseline/src/widget/locales/nl.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/locales/nl.ts.txt
@@ -1,0 +1,133 @@
+import type { WidgetStrings } from '../i18n';
+
+export const nl: WidgetStrings = {
+  // Trigger button & pull tab
+  triggerLabel: 'Feedback',
+  triggerAriaLabel: 'Een fout melden of feedback versturen',
+  dismissButtonAriaLabel: 'Feedbackknop verbergen',
+  pullTabAriaLabel: 'Feedbackknop tonen',
+  dragHandleTitle: 'Feedbackknop verslepen',
+  // Install prompt
+  installRequiredTitle: 'Installatie vereist',
+  connectionErrorTitle: 'Verbindingsfout',
+  installRequiredMessage:
+    'BugDrop vereist installatie van de GitHub-app om issues te kunnen aanmaken.',
+  apiUnreachableMessage:
+    'Kan de BugDrop-API niet bereiken. Controleer uw netwerkverbinding of de URL van de scripttag.',
+  installApp: 'App installeren',
+  // Welcome screen
+  welcomeTitle: 'Deel uw feedback',
+  welcomeHeadline: 'Help ons verbeteren door uw mening te delen',
+  welcomeBodyLine1: 'Meld fouten, stel functies voor of laat feedback achter.',
+  welcomeBodyLine2: 'U kunt optioneel schermafbeeldingen met aantekeningen toevoegen.',
+  getStarted: 'Aan de slag',
+  // Feedback form
+  feedbackFormTitle: 'Feedback versturen',
+  categoryLabel: 'Categorie',
+  categoryBug: 'Fout',
+  categoryFeature: 'Suggestie',
+  categoryQuestion: 'Vraag',
+  nameLabel: 'Naam',
+  namePlaceholder: 'Uw naam',
+  emailLabel: 'E-mail',
+  emailPlaceholder: 'uw@email.nl',
+  titleLabel: 'Titel',
+  titlePlaceholder: 'Korte omschrijving van het probleem of de suggestie',
+  descriptionLabel: 'Omschrijving',
+  descriptionPlaceholder: 'Geef extra details, stappen om het te reproduceren of context...',
+  screenshotAutoNote:
+    'Deze site voegt bij het versturen automatisch een schermafbeelding van de volledige pagina toe, zonder voorbeeld. Controleer uw pagina op gevoelige informatie voordat u verstuurt.',
+  screenshotAutoRedactionNote:
+    'Sommige velden die deze site als privé heeft gemarkeerd, kunnen op ondersteunde pagina’s visueel worden gemaskeerd, maar niet-gemarkeerde gevoelige informatie kan nog steeds worden meegestuurd.',
+  screenshotRequiredNote: '📸 Een schermafbeelding is vereist voordat u kunt versturen.',
+  includeScreenshotLabel: '📸 Schermafbeelding toevoegen',
+  sendConsoleLogsLabel: 'Consolelogboeken meesturen',
+  // Uploads
+  uploadsAriaLabel: 'Uploads',
+  uploadFilesAriaLabel: 'Bestanden uploaden',
+  uploadButton: 'Uploaden',
+  uploadTooMany: (max: number) =>
+    `Upload maximaal ${max} bestanden. Verwijder een bestand voordat u er een toevoegt.`,
+  uploadUnsupportedType:
+    'Dat bestandstype wordt niet ondersteund. Upload een afbeelding, pdf of korte video.',
+  uploadTooLarge: (maxSize: string) => `Het bestand is te groot. Upload bestanden tot ${maxSize}.`,
+  uploadReadError: 'Kan dat bestand niet lezen. Probeer een ander bestand.',
+  removeAttachmentAriaLabel: (name: string) => `${name} verwijderen`,
+  // Common buttons
+  cancel: 'Annuleren',
+  continueButton: 'Doorgaan',
+  submit: 'Versturen',
+  // Submission
+  submittingTitle: 'Versturen...',
+  creatingIssue: 'Issue aanmaken...',
+  rateLimited: (minutes: number) =>
+    `Te veel inzendingen. Probeer het over ${minutes} ${minutes === 1 ? 'minuut' : 'minuten'} opnieuw.`,
+  submitFailedFallback: 'Versturen mislukt',
+  networkError: 'Netwerkfout. Controleer uw verbinding.',
+  submissionFailedTitle: 'Versturen mislukt',
+  tryAgain: 'Opnieuw proberen',
+  // Success modal
+  successTitle: 'Feedback verstuurd!',
+  issueCreated: (issueNumberHtml: string) => `Issue ${issueNumberHtml} is aangemaakt.`,
+  feedbackSubmittedMessage: 'Uw feedback is succesvol verstuurd.',
+  viewOnGitHub: 'Bekijken op GitHub',
+  done: 'Klaar',
+  // Screenshot options
+  captureScreenshotTitle: 'Schermafbeelding maken',
+  chooseWhatToCapture: 'Kies wat u wilt vastleggen:',
+  viewportRedactionWarning:
+    'Bij het vastleggen van het zichtbare deel via de browser kunnen privévelden niet automatisch worden gemaskeerd. Kies “Element selecteren” om automatische maskering te behouden, of controleer en dek gevoelige gebieden af voordat u verstuurt.',
+  redactionReviewNote:
+    'Deze site heeft enkele velden gemarkeerd voor redactie. Controleer de schermafbeelding voordat u verstuurt.',
+  pageTooComplexViewportNote:
+    'Deze pagina is te complex om volledig of per gebied vast te leggen. Leg het zichtbare deel vast of selecteer een specifiek element.',
+  pageTooComplexElementNote:
+    'Deze pagina is te complex om volledig of per gebied vast te leggen. Selecteer in plaats daarvan een specifiek element.',
+  fullPage: 'Volledige pagina',
+  captureViewport: 'Zichtbaar deel vastleggen',
+  selectArea: 'Gebied selecteren',
+  selectElement: 'Element selecteren',
+  skipScreenshot: 'Schermafbeelding overslaan',
+  // Element & area pickers
+  areaPickerInstruction: 'Trek een selectie rond het gebied dat u wilt vastleggen',
+  areaPickerRedactionInstruction:
+    'Trek een selectie rond het gebied dat u wilt vastleggen. Gemarkeerde privévelden kunnen worden gemaskeerd als ze binnen de selectie vallen.',
+  elementPickerInstruction: 'Klik op een element om het vast te leggen',
+  elementPickerTouchInstruction: 'Tik op een element om het vast te leggen',
+  escToCancel: 'ESC om te annuleren',
+  // Capture loading & failures
+  capturingTitle: 'Vastleggen...',
+  capturingScreenshot: 'Schermafbeelding wordt gemaakt...',
+  captureFailedTitle: 'Opname mislukt',
+  captureFailedMessage:
+    'Kan geen schermafbeelding maken. De pagina is mogelijk te complex of de browser staat dit niet toe.',
+  chooseAnotherMethod: 'Kies een andere methode',
+  maskFailureTitle: 'Privacymaskering mislukt',
+  maskFailureMessage:
+    'Automatische redactie van privévelden kon niet worden toegepast. Om uw gegevens te beschermen is deze schermafbeelding verwijderd. U kunt uw feedback nog steeds zonder schermafbeelding versturen.',
+  continueWithoutScreenshot: 'Doorgaan zonder schermafbeelding',
+  // Annotation step
+  reviewScreenshotTitle: 'Schermafbeelding controleren',
+  viewportRedactionUnavailableNote:
+    'Bij deze via de browser vastgelegde schermafbeelding konden privévelden niet automatisch worden gemaskeerd. Controleer en dek gevoelige gebieden af voordat u verstuurt.',
+  redactionCountNote: (count: number) =>
+    count === 1
+      ? '1 privé-item is gemarkeerd voor redactie in deze schermafbeelding. Controleer voordat u verstuurt.'
+      : `${count} privé-items zijn gemarkeerd voor redactie in deze schermafbeelding. Controleer voordat u verstuurt.`,
+  redactionLimitationsNote:
+    'BugDrop heeft alleen de gemeten gemarkeerde vakken afgedekt. Het inspecteert geen pixels binnen ingesloten of gerenderde inhoud zoals iframes, canvas, afbeeldingen, SVG’s, video’s, CSS-achtergronden of aangepaste elementen. Controleer of het zwarte vak het gevoelige gebied volledig bedekt voordat u verstuurt, of maak de afbeelding opnieuw nadat u een groter element hebt gemarkeerd.',
+  annotationInstruction:
+    'Controleer of er geen gevoelige informatie zichtbaar is voordat u verstuurt. Dek gevoelige gebieden af voordat u indient. Redacties worden permanent in de geüploade afbeelding verwerkt.',
+  selectedElementNote: (linkHtml: string) =>
+    `Meer omringende context nodig? Pas ${linkHtml} aan op de BugDrop-scripttag.`,
+  toolDraw: 'Tekenen',
+  toolArrow: 'Pijl',
+  toolRectangle: 'Rechthoek',
+  toolRedact: 'Redigeren',
+  undo: 'Ongedaan maken',
+  retake: 'Opnieuw maken',
+  submitFeedback: 'Feedback versturen',
+  // Capture timeout
+  captureTimeout:
+    'Het maken van de schermafbeelding duurde te lang — de pagina is mogelijk te complex',
+};

--- a/scripts/default-flow-fixed-baseline/src/widget/locales/pl.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/locales/pl.ts.txt
@@ -1,0 +1,146 @@
+import type { WidgetStrings } from '../i18n';
+
+// Polish "few" plural form: 2-4, 22-24, 32-34, ... (but not 12-14).
+function isFew(count: number): boolean {
+  const mod10 = count % 10;
+  const mod100 = count % 100;
+  return mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14);
+}
+
+export const pl: WidgetStrings = {
+  // Trigger button & pull tab
+  triggerLabel: 'Opinia',
+  triggerAriaLabel: 'Zgłoś błąd lub wyślij opinię',
+  dismissButtonAriaLabel: 'Ukryj przycisk opinii',
+  pullTabAriaLabel: 'Pokaż przycisk opinii',
+  dragHandleTitle: 'Przeciągnij przycisk opinii',
+  // Install prompt
+  installRequiredTitle: 'Wymagana instalacja',
+  connectionErrorTitle: 'Błąd połączenia',
+  installRequiredMessage: 'BugDrop wymaga instalacji aplikacji GitHub, aby tworzyć zgłoszenia.',
+  apiUnreachableMessage:
+    'Nie można połączyć się z API BugDrop. Sprawdź połączenie sieciowe lub adres URL w tagu skryptu.',
+  installApp: 'Zainstaluj aplikację',
+  // Welcome screen
+  welcomeTitle: 'Podziel się opinią',
+  welcomeHeadline: 'Pomóż nam się rozwijać, dzieląc się swoimi uwagami',
+  welcomeBodyLine1: 'Zgłaszaj błędy, proponuj funkcje lub zostaw opinię.',
+  welcomeBodyLine2: 'Opcjonalnie możesz dołączyć zrzuty ekranu z adnotacjami.',
+  getStarted: 'Rozpocznij',
+  // Feedback form
+  feedbackFormTitle: 'Wyślij opinię',
+  categoryLabel: 'Kategoria',
+  categoryBug: 'Błąd',
+  categoryFeature: 'Propozycja',
+  categoryQuestion: 'Pytanie',
+  nameLabel: 'Imię i nazwisko',
+  namePlaceholder: 'Twoje imię i nazwisko',
+  emailLabel: 'E-mail',
+  emailPlaceholder: 'twoj@email.com',
+  titleLabel: 'Tytuł',
+  titlePlaceholder: 'Krótki opis problemu lub sugestii',
+  descriptionLabel: 'Opis',
+  descriptionPlaceholder: 'Podaj dodatkowe szczegóły, kroki do odtworzenia lub kontekst...',
+  screenshotAutoNote:
+    'Ta strona automatycznie dołączy zrzut całej strony podczas wysyłania, bez pokazywania podglądu. Przed wysłaniem sprawdź, czy strona nie zawiera poufnych informacji.',
+  screenshotAutoRedactionNote:
+    'Niektóre pola oznaczone przez tę stronę jako prywatne mogą zostać zamaskowane na obsługiwanych stronach, ale nieoznaczone poufne informacje nadal mogą zostać dołączone.',
+  screenshotRequiredNote: '📸 Zrzut ekranu jest wymagany przed wysłaniem.',
+  includeScreenshotLabel: '📸 Dołącz zrzut ekranu',
+  sendConsoleLogsLabel: 'Wyślij logi konsoli',
+  // Uploads
+  uploadsAriaLabel: 'Załączniki',
+  uploadFilesAriaLabel: 'Prześlij pliki',
+  uploadButton: 'Prześlij',
+  uploadTooMany: (max: number) =>
+    `Można przesłać maksymalnie ${max} ${isFew(max) ? 'pliki' : 'plików'}. Usuń plik, aby dodać kolejny.`,
+  uploadUnsupportedType:
+    'Ten typ pliku nie jest obsługiwany. Prześlij obraz, plik PDF lub krótki film.',
+  uploadTooLarge: (maxSize: string) =>
+    `Plik jest za duży. Prześlij pliki o rozmiarze do ${maxSize}.`,
+  uploadReadError: 'Nie udało się odczytać pliku. Spróbuj z innym.',
+  removeAttachmentAriaLabel: (name: string) => `Usuń ${name}`,
+  // Common buttons
+  cancel: 'Anuluj',
+  continueButton: 'Dalej',
+  submit: 'Wyślij',
+  // Submission
+  submittingTitle: 'Wysyłanie...',
+  creatingIssue: 'Tworzenie zgłoszenia...',
+  rateLimited: (minutes: number) =>
+    `Zbyt wiele zgłoszeń. Spróbuj ponownie za ${minutes} ${
+      minutes === 1 ? 'minutę' : isFew(minutes) ? 'minuty' : 'minut'
+    }.`,
+  submitFailedFallback: 'Nie udało się wysłać',
+  networkError: 'Błąd sieci. Sprawdź połączenie z internetem.',
+  submissionFailedTitle: 'Wysyłanie nie powiodło się',
+  tryAgain: 'Spróbuj ponownie',
+  // Success modal
+  successTitle: 'Opinia wysłana!',
+  issueCreated: (issueNumberHtml: string) => `Utworzono zgłoszenie ${issueNumberHtml}.`,
+  feedbackSubmittedMessage: 'Twoja opinia została pomyślnie wysłana.',
+  viewOnGitHub: 'Zobacz na GitHubie',
+  done: 'Gotowe',
+  // Screenshot options
+  captureScreenshotTitle: 'Zrób zrzut ekranu',
+  chooseWhatToCapture: 'Wybierz, co przechwycić:',
+  viewportRedactionWarning:
+    'Przechwytywanie widocznego obszaru przez przeglądarkę nie pozwala automatycznie zamaskować pól prywatnych. Wybierz „Zaznacz element”, aby zachować automatyczne maskowanie, albo sprawdź i zakryj poufne obszary przed wysłaniem.',
+  redactionReviewNote:
+    'Ta strona oznaczyła niektóre pola do zamazania. Sprawdź zrzut ekranu przed wysłaniem.',
+  pageTooComplexViewportNote:
+    'Ta strona jest zbyt złożona, aby przechwycić całą stronę lub zaznaczony obszar. Przechwyć widoczny obszar albo zaznacz konkretny element.',
+  pageTooComplexElementNote:
+    'Ta strona jest zbyt złożona, aby przechwycić całą stronę lub zaznaczony obszar. Zamiast tego zaznacz konkretny element.',
+  fullPage: 'Cała strona',
+  captureViewport: 'Przechwyć widoczny obszar',
+  selectArea: 'Zaznacz obszar',
+  selectElement: 'Zaznacz element',
+  skipScreenshot: 'Pomiń zrzut ekranu',
+  // Element & area pickers
+  areaPickerInstruction: 'Narysuj zaznaczenie wokół obszaru do przechwycenia',
+  areaPickerRedactionInstruction:
+    'Narysuj zaznaczenie wokół obszaru do przechwycenia. Pola oznaczone jako prywatne mogą zostać zamaskowane, jeśli znajdą się w zaznaczeniu.',
+  elementPickerInstruction: 'Kliknij dowolny element, aby go przechwycić',
+  elementPickerTouchInstruction: 'Dotknij dowolny element, aby go przechwycić',
+  escToCancel: 'ESC, aby anulować',
+  // Capture loading & failures
+  capturingTitle: 'Przechwytywanie...',
+  capturingScreenshot: 'Trwa przechwytywanie zrzutu ekranu...',
+  captureFailedTitle: 'Przechwytywanie nie powiodło się',
+  captureFailedMessage:
+    'Nie udało się przechwycić zrzutu ekranu. Strona może być zbyt złożona lub przeglądarka na to nie pozwala.',
+  chooseAnotherMethod: 'Wybierz inną metodę',
+  maskFailureTitle: 'Maskowanie prywatności nie powiodło się',
+  maskFailureMessage:
+    'Nie udało się automatycznie zamazać pól prywatnych. Aby chronić Twoje dane, ten zrzut ekranu został odrzucony. Nadal możesz wysłać opinię bez zrzutu ekranu.',
+  continueWithoutScreenshot: 'Kontynuuj bez zrzutu ekranu',
+  // Annotation step
+  reviewScreenshotTitle: 'Sprawdź zrzut ekranu',
+  viewportRedactionUnavailableNote:
+    'Na tym zrzucie przechwyconym przez przeglądarkę nie udało się automatycznie zamaskować pól prywatnych. Sprawdź i zakryj poufne obszary przed wysłaniem.',
+  redactionCountNote: (count: number) =>
+    `${count} ${
+      count === 1
+        ? 'prywatny element oznaczono'
+        : isFew(count)
+          ? 'prywatne elementy oznaczono'
+          : 'prywatnych elementów oznaczono'
+    } do zamazania na tym zrzucie ekranu. Sprawdź przed wysłaniem.`,
+  redactionLimitationsNote:
+    'BugDrop zakrywa tylko zmierzone, oznaczone obszary. Nie analizuje pikseli wewnątrz osadzonej lub renderowanej zawartości, takiej jak elementy iframe, canvas, obrazy, pliki SVG, filmy, tła CSS czy niestandardowe kontrolki. Przed wysłaniem upewnij się, że czarny prostokąt w pełni zakrywa poufny obszar, albo ponów zrzut po oznaczeniu większego elementu.',
+  annotationInstruction:
+    'Przed wysłaniem sprawdź, czy nie widać poufnych informacji. Zakryj poufne obszary przed przesłaniem. Zamazania są trwale zapisywane w przesyłanym obrazie.',
+  selectedElementNote: (linkHtml: string) =>
+    `Potrzebujesz więcej otaczającego kontekstu? Dostosuj ${linkHtml} w tagu skryptu BugDrop.`,
+  toolDraw: 'Rysuj',
+  toolArrow: 'Strzałka',
+  toolRectangle: 'Prostokąt',
+  toolRedact: 'Zamaż',
+  undo: 'Cofnij',
+  retake: 'Ponów zrzut',
+  submitFeedback: 'Wyślij opinię',
+  // Capture timeout
+  captureTimeout:
+    'Upłynął limit czasu przechwytywania zrzutu ekranu — strona może być zbyt złożona',
+};

--- a/scripts/default-flow-fixed-baseline/src/widget/mask.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/mask.ts.txt
@@ -1,0 +1,298 @@
+interface MaskRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+type RedactionReason = 'developer-marked' | 'sensitive-input';
+type RedactionStrategy = 'canvas-mask';
+type UnsupportedSurfaceReason = 'embedded-document' | 'pixel-content' | 'media-content';
+
+interface RedactionTarget {
+  element: Element;
+  rect: MaskRect;
+  reason: RedactionReason;
+  strategy: RedactionStrategy;
+}
+
+interface UnsupportedRedactionSurface {
+  tagName: string;
+  reason: UnsupportedSurfaceReason;
+  rect: MaskRect;
+}
+
+export interface RedactionSnapshot {
+  targets: RedactionTarget[];
+  unsupportedSurfaces: UnsupportedRedactionSurface[];
+  redactionCount: number;
+}
+
+export interface RedactionSummary {
+  count: number;
+  hasLimitations: boolean;
+}
+
+export class MaskApplicationError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'MaskApplicationError';
+  }
+}
+
+const EXPLICIT_SELECTOR =
+  '[data-bugdrop-mask], [data-bugdrop-redact], [data-bd-redact], [data-bugdrop-redacted]';
+const DEFAULT_SELECTOR =
+  'input[type="password"], input[autocomplete*="cc-number"], input[autocomplete*="cc-csc"], input[autocomplete*="cc-exp"]';
+const UNSUPPORTED_SURFACE_SELECTOR = 'iframe, canvas, img, svg, video';
+const PIXEL_CONTENT_TAGS = new Set(['CANVAS', 'IMG', 'SVG']);
+const MEDIA_CONTENT_TAGS = new Set(['VIDEO']);
+
+function getRedactionReason(el: Element): RedactionReason | null {
+  if (el.matches(EXPLICIT_SELECTOR)) return 'developer-marked';
+  if (el.matches(DEFAULT_SELECTOR)) return 'sensitive-input';
+  return null;
+}
+
+function createTarget(el: Element, reason: RedactionReason): RedactionTarget | null {
+  const rect = el.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) return null;
+  return {
+    element: el,
+    rect: {
+      x: rect.left + window.scrollX,
+      y: rect.top + window.scrollY,
+      w: rect.width,
+      h: rect.height,
+    },
+    reason,
+    strategy: 'canvas-mask',
+  };
+}
+
+export function createRedactionSnapshot(root: Element): RedactionSnapshot {
+  const targets: RedactionTarget[] = [];
+  const unsupportedSurfaces: UnsupportedRedactionSurface[] = [];
+  if (isBugDropOwnedNode(root)) {
+    return { targets, unsupportedSurfaces, redactionCount: 0 };
+  }
+  const rootReason = getRedactionReason(root);
+
+  if (rootReason) {
+    const rootTarget = createTarget(root, rootReason);
+    if (rootTarget) {
+      targets.push(rootTarget);
+      collectUnsupportedSurfaces(root, unsupportedSurfaces);
+    }
+    return {
+      targets,
+      unsupportedSurfaces,
+      redactionCount: targets.length,
+    };
+  }
+
+  walk(root, targets, unsupportedSurfaces);
+  walkOpenShadowRoot(root, targets, unsupportedSurfaces);
+  return {
+    targets,
+    unsupportedSurfaces,
+    redactionCount: targets.length,
+  };
+}
+
+export function createRedactionPlan(root: Element): RedactionSnapshot {
+  return createRedactionSnapshot(root);
+}
+
+export function collectMaskRects(root: Element): MaskRect[] {
+  return createRedactionSnapshot(root).targets.map(target => target.rect);
+}
+
+export function countMaskRects(root: Element = document.body, area?: DOMRect): number {
+  const rects = createRedactionSnapshot(root).targets.map(target => target.rect);
+  if (!area) return rects.length;
+  return rects.filter(rect => intersects(rect, area)).length;
+}
+
+export function summarizeRedactionSnapshot(
+  snapshot: RedactionSnapshot,
+  area?: DOMRect
+): RedactionSummary {
+  const targets = area
+    ? snapshot.targets.filter(target => intersects(target.rect, area))
+    : snapshot.targets;
+  const unsupportedSurfaces = area
+    ? snapshot.unsupportedSurfaces.filter(surface => intersects(surface.rect, area))
+    : snapshot.unsupportedSurfaces;
+
+  return {
+    count: targets.length,
+    hasLimitations: unsupportedSurfaces.length > 0,
+  };
+}
+
+function intersects(rect: MaskRect, area: DOMRect): boolean {
+  return (
+    rect.x < area.x + area.width &&
+    rect.x + rect.w > area.x &&
+    rect.y < area.y + area.height &&
+    rect.y + rect.h > area.y
+  );
+}
+
+function walk(
+  node: Element,
+  targets: RedactionTarget[],
+  unsupportedSurfaces: UnsupportedRedactionSurface[]
+): void {
+  for (const child of Array.from(node.children)) {
+    if (isBugDropOwnedNode(child)) continue;
+    const reason = getRedactionReason(child);
+    if (reason) {
+      const target = createTarget(child, reason);
+      if (target) {
+        targets.push(target);
+        collectUnsupportedSurfaces(child, unsupportedSurfaces);
+      }
+      // Top-most-ancestor rule: do not descend into masked subtrees.
+      continue;
+    }
+    walk(child, targets, unsupportedSurfaces);
+    walkOpenShadowRoot(child, targets, unsupportedSurfaces);
+  }
+}
+
+function walkOpenShadowRoot(
+  node: Element,
+  targets: RedactionTarget[],
+  unsupportedSurfaces: UnsupportedRedactionSurface[]
+): void {
+  const shadowRoot = node.shadowRoot;
+  if (!shadowRoot) return;
+
+  for (const child of Array.from(shadowRoot.children)) {
+    const reason = getRedactionReason(child);
+    if (reason) {
+      const target = createTarget(child, reason);
+      if (target) {
+        targets.push(target);
+        collectUnsupportedSurfaces(child, unsupportedSurfaces);
+      }
+      continue;
+    }
+    walk(child, targets, unsupportedSurfaces);
+    walkOpenShadowRoot(child, targets, unsupportedSurfaces);
+  }
+}
+
+function collectUnsupportedSurfaces(root: Element, surfaces: UnsupportedRedactionSurface[]): void {
+  collectUnsupportedSurface(root, surfaces);
+  for (const child of Array.from(root.querySelectorAll(UNSUPPORTED_SURFACE_SELECTOR))) {
+    collectUnsupportedSurface(child, surfaces);
+  }
+  walkOpenShadowUnsupportedSurfaces(root, surfaces);
+}
+
+function collectUnsupportedSurface(
+  element: Element,
+  surfaces: UnsupportedRedactionSurface[]
+): void {
+  const reason = getUnsupportedSurfaceReason(element);
+  if (!reason) return;
+
+  const target = createTarget(element, getRedactionReason(element) ?? 'developer-marked');
+  if (!target) return;
+
+  surfaces.push({
+    tagName: element.tagName,
+    reason,
+    rect: target.rect,
+  });
+}
+
+function getUnsupportedSurfaceReason(element: Element): UnsupportedSurfaceReason | null {
+  const tagName = element.tagName.toUpperCase();
+  if (tagName === 'IFRAME') return 'embedded-document';
+  if (PIXEL_CONTENT_TAGS.has(tagName)) return 'pixel-content';
+  if (MEDIA_CONTENT_TAGS.has(tagName)) return 'media-content';
+  return null;
+}
+
+function walkOpenShadowUnsupportedSurfaces(
+  root: Element,
+  surfaces: UnsupportedRedactionSurface[]
+): void {
+  const shadowRoot = root.shadowRoot;
+  if (shadowRoot) {
+    for (const child of Array.from(shadowRoot.querySelectorAll(UNSUPPORTED_SURFACE_SELECTOR))) {
+      collectUnsupportedSurface(child, surfaces);
+    }
+  }
+
+  for (const child of Array.from(root.children)) {
+    walkOpenShadowUnsupportedSurfaces(child, surfaces);
+  }
+}
+
+export function translateMaskRect(
+  rect: MaskRect,
+  pixelRatio: number,
+  originOffset: { x: number; y: number },
+  canvasWidth: number,
+  canvasHeight: number
+): MaskRect {
+  const rawX = (rect.x - originOffset.x) * pixelRatio;
+  const rawY = (rect.y - originOffset.y) * pixelRatio;
+  const rawW = rect.w * pixelRatio;
+  const rawH = rect.h * pixelRatio;
+
+  const x = Math.max(0, Math.floor(rawX) - 1);
+  const y = Math.max(0, Math.floor(rawY) - 1);
+  const right = Math.min(canvasWidth, Math.ceil(rawX + rawW) + 1);
+  const bottom = Math.min(canvasHeight, Math.ceil(rawY + rawH) + 1);
+
+  return {
+    x,
+    y,
+    w: right - x,
+    h: bottom - y,
+  };
+}
+
+export async function applyMaskToImage(
+  dataUrl: string,
+  rects: MaskRect[],
+  pixelRatio: number,
+  originOffset: { x: number; y: number } = { x: 0, y: 0 }
+): Promise<string> {
+  if (rects.length === 0) return dataUrl;
+
+  const img = await loadImage(dataUrl);
+  const canvas = document.createElement('canvas');
+  canvas.width = img.naturalWidth || img.width;
+  canvas.height = img.naturalHeight || img.height;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new MaskApplicationError('Failed to get canvas context for privacy masking');
+
+  ctx.drawImage(img, 0, 0);
+  ctx.fillStyle = '#000';
+  for (const rect of rects) {
+    const t = translateMaskRect(rect, pixelRatio, originOffset, canvas.width, canvas.height);
+    if (!(t.w > 0 && t.h > 0)) continue;
+    ctx.fillRect(t.x, t.y, t.w, t.h);
+  }
+
+  return canvas.toDataURL('image/png');
+}
+
+function loadImage(dataUrl: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () =>
+      reject(new MaskApplicationError('Failed to load image for privacy masking'));
+    img.src = dataUrl;
+  });
+}
+import { isBugDropOwnedNode } from './owned-roots';

--- a/scripts/default-flow-fixed-baseline/src/widget/owned-roots.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/owned-roots.ts.txt
@@ -1,0 +1,28 @@
+const BUGDROP_OWNED_SELECTOR = '#bugdrop-host, [data-bugdrop-owned]';
+
+export function isBugDropOwnedNode(node: unknown): boolean {
+  if (node instanceof ShadowRoot) return isBugDropOwnedNode(node.host);
+  if (!(node instanceof Element)) return false;
+  if (node.matches(BUGDROP_OWNED_SELECTOR) || node.closest(BUGDROP_OWNED_SELECTOR)) return true;
+  const root = node.getRootNode();
+  return root instanceof ShadowRoot && isBugDropOwnedNode(root.host);
+}
+
+export async function withBugDropOwnedRootsHidden<T>(action: () => Promise<T>): Promise<T> {
+  const roots = Array.from(document.querySelectorAll<HTMLElement>(BUGDROP_OWNED_SELECTOR));
+  const styles = roots.map(root => ({
+    root,
+    value: root.style.getPropertyValue('visibility'),
+    priority: root.style.getPropertyPriority('visibility'),
+  }));
+
+  for (const { root } of styles) root.style.setProperty('visibility', 'hidden', 'important');
+  try {
+    return await action();
+  } finally {
+    for (const { root, value, priority } of styles) {
+      if (value) root.style.setProperty('visibility', value, priority);
+      else root.style.removeProperty('visibility');
+    }
+  }
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/picker-style.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/picker-style.ts.txt
@@ -1,0 +1,43 @@
+import { resolveAccentColor } from '../defaults';
+import { sanitizeCssColor, sanitizeCssFontFamily, sanitizeNonNegativePixelValue } from './sanitize';
+
+export interface PickerStyle {
+  accentColor?: string;
+  font?: string;
+  radius?: string;
+  borderWidth?: string;
+  bgColor?: string;
+  textColor?: string;
+  borderColor?: string;
+  theme?: string;
+}
+
+export interface ResolvedPickerStyle {
+  accent: string;
+  fontFamily: string;
+  radius: string;
+  bw: string;
+  tooltipBg: string;
+  tooltipText: string;
+  tooltipBorder: string;
+}
+
+export function resolvePickerStyle(style?: PickerStyle): ResolvedPickerStyle {
+  const isDark = style?.theme === 'dark';
+  const radius = sanitizeNonNegativePixelValue(style?.radius);
+  const borderWidth = sanitizeNonNegativePixelValue(style?.borderWidth);
+  const fontFamily = sanitizeCssFontFamily(style?.font);
+
+  return {
+    accent: resolveAccentColor(sanitizeCssColor(style?.accentColor)),
+    fontFamily:
+      style?.font === 'inherit'
+        ? 'system-ui, sans-serif'
+        : fontFamily || "'Space Grotesk', system-ui, sans-serif",
+    radius: radius !== undefined ? `${radius}px` : '6px',
+    bw: borderWidth !== undefined ? String(borderWidth) : '3',
+    tooltipBg: sanitizeCssColor(style?.bgColor) || (isDark ? '#0f172a' : '#1a1a1a'),
+    tooltipText: sanitizeCssColor(style?.textColor) || '#f1f5f9',
+    tooltipBorder: sanitizeCssColor(style?.borderColor) || (isDark ? '#334155' : '#333'),
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/picker-target.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/picker-target.ts.txt
@@ -1,0 +1,132 @@
+const KNOWN_ROLES = new Set([
+  'alert',
+  'alertdialog',
+  'application',
+  'article',
+  'banner',
+  'button',
+  'cell',
+  'checkbox',
+  'columnheader',
+  'combobox',
+  'complementary',
+  'contentinfo',
+  'definition',
+  'dialog',
+  'directory',
+  'document',
+  'feed',
+  'figure',
+  'form',
+  'grid',
+  'gridcell',
+  'group',
+  'heading',
+  'img',
+  'link',
+  'list',
+  'listbox',
+  'listitem',
+  'log',
+  'main',
+  'marquee',
+  'math',
+  'menu',
+  'menubar',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'meter',
+  'navigation',
+  'none',
+  'note',
+  'option',
+  'presentation',
+  'progressbar',
+  'radio',
+  'radiogroup',
+  'region',
+  'row',
+  'rowgroup',
+  'rowheader',
+  'scrollbar',
+  'search',
+  'searchbox',
+  'separator',
+  'slider',
+  'spinbutton',
+  'status',
+  'switch',
+  'tab',
+  'table',
+  'tablist',
+  'tabpanel',
+  'term',
+  'textbox',
+  'timer',
+  'toolbar',
+  'tooltip',
+  'tree',
+  'treegrid',
+  'treeitem',
+]);
+const CLICKABLE_ROLES = new Set([
+  'button',
+  'checkbox',
+  'link',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'radio',
+  'searchbox',
+  'switch',
+  'tab',
+  'textbox',
+]);
+const CLICKABLE_FORM_TAGS = new Set(['button', 'input', 'select', 'textarea']);
+
+export function getSelectionTarget(element: Element): Element {
+  return getNearestClickableAncestor(element) ?? element;
+}
+
+function getNearestClickableAncestor(element: Element): Element | null {
+  const { body, documentElement } = element.ownerDocument;
+  let current: Element | null = element;
+
+  while (current && current !== body && current !== documentElement) {
+    if (isClickableElement(current)) return current;
+    current = current.parentElement;
+  }
+
+  return null;
+}
+
+function isClickableElement(element: Element): boolean {
+  if (element.getAttribute('aria-disabled') === 'true') return false;
+
+  const tagName = element.tagName.toLowerCase();
+  if (tagName === 'a') return element.hasAttribute('href');
+  if (CLICKABLE_FORM_TAGS.has(tagName)) {
+    return !('disabled' in element && (element as HTMLButtonElement).disabled);
+  }
+  if (tagName === 'summary') return true;
+
+  const role = getFirstRecognizedRole(element);
+  if (role && CLICKABLE_ROLES.has(role)) return true;
+
+  const tabIndex = element.getAttribute('tabindex');
+  return tabIndex !== null && Number.parseInt(tabIndex, 10) >= 0;
+}
+
+function getFirstRecognizedRole(element: Element): string | null {
+  const role = element.getAttribute('role');
+  if (!role) return null;
+
+  for (const roleToken of role.split(/\s+/)) {
+    const normalizedRole = roleToken.toLowerCase();
+    if (KNOWN_ROLES.has(normalizedRole)) return normalizedRole;
+  }
+
+  return null;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/picker.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/picker.ts.txt
@@ -1,0 +1,381 @@
+/* eslint-disable max-lines, max-lines-per-function */
+import { resolvePickerStyle, type PickerStyle, type ResolvedPickerStyle } from './picker-style';
+import { getSelectionTarget } from './picker-target';
+import { isBugDropOwnedNode } from './owned-roots';
+import { t } from './i18n';
+
+export { resolvePickerStyle, type PickerStyle };
+
+const PICKER_CHROME_IDS = new Set([
+  'bugdrop-element-picker-overlay',
+  'bugdrop-element-picker-highlight',
+  'bugdrop-element-picker-tooltip',
+  'bugdrop-element-picker-cancel',
+]);
+
+function usesCoarsePointer(): boolean {
+  const hasTouchPoints = navigator.maxTouchPoints > 0;
+  if (!window.matchMedia) return hasTouchPoints;
+
+  return (
+    window.matchMedia('(hover: none), (pointer: coarse), (any-pointer: coarse)').matches ||
+    hasTouchPoints
+  );
+}
+
+function createOverlay(): HTMLDivElement {
+  const overlay = document.createElement('div');
+  overlay.id = 'bugdrop-element-picker-overlay';
+  overlay.style.cssText = `
+    position: fixed;
+    inset: 0;
+    z-index: 2147483647;
+    cursor: crosshair;
+    touch-action: none;
+    user-select: none;
+    background: transparent;
+  `;
+  return overlay;
+}
+
+function createHighlight(
+  style: Pick<ResolvedPickerStyle, 'accent' | 'bw' | 'radius'>
+): HTMLDivElement {
+  const highlight = document.createElement('div');
+  highlight.id = 'bugdrop-element-picker-highlight';
+  highlight.style.cssText = `
+    position: fixed;
+    box-sizing: content-box;
+    pointer-events: none;
+    border: ${style.bw}px solid ${style.accent};
+    background: transparent;
+    z-index: 2147483645;
+    transition: all 0.05s ease-out;
+    box-shadow: none;
+    border-radius: ${style.radius};
+  `;
+  return highlight;
+}
+
+function createTooltip(
+  style: ResolvedPickerStyle,
+  showInlineCancel: boolean
+): { tooltip: HTMLDivElement; cancelButton: HTMLButtonElement | null } {
+  const tooltip = document.createElement('div');
+  tooltip.id = 'bugdrop-element-picker-tooltip';
+  tooltip.style.cssText = `
+    position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: ${style.tooltipBg};
+    color: ${style.tooltipText};
+    padding: 14px 28px;
+    border-radius: ${style.radius};
+    font-family: ${style.fontFamily};
+    font-size: 14px;
+    font-weight: 500;
+    z-index: 2147483647;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border: ${style.bw}px solid ${style.tooltipBorder};
+  `;
+
+  if (!showInlineCancel) {
+    tooltip.textContent = `${t().elementPickerInstruction} (${t().escToCancel})`;
+    return { tooltip, cancelButton: null };
+  }
+
+  const cancelButton = createCancelButton(style.accent);
+  tooltip.append(`${t().elementPickerTouchInstruction} (`, cancelButton, ')');
+  return { tooltip, cancelButton };
+}
+
+function updateHighlight(highlight: HTMLDivElement, element: Element): void {
+  const rect = element.getBoundingClientRect();
+  highlight.style.top = `${rect.top - 2}px`;
+  highlight.style.left = `${rect.left - 2}px`;
+  highlight.style.width = `${rect.width + 4}px`;
+  highlight.style.height = `${rect.height + 4}px`;
+  highlight.style.display = 'block';
+}
+
+interface PickerListeners {
+  overlay: HTMLDivElement;
+  onPointerDown: (e: PointerEvent) => void;
+  onPointerMove: (e: PointerEvent) => void;
+  onPointerUp: (e: PointerEvent) => void;
+  onPointerCancel: (e: PointerEvent) => void;
+  onMouseMove: (e: MouseEvent) => void;
+}
+
+function addPickerListeners(listeners: PickerListeners): void {
+  listeners.overlay.addEventListener('pointerdown', listeners.onPointerDown);
+  listeners.overlay.addEventListener('pointermove', listeners.onPointerMove);
+  listeners.overlay.addEventListener('pointerup', listeners.onPointerUp);
+  listeners.overlay.addEventListener('pointercancel', listeners.onPointerCancel);
+  document.addEventListener('mousemove', listeners.onMouseMove, true);
+}
+
+function removePickerListeners(listeners: PickerListeners): void {
+  listeners.overlay.removeEventListener('pointerdown', listeners.onPointerDown);
+  listeners.overlay.removeEventListener('pointermove', listeners.onPointerMove);
+  listeners.overlay.removeEventListener('pointerup', listeners.onPointerUp);
+  listeners.overlay.removeEventListener('pointercancel', listeners.onPointerCancel);
+  document.removeEventListener('mousemove', listeners.onMouseMove, true);
+}
+
+export function createElementPicker(
+  style?: PickerStyle,
+  signal?: AbortSignal
+): Promise<Element | null> {
+  return new Promise(resolve => {
+    // Small delay to ensure any modal has been removed from the DOM
+    setTimeout(() => {
+      if (signal?.aborted) resolve(null);
+      else startPicker(resolve, style, signal);
+    }, 50);
+  });
+}
+
+function startPicker(
+  resolve: (element: Element | null) => void,
+  style?: PickerStyle,
+  signal?: AbortSignal
+): void {
+  const { accent, fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder } =
+    resolvePickerStyle(style);
+
+  const overlay = createOverlay();
+  document.body.appendChild(overlay);
+
+  const highlight = createHighlight({ accent, bw, radius });
+  document.body.appendChild(highlight);
+
+  const { tooltip, cancelButton } = createTooltip(
+    { accent, fontFamily, radius, bw, tooltipBg, tooltipText, tooltipBorder },
+    usesCoarsePointer()
+  );
+  document.body.appendChild(tooltip);
+
+  let currentElement: Element | null = null;
+  let activePointerId: number | null = null;
+  let resolved = false;
+  let clickBlockerRemovalTimer: number | undefined;
+
+  function isPickerChrome(element: Element): boolean {
+    return (
+      element === overlay ||
+      element === highlight ||
+      element === tooltip ||
+      PICKER_CHROME_IDS.has(element.id)
+    );
+  }
+
+  function getSelectableElementAtPoint(x: number, y: number): Element | undefined {
+    const previousPointerEvents = overlay.style.pointerEvents;
+    overlay.style.pointerEvents = 'none';
+    const elementsAtPoint = (() => {
+      try {
+        return document.elementsFromPoint(x, y);
+      } finally {
+        overlay.style.pointerEvents = previousPointerEvents;
+      }
+    })();
+
+    return elementsAtPoint.find(el => {
+      if (isPickerChrome(el)) return false;
+      if (isBugDropOwnedNode(el)) return false;
+      return true;
+    });
+  }
+
+  function resolveSelectionAtPoint(x: number, y: number, fallback: Element | null) {
+    const target = getSelectableElementAtPoint(x, y);
+    return target ? getSelectionTarget(target) : fallback;
+  }
+
+  function onMouseMove(e: MouseEvent) {
+    // Get the element under the cursor, ignoring our picker elements
+    currentElement = resolveSelectionAtPoint(e.clientX, e.clientY, currentElement);
+    if (!currentElement) return;
+    updateHighlight(highlight, currentElement);
+  }
+
+  function selectElementAtPoint(x: number, y: number, keepClickBlocker = false) {
+    currentElement = resolveSelectionAtPoint(x, y, currentElement);
+    finish(currentElement, keepClickBlocker);
+  }
+
+  function finish(element: Element | null, keepClickBlocker = false) {
+    if (resolved) return;
+    resolved = true;
+    cleanup(keepClickBlocker);
+    resolve(element);
+  }
+
+  const onAbort = () => finish(null);
+
+  function onPointerDown(e: PointerEvent) {
+    if (activePointerId !== null || !e.isPrimary) return;
+    e.preventDefault();
+    e.stopPropagation();
+    activePointerId = e.pointerId;
+    overlay.setPointerCapture?.(e.pointerId);
+    currentElement = resolveSelectionAtPoint(e.clientX, e.clientY, currentElement);
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (activePointerId !== null && e.pointerId !== activePointerId) return;
+    e.preventDefault();
+    e.stopPropagation();
+    onMouseMove(e);
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (activePointerId !== null && e.pointerId !== activePointerId) return;
+    e.preventDefault();
+    e.stopPropagation();
+    activePointerId = null;
+    overlay.releasePointerCapture?.(e.pointerId);
+    selectElementAtPoint(e.clientX, e.clientY, true);
+  }
+
+  function onPointerCancel(e: PointerEvent) {
+    if (e.pointerId !== activePointerId) return;
+    activePointerId = null;
+    overlay.releasePointerCapture?.(e.pointerId);
+  }
+
+  function onClick(e: MouseEvent) {
+    if (resolved) {
+      document.removeEventListener('click', onClick, true);
+      if (isBugDropOwnedNode(e.target)) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      return;
+    }
+
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    if (e.target instanceof Element && e.target.id === 'bugdrop-element-picker-cancel') {
+      finish(null);
+      return;
+    }
+    selectElementAtPoint(e.clientX, e.clientY);
+  }
+
+  function blockPagePointerEvent(e: PointerEvent) {
+    if (e.target instanceof Element && e.target.id === 'bugdrop-element-picker-cancel') return;
+
+    if (e.type === 'pointerdown') onPointerDown(e);
+    if (e.type === 'pointermove') onPointerMove(e);
+    if (e.type === 'pointerup') onPointerUp(e);
+    if (e.type === 'pointercancel') onPointerCancel(e);
+
+    e.preventDefault();
+    e.stopImmediatePropagation();
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      finish(null);
+    }
+  }
+
+  function onCancelClick(e: MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    finish(null);
+  }
+
+  function cleanup(keepClickBlocker = false) {
+    if (clickBlockerRemovalTimer !== undefined) {
+      window.clearTimeout(clickBlockerRemovalTimer);
+      clickBlockerRemovalTimer = undefined;
+    }
+    removePickerListeners({
+      overlay,
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel,
+      onMouseMove,
+    });
+    if (keepClickBlocker) {
+      clickBlockerRemovalTimer = window.setTimeout(() => {
+        document.removeEventListener('click', onClick, true);
+        clickBlockerRemovalTimer = undefined;
+      }, 1000);
+    } else {
+      document.removeEventListener('click', onClick, true);
+    }
+    document.removeEventListener('keydown', onKeyDown);
+    removePagePointerBlockers();
+    cancelButton?.removeEventListener('click', onCancelClick);
+    signal?.removeEventListener('abort', onAbort);
+    overlay.remove();
+    highlight.remove();
+    tooltip.remove();
+    document.body.style.cursor = '';
+  }
+
+  function addPagePointerBlockers() {
+    window.addEventListener('pointerdown', blockPagePointerEvent, true);
+    window.addEventListener('pointermove', blockPagePointerEvent, true);
+    window.addEventListener('pointerup', blockPagePointerEvent, true);
+    window.addEventListener('pointercancel', blockPagePointerEvent, true);
+  }
+
+  function removePagePointerBlockers() {
+    window.removeEventListener('pointerdown', blockPagePointerEvent, true);
+    window.removeEventListener('pointermove', blockPagePointerEvent, true);
+    window.removeEventListener('pointerup', blockPagePointerEvent, true);
+    window.removeEventListener('pointercancel', blockPagePointerEvent, true);
+  }
+
+  // Set cursor and start listening
+  document.body.style.cursor = 'crosshair';
+  addPagePointerBlockers();
+  addPickerListeners({
+    overlay,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+    onMouseMove,
+  });
+  document.addEventListener('click', onClick, true);
+  document.addEventListener('keydown', onKeyDown);
+  cancelButton?.addEventListener('click', onCancelClick);
+  signal?.addEventListener('abort', onAbort, { once: true });
+}
+
+function createCancelButton(accent: string): HTMLButtonElement {
+  const cancelButton = document.createElement('button');
+  cancelButton.id = 'bugdrop-element-picker-cancel';
+  cancelButton.type = 'button';
+  cancelButton.textContent = t().cancel;
+  cancelButton.style.cssText = `
+    align-items: center;
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: ${accent};
+    cursor: pointer;
+    display: inline-flex;
+    font: inherit;
+    font-weight: 700;
+    justify-content: center;
+    margin: -10px -12px;
+    min-height: 44px;
+    min-width: 44px;
+    padding: 10px 12px;
+    pointer-events: auto;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    touch-action: manipulation;
+    white-space: nowrap;
+    width: auto;
+  `;
+  return cancelButton;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/radix-compat.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/radix-compat.ts.txt
@@ -1,0 +1,121 @@
+/*
+ * Compatibility layer for host pages built on Radix-style dismissable layers
+ * (and other focus-scope libraries): stops the host page from treating
+ * interaction with the BugDrop shadow DOM as an "outside" interaction that
+ * would dismiss its own dialogs or yank focus back.
+ */
+
+const ownedRoots = new Set<HTMLElement>();
+let installed = false;
+let replayingFocusOut = false;
+
+export function installRadixDialogCompatibility(host: HTMLElement): () => void {
+  ownedRoots.add(host);
+  if (!installed) installGlobalCompatibilityListeners();
+  let disposed = false;
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    ownedRoots.delete(host);
+  };
+}
+
+function installGlobalCompatibilityListeners(): void {
+  installed = true;
+  const preventBugDropDismissal = (event: Event) => {
+    if (isBugDropInteraction(event)) {
+      event.preventDefault();
+    }
+  };
+  const keepBugDropFocus = (event: Event) => {
+    if (replayingFocusOut) {
+      return;
+    }
+
+    if (isBugDropFocusEvent(event)) {
+      if (event.type === 'focusin') {
+        event.stopImmediatePropagation();
+        return;
+      }
+
+      if (event.type === 'focusout') {
+        replayingFocusOut = true;
+        try {
+          replayHostFocusOut(event);
+        } finally {
+          replayingFocusOut = false;
+        }
+        event.stopImmediatePropagation();
+        return;
+      }
+
+      event.stopImmediatePropagation();
+    }
+  };
+
+  for (const eventType of [
+    'dismissableLayer.pointerDownOutside',
+    'dismissableLayer.interactOutside',
+  ] as const) {
+    document.addEventListener(eventType, preventBugDropDismissal, true);
+  }
+  window.addEventListener('focusin', keepBugDropFocus, true);
+  window.addEventListener('focusout', keepBugDropFocus, true);
+}
+
+function isBugDropInteraction(event: Event): boolean {
+  const originalEvent = (event as CustomEvent<{ originalEvent?: Event }>).detail?.originalEvent;
+  const path =
+    typeof originalEvent?.composedPath === 'function'
+      ? originalEvent.composedPath()
+      : typeof event.composedPath === 'function'
+        ? event.composedPath()
+        : [];
+
+  return Array.from(ownedRoots).some(
+    host => path.includes(host) || (originalEvent?.target ?? event.target) === host
+  );
+}
+
+function isBugDropFocusEvent(event: Event): boolean {
+  if (!(event instanceof FocusEvent)) {
+    return isBugDropInteraction(event);
+  }
+
+  if (event.type === 'focusin') {
+    return isBugDropInteraction(event);
+  }
+
+  if (event.type !== 'focusout') {
+    return false;
+  }
+
+  const nextFocusedNode = event.relatedTarget;
+  const nextFocusIsBugDrop = Array.from(ownedRoots).some(
+    host =>
+      nextFocusedNode === host ||
+      (nextFocusedNode instanceof Node && (host.shadowRoot?.contains(nextFocusedNode) ?? false))
+  );
+  return nextFocusIsBugDrop && !isBugDropInteraction(event);
+}
+
+function replayHostFocusOut(event: Event): void {
+  const path = typeof event.composedPath === 'function' ? event.composedPath() : [];
+  for (const node of path) {
+    if (!(node instanceof HTMLElement)) {
+      continue;
+    }
+
+    node.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: false,
+        composed: false,
+        relatedTarget: event instanceof FocusEvent ? event.relatedTarget : null,
+      })
+    );
+
+    if (node === document.body) {
+      break;
+    }
+  }
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/sanitize.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/sanitize.ts.txt
@@ -1,0 +1,87 @@
+const UNSAFE_CSS_TOKEN_PATTERN = /[;{}<>]|\/\*|\*\/|@import|url\s*\(|<\/style/i;
+const CSS_IDENT_PATTERN = /^-?[_a-zA-Z][_a-zA-Z0-9-]*$/;
+const HEX_COLOR_PATTERN = /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+const CSS_FUNCTION_COLOR_PATTERN =
+  /^(?:rgb|rgba|hsl|hsla)\(\s*[-+.\d%]+\s*(?:,\s*[-+.\d%]+\s*){2,3}\)$/i;
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function sanitizeUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed === 'none') return trimmed;
+
+  try {
+    const url = new URL(trimmed, window.location.href);
+    if (url.protocol === 'https:' || url.protocol === 'http:') {
+      return trimmed;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+export function sanitizeCssColor(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || UNSAFE_CSS_TOKEN_PATTERN.test(trimmed)) return undefined;
+  if (HEX_COLOR_PATTERN.test(trimmed) || CSS_FUNCTION_COLOR_PATTERN.test(trimmed)) return trimmed;
+
+  if (CSS_IDENT_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (typeof CSS !== 'undefined' && CSS.supports?.('color', trimmed)) {
+    return trimmed;
+  }
+
+  return undefined;
+}
+
+export function sanitizeCssFontFamily(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  if (trimmed === 'inherit') return trimmed;
+  if (UNSAFE_CSS_TOKEN_PATTERN.test(trimmed)) return undefined;
+  if (!/^[\w\s"',.-]+$/.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+export function sanitizeNonNegativeNumber(value: string | undefined): number | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(trimmed)) return undefined;
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function sanitizeNonNegativePixelValue(value: string | undefined): number | undefined {
+  const trimmed = value?.trim();
+  const match = trimmed?.match(/^((?:0|[1-9]\d*)(?:\.\d+)?)(?:px)?$/);
+  if (!match) return undefined;
+
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function sanitizePositiveInteger(value: string | undefined): number | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !/^[1-9]\d*$/.test(trimmed)) return undefined;
+
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+export function sanitizeShadowPreset(
+  value: string | undefined
+): 'none' | 'soft' | 'hard' | undefined {
+  if (value === 'none' || value === 'soft' || value === 'hard') return value;
+  return undefined;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/screenshot-options.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/screenshot-options.ts.txt
@@ -1,0 +1,107 @@
+import {
+  beginViewportCapture,
+  canCaptureViewportNatively,
+  getRedactionCount,
+  isFullPageDisabled,
+} from './screenshot';
+import { createModal, redactionNoteHtml } from './ui';
+import { escapeWidgetText, t } from './i18n';
+
+export type ScreenshotChoice =
+  | { kind: 'skip' }
+  | { kind: 'capture' }
+  | { kind: 'element' }
+  | { kind: 'area' }
+  | { kind: 'cancel' }
+  | { kind: 'viewport'; capture: Promise<string> };
+
+export function showScreenshotOptions(
+  root: HTMLElement,
+  opts?: { allowSkip?: boolean }
+): Promise<ScreenshotChoice> {
+  const fullPageDisabled = isFullPageDisabled();
+  const nativeViewportAvailable = fullPageDisabled && canCaptureViewportNatively();
+  const allowSkip = opts?.allowSkip !== false;
+
+  let redactionNote = '';
+  if (nativeViewportAvailable) {
+    redactionNote = redactionNoteHtml(t().viewportRedactionWarning);
+  } else if (getRedactionCount() > 0) {
+    redactionNote = redactionNoteHtml(t().redactionReviewNote);
+  }
+
+  return new Promise(resolve => {
+    const complexNote = fullPageDisabled
+      ? `<p style="margin: 0 0 12px; padding: 8px 12px; background: var(--bd-bg-secondary, #f5f5f5); border-radius: 6px; font-size: 13px; color: var(--bd-text-secondary);">${nativeViewportAvailable ? escapeWidgetText(t().pageTooComplexViewportNote) : escapeWidgetText(t().pageTooComplexElementNote)}</p>`
+      : '';
+
+    let primaryCaptureButton = '';
+    if (!fullPageDisabled) {
+      primaryCaptureButton = `<button class="bd-btn bd-btn-primary" data-action="capture">${escapeWidgetText(t().fullPage)}</button>`;
+    } else if (nativeViewportAvailable) {
+      primaryCaptureButton = `<button class="bd-btn bd-btn-primary" data-action="viewport">${escapeWidgetText(t().captureViewport)}</button>`;
+    }
+
+    const modal = createModal(
+      root,
+      t().captureScreenshotTitle,
+      `
+        <p style="margin: 0 0 16px; color: var(--bd-text-secondary);">${escapeWidgetText(t().chooseWhatToCapture)}</p>
+        ${complexNote}
+        ${redactionNote}
+        <div class="bd-actions bd-screenshot-actions">
+          ${primaryCaptureButton}
+          ${fullPageDisabled ? '' : `<button class="bd-btn bd-btn-secondary" data-action="area">${escapeWidgetText(t().selectArea)}</button>`}
+          <button class="bd-btn bd-btn-secondary" data-action="element">${escapeWidgetText(t().selectElement)}</button>
+          ${allowSkip ? `<button class="bd-btn bd-btn-quiet" data-action="skip">${escapeWidgetText(t().skipScreenshot)}</button>` : ''}
+        </div>
+      `
+    );
+
+    const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
+    const skipBtn = modal.querySelector('[data-action="skip"]') as HTMLElement | null;
+    const elementBtn = modal.querySelector('[data-action="element"]') as HTMLElement;
+    const areaBtn = modal.querySelector('[data-action="area"]') as HTMLElement;
+    const captureBtn = modal.querySelector('[data-action="capture"]') as HTMLElement;
+    const viewportBtn = modal.querySelector('[data-action="viewport"]') as HTMLElement;
+
+    closeBtn?.addEventListener('click', () => {
+      modal.remove();
+      resolve({ kind: 'cancel' });
+    });
+
+    skipBtn?.addEventListener('click', () => {
+      modal.remove();
+      resolve({ kind: 'skip' });
+    });
+
+    elementBtn?.addEventListener('click', () => {
+      modal.remove();
+      resolve({ kind: 'element' });
+    });
+
+    areaBtn?.addEventListener('click', () => {
+      modal.remove();
+      resolve({ kind: 'area' });
+    });
+
+    captureBtn?.addEventListener('click', () => {
+      modal.remove();
+      resolve({ kind: 'capture' });
+    });
+
+    viewportBtn?.addEventListener('click', () => {
+      modal.remove();
+      // beginViewportCapture must run synchronously inside the click handler to
+      // preserve the user gesture required by getDisplayMedia. The in-flight
+      // promise is then handed to capture-flow for awaiting.
+      const capture = beginViewportCapture();
+      capture.catch(() => {
+        // Attach a handler immediately so an early rejection does not surface
+        // as 'Unhandled promise rejection' in the brief window before the
+        // caller awaits this promise. The real error is still raised on await.
+      });
+      resolve({ kind: 'viewport', capture });
+    });
+  });
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/screenshot.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/screenshot.ts.txt
@@ -1,0 +1,347 @@
+import * as htmlToImage from 'html-to-image';
+import type { Options as HtmlToImageOptions } from 'html-to-image/lib/types';
+import { withCaptureTimeout } from './capture-timeout';
+import {
+  applyMaskToImage,
+  countMaskRects,
+  createRedactionSnapshot,
+  summarizeRedactionSnapshot,
+  type RedactionSnapshot,
+  type RedactionSummary,
+} from './mask';
+import { resolveAccentColor } from '../defaults';
+import { isBugDropOwnedNode } from './owned-roots';
+export { cropScreenshot } from './crop-screenshot';
+export { beginViewportCapture } from './viewport-capture';
+
+declare const __BUGDROP_ENABLE_TEST_HOOKS__: boolean;
+
+const DOM_COMPLEXITY_THRESHOLD = 3_000;
+const TRANSPARENT_IMAGE_PLACEHOLDER =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+export const FULL_PAGE_DISABLE_THRESHOLD = 10_000;
+export const SAFARI_FULL_PAGE_DISABLE_THRESHOLD = DOM_COMPLEXITY_THRESHOLD;
+
+export interface CaptureScreenshotOptions {
+  highlightElement?: Element;
+  highlightStyle?: {
+    accentColor?: string;
+    radius?: string;
+    borderWidth?: string;
+  };
+  pixelRatio?: number;
+}
+
+export interface CapturedScreenshot {
+  dataUrl: string;
+  redaction: RedactionSummary;
+}
+
+declare global {
+  interface Window {
+    __bugdropMockToPng?: typeof htmlToImage.toPng;
+  }
+}
+
+export function getDomNodeCount(): number {
+  return document.body.querySelectorAll('*').length;
+}
+
+export function isFullPageDisabled(): boolean {
+  return getDomNodeCount() >= getFullPageDisableThreshold();
+}
+
+export function getFullPageDisableThreshold(userAgent = navigator.userAgent): number {
+  return isSafariBrowser(userAgent)
+    ? SAFARI_FULL_PAGE_DISABLE_THRESHOLD
+    : FULL_PAGE_DISABLE_THRESHOLD;
+}
+
+export function isSafariBrowser(userAgent = navigator.userAgent): boolean {
+  return (
+    /Safari\//.test(userAgent) &&
+    !/(Chrome|Chromium|CriOS|FxiOS|Edg|EdgiOS|OPR|Opera)\//.test(userAgent)
+  );
+}
+
+export function getPixelRatio(isFullPage: boolean, screenshotScale?: number): number {
+  if (isFullPage && getDomNodeCount() > DOM_COMPLEXITY_THRESHOLD) {
+    return 1;
+  }
+  const minScale = screenshotScale ?? 2;
+  return Math.max(window.devicePixelRatio || 1, minScale);
+}
+
+export function canCaptureViewportNatively(): boolean {
+  const isSecureOrigin =
+    window.isSecureContext ||
+    location.protocol === 'https:' ||
+    location.hostname === 'localhost' ||
+    location.hostname === '127.0.0.1';
+  const hasCaptureApi =
+    typeof window.__bugdropMockViewportCapture === 'function' ||
+    typeof navigator.mediaDevices?.getDisplayMedia === 'function';
+
+  return isSecureOrigin && hasCaptureApi;
+}
+
+export async function captureScreenshot(
+  element?: Element,
+  screenshotScale?: number,
+  captureOptions: CaptureScreenshotOptions = {}
+): Promise<CapturedScreenshot> {
+  const target = element || document.body;
+  const isFullPage = !element;
+  const targetRect = element ? getDocumentRect(element) : getDocumentRect(document.body);
+  const highlightRect =
+    captureOptions.highlightElement && target.contains(captureOptions.highlightElement)
+      ? getDocumentRect(captureOptions.highlightElement)
+      : null;
+
+  const pixelRatio = captureOptions.pixelRatio ?? getPixelRatio(isFullPage, screenshotScale);
+  const elementStyle = element ? window.getComputedStyle(element) : null;
+
+  const toPng = getToPng();
+  const opts: HtmlToImageOptions = {
+    cacheBust: false,
+    imagePlaceholder: TRANSPARENT_IMAGE_PLACEHOLDER,
+    pixelRatio,
+    filter: shouldIncludeCaptureNode,
+    // Root margins position an element in its parent, but html-to-image copies them inside its
+    // border-box crop. Preserve computed vertical margins; clear horizontal margins to stop drift.
+    ...(elementStyle && (elementStyle.marginLeft !== '0px' || elementStyle.marginRight !== '0px')
+      ? { style: { margin: `${elementStyle.marginTop} 0px ${elementStyle.marginBottom} 0px` } }
+      : {}),
+  };
+
+  const redactionSnapshot = createRedactionSnapshot(target);
+  const originOffset = element ? { x: targetRect.x, y: targetRect.y } : { x: 0, y: 0 };
+
+  const capturePromise = toPng(target as HTMLElement, opts);
+  const dataUrl = await withCaptureTimeout(capturePromise);
+  const maskedDataUrl = await applyMaskToImage(
+    dataUrl,
+    redactionSnapshot.targets.map(target => target.rect),
+    pixelRatio,
+    originOffset
+  );
+
+  if (!highlightRect) {
+    return capturedScreenshot(maskedDataUrl, redactionSnapshot);
+  }
+
+  return capturedScreenshot(
+    await applyHighlightToImage(
+      maskedDataUrl,
+      highlightRect,
+      targetRect,
+      captureOptions.highlightStyle
+    ),
+    redactionSnapshot
+  );
+}
+
+export async function captureAreaScreenshot(
+  rect: DOMRect,
+  screenshotScale?: number,
+  captureOptions: CaptureScreenshotOptions = {}
+): Promise<CapturedScreenshot> {
+  const pixelRatio = captureOptions.pixelRatio ?? getPixelRatio(true, screenshotScale);
+  const targetRect = { x: rect.x, y: rect.y, w: rect.width, h: rect.height };
+  const highlightRect =
+    captureOptions.highlightElement && document.body.contains(captureOptions.highlightElement)
+      ? getDocumentRect(captureOptions.highlightElement)
+      : null;
+  const toPng = getToPng();
+  const opts: HtmlToImageOptions = {
+    cacheBust: false,
+    imagePlaceholder: TRANSPARENT_IMAGE_PLACEHOLDER,
+    pixelRatio,
+    width: rect.width,
+    height: rect.height,
+    style: {
+      transform: `translate(${-rect.x}px, ${-rect.y}px)`,
+      transformOrigin: 'top left',
+      width: `${document.documentElement.scrollWidth}px`,
+      height: `${document.documentElement.scrollHeight}px`,
+    },
+    filter: shouldIncludeCaptureNode,
+  };
+
+  const redactionSnapshot = createRedactionSnapshot(document.body);
+  const dataUrl = await withCaptureTimeout(toPng(document.body, opts));
+  const maskedDataUrl = await applyMaskToImage(
+    dataUrl,
+    redactionSnapshot.targets.map(target => target.rect),
+    pixelRatio,
+    {
+      x: rect.x,
+      y: rect.y,
+    }
+  );
+
+  if (!highlightRect) {
+    return capturedScreenshot(maskedDataUrl, redactionSnapshot, rect);
+  }
+
+  return capturedScreenshot(
+    await applyHighlightToImage(
+      maskedDataUrl,
+      highlightRect,
+      targetRect,
+      captureOptions.highlightStyle
+    ),
+    redactionSnapshot,
+    rect
+  );
+}
+
+export function getRedactionCount(element?: Element, rect?: DOMRect): number {
+  return countMaskRects(element ?? document.body, rect);
+}
+
+function shouldIncludeCaptureNode(node: HTMLElement): boolean {
+  if (isBugDropOwnedNode(node)) return false;
+
+  if (isHtmlImage(node) && isInvisibleOrZeroSize(node)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isHtmlImage(element: HTMLElement): boolean {
+  return element.tagName?.toUpperCase() === 'IMG';
+}
+
+function isInvisibleOrZeroSize(element: HTMLElement): boolean {
+  const style = (element.ownerDocument.defaultView ?? window).getComputedStyle(element);
+  if (style.display === 'none' || style.visibility === 'hidden') return true;
+
+  const rect = element.getBoundingClientRect();
+  return rect.width <= 0 || rect.height <= 0;
+}
+
+function getToPng(): typeof htmlToImage.toPng {
+  if (
+    (typeof __BUGDROP_ENABLE_TEST_HOOKS__ === 'undefined' || __BUGDROP_ENABLE_TEST_HOOKS__) &&
+    window.__bugdropMockToPng
+  ) {
+    return window.__bugdropMockToPng;
+  }
+  return htmlToImage.toPng;
+}
+
+function capturedScreenshot(
+  dataUrl: string,
+  snapshot: RedactionSnapshot,
+  area?: DOMRect
+): CapturedScreenshot {
+  return {
+    dataUrl,
+    redaction: summarizeRedactionSnapshot(snapshot, area),
+  };
+}
+
+async function applyHighlightToImage(
+  dataUrl: string,
+  rect: { x: number; y: number; w: number; h: number },
+  targetRect: { x: number; y: number; w: number; h: number },
+  style: CaptureScreenshotOptions['highlightStyle'] = {}
+): Promise<string> {
+  if (rect.w <= 0 || rect.h <= 0) return dataUrl;
+
+  const img = await loadImage(dataUrl);
+  const imageWidth = img.naturalWidth || img.width;
+  const imageHeight = img.naturalHeight || img.height;
+  const scaleX = imageWidth / Math.max(1, targetRect.w);
+  const scaleY = imageHeight / Math.max(1, targetRect.h);
+  const averageScale = Math.max(1, (scaleX + scaleY) / 2);
+  const borderWidth = getHighlightBorderWidth(style.borderWidth, averageScale);
+  const innerGap = 2 * averageScale;
+  const padding = innerGap + borderWidth / 2;
+  const rawX = (rect.x - targetRect.x) * scaleX - padding;
+  const rawY = (rect.y - targetRect.y) * scaleY - padding;
+  const rawW = rect.w * scaleX + padding * 2;
+  const rawH = rect.h * scaleY + padding * 2;
+  const overflowLeft = Math.max(0, Math.ceil(-rawX));
+  const overflowTop = Math.max(0, Math.ceil(-rawY));
+  const overflowRight = Math.max(0, Math.ceil(rawX + rawW - imageWidth));
+  const overflowBottom = Math.max(0, Math.ceil(rawY + rawH - imageHeight));
+
+  const canvas = document.createElement('canvas');
+  canvas.width = imageWidth + overflowLeft + overflowRight;
+  canvas.height = imageHeight + overflowTop + overflowBottom;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Failed to get canvas context for selected element highlight');
+  }
+
+  ctx.drawImage(img, overflowLeft, overflowTop);
+
+  const x = Math.round(rawX + overflowLeft);
+  const y = Math.round(rawY + overflowTop);
+  const w = Math.round(rawW);
+  const h = Math.round(rawH);
+  const radius = getHighlightRadius(style.radius, averageScale);
+  const accent = resolveAccentColor(style.accentColor);
+
+  drawRoundedRect(ctx, x, y, w, h, radius);
+  ctx.lineWidth = borderWidth;
+  ctx.strokeStyle = accent;
+  ctx.stroke();
+
+  return canvas.toDataURL('image/png');
+}
+
+function drawRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  radius: number
+): void {
+  const r = Math.max(0, Math.min(radius, w / 2, h / 2));
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function getHighlightBorderWidth(borderWidth: string | undefined, pixelRatio: number): number {
+  const parsed = Number.parseFloat(borderWidth || '3');
+  return Math.max(1, Math.round((Number.isFinite(parsed) ? parsed : 3) * pixelRatio));
+}
+
+function getHighlightRadius(radius: string | undefined, pixelRatio: number): number {
+  const parsed = Number.parseFloat(radius || '6');
+  return Math.max(0, Math.round((Number.isFinite(parsed) ? parsed : 6) * pixelRatio));
+}
+
+function getDocumentRect(element: Element): { x: number; y: number; w: number; h: number } {
+  const rect = element.getBoundingClientRect();
+  return {
+    x: rect.left + window.scrollX,
+    y: rect.top + window.scrollY,
+    w: rect.width,
+    h: rect.height,
+  };
+}
+
+function loadImage(dataUrl: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to load image for selected element highlight'));
+    img.src = dataUrl;
+  });
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/selector-metadata.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/selector-metadata.ts.txt
@@ -1,0 +1,223 @@
+const MAX_FULL_SELECTOR_CLASSES = 3;
+const MAX_FULL_SELECTOR_LENGTH = 1024;
+const MAX_FULL_SELECTOR_SEGMENT_LENGTH = 128;
+
+export function getElementSelector(element: Element): string {
+  const path: string[] = [];
+  const body = element.ownerDocument.body;
+  let current: Element | null = element;
+
+  if (current === body) {
+    return getTagSelector(current);
+  }
+
+  while (current && current !== body) {
+    let selector = getTagSelector(current);
+
+    if (current.id) {
+      selector = `#${escapeCssIdentifier(current.id)}`;
+      path.unshift(selector);
+      break;
+    }
+
+    const classes = getClassNames(current).slice(0, 2);
+    if (classes.length) {
+      selector += `.${classes.map(escapeCssIdentifier).join('.')}`;
+    }
+
+    path.unshift(selector);
+    current = current.parentElement;
+  }
+
+  return path.join(' > ');
+}
+
+export function getFullElementSelector(element: Element): string {
+  const ancestors = getAncestors(element);
+  const path = ancestors.map(getFullSelectorSegment);
+  const structuralPath = ancestors.map(buildStructuralSelectorSegment);
+
+  return limitSelectorLength(path, structuralPath, element);
+}
+
+function getAncestors(element: Element): Element[] {
+  const ancestors: Element[] = [];
+  let current: Element | null = element;
+
+  while (current) {
+    ancestors.unshift(current);
+    current = current.parentElement;
+  }
+
+  return ancestors;
+}
+
+function getFullSelectorSegment(element: Element): string {
+  const selector = buildFullSelectorSegment(element);
+  if (selector.length <= MAX_FULL_SELECTOR_SEGMENT_LENGTH) {
+    return selector;
+  }
+
+  return buildStructuralSelectorSegment(element);
+}
+
+function buildFullSelectorSegment(element: Element): string {
+  let selector = getTagSelector(element);
+
+  if (element.id) {
+    selector += `#${escapeCssIdentifier(element.id)}`;
+  }
+
+  const classes = getClassNames(element).slice(0, MAX_FULL_SELECTOR_CLASSES);
+  if (classes.length > 0) {
+    selector += `.${classes.map(escapeCssIdentifier).join('.')}`;
+  }
+
+  if (!element.id) {
+    selector += getNthOfTypeSuffix(element);
+  }
+
+  return selector;
+}
+
+function buildStructuralSelectorSegment(element: Element): string {
+  return `${getTagSelector(element)}${getNthOfTypeSuffix(element)}`;
+}
+
+function getClassNames(element: Element): string[] {
+  return Array.from(element.classList).filter(Boolean);
+}
+
+function getTagSelector(element: Element): string {
+  return escapeCssIdentifier(element.localName || element.tagName.toLowerCase());
+}
+
+function limitSelectorLength(
+  path: string[],
+  structuralPath: string[],
+  selectedElement: Element
+): string {
+  const fullSelector = path.join(' > ');
+  if (fullSelector.length <= MAX_FULL_SELECTOR_LENGTH) {
+    return fullSelector;
+  }
+
+  const boundedSelector =
+    findBoundedMatchingSelector(path, selectedElement) ||
+    findBoundedMatchingSelector(structuralPath, selectedElement);
+
+  return boundedSelector || buildStructuralSelectorSegment(selectedElement);
+}
+
+function findBoundedMatchingSelector(path: string[], selectedElement: Element): string | null {
+  for (let start = path.length - 1; start >= 0; start -= 1) {
+    const candidate = path.slice(start).join(' > ');
+    if (candidate.length > MAX_FULL_SELECTOR_LENGTH) {
+      continue;
+    }
+    if (selectorMatchesElement(candidate, selectedElement)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function selectorMatchesElement(selector: string, element: Element): boolean {
+  try {
+    return element.ownerDocument.querySelector(selector) === element;
+  } catch {
+    return false;
+  }
+}
+
+function getNthOfTypeSuffix(element: Element): string {
+  const nthOfType = getNthOfType(element);
+  return nthOfType > 1 || hasSameTagSibling(element) ? `:nth-of-type(${nthOfType})` : '';
+}
+
+function getNthOfType(element: Element): number {
+  let index = 1;
+  let sibling = element.previousElementSibling;
+
+  while (sibling) {
+    if (sibling.tagName === element.tagName) {
+      index += 1;
+    }
+    sibling = sibling.previousElementSibling;
+  }
+
+  return index;
+}
+
+function hasSameTagSibling(element: Element): boolean {
+  let sibling = element.previousElementSibling;
+  while (sibling) {
+    if (sibling.tagName === element.tagName) return true;
+    sibling = sibling.previousElementSibling;
+  }
+
+  sibling = element.nextElementSibling;
+  while (sibling) {
+    if (sibling.tagName === element.tagName) return true;
+    sibling = sibling.nextElementSibling;
+  }
+
+  return false;
+}
+
+function escapeCssIdentifier(value: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(value);
+  }
+
+  return escapeCssIdentifierFallback(value);
+}
+
+function escapeCssIdentifierFallback(value: string): string {
+  let result = '';
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value.charAt(index);
+    const codeUnit = value.charCodeAt(index);
+    const isFirst = index === 0;
+    const isSecond = index === 1;
+    const firstCodeUnit = value.charCodeAt(0);
+
+    if (codeUnit === 0x0000) {
+      result += '\uFFFD';
+      continue;
+    }
+
+    if (
+      (codeUnit >= 0x0001 && codeUnit <= 0x001f) ||
+      codeUnit === 0x007f ||
+      (isFirst && codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+      (isSecond && codeUnit >= 0x0030 && codeUnit <= 0x0039 && firstCodeUnit === 0x002d)
+    ) {
+      result += `\\${codeUnit.toString(16)} `;
+      continue;
+    }
+
+    if (isFirst && codeUnit === 0x002d && value.length === 1) {
+      result += '\\-';
+      continue;
+    }
+
+    if (
+      codeUnit >= 0x0080 ||
+      codeUnit === 0x002d ||
+      codeUnit === 0x005f ||
+      (codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+      (codeUnit >= 0x0041 && codeUnit <= 0x005a) ||
+      (codeUnit >= 0x0061 && codeUnit <= 0x007a)
+    ) {
+      result += char;
+      continue;
+    }
+
+    result += `\\${char}`;
+  }
+
+  return result;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/theme.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/theme.ts.txt
@@ -1,0 +1,143 @@
+import { sanitizeCssColor, sanitizeNonNegativePixelValue, sanitizeShadowPreset } from './sanitize';
+import { getAccentHoverColor } from '../defaults';
+
+// src/widget/theme.ts
+
+export type ThemeMode = 'light' | 'dark' | 'auto';
+type ResolvedTheme = 'light' | 'dark';
+
+// Internal structural slice of WidgetConfig — only the fields applyCustomStyles
+// reads. Declared locally to avoid an import cycle with ui.ts / index.ts.
+interface ThemeConfigSlice {
+  accentColor?: string;
+  bgColor?: string;
+  textColor?: string;
+  borderWidth?: string;
+  borderColor?: string;
+  shadow?: string;
+}
+
+export function getSystemTheme(): ResolvedTheme {
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return 'light';
+}
+
+export function resolveTheme(
+  mode: ThemeMode,
+  getSystem: () => ResolvedTheme = getSystemTheme
+): ResolvedTheme {
+  if (mode === 'auto') return getSystem();
+  return mode;
+}
+
+export function isValidTheme(value: unknown): value is ThemeMode {
+  return value === 'light' || value === 'dark' || value === 'auto';
+}
+
+export function applyThemeClass(root: HTMLElement, resolved: ResolvedTheme): void {
+  root.classList.toggle('bd-dark', resolved === 'dark');
+}
+
+export function applyCustomStyles(
+  root: HTMLElement,
+  config: ThemeConfigSlice,
+  resolved: ResolvedTheme
+): void {
+  const isDark = resolved === 'dark';
+
+  // Apply custom accent color if provided
+  const accentColor = sanitizeCssColor(config.accentColor);
+  if (accentColor) {
+    const color = accentColor;
+    root.style.setProperty('--bd-primary', color);
+    root.style.setProperty('--bd-primary-hover', getAccentHoverColor(color));
+    root.style.setProperty('--bd-border-focus', color);
+  }
+
+  // Apply custom background color if provided
+  const bgColor = sanitizeCssColor(config.bgColor);
+  if (bgColor) {
+    root.style.setProperty('--bd-bg-primary', bgColor);
+    if (isDark) {
+      root.style.setProperty('--bd-bg-secondary', `color-mix(in srgb, ${bgColor} 85%, white)`);
+      root.style.setProperty('--bd-bg-tertiary', `color-mix(in srgb, ${bgColor} 70%, white)`);
+    } else {
+      root.style.setProperty('--bd-bg-secondary', `color-mix(in srgb, ${bgColor} 93%, black)`);
+      root.style.setProperty('--bd-bg-tertiary', `color-mix(in srgb, ${bgColor} 85%, black)`);
+    }
+  }
+
+  // Apply custom text color if provided
+  const textColor = sanitizeCssColor(config.textColor);
+  if (textColor) {
+    root.style.setProperty('--bd-text-primary', textColor);
+    const bgBase = bgColor || (isDark ? '#0f172a' : '#fafaf9');
+    root.style.setProperty(
+      '--bd-text-secondary',
+      `color-mix(in srgb, ${textColor} 65%, ${bgBase})`
+    );
+    root.style.setProperty('--bd-text-muted', `color-mix(in srgb, ${textColor} 40%, ${bgBase})`);
+  }
+
+  // Apply custom border styling if provided
+  const borderW = sanitizeNonNegativePixelValue(config.borderWidth) ?? null;
+  const borderC = sanitizeCssColor(config.borderColor) || null;
+  if (borderW !== null || borderC !== null) {
+    const bw = borderW !== null ? `${borderW}px` : '1px';
+    const bc = borderC || 'var(--bd-border)';
+    root.style.setProperty('--bd-border-width', bw);
+    if (borderC) {
+      root.style.setProperty('--bd-border', bc);
+    }
+    root.style.setProperty('--bd-border-style', `var(--bd-border-width) solid ${bc}`);
+  }
+
+  // Apply shadow preset if provided
+  const shadowPreset = sanitizeShadowPreset(config.shadow) || null;
+  if (shadowPreset === 'none') {
+    root.style.setProperty('--bd-shadow-sm', 'none');
+    root.style.setProperty('--bd-shadow-md', 'none');
+    root.style.setProperty('--bd-shadow-lg', 'none');
+    root.style.setProperty('--bd-shadow-glow', 'none');
+  } else if (shadowPreset === 'hard') {
+    const shadowColor = borderC || (isDark ? '#000' : '#1a1a1a');
+    const offset = borderW !== null ? `calc(var(--bd-border-width) + 2px)` : '6px';
+    root.style.setProperty('--bd-shadow-sm', `${shadowColor} 2px 2px 0 0`);
+    root.style.setProperty('--bd-shadow-md', `${shadowColor} ${offset} ${offset} 0 0`);
+    root.style.setProperty('--bd-shadow-lg', `${shadowColor} ${offset} ${offset} 0 0`);
+    root.style.setProperty('--bd-shadow-glow', 'none');
+  }
+}
+
+export function attachSystemThemeListener(
+  onSystemChange: (resolved: ResolvedTheme) => void
+): () => void {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    // Fires in SSR, sandboxed iframes, or environments without matchMedia.
+    // data-theme="auto" will still resolve correctly at init but won't react
+    // to runtime OS theme changes. Warn so integrators can debug.
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn(
+        '[BugDrop] window.matchMedia unavailable; data-theme="auto" will not react to OS theme changes.'
+      );
+    }
+    return () => {
+      /* no-op cleanup */
+    };
+  }
+  const mql = window.matchMedia('(prefers-color-scheme: dark)');
+  const handler = (e: MediaQueryListEvent) => {
+    try {
+      onSystemChange(e.matches ? 'dark' : 'light');
+    } catch (err) {
+      // A throw inside the callback (e.g. detached DOM root) would otherwise
+      // propagate into the browser's event loop. Catch it here so the listener
+      // keeps firing on subsequent OS theme changes.
+      console.warn('[BugDrop] Error applying system theme change:', err);
+    }
+  };
+  mql.addEventListener('change', handler);
+  return () => mql.removeEventListener('change', handler);
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/ui.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/ui.ts.txt
@@ -1,0 +1,1618 @@
+import { resolveTheme, applyThemeClass, applyCustomStyles } from './theme';
+import {
+  escapeHtml,
+  sanitizeCssFontFamily,
+  sanitizeNonNegativePixelValue,
+  sanitizeUrl,
+} from './sanitize';
+import { DEFAULT_ACCENT_COLOR, getAccentHoverColor } from '../defaults';
+import { escapeWidgetText, t } from './i18n';
+
+declare const __BUGDROP_VERSION__: string;
+
+const MODAL_VIEWPORT_MARGIN_PX = 8;
+const DISABLE_MODAL_DRAG_MEDIA_QUERY = '(hover: none), (pointer: coarse)';
+const MOBILE_MODAL_MEDIA_QUERY = '(max-width: 640px)';
+
+interface WidgetConfig {
+  repo: string;
+  apiUrl: string;
+  position: 'bottom-right' | 'bottom-left';
+  theme: 'light' | 'dark' | 'auto';
+  accentColor?: string;
+  font?: string;
+  radius?: string;
+  bgColor?: string;
+  textColor?: string;
+  borderWidth?: string;
+  borderColor?: string;
+  shadow?: string;
+}
+
+export type IssueLinkVisibility = 'public' | 'always' | 'never';
+
+export function shouldRenderIssueLink(
+  issueUrl: string | undefined,
+  isPublic: boolean,
+  issueLinkVisibility: IssueLinkVisibility
+): boolean {
+  const safeIssueUrl = sanitizeUrl(issueUrl);
+  return Boolean(
+    safeIssueUrl &&
+    safeIssueUrl !== 'none' &&
+    safeIssueUrl !== '#' &&
+    issueLinkVisibility !== 'never' &&
+    (isPublic || issueLinkVisibility === 'always')
+  );
+}
+
+export function injectStyles(shadow: ShadowRoot, config: WidgetConfig) {
+  const pos = config.position === 'bottom-left' ? 'left: 0' : 'right: 0';
+  const resolved = resolveTheme(config.theme);
+
+  // Determine font settings
+  const useInheritFont = config.font === 'inherit';
+  const customFont =
+    config.font && config.font !== 'inherit' ? sanitizeCssFontFamily(config.font) : null;
+  const fontImport =
+    useInheritFont || customFont
+      ? ''
+      : `@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap');`;
+  const fontFamily = useInheritFont
+    ? 'inherit'
+    : customFont
+      ? `${customFont}, system-ui, sans-serif`
+      : `'Space Grotesk', system-ui, sans-serif`;
+
+  // Determine radius settings
+  const radiusPx = sanitizeNonNegativePixelValue(config.radius) ?? null;
+  const radiusSm = radiusPx !== null ? `${radiusPx}px` : '6px';
+  const radiusMd = radiusPx !== null ? `${Math.round(radiusPx * 1.4)}px` : '10px';
+  const radiusLg = radiusPx !== null ? `${Math.round(radiusPx * 2)}px` : '14px';
+
+  // Determine border width for CSS variable (still needed by the style block below)
+  const borderW = sanitizeNonNegativePixelValue(config.borderWidth) ?? null;
+
+  const styles = document.createElement('style');
+  styles.textContent = `
+    ${fontImport}
+
+    :host {
+      /* Typography */
+      --bd-font: ${fontFamily};
+
+      /* Radius */
+      --bd-radius-sm: ${radiusSm};
+      --bd-radius-md: ${radiusMd};
+      --bd-radius-lg: ${radiusLg};
+
+      /* Border */
+      --bd-border-width: ${borderW !== null ? `${borderW}px` : '1px'};
+
+      /* Transitions */
+      --bd-transition: 0.15s ease;
+      --bd-transition-slow: 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    /* Light Theme (Default) */
+    .bd-root {
+      --bd-bg-primary: #fafaf9;
+      --bd-bg-secondary: #f5f5f4;
+      --bd-bg-tertiary: #e7e5e4;
+      --bd-text-primary: #1c1917;
+      --bd-text-secondary: #57534e;
+      --bd-text-muted: #a8a29e;
+      --bd-border: #e7e5e4;
+      --bd-border-style: var(--bd-border-width) solid var(--bd-border);
+      --bd-border-focus: ${DEFAULT_ACCENT_COLOR};
+      --bd-primary: ${DEFAULT_ACCENT_COLOR};
+      --bd-primary-hover: ${getAccentHoverColor(DEFAULT_ACCENT_COLOR)};
+      --bd-primary-text: #ffffff;
+      --bd-overlay-bg: rgba(0, 0, 0, 0.4);
+      --bd-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+      --bd-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+      --bd-shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.12);
+      --bd-shadow-glow: none;
+      --bd-success: #22c55e;
+      --bd-error: #ef4444;
+    }
+
+    /* Dark Theme */
+    .bd-root.bd-dark {
+      --bd-bg-primary: #0f172a;
+      --bd-bg-secondary: #1e293b;
+      --bd-bg-tertiary: #334155;
+      --bd-text-primary: #f1f5f9;
+      --bd-text-secondary: #94a3b8;
+      --bd-text-muted: #64748b;
+      --bd-border: #334155;
+      --bd-border-focus: #22d3ee;
+      --bd-primary: #22d3ee;
+      --bd-primary-hover: #06b6d4;
+      --bd-primary-text: #0f172a;
+      --bd-overlay-bg: rgba(0, 0, 0, 0.6);
+      --bd-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.2);
+      --bd-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.3);
+      --bd-shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.4);
+      --bd-shadow-glow: 0 0 40px rgba(34, 211, 238, 0.15);
+      --bd-success: #34d399;
+      --bd-error: #f87171;
+    }
+
+    .bd-root {
+      font-family: var(--bd-font);
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    * {
+      box-sizing: border-box;
+      font-family: inherit;
+    }
+
+    /* Trigger Button (edge label) */
+    .bd-trigger {
+      position: fixed;
+      bottom: 20px;
+      ${pos};
+      height: 44px;
+      min-width: 0;
+      padding: 0 0 0 16px;
+      border-radius: ${radiusPx !== null ? `${radiusPx * 2}px 0 0 ${radiusPx * 2}px` : '22px 0 0 22px'};
+      border: ${borderW !== null ? 'var(--bd-border-style)' : 'none'};
+      background: var(--bd-primary);
+      color: var(--bd-primary-text);
+      cursor: pointer;
+      box-shadow:
+        var(--bd-shadow-md),
+        0 0 0 0 var(--bd-primary);
+      z-index: 999999;
+      transition: transform var(--bd-transition), box-shadow var(--bd-transition), opacity var(--bd-transition);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      overflow: visible;
+      animation: bd-triggerSlideIn 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+      touch-action: none;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
+    .bd-trigger--left {
+      padding: 0 16px 0 0;
+      border-radius: ${radiusPx !== null ? `0 ${radiusPx * 2}px ${radiusPx * 2}px 0` : '0 22px 22px 0'};
+    }
+
+    .bd-trigger--positioned {
+      animation: none;
+    }
+
+    .bd-trigger:hover {
+      transform: scale(1.03);
+      box-shadow:
+        var(--bd-shadow-lg),
+        0 0 20px color-mix(in srgb, var(--bd-primary) 30%, transparent);
+    }
+
+    .bd-trigger:active {
+      transform: scale(0.97);
+    }
+
+    .bd-trigger-icon {
+      font-size: 18px;
+      line-height: 1;
+    }
+
+    .bd-trigger-icon img {
+      width: 18px;
+      height: 18px;
+      object-fit: contain;
+      display: block;
+    }
+
+    .bd-trigger-label {
+      font-size: 14px;
+      font-weight: 600;
+      letter-spacing: 0;
+      white-space: nowrap;
+    }
+
+    .bd-trigger-drag-handle {
+      align-self: center;
+      width: 30px;
+      height: calc(100% - 8px);
+      margin: 4px;
+      border-radius: 7px;
+      background: transparent;
+      cursor: grab;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--bd-primary-text);
+      opacity: 0.95;
+      touch-action: none;
+    }
+
+    .bd-trigger--left .bd-trigger-drag-handle {
+      order: -1;
+    }
+
+    .bd-trigger-drag-handle:hover,
+    .bd-trigger-drag-handle:active,
+    .bd-trigger--dragging .bd-trigger-drag-handle {
+      background: color-mix(in srgb, var(--bd-primary-text) 18%, transparent);
+      opacity: 1;
+    }
+
+    .bd-trigger-drag-handle:hover {
+      cursor: grab;
+    }
+
+    .bd-trigger-drag-handle:active,
+    .bd-trigger--dragging .bd-trigger-drag-handle {
+      cursor: grabbing;
+    }
+
+    .bd-trigger-drag-handle svg {
+      display: block;
+      width: 14px;
+      height: 22px;
+      pointer-events: none;
+    }
+
+    @keyframes bd-triggerSlideIn {
+      from {
+        opacity: 0;
+        transform: translateY(20px) scale(0.9);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+
+    /* Pull Tab (shown after dismissal) */
+    .bd-pull-tab {
+      position: fixed;
+      bottom: 20px;
+      right: 0;
+      width: 24px;
+      height: 48px;
+      border-radius: 8px 0 0 8px;
+      border: none;
+      background: var(--bd-primary);
+      color: var(--bd-primary-text);
+      cursor: pointer;
+      box-shadow: -2px 4px 12px color-mix(in srgb, var(--bd-primary) 30%, transparent);
+      z-index: 999999;
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      animation: bd-pullTabSlideIn 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    .bd-pull-tab:hover {
+      width: 32px;
+      box-shadow: -4px 6px 16px color-mix(in srgb, var(--bd-primary) 40%, transparent);
+    }
+
+    .bd-pull-tab:active {
+      width: 28px;
+    }
+
+    .bd-pull-tab-chevron {
+      font-size: 16px;
+      font-weight: bold;
+      transition: transform 0.2s;
+    }
+
+    .bd-pull-tab:hover .bd-pull-tab-chevron {
+      transform: translateX(-2px);
+    }
+
+    /* Pull tab position for bottom-left */
+    .bd-pull-tab--left {
+      right: auto;
+      left: 0;
+      border-radius: 0 8px 8px 0;
+      box-shadow: 2px 4px 12px color-mix(in srgb, var(--bd-primary) 30%, transparent);
+    }
+
+    .bd-pull-tab--left:hover {
+      box-shadow: 4px 6px 16px color-mix(in srgb, var(--bd-primary) 40%, transparent);
+    }
+
+    .bd-pull-tab--left .bd-pull-tab-chevron {
+      transform: rotate(180deg);
+    }
+
+    .bd-pull-tab--left:hover .bd-pull-tab-chevron {
+      transform: rotate(180deg) translateX(-2px);
+    }
+
+    @media (max-width: 640px) {
+      .bd-pull-tab {
+        bottom: 16px;
+        height: 44px;
+        width: 22px;
+      }
+
+      .bd-pull-tab:hover {
+        width: 28px;
+      }
+    }
+
+    /* Touch devices - always slightly expanded */
+    @media (hover: none) {
+      .bd-pull-tab {
+        width: 28px;
+      }
+    }
+
+    /* Dismissible close button */
+    .bd-trigger-close {
+      position: absolute;
+      top: -4px;
+      right: 4px;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      border: none;
+      background: var(--bd-text-primary);
+      color: var(--bd-bg-primary);
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 1;
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transform: scale(0.8);
+      transition: opacity var(--bd-transition), transform var(--bd-transition);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+      box-shadow: var(--bd-shadow-sm);
+    }
+
+    .bd-trigger--left .bd-trigger-close {
+      right: auto;
+      left: 36px;
+    }
+
+    .bd-trigger--right .bd-trigger-close {
+      right: 36px;
+    }
+
+    .bd-trigger:hover .bd-trigger-close,
+    .bd-trigger-close:focus-visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: scale(1);
+    }
+
+    .bd-trigger-close:hover {
+      background: var(--bd-error);
+      color: white;
+    }
+
+    /* Modal Overlay */
+    .bd-overlay {
+      position: fixed;
+      inset: 0;
+      background: var(--bd-overlay-bg);
+      z-index: 1000000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      animation: bd-fadeIn 0.2s ease;
+    }
+
+    /* Modal */
+    .bd-modal {
+      background: var(--bd-bg-primary);
+      border-radius: var(--bd-radius-lg);
+      border: var(--bd-border-style);
+      box-shadow: var(--bd-shadow-lg), var(--bd-shadow-glow);
+      max-width: 600px;
+      width: 90%;
+      max-height: 90vh;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      animation: bd-slideUp var(--bd-transition-slow);
+    }
+
+    .bd-modal--positioned {
+      position: fixed;
+      margin: 0;
+      animation: none;
+    }
+
+    .bd-modal--dragging {
+      user-select: none;
+    }
+
+    .bd-modal--annotator {
+      width: min(96vw, 1100px);
+      max-width: 1100px;
+    }
+
+    /* Modal Header */
+    .bd-header {
+      position: relative;
+      padding: 16px 20px;
+      border-bottom: var(--bd-border-style);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: var(--bd-bg-primary);
+      animation: bd-fadeIn 0.2s ease 0.05s both;
+      cursor: grab;
+      user-select: none;
+      touch-action: none;
+    }
+
+    .bd-modal-drag-indicator {
+      position: absolute;
+      top: 6px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 28px;
+      height: 10px;
+      display: grid;
+      grid-template-columns: repeat(3, 4px);
+      grid-auto-rows: 4px;
+      gap: 3px 5px;
+      justify-content: center;
+      align-content: center;
+      color: var(--bd-text-muted);
+      opacity: 0.8;
+      pointer-events: none;
+    }
+
+    .bd-modal-drag-indicator span {
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background: currentColor;
+    }
+
+    .bd-modal--dragging .bd-header {
+      cursor: grabbing;
+    }
+
+    .bd-title {
+      margin: 0;
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      color: var(--bd-text-primary);
+    }
+
+    .bd-close {
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: transparent;
+      border: none;
+      border-radius: var(--bd-radius-sm);
+      font-size: 24px;
+      cursor: pointer;
+      color: var(--bd-text-secondary);
+      padding: 0;
+      line-height: 1;
+      transition: background var(--bd-transition), color var(--bd-transition);
+    }
+
+    .bd-close:hover {
+      background: var(--bd-bg-secondary);
+      color: var(--bd-text-primary);
+    }
+
+    /* Modal Body with staggered animation */
+    .bd-body {
+      padding: 20px;
+      overflow-y: auto;
+      flex: 1;
+    }
+
+    .bd-modal--annotator .bd-body {
+      padding-top: 0;
+    }
+
+    .bd-body > *:nth-child(1) { animation: bd-fadeIn 0.2s ease 0.1s both; }
+    .bd-body > *:nth-child(2) { animation: bd-fadeIn 0.2s ease 0.15s both; }
+    .bd-body > *:nth-child(3) { animation: bd-fadeIn 0.2s ease 0.2s both; }
+    .bd-body > *:nth-child(4) { animation: bd-fadeIn 0.2s ease 0.25s both; }
+    .bd-body > *:nth-child(5) { animation: bd-fadeIn 0.2s ease 0.3s both; }
+
+    .bd-version {
+      text-align: center;
+      padding: 4px 0;
+      font-size: 0.7rem;
+      color: var(--bd-text-secondary);
+      opacity: 0.5;
+    }
+
+    /* Form Elements */
+    .bd-form-group {
+      margin-bottom: 16px;
+    }
+
+    .bd-label {
+      display: block;
+      margin-bottom: 6px;
+      font-weight: 500;
+      font-size: 13px;
+      color: var(--bd-text-secondary);
+      letter-spacing: 0.01em;
+    }
+
+    .bd-input, .bd-textarea {
+      width: 100%;
+      padding: 12px 14px;
+      background: var(--bd-bg-primary);
+      border: var(--bd-border-style);
+      border-radius: var(--bd-radius-sm);
+      font-size: 14px;
+      color: var(--bd-text-primary);
+      transition: border-color var(--bd-transition), box-shadow var(--bd-transition);
+    }
+
+    .bd-input::placeholder, .bd-textarea::placeholder {
+      color: var(--bd-text-muted);
+    }
+
+    .bd-input:focus, .bd-textarea:focus {
+      outline: none;
+      border-color: var(--bd-border-focus);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--bd-border-focus) 15%, transparent);
+    }
+
+    .bd-textarea {
+      min-height: 100px;
+      resize: vertical;
+    }
+
+    /* Buttons */
+    .bd-btn {
+      padding: 11px 20px;
+      border-radius: var(--bd-radius-sm);
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all var(--bd-transition);
+      position: relative;
+    }
+
+    .bd-btn-primary {
+      background: var(--bd-primary);
+      color: var(--bd-primary-text);
+      border: none;
+      box-shadow: var(--bd-shadow-sm);
+    }
+
+    .bd-btn-primary:hover {
+      background: var(--bd-primary-hover);
+      box-shadow: var(--bd-shadow-md);
+    }
+
+    .bd-dark .bd-btn-primary:hover {
+      box-shadow: var(--bd-shadow-md), 0 0 20px rgba(34, 211, 238, 0.2);
+    }
+
+    .bd-btn-secondary {
+      background: var(--bd-bg-primary);
+      border: var(--bd-border-style);
+      color: var(--bd-text-primary);
+    }
+
+    .bd-btn-secondary:hover {
+      background: var(--bd-bg-secondary);
+    }
+
+    .bd-btn-quiet {
+      background: transparent;
+      border: none;
+      color: var(--bd-text-secondary);
+      padding-left: 12px;
+      padding-right: 12px;
+    }
+
+    .bd-btn-quiet:hover {
+      background: var(--bd-bg-secondary);
+      color: var(--bd-text-primary);
+    }
+
+    .bd-btn:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
+    .bd-evidence-block {
+      margin: 8px 0 16px;
+    }
+
+    .bd-evidence-row {
+      display: grid;
+      grid-template-columns: minmax(220px, 1fr) auto;
+      align-items: center;
+      gap: 14px;
+    }
+
+    .bd-screenshot-control {
+      min-height: 36px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding-top: 3px;
+    }
+
+    .bd-checkbox {
+      width: 18px;
+      height: 18px;
+      accent-color: var(--bd-primary);
+      cursor: pointer;
+      flex: 0 0 auto;
+    }
+
+    .bd-checkbox-label {
+      color: var(--bd-text-secondary);
+      cursor: pointer;
+      font-size: 0.95rem;
+      line-height: 1.35;
+      user-select: none;
+    }
+
+    .bd-upload-group {
+      min-width: 0;
+      justify-self: end;
+    }
+
+    .bd-upload-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .bd-upload-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      min-height: 32px;
+      padding: 6px 9px;
+      font-size: 13px;
+      white-space: nowrap;
+    }
+
+    .bd-upload-icon {
+      width: 14px;
+      height: 14px;
+      flex: 0 0 auto;
+    }
+
+    .bd-upload-input {
+      display: none;
+    }
+
+    .bd-upload-list {
+      display: grid;
+      gap: 6px;
+      margin-top: 10px;
+    }
+
+    .bd-upload-item {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto 28px;
+      align-items: center;
+      gap: 8px;
+      min-height: 34px;
+      padding: 5px 5px 5px 10px;
+      background: var(--bd-bg-secondary);
+      border: var(--bd-border-style);
+      border-radius: var(--bd-radius-sm);
+    }
+
+    .bd-upload-item__name {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--bd-text-primary);
+      font-size: 13px;
+    }
+
+    .bd-upload-item__meta {
+      color: var(--bd-text-secondary);
+      font-size: 12px;
+      white-space: nowrap;
+    }
+
+    .bd-upload-remove {
+      width: 28px;
+      height: 28px;
+      display: inline-grid;
+      place-items: center;
+      border: none;
+      border-radius: var(--bd-radius-sm);
+      background: transparent;
+      color: var(--bd-text-secondary);
+      cursor: pointer;
+      font-size: 20px;
+      line-height: 1;
+      transition: background var(--bd-transition), color var(--bd-transition);
+    }
+
+    .bd-upload-remove:hover {
+      background: var(--bd-bg-tertiary);
+      color: var(--bd-text-primary);
+    }
+
+    /* Loading States */
+    .bd-btn--loading {
+      color: transparent !important;
+      pointer-events: none;
+    }
+
+    .bd-btn--loading::after {
+      content: '';
+      position: absolute;
+      width: 16px;
+      height: 16px;
+      top: 50%;
+      left: 50%;
+      margin: -8px 0 0 -8px;
+      border: 2px solid currentColor;
+      border-color: var(--bd-primary-text) transparent var(--bd-primary-text) transparent;
+      border-radius: 50%;
+      animation: bd-spin 0.8s linear infinite;
+    }
+
+    .bd-spinner {
+      width: 20px;
+      height: 20px;
+      border: 2px solid var(--bd-border);
+      border-top-color: var(--bd-primary);
+      border-radius: 50%;
+      animation: bd-spin 0.8s linear infinite;
+    }
+
+    .bd-spinner--lg {
+      width: 32px;
+      height: 32px;
+      border-width: 3px;
+    }
+
+    .bd-loading-overlay {
+      position: absolute;
+      inset: 0;
+      background: var(--bd-bg-primary);
+      opacity: 0.95;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      z-index: 10;
+      border-radius: var(--bd-radius-lg);
+    }
+
+    .bd-loading-text {
+      font-size: 14px;
+      color: var(--bd-text-secondary);
+      font-weight: 500;
+    }
+
+    .bd-skeleton {
+      background: linear-gradient(
+        90deg,
+        var(--bd-bg-secondary) 0%,
+        var(--bd-bg-tertiary) 50%,
+        var(--bd-bg-secondary) 100%
+      );
+      background-size: 200% 100%;
+      animation: bd-shimmer 1.5s ease-in-out infinite;
+      border-radius: var(--bd-radius-sm);
+    }
+
+    /* Error States */
+    .bd-error-message {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 12px 14px;
+      background: rgba(239, 68, 68, 0.1);
+      border: 1px solid rgba(239, 68, 68, 0.2);
+      border-radius: var(--bd-radius-sm);
+      color: var(--bd-error);
+      font-size: 13px;
+      margin-bottom: 16px;
+    }
+
+    .bd-dark .bd-error-message {
+      background: rgba(248, 113, 113, 0.1);
+      border-color: rgba(248, 113, 113, 0.2);
+    }
+
+    .bd-error-message__icon {
+      flex-shrink: 0;
+      width: 16px;
+      height: 16px;
+    }
+
+    .bd-error-message__text {
+      flex: 1;
+      line-height: 1.4;
+    }
+
+    .bd-error-message__retry {
+      background: none;
+      border: none;
+      color: inherit;
+      font-weight: 600;
+      cursor: pointer;
+      text-decoration: underline;
+      padding: 0;
+      font-size: 13px;
+    }
+
+    .bd-input--error, .bd-textarea--error {
+      border-color: var(--bd-error) !important;
+    }
+
+    /* Success Modal */
+    .bd-success-content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      padding: 8px 0 16px;
+    }
+
+    .bd-success-icon {
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      background: var(--bd-success);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-bottom: 16px;
+    }
+
+    .bd-success-icon svg {
+      width: 28px;
+      height: 28px;
+      color: white;
+    }
+
+    .bd-success-issue {
+      margin: 0 0 12px;
+      color: var(--bd-text-primary);
+      font-size: 15px;
+    }
+
+    .bd-issue-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--bd-primary);
+      text-decoration: none;
+      font-weight: 500;
+      font-size: 14px;
+      padding: 8px 16px;
+      border-radius: var(--bd-radius-sm);
+      background: var(--bd-bg-secondary);
+      transition: background var(--bd-transition), color var(--bd-transition);
+    }
+
+    .bd-issue-link:hover {
+      background: var(--bd-bg-tertiary);
+      color: var(--bd-primary-hover);
+    }
+
+    .bd-issue-link svg {
+      flex-shrink: 0;
+    }
+
+    .bd-powered-by {
+      margin-top: 12px;
+      padding-top: 12px;
+      border-top: 1px solid var(--bd-border);
+      text-align: center;
+    }
+
+    .bd-powered-by a {
+      color: var(--bd-text-secondary);
+      text-decoration: none;
+      font-size: 12px;
+      transition: color var(--bd-transition);
+    }
+
+    .bd-powered-by a:hover {
+      color: var(--bd-text-primary);
+    }
+
+    .bd-input--error:focus, .bd-textarea--error:focus {
+      box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15) !important;
+    }
+
+    .bd-field-error {
+      color: var(--bd-error);
+      font-size: 12px;
+      margin-top: 4px;
+    }
+
+    /* Actions */
+    .bd-actions {
+      display: flex;
+      gap: 12px;
+      justify-content: flex-end;
+      margin-top: 20px;
+    }
+
+    .bd-success-actions {
+      justify-content: center;
+    }
+
+    .bd-screenshot-actions {
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    /* Tools Toolbar */
+    .bd-tools {
+      display: flex;
+      gap: 6px;
+      padding: 8px;
+      background: var(--bd-bg-secondary);
+      border: var(--bd-border-style);
+      border-radius: var(--bd-radius-md);
+      margin-bottom: 12px;
+    }
+
+    .bd-tool {
+      padding: 8px 14px;
+      background: transparent;
+      border: none;
+      border-radius: var(--bd-radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--bd-text-secondary);
+      cursor: pointer;
+      transition: all var(--bd-transition);
+    }
+
+    .bd-tool:hover {
+      background: var(--bd-bg-tertiary);
+      color: var(--bd-text-primary);
+    }
+
+    .bd-tool.active {
+      background: var(--bd-bg-primary);
+      color: var(--bd-primary);
+      box-shadow: var(--bd-shadow-sm);
+    }
+
+    .bd-annotation-stage {
+      min-height: 240px;
+      max-height: min(58vh, 620px);
+      padding: 18px;
+      border: 1px solid var(--bd-border, #e7e5e4);
+      border-radius: var(--bd-radius-md);
+      background:
+        linear-gradient(45deg, var(--bd-bg-secondary) 25%, transparent 25%),
+        linear-gradient(-45deg, var(--bd-bg-secondary) 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, var(--bd-bg-secondary) 75%),
+        linear-gradient(-45deg, transparent 75%, var(--bd-bg-secondary) 75%),
+        var(--bd-bg-primary);
+      background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+      background-size: 16px 16px;
+      box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--bd-border) 60%, transparent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: auto;
+    }
+
+    .bd-annotation-stage canvas {
+      display: block;
+      max-width: 100%;
+      max-height: calc(min(58vh, 620px) - 36px);
+      width: auto;
+      height: auto;
+      background: #ffffff;
+      box-shadow: var(--bd-shadow-md);
+    }
+
+    /* Preview */
+    .bd-preview {
+      border: var(--bd-border-style);
+      border-radius: var(--bd-radius-md);
+      overflow: hidden;
+      margin-bottom: 16px;
+      box-shadow: var(--bd-shadow-sm);
+    }
+
+    .bd-preview img {
+      width: 100%;
+      display: block;
+    }
+
+    /* Toast Notifications */
+    .bd-toast {
+      position: fixed;
+      bottom: 100px;
+      right: 20px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 18px;
+      border-radius: var(--bd-radius-md);
+      color: white;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000001;
+      box-shadow: var(--bd-shadow-lg);
+      animation: bd-slideIn 0.3s ease;
+    }
+
+    .bd-toast.success {
+      background: var(--bd-success);
+    }
+
+    .bd-toast.error {
+      background: var(--bd-error);
+    }
+
+    /* Animations */
+    @keyframes bd-fadeIn {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    @keyframes bd-slideUp {
+      from { opacity: 0; transform: translateY(24px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+
+    @keyframes bd-slideIn {
+      from { transform: translateX(100%); opacity: 0; }
+      to { transform: translateX(0); opacity: 1; }
+    }
+
+    @keyframes bd-pullTabSlideIn {
+      from { transform: translateX(100%); opacity: 0; }
+      to { transform: translateX(0); opacity: 1; }
+    }
+
+    /* Directional animations for dismiss/restore */
+    @keyframes bd-triggerSlideInFromRight {
+      from {
+        opacity: 0;
+        transform: translateX(100px) scale(0.8);
+      }
+      to {
+        opacity: 1;
+        transform: translateX(0) scale(1);
+      }
+    }
+
+    @keyframes bd-triggerSlideOutToRight {
+      from {
+        opacity: 1;
+        transform: translateX(0) scale(1);
+      }
+      to {
+        opacity: 0;
+        transform: translateX(100px) scale(0.8);
+      }
+    }
+
+    .bd-trigger--dismissing {
+      animation: bd-triggerSlideOutToRight 0.3s cubic-bezier(0.4, 0, 1, 1) forwards;
+    }
+
+    .bd-trigger--restoring {
+      animation: bd-triggerSlideInFromRight 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    @keyframes bd-spin {
+      to { transform: rotate(360deg); }
+    }
+
+    @keyframes bd-shimmer {
+      0% { background-position: 200% 0; }
+      100% { background-position: -200% 0; }
+    }
+
+    /* Mobile Responsiveness */
+    @media (max-width: 640px) {
+      .bd-trigger {
+        height: 40px;
+        padding: 0 0 0 14px;
+        bottom: 16px;
+        gap: 6px;
+      }
+
+      .bd-trigger--left {
+        padding: 0 14px 0 0;
+      }
+
+      .bd-trigger-drag-handle {
+        width: 28px;
+      }
+
+      .bd-trigger-icon {
+        font-size: 16px;
+      }
+
+      .bd-trigger-icon img {
+        width: 16px;
+        height: 16px;
+      }
+
+      .bd-trigger-label {
+        font-size: 13px;
+      }
+
+      .bd-overlay {
+        align-items: flex-end;
+      }
+
+      .bd-modal {
+        width: 100%;
+        max-width: 100%;
+        max-height: 95vh;
+        border-radius: var(--bd-radius-lg) var(--bd-radius-lg) 0 0;
+        animation: bd-slideUpMobile var(--bd-transition-slow);
+      }
+
+      .bd-modal--positioned {
+        position: static;
+        width: 100%;
+      }
+
+      .bd-modal--annotator {
+        width: calc(100% - 16px);
+        max-width: calc(100% - 16px);
+      }
+
+      .bd-header {
+        padding: 16px;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+      }
+
+      .bd-close {
+        width: 44px;
+        height: 44px;
+        font-size: 28px;
+      }
+
+      .bd-body {
+        padding: 16px;
+        padding-bottom: 32px;
+      }
+
+      .bd-btn {
+        padding: 14px 24px;
+        font-size: 16px;
+        min-height: 48px;
+      }
+
+      .bd-input, .bd-textarea {
+        padding: 14px;
+        font-size: 16px;
+        min-height: 48px;
+      }
+
+      .bd-category-option {
+        gap: 4px !important;
+        padding: 8px !important;
+        min-width: 0;
+      }
+
+      .bd-category-option span {
+        font-size: 0.85rem !important;
+        white-space: nowrap;
+      }
+
+      .bd-textarea {
+        min-height: 120px;
+      }
+
+      .bd-evidence-row {
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 8px;
+      }
+
+      .bd-upload-button {
+        min-height: 34px;
+        padding: 7px 10px;
+        font-size: 14px;
+      }
+
+      .bd-actions {
+        flex-direction: column-reverse;
+        gap: 8px;
+      }
+
+      .bd-actions .bd-btn {
+        width: 100%;
+      }
+
+      .bd-screenshot-actions {
+        flex-direction: column;
+      }
+
+      .bd-tools {
+        flex-wrap: wrap;
+      }
+
+      .bd-annotation-stage {
+        min-height: 180px;
+        max-height: 46vh;
+        padding: 12px;
+      }
+
+      .bd-annotation-stage canvas {
+        max-height: calc(46vh - 24px);
+      }
+
+      .bd-tool {
+        flex: 1;
+        min-width: calc(50% - 4px);
+        justify-content: center;
+        padding: 12px;
+        text-align: center;
+      }
+
+      .bd-toast {
+        left: 16px;
+        right: 16px;
+        bottom: 80px;
+        justify-content: center;
+      }
+    }
+
+    @keyframes bd-slideUpMobile {
+      from { opacity: 0; transform: translateY(100%); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* Touch-friendly hover states */
+    @media (hover: none) {
+      .bd-trigger:hover {
+        transform: none;
+        box-shadow: var(--bd-shadow-md);
+      }
+
+      .bd-trigger:active {
+        transform: scale(0.97);
+      }
+
+      /* Always show close button on touch devices */
+      .bd-trigger-close {
+        opacity: 1;
+        pointer-events: auto;
+        transform: scale(1);
+      }
+
+      .bd-header {
+        cursor: default;
+        user-select: auto;
+        touch-action: auto;
+      }
+
+      .bd-modal-drag-indicator {
+        display: none;
+      }
+
+      .bd-btn:hover {
+        background: inherit;
+      }
+
+      .bd-btn-primary:hover {
+        background: var(--bd-primary);
+      }
+
+      .bd-btn-primary:active {
+        background: var(--bd-primary-hover);
+      }
+
+      .bd-btn-secondary:hover {
+        background: var(--bd-bg-primary);
+      }
+
+      .bd-btn-secondary:active {
+        background: var(--bd-bg-secondary);
+      }
+    }
+
+    /* Safe area support for notched devices */
+    @supports (padding-bottom: env(safe-area-inset-bottom)) {
+      .bd-modal {
+        padding-bottom: env(safe-area-inset-bottom);
+      }
+    }
+
+    /* Reduced motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+  `;
+
+  shadow.appendChild(styles);
+
+  // Create root wrapper and apply theme class + custom styles
+  const root = document.createElement('div');
+  root.className = 'bd-root';
+  applyThemeClass(root, resolved);
+  applyCustomStyles(root, config, resolved);
+
+  shadow.appendChild(root);
+
+  return root;
+}
+
+export function redactionNoteHtml(message: string): string {
+  return `<p class="bd-redaction-note" style="margin: 0 0 12px; padding: 8px 12px; background: var(--bd-warning-bg, #fff8e1); border-radius: 6px; font-size: 13px; color: var(--bd-text-secondary);">${escapeHtml(message)}</p>`;
+}
+
+export function createModal(
+  container: HTMLElement,
+  title: string,
+  content: string,
+  showVersion: boolean = false,
+  modalClass: string = ''
+): HTMLElement {
+  const overlay = document.createElement('div');
+  overlay.className = 'bd-overlay';
+  const modalClasses = ['bd-modal', modalClass].filter(Boolean).join(' ');
+
+  const versionBadge = showVersion
+    ? `<div class="bd-version">BugDrop v${typeof __BUGDROP_VERSION__ !== 'undefined' ? __BUGDROP_VERSION__ : 'dev'}</div>`
+    : '';
+
+  overlay.innerHTML = `
+    <div class="${modalClasses}">
+      <div class="bd-header">
+        <span class="bd-modal-drag-indicator" aria-hidden="true">
+          <span></span><span></span><span></span>
+          <span></span><span></span><span></span>
+        </span>
+        <h2 class="bd-title">${escapeHtml(title)}</h2>
+        <button class="bd-close">&times;</button>
+      </div>
+      <div class="bd-body">
+        ${content}
+      </div>
+      ${versionBadge}
+    </div>
+  `;
+
+  container.appendChild(overlay);
+  attachModalDragBehavior(overlay);
+  return overlay;
+}
+
+function attachModalDragBehavior(overlay: HTMLElement): void {
+  if (
+    typeof window.matchMedia !== 'function' ||
+    window.matchMedia(DISABLE_MODAL_DRAG_MEDIA_QUERY).matches
+  ) {
+    return;
+  }
+
+  const modal = overlay.querySelector<HTMLElement>('.bd-modal');
+  const header = overlay.querySelector<HTMLElement>('.bd-header');
+  if (!modal || !header) return;
+  const modalEl = modal;
+  const headerEl = header;
+
+  let pointerId: number | null = null;
+  let startPointerX = 0;
+  let startPointerY = 0;
+  let startLeft = 0;
+  let startTop = 0;
+
+  let cleanupComplete = false;
+  let removalObserver: MutationObserver | null = null;
+
+  const cleanup = () => {
+    if (cleanupComplete) return;
+    cleanupComplete = true;
+    endDrag();
+    window.removeEventListener('resize', handleResize);
+    window.visualViewport?.removeEventListener('resize', handleResize);
+    removalObserver?.disconnect();
+  };
+
+  function clampPosition(left: number, top: number): { left: number; top: number } {
+    const rect = modalEl.getBoundingClientRect();
+    const maxLeft = Math.max(
+      MODAL_VIEWPORT_MARGIN_PX,
+      window.innerWidth - rect.width - MODAL_VIEWPORT_MARGIN_PX
+    );
+    const maxTop = Math.max(
+      MODAL_VIEWPORT_MARGIN_PX,
+      window.innerHeight - rect.height - MODAL_VIEWPORT_MARGIN_PX
+    );
+
+    return {
+      left: Math.min(Math.max(left, MODAL_VIEWPORT_MARGIN_PX), maxLeft),
+      top: Math.min(Math.max(top, MODAL_VIEWPORT_MARGIN_PX), maxTop),
+    };
+  }
+
+  function setModalPosition(left: number, top: number): void {
+    const position = clampPosition(left, top);
+    modalEl.style.left = `${position.left}px`;
+    modalEl.style.top = `${position.top}px`;
+  }
+
+  function handleResize(): void {
+    if (!overlay.isConnected) {
+      cleanup();
+      return;
+    }
+
+    if (!modalEl.classList.contains('bd-modal--positioned')) return;
+    if (window.matchMedia(MOBILE_MODAL_MEDIA_QUERY).matches) {
+      resetPositionedModal();
+      return;
+    }
+
+    reflowPositionedModalWidth();
+    const rect = modalEl.getBoundingClientRect();
+    setModalPosition(rect.left, rect.top);
+  }
+
+  function reflowPositionedModalWidth(): void {
+    modalEl.style.removeProperty('width');
+    modalEl.style.removeProperty('max-width');
+    const rect = modalEl.getBoundingClientRect();
+    const maxResponsiveWidth = Math.floor(window.innerWidth * 0.9);
+    modalEl.style.width = `${Math.min(rect.width, maxResponsiveWidth)}px`;
+    modalEl.style.maxWidth = 'none';
+  }
+
+  function resetPositionedModal(): void {
+    modalEl.classList.remove('bd-modal--positioned', 'bd-modal--dragging');
+    modalEl.style.removeProperty('left');
+    modalEl.style.removeProperty('top');
+    modalEl.style.removeProperty('width');
+    modalEl.style.removeProperty('max-width');
+  }
+
+  function endDrag(): void {
+    if (pointerId === null) return;
+    pointerId = null;
+    modalEl.classList.remove('bd-modal--dragging');
+    window.removeEventListener('pointermove', handlePointerMove);
+    window.removeEventListener('pointerup', handlePointerUp);
+    window.removeEventListener('pointercancel', handlePointerCancel);
+  }
+
+  function handlePointerMove(e: PointerEvent): void {
+    if (pointerId !== e.pointerId) return;
+    setModalPosition(startLeft + e.clientX - startPointerX, startTop + e.clientY - startPointerY);
+  }
+
+  function handlePointerUp(e: PointerEvent): void {
+    if (pointerId !== e.pointerId) return;
+    endDrag();
+  }
+
+  function handlePointerCancel(e: PointerEvent): void {
+    if (pointerId !== e.pointerId) return;
+    endDrag();
+  }
+
+  headerEl.addEventListener('pointerdown', e => {
+    if ((e.target as HTMLElement).closest('button, a, input, textarea, select, label')) return;
+
+    e.preventDefault();
+    const rect = modalEl.getBoundingClientRect();
+
+    pointerId = e.pointerId;
+    startPointerX = e.clientX;
+    startPointerY = e.clientY;
+    startLeft = rect.left;
+    startTop = rect.top;
+
+    modalEl.classList.add('bd-modal--positioned', 'bd-modal--dragging');
+    modalEl.style.width = `${rect.width}px`;
+    modalEl.style.maxWidth = 'none';
+    setModalPosition(startLeft, startTop);
+
+    headerEl.setPointerCapture(e.pointerId);
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointercancel', handlePointerCancel);
+  });
+
+  window.addEventListener('resize', handleResize);
+  window.visualViewport?.addEventListener('resize', handleResize);
+
+  if (overlay.parentNode) {
+    removalObserver = new MutationObserver(() => {
+      if (!overlay.isConnected) cleanup();
+    });
+    removalObserver.observe(overlay.parentNode, { childList: true });
+  }
+}
+
+export function showSuccessModal(
+  container: HTMLElement,
+  issueNumber: number,
+  issueUrl: string,
+  isPublic: boolean,
+  issueLinkVisibility: IssueLinkVisibility = 'public'
+): Promise<void> {
+  return new Promise(resolve => {
+    const safeIssueUrl = sanitizeUrl(issueUrl);
+    const shouldShowIssueLink = shouldRenderIssueLink(issueUrl, isPublic, issueLinkVisibility);
+    const issueLink =
+      shouldShowIssueLink && safeIssueUrl
+        ? `<a href="${escapeHtml(safeIssueUrl)}" target="_blank" rel="noopener noreferrer" class="bd-issue-link">
+          <svg viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
+            <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"/>
+          </svg>
+          ${escapeWidgetText(t().viewOnGitHub)}
+        </a>`
+        : '';
+    const issueInfo =
+      isPublic || (issueLinkVisibility === 'always' && shouldShowIssueLink)
+        ? `
+        <p class="bd-success-issue">${t().issueCreated(`<strong>#${issueNumber}</strong>`)}</p>
+        ${issueLink}
+      `
+        : `<p class="bd-success-issue">${escapeWidgetText(t().feedbackSubmittedMessage)}</p>`;
+
+    const modal = createModal(
+      container,
+      t().successTitle,
+      `
+        <div class="bd-success-content">
+          <div class="bd-success-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
+              <polyline points="22 4 12 14.01 9 11.01"/>
+            </svg>
+          </div>
+          ${issueInfo}
+        </div>
+        <div class="bd-actions bd-success-actions">
+          <button class="bd-btn bd-btn-primary" data-action="done">${escapeWidgetText(t().done)}</button>
+        </div>
+        <div class="bd-powered-by">
+          <a href="https://github.com/mean-weasel/bugdrop" target="_blank" rel="noopener noreferrer">Powered by BugDrop</a>
+        </div>
+      `,
+      true
+    );
+
+    const closeBtn = modal.querySelector('.bd-close') as HTMLElement;
+    const doneBtn = modal.querySelector('[data-action="done"]') as HTMLElement;
+
+    const closeModal = () => {
+      modal.remove();
+      resolve();
+    };
+
+    closeBtn?.addEventListener('click', closeModal);
+    doneBtn?.addEventListener('click', closeModal);
+  });
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/answer-validation.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/answer-validation.ts.txt
@@ -1,0 +1,86 @@
+import type { VariantField } from './public-types';
+
+type NormalizedVariantAnswer = string | number;
+
+export class VariantAnswerError extends TypeError {
+  constructor(
+    public readonly fieldId: string | null,
+    message: string
+  ) {
+    super(message);
+    this.name = 'VariantAnswerError';
+  }
+}
+
+export function assertKnownVariantAnswerKeys(
+  fields: ReadonlyArray<VariantField>,
+  answers: Record<string, unknown>
+): void {
+  if (!isObject(answers)) {
+    throw new VariantAnswerError(null, 'BugDrop variant answers must be an object');
+  }
+  const knownFields = new Set(fields.map(field => field.id));
+  const unknown = Object.keys(answers).find(key => !knownFields.has(key));
+  if (unknown) {
+    throw new VariantAnswerError(null, `Unknown BugDrop variant answer: ${unknown}`);
+  }
+}
+
+export function normalizeVariantAnswers(
+  fields: ReadonlyArray<VariantField>,
+  answers: Record<string, unknown>
+): Record<string, NormalizedVariantAnswer> {
+  assertKnownVariantAnswerKeys(fields, answers);
+  return Object.fromEntries(
+    fields.map(field => [field.id, normalizeVariantAnswer(field, answers[field.id])])
+  );
+}
+
+function normalizeVariantAnswer(field: VariantField, raw: unknown): NormalizedVariantAnswer {
+  if (field.type === 'shortText' || field.type === 'longText') {
+    if (raw === undefined || raw === null || raw === '') {
+      if (field.required) throw fieldError(field, `Answer ${field.id} is required`);
+      return '';
+    }
+    if (typeof raw !== 'string') {
+      throw fieldError(field, `Answer ${field.id} must be text`);
+    }
+    const value = raw.trim();
+    if (field.required && !value) throw fieldError(field, `Answer ${field.id} is required`);
+    const minimum = field.minLength ?? 0;
+    const maximum = field.maxLength ?? (field.type === 'shortText' ? 500 : 5_000);
+    if (value.length < minimum || value.length > maximum) {
+      throw fieldError(field, `Answer ${field.id} must be ${minimum}-${maximum} characters`);
+    }
+    return value;
+  }
+
+  if (field.type === 'rating') {
+    const scale = field.scale ?? 5;
+    if (raw === undefined || raw === null || raw === '') {
+      if (field.required) throw fieldError(field, `Answer ${field.id} is required`);
+      return '';
+    }
+    if (!Number.isInteger(raw) || (raw as number) < 1 || (raw as number) > scale) {
+      throw fieldError(field, `Answer ${field.id} must be a rating from 1-${scale}`);
+    }
+    return raw as number;
+  }
+
+  if (raw === undefined || raw === null || raw === '') {
+    if (field.required) throw fieldError(field, `Answer ${field.id} is required`);
+    return '';
+  }
+  if (typeof raw !== 'string' || !field.options.some(option => option.value === raw)) {
+    throw fieldError(field, `Answer ${field.id} must be a configured choice`);
+  }
+  return raw;
+}
+
+function fieldError(field: VariantField, message: string): VariantAnswerError {
+  return new VariantAnswerError(field.id, message);
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/fields/index.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/fields/index.ts.txt
@@ -1,0 +1,13 @@
+import type { VariantField } from '../public-types';
+import { createLongTextController } from './long-text';
+import { createRatingController } from './rating';
+import { createShortTextController } from './short-text';
+import { createSingleChoiceController } from './single-choice';
+import type { FieldController } from './types';
+
+export function createFieldController(field: VariantField, instanceId: string): FieldController {
+  if (field.type === 'shortText') return createShortTextController(field, instanceId);
+  if (field.type === 'longText') return createLongTextController(field, instanceId);
+  if (field.type === 'rating') return createRatingController(field, instanceId);
+  return createSingleChoiceController(field, instanceId);
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/fields/long-text.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/fields/long-text.ts.txt
@@ -1,0 +1,28 @@
+import type { LongTextField } from '../public-types';
+import { applyTextControlAttributes, createFieldScaffold } from './shared';
+import type { FieldController } from './types';
+
+export function createLongTextController(
+  field: LongTextField,
+  instanceId: string
+): FieldController {
+  const scaffold = createFieldScaffold(field, instanceId);
+  const textarea = document.createElement('textarea');
+  textarea.rows = field.rows ?? 4;
+  applyTextControlAttributes(textarea, field, scaffold);
+
+  return {
+    field,
+    element: scaffold.wrapper,
+    getValue: () => textarea.value,
+    setValue(value) {
+      textarea.value = typeof value === 'string' ? value : '';
+    },
+    setError: message => scaffold.setError(textarea, message),
+    setDisabled: disabled => {
+      textarea.disabled = disabled;
+    },
+    focus: () => textarea.focus(),
+    dispose() {},
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/fields/rating.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/fields/rating.ts.txt
@@ -1,0 +1,109 @@
+import type { RatingField } from '../public-types';
+import { createFieldScaffold } from './shared';
+import type { FieldController } from './types';
+
+export function createRatingController(field: RatingField, instanceId: string): FieldController {
+  const scaffold = createFieldScaffold(field, instanceId);
+  const scale = field.scale ?? 5;
+  const group = document.createElement('div');
+  group.id = scaffold.controlId;
+  group.className = 'bdv-rating';
+  group.setAttribute('role', 'radiogroup');
+  group.setAttribute('aria-labelledby', scaffold.labelId);
+  group.setAttribute('aria-required', String(field.required ?? false));
+  if (scaffold.describedBy) group.setAttribute('aria-describedby', scaffold.describedBy);
+
+  const buttons: HTMLButtonElement[] = [];
+  let selected: number | null = null;
+
+  const renderSelection = () => {
+    for (const [index, button] of buttons.entries()) {
+      const value = index + 1;
+      const active = selected !== null && value <= selected;
+      button.classList.toggle('bdv-rating-option--active', active);
+      button.setAttribute('aria-checked', String(value === selected));
+      button.tabIndex = value === (selected ?? 1) ? 0 : -1;
+    }
+  };
+  const select = (value: number, focus = false) => {
+    selected = value;
+    renderSelection();
+    if (focus) buttons[value - 1]?.focus();
+  };
+  const listeners: Array<{
+    button: HTMLButtonElement;
+    click: () => void;
+    keydown: (event: KeyboardEvent) => void;
+  }> = [];
+
+  for (let value = 1; value <= scale; value += 1) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'bdv-rating-option';
+    button.setAttribute('role', 'radio');
+    button.setAttribute('aria-label', `${value} ${value === 1 ? 'star' : 'stars'}`);
+    button.textContent = field.icon === 'number' ? String(value) : '★';
+    const click = () => select(value);
+    const keydown = (event: KeyboardEvent) => {
+      let next: number | null = null;
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        next = value === scale ? 1 : value + 1;
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        next = value === 1 ? scale : value - 1;
+      } else if (event.key === 'Home') {
+        next = 1;
+      } else if (event.key === 'End') {
+        next = scale;
+      } else if (event.key === 'Enter' || event.key === ' ') {
+        next = value;
+      }
+      if (next === null) return;
+      event.preventDefault();
+      select(next, true);
+    };
+    button.addEventListener('click', click);
+    button.addEventListener('keydown', keydown);
+    listeners.push({ button, click, keydown });
+    buttons.push(button);
+    group.appendChild(button);
+  }
+  scaffold.wrapper.insertBefore(group, scaffold.wrapper.querySelector('.bdv-error'));
+
+  if (field.lowLabel || field.highLabel) {
+    const labels = document.createElement('div');
+    labels.className = 'bdv-rating-labels';
+    const low = document.createElement('span');
+    low.textContent = field.lowLabel ?? '';
+    const high = document.createElement('span');
+    high.textContent = field.highLabel ?? '';
+    labels.append(low, high);
+    scaffold.wrapper.insertBefore(labels, scaffold.wrapper.querySelector('.bdv-error'));
+  }
+  renderSelection();
+
+  return {
+    field,
+    element: scaffold.wrapper,
+    getValue: () => selected ?? '',
+    setValue(value) {
+      selected =
+        Number.isInteger(value) && (value as number) >= 1 && (value as number) <= scale
+          ? (value as number)
+          : null;
+      renderSelection();
+    },
+    setError: message => scaffold.setError(group, message),
+    setDisabled(disabled) {
+      for (const button of buttons) button.disabled = disabled;
+    },
+    focus() {
+      buttons[(selected ?? 1) - 1]?.focus();
+    },
+    dispose() {
+      for (const listener of listeners) {
+        listener.button.removeEventListener('click', listener.click);
+        listener.button.removeEventListener('keydown', listener.keydown);
+      }
+    },
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/fields/shared.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/fields/shared.ts.txt
@@ -1,0 +1,76 @@
+import type { VariantField } from '../public-types';
+import type { FieldScaffold } from './types';
+
+export function createFieldScaffold(field: VariantField, instanceId: string): FieldScaffold {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'bdv-field';
+  wrapper.dataset.bugdropField = field.id;
+  wrapper.dataset.span = String(field.layout?.span ?? 1);
+
+  const controlId = `${instanceId}-${field.id}`;
+  const labelId = `${controlId}-label`;
+  const helpId = `${controlId}-help`;
+  const errorId = `${controlId}-error`;
+
+  const label = document.createElement('label');
+  label.className = 'bdv-label';
+  label.id = labelId;
+  label.htmlFor = controlId;
+  label.textContent = field.label;
+  if (field.required) {
+    const required = document.createElement('span');
+    required.className = 'bdv-required';
+    required.textContent = ' *';
+    required.setAttribute('aria-hidden', 'true');
+    label.appendChild(required);
+  }
+  wrapper.appendChild(label);
+
+  const describedBy: string[] = [];
+  if (field.helpText) {
+    const help = document.createElement('div');
+    help.className = 'bdv-help';
+    help.id = helpId;
+    help.textContent = field.helpText;
+    wrapper.appendChild(help);
+    describedBy.push(helpId);
+  }
+
+  const error = document.createElement('div');
+  error.className = 'bdv-error';
+  error.id = errorId;
+  error.hidden = true;
+  error.setAttribute('aria-live', 'polite');
+  wrapper.appendChild(error);
+  describedBy.push(errorId);
+
+  return {
+    wrapper,
+    label,
+    controlId,
+    labelId,
+    describedBy: describedBy.join(' ') || null,
+    setError(target, message) {
+      error.textContent = message ?? '';
+      error.hidden = !message;
+      if (message) target.setAttribute('aria-invalid', 'true');
+      else target.removeAttribute('aria-invalid');
+    },
+  };
+}
+
+export function applyTextControlAttributes(
+  control: HTMLInputElement | HTMLTextAreaElement,
+  field: Extract<VariantField, { type: 'shortText' | 'longText' }>,
+  scaffold: FieldScaffold
+): void {
+  control.id = scaffold.controlId;
+  control.className = 'bdv-input';
+  control.required = field.required ?? false;
+  control.setAttribute('aria-required', String(field.required ?? false));
+  if (scaffold.describedBy) control.setAttribute('aria-describedby', scaffold.describedBy);
+  if (field.placeholder) control.placeholder = field.placeholder;
+  control.minLength = field.minLength ?? 0;
+  control.maxLength = field.maxLength ?? (field.type === 'shortText' ? 500 : 5_000);
+  scaffold.wrapper.insertBefore(control, scaffold.wrapper.querySelector('.bdv-error'));
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/fields/short-text.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/fields/short-text.ts.txt
@@ -1,0 +1,28 @@
+import type { ShortTextField } from '../public-types';
+import { applyTextControlAttributes, createFieldScaffold } from './shared';
+import type { FieldController } from './types';
+
+export function createShortTextController(
+  field: ShortTextField,
+  instanceId: string
+): FieldController {
+  const scaffold = createFieldScaffold(field, instanceId);
+  const input = document.createElement('input');
+  input.type = 'text';
+  applyTextControlAttributes(input, field, scaffold);
+
+  return {
+    field,
+    element: scaffold.wrapper,
+    getValue: () => input.value,
+    setValue(value) {
+      input.value = typeof value === 'string' ? value : '';
+    },
+    setError: message => scaffold.setError(input, message),
+    setDisabled: disabled => {
+      input.disabled = disabled;
+    },
+    focus: () => input.focus(),
+    dispose() {},
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/fields/single-choice.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/fields/single-choice.ts.txt
@@ -1,0 +1,52 @@
+import type { SingleChoiceField } from '../public-types';
+import { createFieldScaffold } from './shared';
+import type { FieldController } from './types';
+
+export function createSingleChoiceController(
+  field: SingleChoiceField,
+  instanceId: string
+): FieldController {
+  const scaffold = createFieldScaffold(field, instanceId);
+  const group = document.createElement('div');
+  group.className = `choice ${field.display ?? ''}`;
+  group.setAttribute('role', 'radiogroup');
+  group.setAttribute('aria-labelledby', scaffold.labelId);
+  group.setAttribute('aria-required', String(field.required ?? false));
+  if (scaffold.describedBy) group.setAttribute('aria-describedby', scaffold.describedBy);
+
+  const inputs = field.options.map(option => {
+    const label = document.createElement('label');
+    const input = document.createElement('input');
+    input.type = 'radio';
+    input.name = scaffold.controlId;
+    input.value = option.value;
+    label.append(input, option.label);
+    if (option.description) {
+      const description = document.createElement('span');
+      description.className = 'bdv-help';
+      description.textContent = option.description;
+      label.appendChild(description);
+    }
+    group.appendChild(label);
+    return input;
+  });
+  scaffold.wrapper.insertBefore(group, scaffold.wrapper.querySelector('.bdv-error'));
+  const selected = () => group.querySelector<HTMLInputElement>(':checked');
+
+  return {
+    field,
+    element: scaffold.wrapper,
+    getValue: () => selected()?.value ?? '',
+    setValue(value) {
+      for (const input of inputs) input.checked = input.value === value;
+    },
+    setError: message => scaffold.setError(group, message),
+    setDisabled(disabled) {
+      for (const input of inputs) input.disabled = disabled;
+    },
+    focus() {
+      (selected() ?? inputs[0])?.focus();
+    },
+    dispose() {},
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/flow-definition.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/flow-definition.ts.txt
@@ -1,0 +1,25 @@
+import type { VariantConfig } from './public-types';
+
+export const VARIANT_DEFINITION_ID = 'bugdrop-variant@1' as const;
+
+export interface VariantDefinition {
+  readonly id: typeof VARIANT_DEFINITION_ID;
+  readonly variantId: string;
+  readonly screens: readonly [
+    Readonly<{
+      kind: 'variant';
+      config: Readonly<VariantConfig>;
+    }>,
+  ];
+}
+
+export function normalizeVariantDefinition(config: Readonly<VariantConfig>): VariantDefinition {
+  const screen = Object.freeze({ kind: 'variant' as const, config });
+  const screens = Object.freeze([screen]) as VariantDefinition['screens'];
+
+  return Object.freeze({
+    id: VARIANT_DEFINITION_ID,
+    variantId: config.id,
+    screens,
+  });
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/form.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/form.ts.txt
@@ -1,0 +1,236 @@
+import {
+  assertKnownVariantAnswerKeys,
+  normalizeVariantAnswers,
+  VariantAnswerError,
+} from './answer-validation';
+import { createFieldController } from './fields';
+import type {
+  HeadlessSubmitOptions,
+  SubmissionResult,
+  VariantConfig,
+  VariantContext,
+} from './public-types';
+
+interface VariantFormOptions {
+  config: Readonly<VariantConfig>;
+  instanceId: string;
+  context?: VariantContext;
+  initialAnswers?: Record<string, unknown>;
+  submit(
+    answers: Record<string, unknown>,
+    options: HeadlessSubmitOptions
+  ): Promise<SubmissionResult>;
+  cancel?: { label: string; onCancel(): void };
+  onSubmitted?(result: SubmissionResult): void;
+}
+
+interface VariantFormController {
+  readonly element: HTMLElement;
+  reset(): void;
+  dispose(): void;
+}
+
+export function createVariantForm(options: VariantFormOptions): VariantFormController {
+  const { config, instanceId } = options;
+  const context = { ...(options.context ?? {}) };
+  const initialAnswers = { ...(options.initialAnswers ?? {}) };
+  assertKnownVariantAnswerKeys(config.fields, initialAnswers);
+
+  const surface = document.createElement('section');
+  surface.className = 'bdv-surface';
+  const titleId = `${instanceId}-title`;
+  surface.setAttribute('aria-labelledby', titleId);
+
+  const header = document.createElement('div');
+  header.className = 'bdv-header';
+  const title = document.createElement('h2');
+  title.className = 'bdv-title';
+  title.id = titleId;
+  title.textContent = config.content.title;
+  header.appendChild(title);
+  if (config.content.description) {
+    const description = document.createElement('p');
+    description.className = 'bdv-description';
+    description.textContent = config.content.description;
+    header.appendChild(description);
+  }
+  surface.appendChild(header);
+
+  const form = document.createElement('form');
+  form.className = 'bdv-form';
+  form.noValidate = true;
+  const fieldsElement = document.createElement('div');
+  fieldsElement.className = 'bdv-fields';
+  const controllers = config.fields.map(field => createFieldController(field, instanceId));
+  for (const controller of controllers) fieldsElement.appendChild(controller.element);
+  form.appendChild(fieldsElement);
+
+  const actions = document.createElement('div');
+  actions.className = 'bdv-actions';
+  const submitButton = document.createElement('button');
+  submitButton.type = 'submit';
+  submitButton.className = 'bdv-submit';
+  submitButton.textContent = config.content.submitLabel ?? 'Submit';
+  actions.appendChild(submitButton);
+  let cancelButton: HTMLButtonElement | undefined;
+  if (options.cancel) {
+    cancelButton = document.createElement('button');
+    cancelButton.type = 'button';
+    cancelButton.className = 'bdv-cancel';
+    cancelButton.textContent = options.cancel.label;
+    cancelButton.addEventListener('click', options.cancel.onCancel);
+    actions.appendChild(cancelButton);
+  }
+  form.appendChild(actions);
+
+  const status = document.createElement('p');
+  status.className = 'bdv-status';
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+  form.appendChild(status);
+  surface.appendChild(form);
+
+  const { success, successLink } = createSuccessState(config);
+  surface.appendChild(success);
+
+  let submissionId = createRuntimeId('submission');
+  let busy = false;
+  let disposed = false;
+
+  const setBusy = (value: boolean) => {
+    busy = value;
+    form.setAttribute('aria-busy', String(value));
+    submitButton.disabled = value;
+    if (cancelButton) cancelButton.disabled = value;
+    for (const controller of controllers) controller.setDisabled(value);
+  };
+  const clearErrors = () => {
+    status.textContent = '';
+    status.removeAttribute('data-kind');
+    for (const controller of controllers) controller.setError(null);
+  };
+  const applyInitialAnswers = () => {
+    for (const controller of controllers) {
+      controller.setValue(initialAnswers[controller.field.id] ?? '');
+    }
+  };
+  const collectAnswers = () =>
+    Object.fromEntries(controllers.map(controller => [controller.field.id, controller.getValue()]));
+
+  const handleSubmit = async (event: SubmitEvent) => {
+    event.preventDefault();
+    if (busy || disposed) return;
+    clearErrors();
+
+    let answers: Record<string, string | number>;
+    try {
+      answers = normalizeVariantAnswers(config.fields, collectAnswers());
+    } catch (error) {
+      if (error instanceof VariantAnswerError && error.fieldId) {
+        const controller = controllers.find(candidate => candidate.field.id === error.fieldId);
+        controller?.setError(readableFieldError(error));
+        controller?.focus();
+      } else {
+        status.textContent = error instanceof Error ? error.message : 'Please check your response.';
+        status.dataset.kind = 'error';
+      }
+      return;
+    }
+
+    setBusy(true);
+    status.textContent = 'Submitting…';
+    try {
+      const result = await options.submit(answers, { context, submissionId });
+      if (disposed) return;
+      setBusy(false);
+      successLink.hidden = !result.isPublic;
+      if (result.isPublic) successLink.href = result.issueUrl;
+      form.hidden = true;
+      success.hidden = false;
+      success.focus();
+      options.onSubmitted?.(result);
+    } catch (error) {
+      if (disposed) return;
+      status.textContent = error instanceof Error ? error.message : 'Failed to submit feedback.';
+      status.dataset.kind = 'error';
+      setBusy(false);
+    }
+  };
+  const preventImplicitSubmit = (event: KeyboardEvent) => {
+    if (
+      event.key === 'Enter' &&
+      event.target instanceof HTMLInputElement &&
+      event.target.type !== 'submit'
+    ) {
+      event.preventDefault();
+    }
+  };
+  form.addEventListener('submit', handleSubmit);
+  form.addEventListener('keydown', preventImplicitSubmit);
+  applyInitialAnswers();
+
+  return {
+    element: surface,
+    reset() {
+      if (busy || disposed) return;
+      submissionId = createRuntimeId('submission');
+      clearErrors();
+      applyInitialAnswers();
+      success.hidden = true;
+      successLink.removeAttribute('href');
+      form.hidden = false;
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      form.removeEventListener('submit', handleSubmit);
+      form.removeEventListener('keydown', preventImplicitSubmit);
+      if (cancelButton && options.cancel) {
+        cancelButton.removeEventListener('click', options.cancel.onCancel);
+      }
+      for (const controller of controllers) controller.dispose();
+    },
+  };
+}
+
+export function createRuntimeId(prefix: string): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return `${prefix}-${globalThis.crypto.randomUUID()}`;
+  }
+  if (typeof globalThis.crypto?.getRandomValues !== 'function') {
+    throw new Error(
+      'BugDrop rendered variants require a cryptographically secure random generator'
+    );
+  }
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
+  return `${prefix}-${Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+function createSuccessState(config: Readonly<VariantConfig>) {
+  const success = document.createElement('div');
+  success.className = 'bdv-success';
+  success.hidden = true;
+  success.tabIndex = -1;
+  const title = document.createElement('h3');
+  title.className = 'bdv-success-title';
+  title.textContent = config.content.successTitle ?? 'Thanks for your feedback!';
+  const message = document.createElement('p');
+  message.className = 'bdv-success-message';
+  message.textContent = config.content.successMessage ?? 'Your response was submitted.';
+  const successLink = document.createElement('a');
+  successLink.className = 'bdv-success-link';
+  successLink.textContent = 'View GitHub Issue';
+  successLink.target = '_blank';
+  successLink.rel = 'noopener noreferrer';
+  success.append(title, message, successLink);
+  return { success, successLink };
+}
+
+function readableFieldError(error: VariantAnswerError): string {
+  if (!error.fieldId) return error.message;
+  const prefix = `Answer ${error.fieldId} `;
+  const detail = error.message.startsWith(prefix)
+    ? error.message.slice(prefix.length)
+    : error.message;
+  return detail.charAt(0).toUpperCase() + detail.slice(1);
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/issue-draft.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/issue-draft.ts.txt
@@ -1,0 +1,104 @@
+import type {
+  VariantConfig,
+  VariantContext,
+  VariantField,
+  VariantIssueSection,
+} from './public-types';
+import { normalizeVariantAnswers } from './answer-validation';
+
+interface CompiledIssueDraft {
+  title: string;
+  classification?: 'bug' | 'feature' | 'question' | 'feedback';
+  sections: Array<{ heading: string; value: string; format: 'text' | 'quote' | 'code' }>;
+}
+
+export function compileIssueDraft(
+  config: Readonly<VariantConfig>,
+  answers: Record<string, unknown>,
+  context: VariantContext = {}
+): CompiledIssueDraft {
+  validateContext(context);
+  const normalizedAnswers = normalizeVariantAnswers(config.fields, answers);
+  const title = config.issue.title
+    .replace(/{{\s*([^{}]+?)\s*}}/g, (_match, reference: string) => {
+      const value = reference.startsWith('context.')
+        ? context[reference.slice('context.'.length)]
+        : normalizedAnswers[reference];
+      return displayValue(config.fields, reference, value, 'text');
+    })
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 256)
+    .trim();
+  if (!title) throw new TypeError('BugDrop variant produced an empty Issue title');
+
+  const sections = (config.issue.sections ?? []).flatMap(section => {
+    const value = resolveSectionValue(section, config.fields, normalizedAnswers, context);
+    if (!value.trim() && section.omitWhenEmpty) return [];
+    return [
+      {
+        heading: section.heading.trim(),
+        value: value.trim() ? value : 'Not provided.',
+        format: workerFormat(section),
+      },
+    ];
+  });
+  return {
+    title,
+    ...(config.issue.classification ? { classification: config.issue.classification } : {}),
+    sections,
+  };
+}
+
+function resolveSectionValue(
+  section: VariantIssueSection,
+  fields: ReadonlyArray<VariantField>,
+  answers: Record<string, string | number>,
+  context: VariantContext
+): string {
+  if ('context' in section) return String(context[section.context] ?? '');
+  return displayValue(fields, section.field, answers[section.field], section.format ?? 'text');
+}
+
+function displayValue(
+  fields: ReadonlyArray<VariantField>,
+  fieldId: string,
+  value: unknown,
+  format: string
+): string {
+  if (value === undefined || value === null || value === '') return '';
+  const field = fields.find(candidate => candidate.id === fieldId);
+  if (format === 'stars' && field?.type === 'rating' && typeof value === 'number') {
+    const scale = field.scale ?? 5;
+    return `${'★'.repeat(value)}${'☆'.repeat(scale - value)} (${value}/${scale})`;
+  }
+  if (format === 'choice' && field?.type === 'singleChoice') {
+    return field.options.find(option => option.value === value)?.label ?? String(value);
+  }
+  return String(value);
+}
+
+function workerFormat(section: VariantIssueSection): 'text' | 'quote' | 'code' {
+  return section.format === 'quote' || section.format === 'code' ? section.format : 'text';
+}
+
+function validateContext(context: VariantContext): void {
+  if (!isObject(context) || Object.keys(context).length > 50) {
+    throw new TypeError('BugDrop variant context must contain at most 50 values');
+  }
+  for (const [key, value] of Object.entries(context)) {
+    if (!/^[a-z][a-z0-9_-]{0,63}$/.test(key)) throw new TypeError(`Invalid context key: ${key}`);
+    if (!['string', 'number', 'boolean'].includes(typeof value) && value !== null) {
+      throw new TypeError(`Invalid context value: ${key}`);
+    }
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+      throw new TypeError(`Invalid context value: ${key}`);
+    }
+    if (String(value ?? '').length > 5_000)
+      throw new TypeError(`Context value is too long: ${key}`);
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/manager.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/manager.ts.txt
@@ -1,0 +1,66 @@
+import type {
+  VariantConfig,
+  VariantHandle,
+  VariantMountOptions,
+  VariantOpenOptions,
+} from './public-types';
+import { normalizeVariantDefinition, type VariantDefinition } from './flow-definition';
+import { mountInlineVariant } from './presentations/inline';
+import { createBusyOpenedVariant, openModalVariant } from './presentations/modal';
+import { validateAndFreezeVariantConfig } from './validate-config';
+import { submitVariant, type VariantTransportConfig } from './submission';
+
+export interface VariantManager {
+  register(config: VariantConfig): VariantHandle;
+}
+
+export function createVariantManager(
+  transport: VariantTransportConfig,
+  runtime: { isLegacyModalOpen(): boolean } = { isLegacyModalOpen: () => false }
+): VariantManager {
+  const variants = new Map<string, VariantDefinition>();
+
+  return {
+    register(config) {
+      const normalized = validateAndFreezeVariantConfig(config);
+      if (variants.has(normalized.id)) {
+        throw new TypeError(`BugDrop variant is already registered: ${normalized.id}`);
+      }
+      const definition = normalizeVariantDefinition(normalized);
+      variants.set(normalized.id, definition);
+
+      const screen = definition.screens[0];
+      const screenConfig = screen.config;
+      const submitFromDefinition = (
+        answers: Record<string, unknown>,
+        options: Parameters<typeof submitVariant>[3] = {}
+      ) => submitVariant(transport, screenConfig, answers, options);
+
+      return Object.freeze({
+        id: definition.variantId,
+        open(options?: VariantOpenOptions) {
+          if (screenConfig.presentation.kind !== 'modal') {
+            throw new TypeError('BugDrop open() requires a modal variant');
+          }
+          if (runtime.isLegacyModalOpen()) return createBusyOpenedVariant(definition.variantId);
+          return openModalVariant({
+            config: screenConfig,
+            options,
+            submit: submitFromDefinition,
+          });
+        },
+        mount(target: HTMLElement, options?: VariantMountOptions) {
+          return mountInlineVariant({
+            config: screenConfig,
+            target,
+            options,
+            submit: submitFromDefinition,
+          });
+        },
+        submit(answers: Record<string, unknown>, options = {}) {
+          return submitFromDefinition(answers, options);
+        },
+      });
+    },
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/modal-coordinator.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/modal-coordinator.ts.txt
@@ -1,0 +1,16 @@
+interface ActiveVariantModal {
+  close(): void;
+}
+
+let activeVariantModal: ActiveVariantModal | undefined;
+
+export function closeActiveVariantModal(): void {
+  activeVariantModal?.close();
+}
+
+export function setActiveVariantModal(modal: ActiveVariantModal): () => void {
+  activeVariantModal = modal;
+  return () => {
+    if (activeVariantModal === modal) activeVariantModal = undefined;
+  };
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/presentations/inline.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/presentations/inline.ts.txt
@@ -1,0 +1,63 @@
+import { assertKnownVariantAnswerKeys } from '../answer-validation';
+import { createRuntimeId, createVariantForm } from '../form';
+import type {
+  MountedVariant,
+  VariantConfig,
+  VariantMountOptions,
+  SubmissionResult,
+} from '../public-types';
+import { createStyledVariantRoot } from '../styles';
+import { installRadixDialogCompatibility } from '../../radix-compat';
+
+interface InlineMountOptions {
+  config: Readonly<VariantConfig>;
+  target: HTMLElement;
+  options?: VariantMountOptions;
+  submit(
+    answers: Record<string, unknown>,
+    options: { context?: VariantMountOptions['context']; submissionId?: string }
+  ): Promise<SubmissionResult>;
+}
+
+export function mountInlineVariant(input: InlineMountOptions): MountedVariant {
+  if (!(input.target instanceof HTMLElement)) {
+    throw new TypeError('BugDrop inline variant target must be an HTMLElement');
+  }
+  if (input.config.presentation.kind !== 'inline') {
+    throw new TypeError('BugDrop mount() requires an inline variant');
+  }
+  assertKnownVariantAnswerKeys(input.config.fields, input.options?.initialAnswers ?? {});
+
+  const instanceId = createRuntimeId(input.config.id);
+  const host = document.createElement('div');
+  host.dataset.bugdropOwned = '';
+  host.dataset.bugdropInstance = instanceId;
+  const shadow = host.attachShadow({ mode: 'open' });
+  const disposeRadix = installRadixDialogCompatibility(host);
+  const styled = createStyledVariantRoot(shadow, input.config, 'inline');
+  const form = createVariantForm({
+    config: input.config,
+    instanceId,
+    context: input.options?.context,
+    initialAnswers: input.options?.initialAnswers,
+    submit: input.submit,
+  });
+  styled.root.appendChild(form.element);
+  input.target.appendChild(host);
+
+  let unmounted = false;
+  return Object.freeze({
+    instanceId,
+    reset() {
+      if (!unmounted) form.reset();
+    },
+    unmount() {
+      if (unmounted) return;
+      unmounted = true;
+      form.dispose();
+      disposeRadix();
+      styled.dispose();
+      host.remove();
+    },
+  });
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/presentations/modal.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/presentations/modal.ts.txt
@@ -1,0 +1,159 @@
+import { assertKnownVariantAnswerKeys } from '../answer-validation';
+import { createRuntimeId, createVariantForm } from '../form';
+import { closeActiveVariantModal, setActiveVariantModal } from '../modal-coordinator';
+import type {
+  OpenedVariant,
+  SubmissionResult,
+  VariantConfig,
+  VariantOpenOptions,
+  VariantOutcome,
+} from '../public-types';
+import { createStyledVariantRoot } from '../styles';
+import { installRadixDialogCompatibility } from '../../radix-compat';
+
+interface ModalOpenInput {
+  config: Readonly<VariantConfig>;
+  options?: VariantOpenOptions;
+  submit(
+    answers: Record<string, unknown>,
+    options: { context?: VariantOpenOptions['context']; submissionId?: string }
+  ): Promise<SubmissionResult>;
+}
+
+export function openModalVariant(input: ModalOpenInput): OpenedVariant {
+  if (input.config.presentation.kind !== 'modal') {
+    throw new TypeError('BugDrop open() requires a modal variant');
+  }
+  assertKnownVariantAnswerKeys(input.config.fields, input.options?.initialAnswers ?? {});
+  closeActiveVariantModal();
+
+  const instanceId = createRuntimeId(input.config.id);
+  const previousFocus =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const previousOverflow = document.body.style.getPropertyValue('overflow');
+  const previousOverflowPriority = document.body.style.getPropertyPriority('overflow');
+  const host = document.createElement('div');
+  host.dataset.bugdropOwned = '';
+  host.dataset.bugdropInstance = instanceId;
+  Object.assign(host.style, { position: 'fixed', inset: '0', zIndex: '2147483646' });
+  const shadow = host.attachShadow({ mode: 'open' });
+  const styled = createStyledVariantRoot(shadow, input.config, 'modal');
+  const overlay = document.createElement('div');
+  overlay.className = 'bdv-overlay';
+  styled.root.appendChild(overlay);
+
+  let resolveOutcome!: (outcome: VariantOutcome) => void;
+  const result = new Promise<VariantOutcome>(resolve => {
+    resolveOutcome = resolve;
+  });
+  let settled = false;
+  let closed = false;
+  let unregisterActive = () => {};
+  const settle = (outcome: VariantOutcome) => {
+    if (settled) return;
+    settled = true;
+    resolveOutcome(outcome);
+  };
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    settle({ status: 'closed' });
+    unregisterActive();
+    shadow.removeEventListener('keydown', handleKeydown);
+    overlay.removeEventListener('pointerdown', handleBackdropPointerDown);
+    form.dispose();
+    disposeRadix();
+    styled.dispose();
+    host.remove();
+    restoreBodyOverflow(previousOverflow, previousOverflowPriority);
+    if (previousFocus?.isConnected) previousFocus.focus();
+  };
+
+  const form = createVariantForm({
+    config: input.config,
+    instanceId,
+    context: input.options?.context,
+    initialAnswers: input.options?.initialAnswers,
+    submit: input.submit,
+    cancel: { label: input.config.content.cancelLabel ?? 'Cancel', onCancel: close },
+    onSubmitted: submission => settle({ status: 'submitted', result: submission }),
+  });
+  form.element.setAttribute('role', 'dialog');
+  form.element.setAttribute('aria-modal', 'true');
+  form.element.dataset.size = input.config.presentation.size ?? 'default';
+
+  const closeButton = document.createElement('button');
+  closeButton.type = 'button';
+  closeButton.className = 'bdv-close';
+  closeButton.setAttribute('aria-label', 'Close');
+  closeButton.textContent = '×';
+  closeButton.addEventListener('click', close, { once: true });
+  form.element.prepend(closeButton);
+  overlay.appendChild(form.element);
+
+  function handleKeydown(event: Event) {
+    if (!(event instanceof KeyboardEvent)) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const focusable = getFocusable(form.element);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      form.element.focus();
+      return;
+    }
+    const active = shadow.activeElement;
+    const first = focusable[0];
+    const last = focusable.at(-1)!;
+    if (event.shiftKey && (active === first || !form.element.contains(active))) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+  function handleBackdropPointerDown(event: PointerEvent) {
+    if (event.target === overlay) close();
+  }
+
+  document.body.style.setProperty('overflow', 'hidden');
+  document.body.appendChild(host);
+  const disposeRadix = installRadixDialogCompatibility(host);
+  shadow.addEventListener('keydown', handleKeydown);
+  overlay.addEventListener('pointerdown', handleBackdropPointerDown);
+  const opened = Object.freeze({ instanceId, result, close });
+  unregisterActive = setActiveVariantModal(opened);
+  queueMicrotask(() => {
+    if (closed) return;
+    const preferred = form.element.querySelector<HTMLElement>(
+      'textarea:not(:disabled), input:not(:disabled), [role="radio"][tabindex="0"]'
+    );
+    (preferred ?? getFocusable(form.element)[0] ?? form.element).focus();
+  });
+  return opened;
+}
+
+export function createBusyOpenedVariant(variantId: string): OpenedVariant {
+  return Object.freeze({
+    instanceId: createRuntimeId(variantId),
+    result: Promise.resolve<VariantOutcome>({ status: 'busy' }),
+    close() {},
+  });
+}
+
+function getFocusable(root: HTMLElement): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'button:not(:disabled), input:not(:disabled), textarea:not(:disabled), select:not(:disabled), a[href], [tabindex]:not([tabindex="-1"])'
+    )
+  ).filter(element => !element.hidden && element.getAttribute('aria-hidden') !== 'true');
+}
+
+function restoreBodyOverflow(value: string, priority: string): void {
+  if (value) document.body.style.setProperty('overflow', value, priority);
+  else document.body.style.removeProperty('overflow');
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/styles.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/styles.ts.txt
@@ -1,0 +1,250 @@
+import { sanitizeCssColor } from '../sanitize';
+import { attachSystemThemeListener, resolveTheme } from '../theme';
+import type { VariantConfig } from './public-types';
+
+interface StyledVariantRoot {
+  readonly root: HTMLDivElement;
+  dispose(): void;
+}
+
+export function createStyledVariantRoot(
+  shadow: ShadowRoot,
+  config: Readonly<VariantConfig>,
+  presentation: 'inline' | 'modal'
+): StyledVariantRoot {
+  const style = document.createElement('style');
+  style.textContent = VARIANT_CSS;
+  shadow.appendChild(style);
+
+  const root = document.createElement('div');
+  root.className = 'bdv-root';
+  root.dataset.presentation = presentation;
+  if (config.presentation.kind === 'modal') {
+    root.dataset.size = config.presentation.size ?? 'default';
+  }
+  root.dataset.density = config.appearance?.density ?? 'comfortable';
+  root.dataset.columns = String(config.presentation.columns ?? 1);
+  const accent = sanitizeCssColor(config.appearance?.accentColor);
+  if (accent) root.style.setProperty('--bdv-accent', accent);
+  shadow.appendChild(root);
+
+  const mode = config.appearance?.theme ?? 'auto';
+  const applyTheme = (resolved: 'light' | 'dark') => {
+    root.classList.toggle('bdv-dark', resolved === 'dark');
+  };
+  applyTheme(resolveTheme(mode));
+  const detachTheme = mode === 'auto' ? attachSystemThemeListener(applyTheme) : () => {};
+
+  return {
+    root,
+    dispose() {
+      detachTheme();
+      style.remove();
+      root.remove();
+    },
+  };
+}
+
+const VARIANT_CSS = `
+  :host {
+    --bdv-accent: #2563eb;
+    display: block;
+    color-scheme: light;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; }
+
+  .bdv-root {
+    --bdv-bg: #fff;
+    --bdv-bg-muted: #f8fafc;
+    --bdv-text: #0f172a;
+    --bdv-text-muted: #64748b;
+    --bdv-border: #cbd5e1;
+    --bdv-danger: #b91c1c;
+    --bdv-success: #047857;
+    color: var(--bdv-text);
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+  }
+
+  .bdv-root.bdv-dark {
+    --bdv-bg: #0f172a;
+    --bdv-bg-muted: #1e293b;
+    --bdv-text: #f8fafc;
+    --bdv-text-muted: #94a3b8;
+    --bdv-border: #475569;
+    --bdv-danger: #fca5a5;
+    --bdv-success: #6ee7b7;
+    color-scheme: dark;
+  }
+
+  .bdv-surface {
+    position: relative;
+    width: 100%;
+    border: 1px solid var(--bdv-border);
+    border-radius: 14px;
+    background: var(--bdv-bg);
+    color: var(--bdv-text);
+    padding: 24px;
+    box-shadow: 0 8px 28px #0f172a1a;
+  }
+
+  .bdv-root[data-density="compact"] .bdv-surface { padding: 16px; }
+  .bdv-header { margin-bottom: 20px; }
+  .bdv-title { margin: 0; font-size: 1.25rem; line-height: 1.3; }
+  .bdv-description { margin: 8px 0 0; color: var(--bdv-text-muted); }
+
+  .bdv-fields {
+    display: grid;
+    grid-template-columns: repeat(var(--bdv-columns, 1), minmax(0, 1fr));
+    gap: 18px;
+  }
+  .bdv-root[data-columns="2"] .bdv-fields { --bdv-columns: 2; }
+  .bdv-field[data-span="2"] { grid-column: span 2; }
+  .bdv-field { min-width: 0; }
+  .bdv-label { display: block; margin-bottom: 6px; font-weight: 650; }
+  .bdv-required { color: var(--bdv-danger); }
+  .bdv-help { margin: -2px 0 7px; color: var(--bdv-text-muted); font-size: .875rem; }
+  .bdv-error { margin-top: 6px; color: var(--bdv-danger); font-size: .875rem; }
+
+  .bdv-input {
+    width: 100%;
+    min-height: 44px;
+    border: 1px solid var(--bdv-border);
+    border-radius: 9px;
+    background: var(--bdv-bg);
+    color: var(--bdv-text);
+    padding: 10px 12px;
+    font: inherit;
+  }
+  textarea.bdv-input { min-height: 108px; resize: vertical; }
+  .bdv-input:focus-visible,
+  .bdv-rating-option:focus-visible,
+  .choice > label:has(:focus-visible),
+  .bdv-submit:focus-visible,
+  .bdv-cancel:focus-visible,
+  .bdv-close:focus-visible,
+  .bdv-success-link:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--bdv-accent) 35%, transparent);
+    outline-offset: 2px;
+  }
+  [aria-invalid="true"] { border-color: var(--bdv-danger); }
+
+  .bdv-rating { display: flex; flex-wrap: wrap; gap: 6px; }
+  .bdv-rating-option {
+    width: 44px;
+    height: 44px;
+    border: 1px solid var(--bdv-border);
+    border-radius: 9px;
+    background: var(--bdv-bg-muted);
+    color: var(--bdv-text-muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: 1.4rem;
+    line-height: 1;
+  }
+  .bdv-rating-option:hover,
+  .bdv-rating-option--active { color: var(--bdv-accent); border-color: var(--bdv-accent); }
+  .bdv-rating-option:disabled { cursor: wait; opacity: .65; }
+  .bdv-rating-labels {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 5px;
+    color: var(--bdv-text-muted);
+    font-size: .8rem;
+  }
+
+  .choice { display: grid; gap: 8px; }
+  .choice > label {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    min-height: 44px;
+    align-items: center;
+    gap: 0 10px;
+    border: 1px solid transparent;
+    border-radius: 9px;
+    cursor: pointer;
+    padding: 9px 10px;
+    font-weight: 650;
+  }
+  .choice > label:has(:checked) { border-color: var(--bdv-accent); }
+  .cards > *, .buttons > * { background: var(--bdv-bg-muted); border-color: var(--bdv-border); }
+  .buttons { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
+  .choice input { grid-row: span 2; width: 20px; height: 20px; accent-color: var(--bdv-accent); }
+  .choice .bdv-help { margin: 0; font-weight: 400; }
+  .choice :disabled ~ * { opacity: .65; }
+
+  .bdv-actions { display: flex; align-items: center; gap: 12px; margin-top: 20px; }
+  .bdv-submit {
+    min-height: 44px;
+    border: 0;
+    border-radius: 9px;
+    background: var(--bdv-accent);
+    color: #fff;
+    cursor: pointer;
+    padding: 10px 18px;
+    font: inherit;
+    font-weight: 700;
+  }
+  .bdv-cancel {
+    min-height: 44px;
+    border: 1px solid var(--bdv-border);
+    border-radius: 9px;
+    background: var(--bdv-bg);
+    color: var(--bdv-text);
+    cursor: pointer;
+    padding: 10px 18px;
+    font: inherit;
+    font-weight: 650;
+  }
+  .bdv-cancel:disabled { cursor: wait; opacity: .65; }
+  .bdv-overlay {
+    display: grid;
+    height: 100%;
+    min-height: 0;
+    align-items: safe center;
+    justify-items: center;
+    overflow: auto;
+    padding: max(20px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right))
+      max(20px, env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left));
+    background: #0f172a8f;
+  }
+  .bdv-root[data-presentation="modal"] { height: 100%; }
+  .bdv-root[data-presentation="modal"] .bdv-surface { max-width: 560px; }
+  .bdv-root[data-size="compact"] .bdv-surface { max-width: 440px; }
+  .bdv-root[data-size="wide"] .bdv-surface { max-width: 760px; }
+  .bdv-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    display: grid;
+    width: 44px;
+    height: 44px;
+    place-items: center;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--bdv-text-muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: 1.6rem;
+    line-height: 1;
+  }
+  .bdv-close:hover { background: var(--bdv-bg-muted); color: var(--bdv-text); }
+  .bdv-root[data-presentation="modal"] .bdv-header { padding-right: 36px; }
+  .bdv-submit:disabled { cursor: wait; opacity: .65; }
+  .bdv-status { min-height: 1.5em; margin: 12px 0 0; color: var(--bdv-text-muted); }
+  .bdv-status[data-kind="error"] { color: var(--bdv-danger); }
+  .bdv-success { outline: none; }
+  .bdv-success-title { margin: 0; color: var(--bdv-success); font-size: 1.2rem; }
+  .bdv-success-message { margin: 8px 0 0; color: var(--bdv-text-muted); }
+  .bdv-success-link { display: inline-block; margin-top: 14px; color: var(--bdv-accent); }
+
+  @media (max-width: 640px) {
+    .bdv-root[data-columns="2"] .bdv-fields { --bdv-columns: 1; }
+    .bdv-field[data-span="2"] { grid-column: span 1; }
+    .bdv-surface { padding: 18px; }
+    .bdv-root[data-presentation="modal"] .bdv-surface { max-width: none; }
+  }
+`;

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/submission.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/submission.ts.txt
@@ -1,0 +1,123 @@
+import { getAuthHeaders, type BugDropAuthTokenProvider } from '../auth-token';
+import type { HeadlessSubmitOptions, SubmissionResult, VariantConfig } from './public-types';
+import { compileIssueDraft } from './issue-draft';
+
+export interface VariantTransportConfig {
+  repo: string;
+  apiUrl: string;
+  authTokenProvider?: BugDropAuthTokenProvider;
+}
+
+export async function submitVariant(
+  transport: VariantTransportConfig,
+  config: Readonly<VariantConfig>,
+  answers: Record<string, unknown>,
+  options: HeadlessSubmitOptions = {}
+): Promise<SubmissionResult> {
+  const submissionId = options.submissionId ?? createSubmissionId();
+  const issue = compileIssueDraft(config, answers, options.context);
+  const response = await fetch(`${transport.apiUrl}/feedback`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await getAuthHeaders(transport.authTokenProvider)),
+    },
+    body: JSON.stringify({
+      kind: 'bugdrop.variant-submission',
+      schemaVersion: 1,
+      repo: transport.repo,
+      variantId: config.id,
+      submissionId,
+      issue,
+      metadata: collectMetadata(),
+    }),
+  });
+  const result = (await response.json()) as Record<string, unknown>;
+  if (!response.ok || result.success !== true) {
+    throw new Error(typeof result.error === 'string' ? result.error : 'Failed to submit feedback');
+  }
+  if (
+    !Number.isInteger(result.issueNumber) ||
+    (result.issueNumber as number) <= 0 ||
+    typeof result.issueUrl !== 'string' ||
+    !isCanonicalIssueUrl(result.issueUrl, transport.repo, result.issueNumber as number) ||
+    typeof result.isPublic !== 'boolean'
+  ) {
+    throw new Error('BugDrop received an invalid Issue result');
+  }
+  return {
+    issueNumber: result.issueNumber as number,
+    issueUrl: result.issueUrl,
+    isPublic: result.isPublic,
+    ...(Array.isArray(result.labelMappingWarnings) &&
+    result.labelMappingWarnings.every(value => typeof value === 'string')
+      ? { labelMappingWarnings: result.labelMappingWarnings as string[] }
+      : {}),
+  };
+}
+
+function createSubmissionId(): string {
+  if (typeof crypto?.randomUUID === 'function') return crypto.randomUUID();
+  if (typeof crypto?.getRandomValues !== 'function') {
+    throw new Error('BugDrop variants require a cryptographically secure random generator');
+  }
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function collectMetadata() {
+  const url = new URL(window.location.href);
+  url.search = '';
+  url.hash = '';
+  return {
+    url: url.toString(),
+    userAgent: navigator.userAgent,
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    timestamp: new Date().toISOString(),
+    browser: parseBrowser(navigator.userAgent),
+    os: parseOS(navigator.userAgent),
+    devicePixelRatio: window.devicePixelRatio,
+    language: navigator.language,
+  };
+}
+
+function parseBrowser(userAgent: string): { name: string; version: string } {
+  for (const [name, pattern] of [
+    ['Edge', /Edg\/(\d+[\d.]*)/],
+    ['Chrome', /Chrome\/(\d+[\d.]*)/],
+    ['Safari', /Version\/(\d+[\d.]*).*Safari/],
+    ['Firefox', /Firefox\/(\d+[\d.]*)/],
+  ] as const) {
+    const match = userAgent.match(pattern);
+    if (match) return { name, version: match[1] ?? 'unknown' };
+  }
+  return { name: 'Unknown', version: 'unknown' };
+}
+
+function parseOS(userAgent: string): { name: string; version: string } {
+  const match = userAgent.match(/(?:Mac OS X|Windows NT|Android) ([\d_.]+)/);
+  if (match) {
+    const name = userAgent.includes('Mac OS X')
+      ? 'macOS'
+      : userAgent.includes('Windows NT')
+        ? 'Windows'
+        : 'Android';
+    return { name, version: (match[1] ?? 'unknown').replaceAll('_', '.') };
+  }
+  return { name: userAgent.includes('Linux') ? 'Linux' : 'Unknown', version: 'unknown' };
+}
+
+function isCanonicalIssueUrl(url: string, repo: string, issueNumber: number): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.protocol === 'https:' &&
+      parsed.hostname === 'github.com' &&
+      parsed.pathname.toLowerCase() === `/${repo}/issues/${issueNumber}`.toLowerCase() &&
+      !parsed.search &&
+      !parsed.hash
+    );
+  } catch {
+    return false;
+  }
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/variants/validate-config.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/variants/validate-config.ts.txt
@@ -1,0 +1,355 @@
+/* eslint-disable max-lines -- Keep complete synchronous public-config validation at one boundary. */
+import type { VariantConfig, VariantField, VariantIssueSection } from './public-types';
+
+const ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
+const PLACEHOLDER_PATTERN = /{{\s*([^{}]+?)\s*}}/g;
+const CLASSIFICATIONS = new Set(['bug', 'feature', 'question', 'feedback']);
+const FIELD_TYPES = new Set(['shortText', 'longText', 'rating', 'singleChoice']);
+const TOP_LEVEL_KEYS = new Set([
+  'id',
+  'configVersion',
+  'presentation',
+  'appearance',
+  'content',
+  'fields',
+  'issue',
+]);
+const CONTENT_KEYS = new Set([
+  'title',
+  'description',
+  'submitLabel',
+  'cancelLabel',
+  'successTitle',
+  'successMessage',
+]);
+const APPEARANCE_KEYS = new Set(['theme', 'accentColor', 'density']);
+const ISSUE_KEYS = new Set(['classification', 'title', 'sections']);
+const BASE_FIELD_KEYS = ['id', 'type', 'label', 'helpText', 'required', 'layout'];
+const FIELD_KEYS: Record<VariantField['type'], Set<string>> = {
+  shortText: new Set([...BASE_FIELD_KEYS, 'placeholder', 'minLength', 'maxLength']),
+  longText: new Set([...BASE_FIELD_KEYS, 'placeholder', 'rows', 'minLength', 'maxLength']),
+  rating: new Set([...BASE_FIELD_KEYS, 'scale', 'icon', 'lowLabel', 'highLabel']),
+  singleChoice: new Set([...BASE_FIELD_KEYS, 'options', 'display']),
+};
+
+export function validateAndFreezeVariantConfig(input: VariantConfig): Readonly<VariantConfig> {
+  if (!isObject(input)) throw new TypeError('BugDrop variant config must be an object');
+  assertOnlyKeys(input, TOP_LEVEL_KEYS, 'variant config');
+  if (typeof input.id !== 'string' || !ID_PATTERN.test(input.id) || input.id === 'legacy') {
+    throw new TypeError('BugDrop variant id must match [a-z][a-z0-9_-]{0,63} and cannot be legacy');
+  }
+  if (input.configVersion !== undefined && input.configVersion !== 1) {
+    throw new TypeError('BugDrop variant configVersion must be 1');
+  }
+  validatePresentation(input.presentation);
+  validateAppearance(input.appearance);
+  validateContent(input.content);
+  if (!Array.isArray(input.fields) || input.fields.length === 0 || input.fields.length > 20) {
+    throw new TypeError('BugDrop variant fields must contain 1-20 entries');
+  }
+
+  const fields = new Map<string, VariantField>();
+  for (const field of input.fields) validateField(field, fields);
+  validateIssue(input, fields);
+
+  return deepFreeze(clone(input));
+}
+
+function validatePresentation(value: VariantConfig['presentation']): void {
+  if (!isObject(value) || (value.kind !== 'modal' && value.kind !== 'inline')) {
+    throw new TypeError('BugDrop variant presentation must be modal or inline');
+  }
+  assertOnlyKeys(
+    value,
+    value.kind === 'modal' ? new Set(['kind', 'size', 'columns']) : new Set(['kind', 'columns']),
+    'variant presentation'
+  );
+  if (value.columns !== undefined && value.columns !== 1 && value.columns !== 2) {
+    throw new TypeError('BugDrop variant presentation columns must be 1 or 2');
+  }
+  if (
+    value.kind === 'modal' &&
+    value.size !== undefined &&
+    !['compact', 'default', 'wide'].includes(value.size)
+  ) {
+    throw new TypeError('BugDrop modal size must be compact, default, or wide');
+  }
+}
+
+function validateAppearance(value: VariantConfig['appearance']): void {
+  if (value === undefined) return;
+  if (!isObject(value)) throw new TypeError('BugDrop variant appearance must be an object');
+  assertOnlyKeys(value, APPEARANCE_KEYS, 'variant appearance');
+  if (value.theme !== undefined && !['light', 'dark', 'auto'].includes(value.theme)) {
+    throw new TypeError('BugDrop variant appearance theme is invalid');
+  }
+  if (
+    value.accentColor !== undefined &&
+    (!nonEmptyString(value.accentColor, 120) || hasControlChars(value.accentColor))
+  ) {
+    throw new TypeError('BugDrop variant appearance accentColor is invalid');
+  }
+  if (
+    value.density !== undefined &&
+    value.density !== 'compact' &&
+    value.density !== 'comfortable'
+  ) {
+    throw new TypeError('BugDrop variant appearance density is invalid');
+  }
+}
+
+function validateContent(value: VariantConfig['content']): void {
+  if (!isObject(value)) throw new TypeError('BugDrop variant content must be an object');
+  assertOnlyKeys(value, CONTENT_KEYS, 'variant content');
+  if (!nonEmptyString(value.title, 500)) {
+    throw new TypeError('BugDrop variant content.title is required');
+  }
+  validateOptionalCopy(value.description, 'description', 2_000);
+  validateOptionalCopy(value.submitLabel, 'submitLabel', 120);
+  validateOptionalCopy(value.cancelLabel, 'cancelLabel', 120);
+  validateOptionalCopy(value.successTitle, 'successTitle', 500);
+  validateOptionalCopy(value.successMessage, 'successMessage', 2_000);
+}
+
+function validateOptionalCopy(value: unknown, key: string, maximum: number): void {
+  if (value !== undefined && !nonEmptyString(value, maximum)) {
+    throw new TypeError(`BugDrop variant content.${key} is invalid`);
+  }
+}
+
+function validateField(field: VariantField, fields: Map<string, VariantField>): void {
+  if (
+    !isObject(field) ||
+    !FIELD_TYPES.has(field.type) ||
+    typeof field.id !== 'string' ||
+    !ID_PATTERN.test(field.id)
+  ) {
+    throw new TypeError('BugDrop variant field has an invalid type or id');
+  }
+  assertOnlyKeys(field, FIELD_KEYS[field.type], `field ${field.id}`);
+  if (fields.has(field.id)) throw new TypeError(`Duplicate BugDrop variant field id: ${field.id}`);
+  fields.set(field.id, field);
+  if (!nonEmptyString(field.label, 500)) throw new TypeError(`Field ${field.id} requires a label`);
+  if (field.helpText !== undefined && !nonEmptyString(field.helpText, 1_000)) {
+    throw new TypeError(`Field ${field.id} has invalid helpText`);
+  }
+  if (field.required !== undefined && typeof field.required !== 'boolean') {
+    throw new TypeError(`Field ${field.id} required must be boolean`);
+  }
+  validateLayout(field);
+
+  if (field.type === 'shortText' || field.type === 'longText') {
+    validateTextField(field);
+  } else if (field.type === 'rating') {
+    validateRatingField(field);
+  } else {
+    validateChoiceField(field);
+  }
+}
+
+function validateLayout(field: VariantField): void {
+  if (field.layout === undefined) return;
+  if (!isObject(field.layout)) throw new TypeError(`Field ${field.id} layout must be an object`);
+  assertOnlyKeys(field.layout, new Set(['span']), `field ${field.id} layout`);
+  if (field.layout.span !== undefined && field.layout.span !== 1 && field.layout.span !== 2) {
+    throw new TypeError(`Field ${field.id} layout span must be 1 or 2`);
+  }
+}
+
+function validateTextField(field: Extract<VariantField, { type: 'shortText' | 'longText' }>): void {
+  if (field.placeholder !== undefined && !nonEmptyString(field.placeholder, 500)) {
+    throw new TypeError(`Field ${field.id} has invalid placeholder`);
+  }
+  const defaultMaximum = field.type === 'shortText' ? 500 : 5_000;
+  if (
+    (field.minLength !== undefined && !isBoundedInteger(field.minLength, 0, 5_000)) ||
+    (field.maxLength !== undefined && !isBoundedInteger(field.maxLength, 1, 5_000))
+  ) {
+    throw new TypeError(`Field ${field.id} has invalid text bounds`);
+  }
+  const minimum = field.minLength === undefined ? 0 : field.minLength;
+  const maximum = field.maxLength === undefined ? defaultMaximum : field.maxLength;
+  if (
+    !isBoundedInteger(minimum, 0, 5_000) ||
+    !isBoundedInteger(maximum, 1, 5_000) ||
+    minimum > maximum
+  ) {
+    throw new TypeError(`Field ${field.id} has invalid text bounds`);
+  }
+  if (
+    field.type === 'longText' &&
+    field.rows !== undefined &&
+    !isBoundedInteger(field.rows, 1, 50)
+  ) {
+    throw new TypeError(`Field ${field.id} rows must be an integer from 1-50`);
+  }
+}
+
+function validateRatingField(field: Extract<VariantField, { type: 'rating' }>): void {
+  if (field.scale !== undefined && field.scale !== 5 && field.scale !== 10) {
+    throw new TypeError(`Field ${field.id} rating scale must be 5 or 10`);
+  }
+  if (field.icon !== undefined && field.icon !== 'star' && field.icon !== 'number') {
+    throw new TypeError(`Field ${field.id} rating icon must be star or number`);
+  }
+  if (field.lowLabel !== undefined && !nonEmptyString(field.lowLabel, 500)) {
+    throw new TypeError(`Field ${field.id} has invalid lowLabel`);
+  }
+  if (field.highLabel !== undefined && !nonEmptyString(field.highLabel, 500)) {
+    throw new TypeError(`Field ${field.id} has invalid highLabel`);
+  }
+}
+
+function validateChoiceField(field: Extract<VariantField, { type: 'singleChoice' }>): void {
+  if (!Array.isArray(field.options) || field.options.length < 2 || field.options.length > 50) {
+    throw new TypeError(`Field ${field.id} requires 2-50 choices`);
+  }
+  if (
+    field.display !== undefined &&
+    field.display !== 'radio' &&
+    field.display !== 'cards' &&
+    field.display !== 'buttons'
+  ) {
+    throw new TypeError(`Field ${field.id} choice display is invalid`);
+  }
+  const values = new Set<string>();
+  for (const option of field.options) {
+    if (!isObject(option)) throw new TypeError(`Field ${field.id} has an invalid choice`);
+    assertOnlyKeys(option, new Set(['value', 'label', 'description']), `field ${field.id} choice`);
+    if (!nonEmptyString(option.value, 120) || !nonEmptyString(option.label, 500)) {
+      throw new TypeError(`Field ${field.id} has an invalid choice`);
+    }
+    if (option.description !== undefined && !nonEmptyString(option.description, 1_000)) {
+      throw new TypeError(`Field ${field.id} has an invalid choice description`);
+    }
+    if (values.has(option.value)) throw new TypeError(`Field ${field.id} has duplicate choices`);
+    values.add(option.value);
+  }
+}
+
+function validateIssue(config: VariantConfig, fields: Map<string, VariantField>): void {
+  if (!isObject(config.issue)) throw new TypeError('BugDrop variant issue must be an object');
+  assertOnlyKeys(config.issue, ISSUE_KEYS, 'variant issue');
+  if (!nonEmptyString(config.issue.title, 2_000)) {
+    throw new TypeError('BugDrop variant issue.title is required');
+  }
+  if (
+    config.issue.classification !== undefined &&
+    !CLASSIFICATIONS.has(config.issue.classification)
+  ) {
+    throw new TypeError('BugDrop variant issue.classification is invalid');
+  }
+  for (const token of config.issue.title.matchAll(PLACEHOLDER_PATTERN)) {
+    const reference = token[1];
+    if (reference.startsWith('context.')) {
+      if (!ID_PATTERN.test(reference.slice('context.'.length))) throw invalidTemplate();
+    } else if (!fields.has(reference)) {
+      throw new TypeError(`Unknown BugDrop variant title field: ${reference}`);
+    }
+  }
+  if (config.issue.title.replace(PLACEHOLDER_PATTERN, '').includes('{{')) throw invalidTemplate();
+
+  if (config.issue.sections !== undefined && !Array.isArray(config.issue.sections)) {
+    throw new TypeError('BugDrop variant Issue accepts at most 20 sections');
+  }
+  const sections = config.issue.sections ?? [];
+  if (sections.length > 20)
+    throw new TypeError('BugDrop variant Issue accepts at most 20 sections');
+  const headings = new Set<string>();
+  for (const section of sections) validateSection(section, fields, headings);
+}
+
+function validateSection(
+  section: VariantIssueSection,
+  fields: Map<string, VariantField>,
+  headings: Set<string>
+): void {
+  if (!isObject(section) || !nonEmptyString(section.heading, 120)) {
+    throw new TypeError('BugDrop variant Issue section requires a heading');
+  }
+  const isFieldSection = 'field' in section;
+  const isContextSection = 'context' in section;
+  if (isFieldSection === isContextSection) {
+    throw new TypeError('BugDrop variant Issue section must reference one field or context key');
+  }
+  assertOnlyKeys(
+    section,
+    isFieldSection
+      ? new Set(['heading', 'field', 'format', 'omitWhenEmpty'])
+      : new Set(['heading', 'context', 'format', 'omitWhenEmpty']),
+    'variant Issue section'
+  );
+  if (section.omitWhenEmpty !== undefined && typeof section.omitWhenEmpty !== 'boolean') {
+    throw new TypeError('BugDrop variant Issue section omitWhenEmpty must be boolean');
+  }
+  const heading = section.heading.trim().toLowerCase();
+  if (headings.has(heading))
+    throw new TypeError(`Duplicate BugDrop Issue heading: ${section.heading}`);
+  headings.add(heading);
+
+  if (isFieldSection) {
+    const field = fields.get(section.field);
+    if (!field) throw new TypeError(`Unknown Issue field: ${section.field}`);
+    const format = section.format === undefined ? 'text' : section.format;
+    if (!['text', 'quote', 'stars', 'choice'].includes(format)) {
+      throw new TypeError(`Invalid Issue field format: ${String(format)}`);
+    }
+    if (format === 'stars' && field.type !== 'rating') {
+      throw new TypeError('BugDrop stars format requires a rating field');
+    }
+    if (format === 'choice' && field.type !== 'singleChoice') {
+      throw new TypeError('BugDrop choice format requires a singleChoice field');
+    }
+  } else {
+    if (typeof section.context !== 'string' || !ID_PATTERN.test(section.context)) {
+      throw new TypeError(`Invalid Issue context key: ${section.context}`);
+    }
+    if (section.format !== undefined && section.format !== 'text' && section.format !== 'code') {
+      throw new TypeError(`Invalid Issue context format: ${String(section.format)}`);
+    }
+  }
+}
+
+function invalidTemplate(): TypeError {
+  return new TypeError('BugDrop variant title contains an invalid placeholder');
+}
+
+function assertOnlyKeys(value: Record<string, unknown>, allowed: Set<string>, label: string): void {
+  const unknown = Object.keys(value).find(key => !allowed.has(key));
+  if (unknown) throw new TypeError(`Unknown BugDrop ${label} property: ${unknown}`);
+}
+
+function nonEmptyString(value: unknown, maximum: number): value is string {
+  return typeof value === 'string' && value.trim().length > 0 && value.length <= maximum;
+}
+
+function isBoundedInteger(value: unknown, minimum: number, maximum: number): value is number {
+  return Number.isInteger(value) && (value as number) >= minimum && (value as number) <= maximum;
+}
+
+function hasControlChars(value: string): boolean {
+  return Array.from(value).some(character => {
+    const code = character.charCodeAt(0);
+    return code < 0x20 || code === 0x7f;
+  });
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function clone<T>(value: T): T {
+  if (Array.isArray(value)) return value.map(item => clone(item)) as T;
+  if (isObject(value)) {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, clone(item)])) as T;
+  }
+  return value;
+}
+
+function deepFreeze<T>(value: T): Readonly<T> {
+  if (value && typeof value === 'object') {
+    Object.freeze(value);
+    for (const child of Object.values(value)) deepFreeze(child);
+  }
+  return value;
+}

--- a/scripts/default-flow-fixed-baseline/src/widget/viewport-capture.ts.txt
+++ b/scripts/default-flow-fixed-baseline/src/widget/viewport-capture.ts.txt
@@ -1,0 +1,228 @@
+import { withCaptureTimeout } from './capture-timeout';
+import { withBugDropOwnedRootsHidden } from './owned-roots';
+
+type DisplayMediaOptionsWithCurrentTab = DisplayMediaStreamOptions & {
+  preferCurrentTab?: boolean;
+};
+
+type VideoElementWithFrameCallback = HTMLVideoElement & {
+  requestVideoFrameCallback?: (callback: () => void) => number;
+  cancelVideoFrameCallback?: (callbackId: number) => void;
+};
+
+interface CaptureResourceOwner {
+  attachStream: () => void;
+  cleanup: () => void;
+}
+
+declare global {
+  interface Window {
+    __bugdropMockViewportCapture?: () => Promise<string>;
+  }
+}
+
+export function beginViewportCapture(): Promise<string> {
+  return withBugDropOwnedRootsHidden(beginVisibleViewportCapture);
+}
+
+function beginVisibleViewportCapture(): Promise<string> {
+  if (window.__bugdropMockViewportCapture) return window.__bugdropMockViewportCapture();
+
+  if (!navigator.mediaDevices?.getDisplayMedia) {
+    return Promise.reject(new Error('Screen Capture API is not available'));
+  }
+
+  const displayMediaOptions: DisplayMediaOptionsWithCurrentTab = {
+    video: { displaySurface: 'browser' },
+    audio: false,
+    preferCurrentTab: true,
+  };
+
+  const controller = new AbortController();
+  const capturePromise = navigator.mediaDevices
+    .getDisplayMedia(displayMediaOptions)
+    .then(stream => captureVideoFrame(stream, controller.signal));
+
+  return withCaptureTimeout(capturePromise, () => controller.abort());
+}
+
+async function captureVideoFrame(stream: MediaStream, signal: AbortSignal): Promise<string> {
+  const video = document.createElement('video') as VideoElementWithFrameCallback;
+  video.muted = true;
+  video.playsInline = true;
+  const resources = createCaptureResourceOwner(stream, video, signal);
+
+  try {
+    validateBrowserSurface(stream);
+    throwIfAborted(signal);
+    await waitForVideoFrame(video, stream, signal, resources);
+    throwIfAborted(signal);
+
+    const width = video.videoWidth || window.innerWidth;
+    const height = video.videoHeight || window.innerHeight;
+    if (!width || !height) {
+      throw new Error('Screen capture stream did not provide a video frame');
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Failed to get canvas context');
+    }
+
+    ctx.drawImage(video, 0, 0, width, height);
+    return canvas.toDataURL('image/png');
+  } finally {
+    resources.cleanup();
+  }
+}
+
+function validateBrowserSurface(stream: MediaStream): void {
+  const [track] = stream.getVideoTracks();
+  const displaySurface = track?.getSettings().displaySurface;
+  if (displaySurface && displaySurface !== 'browser') {
+    throw new Error('Please choose the current browser tab for viewport capture');
+  }
+}
+
+function createCaptureResourceOwner(
+  stream: MediaStream,
+  video: VideoElementWithFrameCallback,
+  signal: AbortSignal
+): CaptureResourceOwner {
+  let cleaned = false;
+  let streamAttached = false;
+  const cleanups: Array<() => void> = [];
+
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    for (const dispose of cleanups.splice(0)) dispose();
+    for (const track of stream.getTracks()) track.stop();
+    if (streamAttached) video.srcObject = null;
+  };
+  const onAbort = () => cleanup();
+  signal.addEventListener('abort', onAbort, { once: true });
+  cleanups.push(() => signal.removeEventListener('abort', onAbort));
+  if (signal.aborted) cleanup();
+
+  return {
+    attachStream: () => {
+      if (cleaned) return;
+      video.srcObject = stream;
+      streamAttached = true;
+    },
+    cleanup,
+  };
+}
+
+async function waitForVideoFrame(
+  video: VideoElementWithFrameCallback,
+  stream: MediaStream,
+  signal: AbortSignal,
+  resources: CaptureResourceOwner
+): Promise<void> {
+  resources.attachStream();
+  throwIfAborted(signal);
+  let playPromise: Promise<void>;
+  try {
+    playPromise = video.play();
+  } catch {
+    playPromise = Promise.resolve();
+  }
+  await raceWithAbort(
+    playPromise.then(
+      () => undefined,
+      () => undefined
+    ),
+    signal
+  );
+
+  if (typeof video.requestVideoFrameCallback === 'function') {
+    await waitForVideoFrameCallback(video, signal);
+    if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+      return;
+    }
+  }
+
+  if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+    return;
+  }
+
+  await waitForVideoReadyEvent(video, signal);
+}
+
+function raceWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(createAbortError());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener('abort', onAbort);
+      reject(createAbortError());
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      value => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      error => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+function waitForVideoFrameCallback(
+  video: VideoElementWithFrameCallback,
+  signal: AbortSignal
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let callbackId: number | undefined;
+    const timer = setTimeout(() => settle(resolve), 250);
+    const onAbort = () => settle(() => reject(createAbortError()));
+    const settle = (complete: () => void) => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      if (callbackId !== undefined) video.cancelVideoFrameCallback?.(callbackId);
+      callbackId = undefined;
+      complete();
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    callbackId = video.requestVideoFrameCallback?.(() => settle(resolve));
+    if (signal.aborted) onAbort();
+  });
+}
+
+function waitForVideoReadyEvent(video: HTMLVideoElement, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => settle(resolve), 250);
+    const onReady = () => settle(resolve);
+    const onError = () => settle(() => reject(new Error('Failed to load screen capture stream')));
+    const onAbort = () => settle(() => reject(createAbortError()));
+    const settle = (complete: () => void) => {
+      clearTimeout(timer);
+      video.removeEventListener('loadeddata', onReady);
+      video.removeEventListener('canplay', onReady);
+      video.removeEventListener('error', onError);
+      signal.removeEventListener('abort', onAbort);
+      complete();
+    };
+    video.addEventListener('loadeddata', onReady);
+    video.addEventListener('canplay', onReady);
+    video.addEventListener('error', onError);
+    signal.addEventListener('abort', onAbort, { once: true });
+    if (signal.aborted) onAbort();
+  });
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw createAbortError();
+}
+
+function createAbortError(): DOMException {
+  return new DOMException('Viewport capture aborted', 'AbortError');
+}

--- a/src/widget/default-flow/definition.ts
+++ b/src/widget/default-flow/definition.ts
@@ -1,5 +1,8 @@
 import type { BugDropAuthTokenProvider } from '../auth-token';
 import type { IssueLinkVisibility } from '../ui';
+import { normalizeFlowDefinition, type FlowDefinition } from '../flows/definition';
+import type { FlowConfig } from '../flows/public-types';
+import { validateAndFreezeFlowConfig } from '../flows/validate-config';
 
 export const DEFAULT_DEFINITION_ID = 'bugdrop-default@1' as const;
 
@@ -30,6 +33,7 @@ export interface DefaultDefinitionInput {
 
 export interface DefaultDefinition {
   readonly id: typeof DEFAULT_DEFINITION_ID;
+  readonly flow: FlowDefinition;
   readonly steps: readonly [
     Readonly<{ kind: 'welcome'; enabled: boolean; remember: boolean }>,
     Readonly<{
@@ -119,8 +123,61 @@ export function normalizeDefaultDefinition(input: DefaultDefinitionInput): Defau
     }),
   ]) as DefaultDefinition['steps'];
 
+  const config: FlowConfig = {
+    configVersion: 1,
+    id: 'bugdrop-default-v1',
+    presentation: { kind: 'modal' },
+    forms: [
+      {
+        id: 'details',
+        title: 'Send Feedback',
+        fields: [
+          { id: 'title', type: 'shortText', label: 'Title', required: true },
+          { id: 'description', type: 'longText', label: 'Description' },
+          {
+            id: 'category',
+            type: 'singleChoice',
+            label: 'Category',
+            required: true,
+            options: [
+              { value: 'bug', label: 'Bug' },
+              { value: 'feature', label: 'Feature' },
+              { value: 'question', label: 'Question' },
+            ],
+          },
+          { id: 'attachments', type: 'attachments', label: 'Attachments' },
+          { id: 'send-console-logs', type: 'checkbox', label: 'Include console logs' },
+          { id: 'name', type: 'shortText', label: 'Name' },
+          { id: 'email', type: 'shortText', label: 'Email' },
+        ],
+      },
+    ],
+    screens: [
+      {
+        id: 'welcome',
+        type: 'message',
+        title: 'Share feedback',
+        when: { context: 'show-welcome', equals: true },
+      },
+      { id: 'details', type: 'form', form: 'details' },
+      { id: 'screenshot', type: 'screenshot', mode: input.screenshotMode },
+    ],
+    issue: {
+      classification: 'bug',
+      title: '{{details.title}}',
+      sections: [{ heading: 'Description', answer: 'details.description', omitWhenEmpty: true }],
+    },
+    evidence: {
+      attachments: 'details.attachments',
+      sendConsoleLogs: 'details.send-console-logs',
+      submitter: { name: 'details.name', email: 'details.email' },
+    },
+  };
+  const flow = normalizeFlowDefinition(validateAndFreezeFlowConfig(config));
+
   return Object.freeze({
     id: DEFAULT_DEFINITION_ID,
+    flow,
     steps,
     system: Object.freeze({
       preflight: Object.freeze({

--- a/src/widget/default-flow/runtime.ts
+++ b/src/widget/default-flow/runtime.ts
@@ -6,6 +6,7 @@ import type {
   DefaultSubmissionRecipe,
   DefaultWelcomeStep,
 } from './definition';
+import { FlowRuntime } from '../flows/runtime';
 
 type DefaultPreflightResult =
   { status: 'installed' } | { status: 'not_installed' | 'unreachable'; appName?: string };
@@ -34,20 +35,30 @@ export async function runDefaultJourney<Details, Capture>(
   }
 
   const welcome = definition.steps[0];
-  if (welcome.enabled) {
+  const runtime = new FlowRuntime(definition.flow, { 'show-welcome': welcome.enabled });
+  if (runtime.current()?.id === 'welcome') {
     if (!(await ports.showWelcome(welcome))) return 'finished';
     if (welcome.remember) ports.rememberWelcome(welcome);
+    runtime.next();
   }
 
   const detailsStep = definition.steps[1];
   const screenshotStep = definition.steps[2];
   let details: Details | null = null;
   while (true) {
+    if (runtime.current()?.id !== 'details')
+      throw new Error('Default flow expected details screen');
     details = await ports.showDetails(detailsStep, details);
     if (!details) return 'finished';
 
+    runtime.next();
+    if (runtime.current()?.id !== 'screenshot')
+      throw new Error('Default flow expected screenshot screen');
     const capture = await ports.capture(screenshotStep, details);
-    if (capture.returnToDetails) continue;
+    if (capture.returnToDetails) {
+      runtime.back();
+      continue;
+    }
 
     await ports.submit(definition.system.submission, details, capture);
     return 'finished';

--- a/src/widget/flows/field-validation.ts
+++ b/src/widget/flows/field-validation.ts
@@ -29,7 +29,7 @@ export function isAllowedFlowAttachmentType(value: string): boolean {
   return ALLOWED_ATTACHMENT_TYPES.has(value);
 }
 
-export interface NormalizedFlowOpenOptions {
+interface NormalizedFlowOpenOptions {
   context: Readonly<Record<string, FlowScalar>>;
   initialAnswers: Record<string, unknown>;
 }

--- a/src/widget/flows/issue-draft.ts
+++ b/src/widget/flows/issue-draft.ts
@@ -1,6 +1,6 @@
 import type { FlowConfig, FlowIssueSection, FlowScalar } from './public-types';
 
-export interface FlowIssueDraft {
+interface FlowIssueDraft {
   title: string;
   description: string;
   category: 'bug' | 'feature' | 'question';

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -1098,10 +1098,11 @@ async function openFeedbackFlow(
   // Mark modal as open
   _isModalOpen = true;
 
-  if (
-    __BUGDROP_DEFAULT_FLOW_RUNTIME__ === 'private' ||
-    (__BUGDROP_ENABLE_TEST_HOOKS__ && shouldUsePrivateDefaultJourney())
-  ) {
+  const testRuntime = __BUGDROP_ENABLE_TEST_HOOKS__ ? requestedDefaultJourney() : undefined;
+  const useFlowRuntime =
+    testRuntime === 'private' ||
+    (testRuntime !== 'fixed' && __BUGDROP_DEFAULT_FLOW_RUNTIME__ === 'private');
+  if (useFlowRuntime) {
     const outcome = await runPrivateDefaultJourney(root, config, opts);
     if (outcome === 'preflight-blocked') return;
   } else {
@@ -1123,11 +1124,10 @@ async function openFeedbackFlow(
   _isModalOpen = false;
 }
 
-function shouldUsePrivateDefaultJourney(): boolean {
-  return (
-    (window as unknown as { __bugdropDefaultFlowRuntime?: unknown }).__bugdropDefaultFlowRuntime ===
-    'private'
-  );
+function requestedDefaultJourney(): 'fixed' | 'private' | undefined {
+  const value = (window as unknown as { __bugdropDefaultFlowRuntime?: unknown })
+    .__bugdropDefaultFlowRuntime;
+  return value === 'fixed' || value === 'private' ? value : undefined;
 }
 
 async function runFixedDefaultJourney(

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -188,6 +188,7 @@ then
 fi
 
 require_literal "$playwright_config" "'chromium-live'"
+require_literal "$playwright_config" "'chromium-flow-live'"
 require_literal "$playwright_config" "'chromium-live-radix'"
 require_literal "$playwright_config" "'chromium-cross-browser-live'"
 require_literal "$playwright_config" "'firefox-cross-browser-live'"
@@ -199,6 +200,7 @@ local_discovery=$(env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL \
 grep -Fq '[chromium]' <<< "$local_discovery" || fail 'local Chromium project was not discovered'
 for excluded_project in \
   chromium-live \
+  chromium-flow-live \
   chromium-live-radix \
   chromium-cross-browser-live \
   firefox-cross-browser-live \
@@ -211,6 +213,7 @@ done
 
 for live_project in \
   chromium-live \
+  chromium-flow-live \
   chromium-live-radix \
   chromium-cross-browser-live \
   firefox-cross-browser-live \
@@ -296,6 +299,7 @@ fi
 for command in \
   'npx wrangler deploy --env preview' \
   'npx playwright test --project=chromium-live --workers=1 --retries=0' \
+  'npx playwright test --project=chromium-flow-live --workers=1 --retries=0' \
   'make test-live-radix' \
   'make test-live-cross-browser BROWSER=chromium' \
   'make test-live-cross-browser BROWSER=firefox' \
@@ -317,6 +321,28 @@ grep -Fq 'ACTUAL_SHA" = "$EXPECTED_WIDGET_SHA256"' <<< "$critical" ||
   fail 'deployed widget bytes are not polled to an exact hash match'
 grep -Fq 'EXACT_WIDGET_FIXTURE_PATH=' <<< "$critical" ||
   fail 'the exact deployed widget snapshot path is not recorded'
+grep -Fq 'EXACT_CLASSIC_WIDGET_FIXTURE_PATH=' <<< "$critical" ||
+  fail 'the exact classic widget snapshot path is not recorded'
+grep -Fq 'EXPECTED_CLASSIC_WIDGET_SHA256=' <<< "$critical" ||
+  fail 'the classic preview widget hash is not recorded'
+grep -Fq 'ACTUAL_SHA" = "$EXPECTED_CLASSIC_WIDGET_SHA256"' <<< "$critical" ||
+  fail 'deployed classic widget bytes are not polled to an exact hash match'
+grep -Fq 'mv "$CANDIDATE_PATH" "$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"' <<< "$critical" ||
+  fail 'the verified classic widget is not retained as the exact browser fixture'
+grep -Fq 'public/widget.classic.js' <<< "$critical" ||
+  fail 'the classic preview widget is not staged for deployment'
+grep -Fq 'BUGDROP_DEFAULT_FLOW_RUNTIME=fixed' <<< "$critical" ||
+  fail 'the classic preview widget is not built with the fixed controller'
+[[ $(grep -Fc 'EXACT_WIDGET_FIXTURE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"' <<< "$critical") -eq 6 ]] ||
+  fail 'every legacy preview browser lane must use the classic widget fixture'
+flow_live_step=$(sed -n \
+  '/- name: Run composable FlowConfig live E2E tests/,/- name: Run classic live Radix E2E tests/p' \
+  <<< "$critical")
+grep -Fq 'npx playwright test --project=chromium-flow-live --workers=1 --retries=0' <<< "$flow_live_step" ||
+  fail 'the composable-flow preview lane is missing'
+if grep -Fq 'EXACT_CLASSIC_WIDGET_FIXTURE_PATH' <<< "$flow_live_step"; then
+  fail 'the composable-flow preview lane must not use the classic widget fixture'
+fi
 grep -Fq 'EXACT_WIDGET_FIXTURE_PATH=$RUNNER_TEMP/' <<< "$critical" ||
   fail "Playwright may delete the exact widget snapshot unless it lives in RUNNER_TEMP"
 if grep -Fq 'EXACT_WIDGET_FIXTURE_PATH=$GITHUB_WORKSPACE/test-results/' <<< "$critical"; then

--- a/test/defaultFlowBuild.test.ts
+++ b/test/defaultFlowBuild.test.ts
@@ -127,7 +127,7 @@ describe('internal default-flow build selector', () => {
     }
     expect(fixedSource).not.toContain('bugdrop-default@1');
     expect(flowSource).toContain('bugdrop-flow@1');
-  }, 20_000);
+  }, 40_000);
 
   it('rejects unsupported selector values', () => {
     const result = spawnSync(process.execPath, [join(ROOT, 'scripts/build-widget.js')], {

--- a/test/defaultFlowBuild.test.ts
+++ b/test/defaultFlowBuild.test.ts
@@ -77,24 +77,24 @@ afterEach(async () => {
 });
 
 describe('internal default-flow build selector', () => {
-  it('defaults to fixed and restores byte-identical fixed output after a private build', async () => {
-    const fixedBefore = await build(undefined, 'fixed-before');
-    const privateBuild = await build('private', 'private');
+  it('defaults to flow and restores byte-identical fixed rollback output', async () => {
+    const fixedBefore = await build('fixed', 'fixed-before');
+    const flowBuild = await build(undefined, 'flow');
     const fixedAfter = await build('fixed', 'fixed-after');
 
     expect(fixedAfter.files).toEqual(fixedBefore.files);
-    expect(privateBuild.files['widget.js']).not.toEqual(fixedBefore.files['widget.js']);
+    expect(flowBuild.files['widget.js']).not.toEqual(fixedBefore.files['widget.js']);
 
     const fixedSource = fixedBefore.files['widget.js'].toString('utf8');
-    const privateSource = privateBuild.files['widget.js'].toString('utf8');
-    for (const source of [fixedSource, privateSource]) {
+    const flowSource = flowBuild.files['widget.js'].toString('utf8');
+    for (const source of [fixedSource, flowSource]) {
       expect(source).not.toContain('__bugdropDefaultFlowRuntime');
       expect(source).not.toContain('__bugdropMockToPng');
       expect(source).toContain('registerFlow');
       expect(source).not.toContain('FlowConfig');
     }
     expect(fixedSource).not.toContain('bugdrop-default@1');
-    expect(privateSource).toContain('bugdrop-default@1');
+    expect(flowSource).toContain('bugdrop-flow@1');
   }, 20_000);
 
   it('rejects unsupported selector values', () => {

--- a/test/defaultFlowBuild.test.ts
+++ b/test/defaultFlowBuild.test.ts
@@ -276,4 +276,24 @@ describe('internal default-flow build selector', () => {
       expect(execution.result.stderr).toContain('Fixed default baseline');
     }
   }, 20_000);
+
+  it('fails closed when an expected baseline candidate is a symlink', async () => {
+    const index = join(candidate, 'src/widget/index.ts');
+    const target = join(candidate, 'src/widget/index-current.ts');
+    await cp(index, target);
+    await rm(index);
+    await symlink('index-current.ts', index);
+
+    const execution = await runBuild('fixed', 'symlinked-index');
+    expect(execution.result.status).toBe(1);
+    expect(execution.result.stderr).toContain(
+      'Fixed default baseline candidate must be a regular file: src/widget/index.ts'
+    );
+  });
+
+  it('builds the complete fixed baseline against the supported older candidate fixture', async () => {
+    const olderCandidate = join(ROOT, 'test/fixtures/release/static-assets/older-candidate');
+    const execution = await runBuild('fixed', 'older-candidate', { sourceDir: olderCandidate });
+    expect(execution.result.status, execution.result.stderr).toBe(0);
+  });
 });

--- a/test/defaultFlowBuild.test.ts
+++ b/test/defaultFlowBuild.test.ts
@@ -1,5 +1,16 @@
 import { spawnSync } from 'node:child_process';
-import { cp, mkdtemp, mkdir, readFile, readdir, rm } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import {
+  chmod,
+  cp,
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
 
@@ -10,6 +21,11 @@ const GENERATED_ASSET =
   /^(?:widget\.js|widget\.v[^/]+\.js|versions\.json|checksums\.sha256|static-package\.json)$/;
 const tempRoots: string[] = [];
 let candidate = '';
+type BuildOptions = {
+  controllerRoot?: string;
+  sourceDir?: string;
+  environment?: Record<string, string>;
+};
 
 async function snapshot(root: string, current = root): Promise<Record<string, Buffer>> {
   const result: Record<string, Buffer> = {};
@@ -21,22 +37,29 @@ async function snapshot(root: string, current = root): Promise<Record<string, Bu
   return result;
 }
 
-async function build(runtime: 'fixed' | 'private' | undefined, label: string) {
+async function runBuild(
+  runtime: 'fixed' | 'private' | undefined,
+  label: string,
+  options: BuildOptions = {}
+) {
+  const controllerRoot = options.controllerRoot ?? ROOT;
+  const sourceDir = options.sourceDir ?? candidate;
   const outputDir = join(await mkdtemp(join(tmpdir(), `bugdrop-default-${label}-`)), 'public');
   tempRoots.push(resolve(outputDir, '..'));
   const environment = { ...process.env };
   delete environment.BUGDROP_TEST_HOOKS;
   if (runtime) environment.BUGDROP_DEFAULT_FLOW_RUNTIME = runtime;
   else delete environment.BUGDROP_DEFAULT_FLOW_RUNTIME;
+  Object.assign(environment, options.environment);
 
   const result = spawnSync(
     process.execPath,
     [
-      join(ROOT, 'scripts/build-widget.js'),
+      join(controllerRoot, 'scripts/build-widget.js'),
       '--mode',
       'release',
       '--source-dir',
-      candidate,
+      sourceDir,
       '--output-dir',
       outputDir,
       '--version',
@@ -56,8 +79,17 @@ async function build(runtime: 'fixed' | 'private' | undefined, label: string) {
     ],
     { cwd: ROOT, encoding: 'utf8', env: environment }
   );
-  expect(result.status, result.stderr).toBe(0);
-  return { outputDir, files: await snapshot(outputDir) };
+  return { outputDir, result };
+}
+
+async function build(
+  runtime: 'fixed' | 'private' | undefined,
+  label: string,
+  options: BuildOptions = {}
+) {
+  const execution = await runBuild(runtime, label, options);
+  expect(execution.result.status, execution.result.stderr).toBe(0);
+  return { outputDir: execution.outputDir, files: await snapshot(execution.outputDir) };
 }
 
 beforeEach(async () => {
@@ -107,4 +139,141 @@ describe('internal default-flow build selector', () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('Unsupported default flow runtime');
   });
+
+  it('uses complete baseline assets without Git and resolves dependencies from the candidate', async () => {
+    const controller = await mkdtemp(join(tmpdir(), 'bugdrop-fixed-controller-'));
+    const gitlessCandidate = await mkdtemp(join(tmpdir(), 'bugdrop-fixed-candidate-'));
+    tempRoots.push(controller, gitlessCandidate);
+    await cp(join(ROOT, 'scripts'), join(controller, 'scripts'), { recursive: true });
+    await cp(join(ROOT, 'package.json'), join(gitlessCandidate, 'package.json'));
+    await cp(join(ROOT, 'tsconfig.json'), join(gitlessCandidate, 'tsconfig.json'));
+    await cp(join(ROOT, 'src'), join(gitlessCandidate, 'src'), { recursive: true });
+    await cp(join(ROOT, 'public'), join(gitlessCandidate, 'public'), {
+      recursive: true,
+      filter: source =>
+        source === join(ROOT, 'public') || !GENERATED_ASSET.test(source.split('/').at(-1) ?? ''),
+    });
+    await mkdir(join(controller, 'node_modules/@esbuild'), { recursive: true });
+    await mkdir(join(gitlessCandidate, 'node_modules'), { recursive: true });
+    await symlink(
+      join(ROOT, 'node_modules/esbuild'),
+      join(controller, 'node_modules/esbuild'),
+      'dir'
+    );
+    await symlink(
+      join(ROOT, 'node_modules/@esbuild/darwin-arm64'),
+      join(controller, 'node_modules/@esbuild/darwin-arm64'),
+      'dir'
+    );
+    await symlink(
+      join(ROOT, 'node_modules/html-to-image'),
+      join(gitlessCandidate, 'node_modules/html-to-image'),
+      'dir'
+    );
+    const fakeBin = join(controller, 'fake-bin');
+    const gitMarker = join(controller, 'git-was-invoked');
+    await mkdir(fakeBin);
+    const fakeGit = join(fakeBin, 'git');
+    await writeFile(fakeGit, `#!/bin/sh\n: > '${gitMarker}'\nexit 1\n`);
+    await chmod(fakeGit, 0o700);
+
+    expect(spawnSync('git', ['-C', controller, 'rev-parse', '--git-dir']).status).not.toBe(0);
+    expect(spawnSync('git', ['-C', gitlessCandidate, 'rev-parse', '--git-dir']).status).not.toBe(0);
+
+    const fixed = await build('fixed', 'gitless-fixed', {
+      controllerRoot: controller,
+      sourceDir: gitlessCandidate,
+      environment: { PATH: `${fakeBin}:${process.env.PATH ?? ''}` },
+    });
+    await expect(readFile(gitMarker)).rejects.toThrow();
+    expect(createHash('sha256').update(fixed.files['widget.js']).digest('hex')).toBe(
+      '43eed5cd5134d802b675bbf8a5b28b4fff85224bfdd5a649dbf7ff31b6e6ece7'
+    );
+  }, 20_000);
+
+  it('fails closed before bundling for invalid baseline manifests and assets', async () => {
+    const cases: Array<[string, (controller: string) => Promise<void>]> = [
+      [
+        'malformed',
+        controller =>
+          writeFile(join(controller, 'scripts/default-flow-fixed-baseline/manifest.json'), '{'),
+      ],
+      [
+        'duplicate',
+        async controller => {
+          const path = join(controller, 'scripts/default-flow-fixed-baseline/manifest.json');
+          const manifest = JSON.parse(await readFile(path, 'utf8'));
+          manifest.files[1].candidatePath = manifest.files[0].candidatePath;
+          await writeFile(path, `${JSON.stringify(manifest)}\n`);
+        },
+      ],
+      [
+        'traversing',
+        async controller => {
+          const path = join(controller, 'scripts/default-flow-fixed-baseline/manifest.json');
+          const manifest = JSON.parse(await readFile(path, 'utf8'));
+          manifest.files[0].candidatePath = '../index.ts';
+          await writeFile(path, `${JSON.stringify(manifest)}\n`);
+        },
+      ],
+      [
+        'outside',
+        async controller => {
+          const path = join(controller, 'scripts/default-flow-fixed-baseline/manifest.json');
+          const manifest = JSON.parse(await readFile(path, 'utf8'));
+          manifest.files[0].assetPath = '../index.ts.txt';
+          await writeFile(path, `${JSON.stringify(manifest)}\n`);
+        },
+      ],
+      [
+        'missing',
+        controller =>
+          rm(
+            join(
+              controller,
+              'scripts/default-flow-fixed-baseline/src/widget/default-flow/runtime.ts.txt'
+            )
+          ),
+      ],
+      [
+        'length',
+        async controller => {
+          const path = join(controller, 'scripts/default-flow-fixed-baseline/manifest.json');
+          const manifest = JSON.parse(await readFile(path, 'utf8'));
+          manifest.files[0].length += 1;
+          await writeFile(path, `${JSON.stringify(manifest)}\n`);
+        },
+      ],
+      [
+        'digest',
+        async controller => {
+          const path = join(controller, 'scripts/default-flow-fixed-baseline/manifest.json');
+          const manifest = JSON.parse(await readFile(path, 'utf8'));
+          manifest.files[0].sha256 = '0'.repeat(64);
+          await writeFile(path, `${JSON.stringify(manifest)}\n`);
+        },
+      ],
+    ];
+
+    for (const [label, corrupt] of cases) {
+      const controller = await mkdtemp(join(tmpdir(), `bugdrop-fixed-${label}-`));
+      tempRoots.push(controller);
+      await cp(join(ROOT, 'scripts'), join(controller, 'scripts'), { recursive: true });
+      await mkdir(join(controller, 'node_modules/@esbuild'), { recursive: true });
+      await symlink(
+        join(ROOT, 'node_modules/esbuild'),
+        join(controller, 'node_modules/esbuild'),
+        'dir'
+      );
+      await symlink(
+        join(ROOT, 'node_modules/@esbuild/darwin-arm64'),
+        join(controller, 'node_modules/@esbuild/darwin-arm64'),
+        'dir'
+      );
+      await corrupt(controller);
+      const execution = await runBuild('fixed', label, { controllerRoot: controller });
+      expect(execution.result.status).toBe(1);
+      expect(execution.result.stderr).toContain('Fixed default baseline');
+    }
+  }, 20_000);
 });

--- a/test/defaultFlowDefinition.test.ts
+++ b/test/defaultFlowDefinition.test.ts
@@ -46,6 +46,13 @@ describe('private default definition normalizer', () => {
       );
 
       expect(definition.id).toBe(DEFAULT_DEFINITION_ID);
+      expect(definition.flow.compiler).toBe('bugdrop-flow@1');
+      expect(definition.flow.config.configVersion).toBe(1);
+      expect(definition.flow.screens.map(screen => screen.id)).toEqual([
+        'welcome',
+        'details',
+        'screenshot',
+      ]);
       expect(definition.steps[0]).toEqual({ kind: 'welcome', enabled, remember });
     }
   );
@@ -104,6 +111,7 @@ describe('private default definition normalizer', () => {
     );
 
     expect(Object.isFrozen(definition)).toBe(true);
+    expect(Object.isFrozen(definition.flow.config)).toBe(true);
     expect(Object.isFrozen(definition.steps)).toBe(true);
     expect(definition.steps.every(Object.isFrozen)).toBe(true);
     expect(Object.isFrozen(definition.system)).toBe(true);


### PR DESCRIPTION
## Summary

- compile the built-in default journey through the shared FlowConfig V1 validator/compiler and FlowRuntime
- preserve the existing legacy UI, capture, submission, focus, accessibility, concurrency, and payload ports
- retain a compile-time-only fixed implementation as an authenticated rollback path
- make rollback self-contained with three exact, digest-pinned baseline source snapshots; no Git history is required at build time

## Proof

- paired fixed/flow compatibility: 23/23 with exact normalized traces and request payloads
- release-mode production: 5/5
- full E2E: 317/317
- validation: 1,418/1,418; focused engine suite: 147/147
- release: 449; workflow: 193 plus contract; static: 26
- explicit fixed bundle remains byte-identical to the pre-adoption baseline: `43eed5cd5134d802b675bbf8a5b28b4fff85224bfdd5a649dbf7ff31b6e6ece7`
- Git-less controller/candidate regression proves zero Git invocation and candidate-owned dependency resolution
- rollback build: `BUGDROP_DEFAULT_FLOW_RUNTIME=fixed npm run build:widget`

## Safety

No public or production runtime selector is exposed. Manifest/path/length/digest corruption fails closed. The immutable v1.56.0 artifact remains the external rollback boundary.

## Review

The required PR review toolkit found and independently validated one blocking rollback defect in the first head (shallow controller Git-history dependency). It was fixed with self-contained authenticated snapshots. Corrected-head focused correctness, tests, contracts, and silent-failure re-review found no high-confidence issues. The native Codex baseline could not rerun on the corrected head because the local Codex review quota was exhausted; this limitation is recorded explicitly.