### PR TITLE
fix: add cumulative rating hover preview

### DIFF
--- a/e2e/variant-inline.spec.ts
+++ b/e2e/variant-inline.spec.ts
@@ -76,7 +76,112 @@ test.describe('rendered inline variants', () => {
       'aria-checked',
       'true'
     );
+    const stars = rating.getByRole('radio');
+    const selectedStyle = await stars.nth(1).evaluate(element => {
+      const style = getComputedStyle(element);
+      return `${style.color}|${style.borderColor}|${style.backgroundColor}`;
+    });
+    const idleStyle = await stars.nth(4).evaluate(element => {
+      const style = getComputedStyle(element);
+      return `${style.color}|${style.borderColor}|${style.backgroundColor}`;
+    });
+    await rating.getByRole('radio', { name: '4 stars' }).hover();
+    await expect(stars.nth(0)).toHaveClass(/bdv-rating-option--preview/);
+    await expect(stars.nth(1)).toHaveClass(/bdv-rating-option--preview/);
+    await expect(stars.nth(2)).toHaveClass(/bdv-rating-option--preview/);
+    await expect(stars.nth(3)).toHaveClass(/bdv-rating-option--preview/);
+    await expect(stars.nth(4)).not.toHaveClass(/bdv-rating-option--preview/);
+    await expect(rating.getByRole('radio', { name: '2 stars' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    const previewStyle = await stars.nth(3).evaluate(element => {
+      const style = getComputedStyle(element);
+      return `${style.color}|${style.borderColor}|${style.backgroundColor}`;
+    });
+    expect(previewStyle).not.toBe(idleStyle);
+    expect(previewStyle).not.toBe(selectedStyle);
+
+    await rating.getByRole('radio', { name: '5 stars' }).click();
+    await page.mouse.move(0, 0);
+    for (let index = 0; index < 5; index += 1) {
+      await expect(stars.nth(index)).not.toHaveClass(/bdv-rating-option--preview/);
+      await expect(stars.nth(index)).toHaveClass(/bdv-rating-option--active/);
+    }
+    await expect(rating.getByRole('radio', { name: '5 stars' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+
+    await rating.getByRole('radio', { name: '2 stars' }).hover();
+    for (let index = 0; index < 2; index += 1) {
+      await expect(stars.nth(index)).toHaveClass(/bdv-rating-option--preview/);
+    }
+    for (let index = 2; index < 5; index += 1) {
+      await expect(stars.nth(index)).not.toHaveClass(/bdv-rating-option--preview/);
+    }
+    for (let index = 0; index < 5; index += 1) {
+      await expect(stars.nth(index)).not.toHaveClass(/bdv-rating-option--active/);
+    }
+    await expect(rating.getByRole('radio', { name: '5 stars' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    await expect(rating.getByRole('radio', { name: '5 stars' })).toHaveAttribute('tabindex', '0');
+    const secondStarBox = await stars.nth(1).boundingBox();
+    const thirdStarBox = await stars.nth(2).boundingBox();
+    expect(secondStarBox).not.toBeNull();
+    expect(thirdStarBox).not.toBeNull();
+    const gapWidth = thirdStarBox!.x - (secondStarBox!.x + secondStarBox!.width);
+    expect(gapWidth).toBeCloseTo(6, 0);
+    const gapX = secondStarBox!.x + secondStarBox!.width + gapWidth / 2;
+    const gapY = secondStarBox!.y + secondStarBox!.height / 2;
+    await page.mouse.move(gapX, gapY);
+    for (let index = 0; index < 5; index += 1) {
+      await expect(stars.nth(index)).not.toHaveClass(/bdv-rating-option--preview/);
+      await expect(stars.nth(index)).toHaveClass(/bdv-rating-option--active/);
+    }
+    await expect(rating.getByRole('radio', { name: '5 stars' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    await expect(rating.getByRole('radio', { name: '5 stars' })).toHaveAttribute('tabindex', '0');
+
+    await rating.getByRole('radio', { name: '3 stars' }).hover();
+    for (let index = 0; index < 3; index += 1) {
+      await expect(stars.nth(index)).toHaveClass(/bdv-rating-option--preview/);
+    }
+    for (let index = 3; index < 5; index += 1) {
+      await expect(stars.nth(index)).not.toHaveClass(/bdv-rating-option--preview/);
+    }
+    const ratingBox = await rating.boundingBox();
+    const lastStarBox = await stars.nth(4).boundingBox();
+    expect(ratingBox).not.toBeNull();
+    expect(lastStarBox).not.toBeNull();
+    const trailingX = ratingBox!.x + ratingBox!.width - 1;
+    expect(trailingX).toBeGreaterThan(lastStarBox!.x + lastStarBox!.width);
+    await page.mouse.move(trailingX, ratingBox!.y + ratingBox!.height / 2);
+    for (let index = 0; index < 5; index += 1) {
+      await expect(stars.nth(index)).not.toHaveClass(/bdv-rating-option--preview/);
+      await expect(stars.nth(index)).toHaveClass(/bdv-rating-option--active/);
+    }
+    await expect(rating.getByRole('radio', { name: '5 stars' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    await expect(rating.getByRole('radio', { name: '5 stars' })).toHaveAttribute('tabindex', '0');
+
     await rating.getByRole('radio', { name: '4 stars' }).click();
+    await page.mouse.move(0, 0);
+    await expect(rating.getByRole('radio', { name: '4 stars' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    const clickedStyle = await stars.nth(3).evaluate(element => {
+      const style = getComputedStyle(element);
+      return `${style.color}|${style.borderColor}|${style.backgroundColor}`;
+    });
+    expect(clickedStyle).not.toBe(previewStyle);
     expect(submissions).toHaveLength(0);
     await host.getByRole('textbox', { name: 'Anything else?' }).fill('  Fast and clear.  ');
     expect(submissions).toHaveLength(0);
@@ -97,7 +202,7 @@ test.describe('rendered inline variants', () => {
           { heading: 'Comment', value: 'Fast and clear.', format: 'text' },
         ],
       },
-      metadata: { url: 'http://localhost:8787/test/' },
+      metadata: { url: new URL('/test/', page.url()).href },
     });
     expect(submissions[0]?.submissionId).toEqual(expect.any(String));
     expect(submissions[0]).not.toHaveProperty('labels');
@@ -217,6 +322,15 @@ test.describe('rendered inline variants', () => {
     await expect(page.locator('#first-review-slot > [data-bugdrop-owned]')).toHaveCount(0);
     const second = page.locator('#second-review-slot > [data-bugdrop-owned]');
     await expect(second).toHaveAttribute('data-bugdrop-instance', instances.second);
+    await expect(second.getByRole('radio', { name: '5 stars' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    await second.getByRole('radio', { name: '2 stars' }).hover();
+    const secondStars = second.getByRole('radio');
+    await expect(secondStars.nth(0)).toHaveClass(/bdv-rating-option--preview/);
+    await expect(secondStars.nth(1)).toHaveClass(/bdv-rating-option--preview/);
+    await expect(secondStars.nth(2)).not.toHaveClass(/bdv-rating-option--preview/);
     await expect(second.getByRole('radio', { name: '5 stars' })).toHaveAttribute(
       'aria-checked',
       'true'

--- a/src/widget/variants/fields/rating.ts
+++ b/src/widget/variants/fields/rating.ts
@@ -15,18 +15,22 @@ export function createRatingController(field: RatingField, instanceId: string): 
 
   const buttons: HTMLButtonElement[] = [];
   let selected: number | null = null;
+  let previewed: number | null = null;
 
   const renderSelection = () => {
     for (const [index, button] of buttons.entries()) {
       const value = index + 1;
-      const active = selected !== null && value <= selected;
+      const active = previewed === null && selected !== null && value <= selected;
+      const preview = previewed !== null && value <= previewed;
       button.classList.toggle('bdv-rating-option--active', active);
+      button.classList.toggle('bdv-rating-option--preview', preview);
       button.setAttribute('aria-checked', String(value === selected));
       button.tabIndex = value === (selected ?? 1) ? 0 : -1;
     }
   };
   const select = (value: number, focus = false) => {
     selected = value;
+    previewed = null;
     renderSelection();
     if (focus) buttons[value - 1]?.focus();
   };
@@ -34,7 +38,18 @@ export function createRatingController(field: RatingField, instanceId: string): 
     button: HTMLButtonElement;
     click: () => void;
     keydown: (event: KeyboardEvent) => void;
+    pointerenter: () => void;
   }> = [];
+  const clearPreview = () => {
+    if (previewed === null) return;
+    previewed = null;
+    renderSelection();
+  };
+  const handleGroupPointerMove = (event: PointerEvent) => {
+    const target = event.target;
+    if (target instanceof HTMLButtonElement && buttons.includes(target) && !target.disabled) return;
+    clearPreview();
+  };
 
   for (let value = 1; value <= scale; value += 1) {
     const button = document.createElement('button');
@@ -44,6 +59,11 @@ export function createRatingController(field: RatingField, instanceId: string): 
     button.setAttribute('aria-label', `${value} ${value === 1 ? 'star' : 'stars'}`);
     button.textContent = field.icon === 'number' ? String(value) : '★';
     const click = () => select(value);
+    const pointerenter = () => {
+      if (button.disabled) return;
+      previewed = value;
+      renderSelection();
+    };
     const keydown = (event: KeyboardEvent) => {
       let next: number | null = null;
       if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
@@ -63,10 +83,13 @@ export function createRatingController(field: RatingField, instanceId: string): 
     };
     button.addEventListener('click', click);
     button.addEventListener('keydown', keydown);
-    listeners.push({ button, click, keydown });
+    button.addEventListener('pointerenter', pointerenter);
+    listeners.push({ button, click, keydown, pointerenter });
     buttons.push(button);
     group.appendChild(button);
   }
+  group.addEventListener('pointermove', handleGroupPointerMove);
+  group.addEventListener('pointerleave', clearPreview);
   scaffold.wrapper.insertBefore(group, scaffold.wrapper.querySelector('.bdv-error'));
 
   if (field.lowLabel || field.highLabel) {
@@ -90,19 +113,25 @@ export function createRatingController(field: RatingField, instanceId: string): 
         Number.isInteger(value) && (value as number) >= 1 && (value as number) <= scale
           ? (value as number)
           : null;
+      previewed = null;
       renderSelection();
     },
     setError: message => scaffold.setError(group, message),
     setDisabled(disabled) {
       for (const button of buttons) button.disabled = disabled;
+      if (disabled) clearPreview();
     },
     focus() {
       buttons[(selected ?? 1) - 1]?.focus();
     },
     dispose() {
+      clearPreview();
+      group.removeEventListener('pointermove', handleGroupPointerMove);
+      group.removeEventListener('pointerleave', clearPreview);
       for (const listener of listeners) {
         listener.button.removeEventListener('click', listener.click);
         listener.button.removeEventListener('keydown', listener.keydown);
+        listener.button.removeEventListener('pointerenter', listener.pointerenter);
       }
     },
   };

--- a/src/widget/variants/styles.ts
+++ b/src/widget/variants/styles.ts
@@ -144,8 +144,16 @@ const VARIANT_CSS = `
     font-size: 1.4rem;
     line-height: 1;
   }
-  .bdv-rating-option:hover,
-  .bdv-rating-option--active { color: var(--bdv-accent); border-color: var(--bdv-accent); }
+  .bdv-rating-option--active {
+    color: var(--bdv-accent);
+    border-color: var(--bdv-accent);
+    background: color-mix(in srgb, var(--bdv-accent) 18%, var(--bdv-bg-muted));
+  }
+  .bdv-rating-option--preview {
+    color: color-mix(in srgb, var(--bdv-accent) 70%, var(--bdv-text-muted));
+    border-color: color-mix(in srgb, var(--bdv-accent) 55%, var(--bdv-border));
+    background: color-mix(in srgb, var(--bdv-accent) 8%, var(--bdv-bg-muted));
+  }
   .bdv-rating-option:disabled { cursor: wait; opacity: .65; }
   .bdv-rating-labels {
     display: flex;

--- a/test/variantFields.test.ts
+++ b/test/variantFields.test.ts
@@ -59,7 +59,7 @@ describe('rendered variant field controllers', () => {
     expect(short.element.querySelector('input')?.hasAttribute('aria-invalid')).toBe(false);
   });
 
-  it('supports pointer and keyboard rating selection without a form submit control', () => {
+  it('previews cumulative pointer ratings without changing the selected radio value', () => {
     const rating = createFieldController(
       {
         id: 'rating',
@@ -77,17 +77,112 @@ describe('rendered variant field controllers', () => {
     expect(buttons).toHaveLength(5);
     expect(buttons.every(button => button.type === 'button')).toBe(true);
 
-    buttons[2]?.click();
-    expect(rating.getValue()).toBe(3);
-    buttons[2]?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    buttons[3]?.dispatchEvent(new Event('pointerenter'));
+    expect(buttons.map(button => button.classList.contains('bdv-rating-option--preview'))).toEqual([
+      true,
+      true,
+      true,
+      true,
+      false,
+    ]);
+    expect(rating.getValue()).toBe('');
+    expect(buttons.map(button => button.getAttribute('aria-checked'))).toEqual([
+      'false',
+      'false',
+      'false',
+      'false',
+      'false',
+    ]);
+
+    buttons[3]?.click();
     expect(rating.getValue()).toBe(4);
     expect(buttons[3]?.getAttribute('aria-checked')).toBe('true');
+    expect(buttons.map(button => button.classList.contains('bdv-rating-option--active'))).toEqual([
+      true,
+      true,
+      true,
+      true,
+      false,
+    ]);
+    expect(buttons.some(button => button.classList.contains('bdv-rating-option--preview'))).toBe(
+      false
+    );
+
+    buttons[3]?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(rating.getValue()).toBe(5);
+    expect(buttons[4]?.getAttribute('aria-checked')).toBe('true');
+
+    buttons[1]?.dispatchEvent(new Event('pointerenter'));
+    expect(rating.getValue()).toBe(5);
+    expect(buttons.map(button => button.classList.contains('bdv-rating-option--preview'))).toEqual([
+      true,
+      true,
+      false,
+      false,
+      false,
+    ]);
+    expect(buttons.map(button => button.classList.contains('bdv-rating-option--active'))).toEqual([
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
+    expect(buttons.map(button => button.getAttribute('aria-checked'))).toEqual([
+      'false',
+      'false',
+      'false',
+      'false',
+      'true',
+    ]);
+    expect(buttons.map(button => button.tabIndex)).toEqual([-1, -1, -1, -1, 0]);
+    buttons[2]?.dispatchEvent(new Event('pointerenter'));
+    expect(buttons.map(button => button.classList.contains('bdv-rating-option--preview'))).toEqual([
+      true,
+      true,
+      true,
+      false,
+      false,
+    ]);
+    const group = rating.element.querySelector('.bdv-rating');
+    group?.dispatchEvent(new Event('pointermove', { bubbles: true }));
+    expect(buttons.some(button => button.classList.contains('bdv-rating-option--preview'))).toBe(
+      false
+    );
+    expect(buttons.map(button => button.classList.contains('bdv-rating-option--active'))).toEqual([
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]);
+    expect(rating.getValue()).toBe(5);
+    expect(buttons[4]?.getAttribute('aria-checked')).toBe('true');
 
     rating.setDisabled(true);
     expect(buttons.every(button => button.disabled)).toBe(true);
+    buttons[2]?.dispatchEvent(new Event('pointerenter'));
+    expect(buttons.some(button => button.classList.contains('bdv-rating-option--preview'))).toBe(
+      false
+    );
+    rating.setDisabled(false);
+    buttons[2]?.dispatchEvent(new Event('pointerenter'));
+    expect(buttons[2]?.classList.contains('bdv-rating-option--preview')).toBe(true);
+    group?.dispatchEvent(new Event('pointerleave'));
+    expect(buttons.some(button => button.classList.contains('bdv-rating-option--preview'))).toBe(
+      false
+    );
     rating.setValue('invalid');
     expect(rating.getValue()).toBe('');
+    buttons[2]?.dispatchEvent(new Event('pointerenter'));
     rating.dispose();
+    expect(buttons.some(button => button.classList.contains('bdv-rating-option--preview'))).toBe(
+      false
+    );
+    buttons[2]?.dispatchEvent(new Event('pointerenter'));
+    expect(buttons.some(button => button.classList.contains('bdv-rating-option--preview'))).toBe(
+      false
+    );
   });
 
   it.each(['radio', 'cards', 'buttons'] as const)(


### PR DESCRIPTION
## Summary

- preview every rating option from 1 through the hovered value with a lighter state
- preserve the selected value, ARIA state, keyboard behavior, disabled state, disposal, and independent instances
- clear preview when the pointer enters inter-star gaps, trailing space, or leaves the group
- add unit and real-browser coverage for upward and downward previews, gap restoration, and cumulative selection

## Verification

- `npm run validate` — 89 files, 1420 tests passed
- `npm run test -- test/variantFields.test.ts` — 6/6 passed
- `PLAYWRIGHT_BASE_URL=http://bugdrop.localhost:8787 npm run test:e2e -- e2e/variant-inline.spec.ts --project=chromium` — 4/4 passed
- required PR review toolkit — no remaining high-confidence findings after two validated pointer-state corrections
- `git diff --check` — passed

## Scope

This PR does not change public FlowConfig types, submission behavior, the classic default journey, release configuration, or published artifacts.