### PR TITLE
test: prove default styling parity on preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,6 +550,7 @@ jobs:
         run: >-
           EXACT_WIDGET_FIXTURE_PATH="$EXACT_WIDGET_FIXTURE_PATH"
           EXPECTED_WIDGET_SHA256="$EXPECTED_WIDGET_SHA256"
+          BUGDROP_STYLE_SNAPSHOT_PATH="$RUNNER_TEMP/chromium-live-candidate-style-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
           PLAYWRIGHT_JSON_OUTPUT_NAME="$RUNNER_TEMP/chromium-live-candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
           npx playwright test --project=chromium-live --workers=1 --retries=0 --reporter=json
         env:
@@ -559,6 +560,7 @@ jobs:
         run: >-
           EXACT_WIDGET_FIXTURE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"
           EXPECTED_WIDGET_SHA256="$EXPECTED_CLASSIC_WIDGET_SHA256"
+          BUGDROP_STYLE_SNAPSHOT_PATH="$RUNNER_TEMP/chromium-live-classic-style-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
           PLAYWRIGHT_JSON_OUTPUT_NAME="$RUNNER_TEMP/chromium-live-classic-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
           npx playwright test --project=chromium-live --workers=1 --retries=0 --reporter=json
         env:
@@ -595,15 +597,25 @@ jobs:
           const [candidate, classic] = reportPaths.map(path =>
             flatten(JSON.parse(fs.readFileSync(path, 'utf8')))
           );
+          const stylePaths = [
+            `${process.env.RUNNER_TEMP}/chromium-live-candidate-style-${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}.json`,
+            `${process.env.RUNNER_TEMP}/chromium-live-classic-style-${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}.json`,
+          ];
+          const [candidateStyle, classicStyle] = stylePaths.map(path =>
+            JSON.parse(fs.readFileSync(path, 'utf8'))
+          );
+          if (JSON.stringify(candidateStyle) !== JSON.stringify(classicStyle)) {
+            throw new Error('Candidate and classic configured-style snapshots differ.');
+          }
           const candidateJson = JSON.stringify(candidate);
           if (candidateJson !== JSON.stringify(classic)) {
             throw new Error('Candidate and classic chromium-live identifiers/outcomes differ.');
           }
           const passed = candidate.filter(test => test.status === 'expected').length;
           const skipped = candidate.filter(test => test.status === 'skipped');
-          if (candidate.length !== 22 || passed !== 21 || skipped.length !== 1) {
+          if (candidate.length !== 23 || passed !== 22 || skipped.length !== 1) {
             throw new Error(
-              `Expected 22 chromium-live tests with 21 passed and 1 skipped; got ${candidate.length}, ${passed}, ${skipped.length}.`
+              `Expected 23 chromium-live tests with 22 passed and 1 skipped; got ${candidate.length}, ${passed}, ${skipped.length}.`
             );
           }
           if (
@@ -740,6 +752,8 @@ jobs:
             playwright-report/
             ${{ runner.temp }}/chromium-live-candidate-${{ github.run_id }}-${{ github.run_attempt }}.json
             ${{ runner.temp }}/chromium-live-classic-${{ github.run_id }}-${{ github.run_attempt }}.json
+            ${{ runner.temp }}/chromium-live-candidate-style-${{ github.run_id }}-${{ github.run_attempt }}.json
+            ${{ runner.temp }}/chromium-live-classic-style-${{ github.run_id }}-${{ github.run_attempt }}.json
           if-no-files-found: warn
           retention-days: 7
 

--- a/e2e/widget.live.spec.ts
+++ b/e2e/widget.live.spec.ts
@@ -1,3 +1,4 @@
+import { writeFile } from 'node:fs/promises';
 import { expect, type Locator, type Page } from '@playwright/test';
 import {
   assertExactPreviewWidgetResponse,
@@ -52,9 +53,13 @@ async function mockInstalledRepo(page: Page) {
   });
 }
 
-async function loadDeployedWidgetFixture(page: Page, dataset: Record<string, string>) {
+async function loadDeployedWidgetFixture(
+  page: Page,
+  dataset: Record<string, string>,
+  options: { fixturePath?: string; bodyStyle?: string } = {}
+) {
   const widgetOrigin = expectedWidgetOrigin || 'https://bugdrop-preview.neonwatty.workers.dev';
-  const fixturePath = '/bugdrop-live-locale-fixture';
+  const fixturePath = options.fixturePath ?? '/bugdrop-live-locale-fixture';
   const dataAttributes = Object.entries(dataset)
     .map(([key, value]) => `data-${key}="${value}"`)
     .join('\n          ');
@@ -67,7 +72,7 @@ async function loadDeployedWidgetFixture(page: Page, dataset: Record<string, str
         <!doctype html>
         <html lang="en-US">
           <head><title>BugDrop live fixture</title></head>
-          <body>
+          <body style="${options.bodyStyle ?? ''}">
             <main>
               <h1>BugDrop live fixture</h1>
               <p>Fixture page for deployed widget smoke tests.</p>
@@ -84,6 +89,93 @@ async function loadDeployedWidgetFixture(page: Page, dataset: Record<string, str
   });
 
   await page.goto(fixturePath);
+}
+
+async function brandedAppearance(page: Page) {
+  return page.evaluate(() => {
+    const shadow = document.querySelector('#bugdrop-host')?.shadowRoot;
+    const root = shadow?.querySelector('.bd-root');
+    const trigger = shadow?.querySelector('.bd-trigger');
+    const modal = shadow?.querySelector('.bd-modal');
+    const title = shadow?.querySelector('.bd-title');
+    const primaryButton = shadow?.querySelector('.bd-btn-primary');
+    if (!(root && trigger)) throw new Error('Expected branded widget root and trigger');
+
+    const rootStyle = getComputedStyle(root);
+    const triggerStyle = getComputedStyle(trigger);
+    const modalStyle = modal ? getComputedStyle(modal) : null;
+    const titleStyle = title ? getComputedStyle(title) : null;
+    const buttonStyle = primaryButton ? getComputedStyle(primaryButton) : null;
+    return {
+      dark: root.classList.contains('bd-dark'),
+      variables: {
+        font: rootStyle.getPropertyValue('--bd-font').trim(),
+        primary: rootStyle.getPropertyValue('--bd-primary').trim(),
+        background: rootStyle.getPropertyValue('--bd-bg-primary').trim(),
+        text: rootStyle.getPropertyValue('--bd-text-primary').trim(),
+        borderWidth: rootStyle.getPropertyValue('--bd-border-width').trim(),
+        border: rootStyle.getPropertyValue('--bd-border').trim(),
+        shadow: rootStyle.getPropertyValue('--bd-shadow-lg').trim(),
+      },
+      trigger: {
+        background: triggerStyle.backgroundColor,
+        color: triggerStyle.color,
+        font: triggerStyle.fontFamily,
+        borderWidth: triggerStyle.borderTopWidth,
+        borderColor: triggerStyle.borderTopColor,
+        leftRadius: triggerStyle.borderTopLeftRadius,
+        rightRadius: triggerStyle.borderTopRightRadius,
+      },
+      modal: modalStyle
+        ? {
+            background: modalStyle.backgroundColor,
+            borderWidth: modalStyle.borderTopWidth,
+            borderColor: modalStyle.borderTopColor,
+            radius: modalStyle.borderTopLeftRadius,
+            shadow: modalStyle.boxShadow,
+          }
+        : null,
+      titleColor: titleStyle?.color ?? null,
+      primaryButtonBackground: buttonStyle?.backgroundColor ?? null,
+    };
+  });
+}
+
+function expectBrandedAppearance(
+  appearance: Awaited<ReturnType<typeof brandedAppearance>>,
+  options: { modal: boolean; fontVariable?: string; triggerFont?: string }
+) {
+  expect(appearance.variables).toEqual({
+    font: options.fontVariable ?? 'monospace, system-ui, sans-serif',
+    primary: '#b91c1c',
+    background: '#fef3c7',
+    text: '#422006',
+    borderWidth: '3px',
+    border: '#7c2d12',
+    shadow: '#7c2d12 calc(3px + 2px) calc(3px + 2px) 0 0',
+  });
+  expect(appearance.trigger).toEqual({
+    background: 'rgb(185, 28, 28)',
+    color: appearance.dark ? 'rgb(15, 23, 42)' : 'rgb(255, 255, 255)',
+    font: options.triggerFont ?? 'monospace, system-ui, sans-serif',
+    borderWidth: '3px',
+    borderColor: 'rgb(124, 45, 18)',
+    leftRadius: '0px',
+    rightRadius: '8px',
+  });
+  if (!options.modal) {
+    expect(appearance.modal).toBeNull();
+    return;
+  }
+  const { shadow: _shadow, ...modal } = appearance.modal;
+  expect(modal).toEqual({
+    background: 'rgb(254, 243, 199)',
+    borderWidth: '3px',
+    borderColor: 'rgb(124, 45, 18)',
+    radius: '8px',
+  });
+  expect(appearance.titleColor).toBe('rgb(66, 32, 6)');
+  expect(appearance.primaryButtonBackground).toBe('rgb(185, 28, 28)');
 }
 
 async function addCorsBlockedImage(page: Page) {
@@ -383,6 +475,108 @@ test.describe('Localization (Live)', () => {
 });
 
 test.describe('Feedback Button (Live)', () => {
+  test('preserves configured styling across the exact default-flow artifact', async ({ page }) => {
+    const appearances: Array<{
+      state: string;
+      appearance: Awaited<ReturnType<typeof brandedAppearance>>;
+    }> = [];
+    const recordAppearance = async (state: string, modal: boolean) => {
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(200);
+      const appearance = await brandedAppearance(page);
+      expectBrandedAppearance(appearance, { modal });
+      appearances.push({ state, appearance });
+    };
+    await mockInstalledRepo(page);
+    let attempts = 0;
+    await page.route('**/feedback', async route => {
+      attempts += 1;
+      await route.fulfill({
+        status: attempts === 1 ? 500 : 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          attempts === 1
+            ? { success: false, error: 'Deliberate branded retry' }
+            : { success: true, issueNumber: 1, issueUrl: '#', isPublic: false }
+        ),
+      });
+    });
+    const brandedDataset = {
+      theme: 'light',
+      position: 'bottom-left',
+      color: '#b91c1c',
+      font: 'monospace',
+      radius: '4',
+      bg: '#fef3c7',
+      text: '#422006',
+      'border-width': '3',
+      'border-color': '#7c2d12',
+      shadow: 'hard',
+      icon: 'none',
+      label: 'Brand feedback',
+    };
+    await loadDeployedWidgetFixture(page, brandedDataset);
+
+    const host = page.locator('#bugdrop-host');
+    const trigger = host.locator('css=.bd-trigger');
+    await expect(trigger).toBeVisible({ timeout: 10_000 });
+    await expect(trigger.locator('css=.bd-trigger-label')).toHaveText('Brand feedback');
+    await expect(trigger.locator('css=.bd-trigger-icon')).toHaveCount(0);
+    await recordAppearance('trigger-light', false);
+
+    await page.evaluate(() => window.BugDrop?.setTheme('dark'));
+    await expect.poll(async () => (await brandedAppearance(page)).dark).toBe(true);
+    await recordAppearance('trigger-dark', false);
+    await page.evaluate(() => window.BugDrop?.setTheme('light'));
+
+    await trigger.click();
+    await expect(host.locator('css=[data-action="continue"]')).toBeVisible();
+    await recordAppearance('welcome', true);
+    await host.locator('css=[data-action="continue"]').click();
+
+    const title = host.locator('css=#title');
+    await expect(title).toBeVisible();
+    await host.locator('css=#submit-btn').click();
+    await expect(title).toBeFocused();
+    expect(await title.evaluate(element => element.matches(':invalid'))).toBe(true);
+    await expect(title).toHaveCSS('border-top-color', 'rgb(185, 28, 28)');
+    await recordAppearance('validation', true);
+
+    await title.fill('Branded compatibility');
+    await host.locator('css=#include-screenshot').uncheck();
+    await host.locator('css=#submit-btn').click();
+    await expect(host.locator('css=.bd-title')).toHaveText('Submission Failed');
+    await expect(host.locator('css=.bd-error-message__text')).toHaveText(
+      'Deliberate branded retry'
+    );
+    await recordAppearance('failure', true);
+
+    await host.locator('css=[data-action="retry"]').click();
+    await expect(host.locator('css=.bd-success-icon')).toBeVisible({ timeout: 10_000 });
+    expect(attempts).toBe(2);
+    await recordAppearance('success', true);
+
+    await loadDeployedWidgetFixture(
+      page,
+      { ...brandedDataset, font: 'inherit' },
+      {
+        fixturePath: '/bugdrop-live-inherited-font-fixture',
+        bodyStyle: 'font-family: Georgia, serif',
+      }
+    );
+    await expect(page.locator('#bugdrop-host').locator('css=.bd-trigger')).toBeVisible();
+    const inheritedAppearance = await brandedAppearance(page);
+    expectBrandedAppearance(inheritedAppearance, {
+      modal: false,
+      fontVariable: '',
+      triggerFont: 'Georgia, serif',
+    });
+    appearances.push({ state: 'font-inherit', appearance: inheritedAppearance });
+
+    const snapshotPath = process.env.BUGDROP_STYLE_SNAPSHOT_PATH?.trim();
+    if (snapshotPath) await writeFile(snapshotPath, `${JSON.stringify(appearances, null, 2)}\n`);
+  });
+
   test('feedback button is visible and clickable', async ({ page }) => {
     await page.goto(venuePath);
 

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -427,15 +427,22 @@ done
 
 legacy_command='npx playwright test --project=chromium-live --workers=1 --retries=0 --reporter=json'
 require_paired_lane 'Run candidate legacy and default live E2E tests' \
-  EXACT_WIDGET_FIXTURE_PATH EXPECTED_WIDGET_SHA256 "$legacy_command"
+  EXACT_WIDGET_FIXTURE_PATH EXPECTED_WIDGET_SHA256 \
+  'chromium-live-candidate-style-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json' "$legacy_command"
 require_paired_lane 'Run classic legacy and default live E2E tests' \
-  EXACT_CLASSIC_WIDGET_FIXTURE_PATH EXPECTED_CLASSIC_WIDGET_SHA256 "$legacy_command"
+  EXACT_CLASSIC_WIDGET_FIXTURE_PATH EXPECTED_CLASSIC_WIDGET_SHA256 \
+  'chromium-live-classic-style-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json' "$legacy_command"
 require_count "$critical" "$legacy_command" 2 'paired chromium-live execution'
+require_literal "$live_spec" \
+  'preserves configured styling across the exact default-flow artifact'
+require_literal "$live_spec" "font: 'monospace'"
+require_literal "$live_spec" "shadow: 'hard'"
 
 comparison=$(step_block "$ci_workflow" 'Require identical candidate and classic legacy outcomes')
 for comparison_check in \
   'Candidate and classic chromium-live identifiers/outcomes differ.' \
-  'candidate.length !== 22 || passed !== 21 || skipped.length !== 1' \
+  'Candidate and classic configured-style snapshots differ.' \
+  'candidate.length !== 23 || passed !== 22 || skipped.length !== 1' \
   'privacy masking failure UX works on the deployed production widget'; do
   grep -Fq "$comparison_check" <<< "$comparison" ||
     fail "paired chromium-live comparison is missing: $comparison_check"
@@ -528,15 +535,25 @@ require_count "$failure_artifact" 'path: |' 1 'preview report uploader path list
 require_count "$failure_artifact" 'playwright-report/' 1 'preview HTML failure report'
 candidate_json_report='${{ runner.temp }}/chromium-live-candidate-${{ github.run_id }}-${{ github.run_attempt }}.json'
 classic_json_report='${{ runner.temp }}/chromium-live-classic-${{ github.run_id }}-${{ github.run_attempt }}.json'
+candidate_style_report='${{ runner.temp }}/chromium-live-candidate-style-${{ github.run_id }}-${{ github.run_attempt }}.json'
+classic_style_report='${{ runner.temp }}/chromium-live-classic-style-${{ github.run_id }}-${{ github.run_attempt }}.json'
 require_count "$failure_artifact" "$candidate_json_report" 1 \
   'candidate run-attempt JSON failure report'
 require_count "$failure_artifact" "$classic_json_report" 1 \
   'classic run-attempt JSON failure report'
+require_count "$failure_artifact" "$candidate_style_report" 1 \
+  'candidate configured-style failure report'
+require_count "$failure_artifact" "$classic_style_report" 1 \
+  'classic configured-style failure report'
 require_count "$failure_artifact" 'if-no-files-found: warn' 1 \
   'partial preview report availability'
-for available_report in "$candidate_json_report" "$classic_json_report"; do
+for available_report in \
+  "$candidate_json_report" "$classic_json_report" \
+  "$candidate_style_report" "$classic_style_report"; do
   matched_reports=0
-  for configured_report in "$candidate_json_report" "$classic_json_report"; do
+  for configured_report in \
+    "$candidate_json_report" "$classic_json_report" \
+    "$candidate_style_report" "$classic_style_report"; do
     [[ $available_report == "$configured_report" ]] && ((matched_reports += 1))
   done
   [[ $matched_reports -eq 1 ]] ||

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -72,12 +72,15 @@ require_paired_lane() {
   local name=$1
   local fixture=$2
   local digest=$3
-  local command=$4
+  local command=${5:-$4}
   local block
   block=$(step_block "$ci_workflow" "$name")
   [[ -n "$block" ]] || fail "paired preview lane is missing: $name"
   require_count "$block" "EXACT_WIDGET_FIXTURE_PATH=\"\$$fixture\"" 1 "$name"
   require_count "$block" "EXPECTED_WIDGET_SHA256=\"\$$digest\"" 1 "$name"
+  if [[ $# -eq 5 ]]; then
+    require_count "$block" "$4" 1 "$name style snapshot"
+  fi
   require_count "$block" "$command" 1 "$name"
   if [[ $fixture == EXACT_WIDGET_FIXTURE_PATH ]] &&
     grep -Fq 'EXACT_CLASSIC_WIDGET_FIXTURE_PATH' <<< "$block"; then


### PR DESCRIPTION
## Summary

- exercise a deliberately branded built-in default journey against both exact preview artifacts
- assert documented styling configuration through light/dark, welcome, validation, failure/retry, success, and inherited-font states
- compare candidate and fixed/classic computed-style snapshots fail-closed in the merge-group workflow

## Verification

- focused candidate styling test: pass, retries=0
- focused fixed/classic styling test: pass, retries=0
- seven-state snapshots byte-identical
- `bash test/ci-workflow-contract.test.sh`
- `npm run test:release-workflow` (193/193)
- `npm run typecheck --if-present`
- `npm run validate` (89 files, 1420 tests)

## Release boundary

This PR performs no release mutation. After merge-group preview proof, the previous v1.56.1 dry-run identities are stale and a new dry run is required before live-release authority.