### PR TITLE
test: expand composable flow coverage

### DIFF
--- a/e2e/public-flow.flow-live.spec.ts
+++ b/e2e/public-flow.flow-live.spec.ts
@@ -1,9 +1,18 @@
 import { expect, type Page } from '@playwright/test';
+import { flowRecipes, type FlowRecipeId } from '../test/fixtures/flow-recipes';
 import {
   assertExactPreviewWidgetResponse,
   test,
   waitForPreviewWidgetResponse,
 } from './live-preview-widget';
+
+type Payload = Record<string, unknown> & {
+  title: string;
+  description: string;
+  category: string;
+  screenshot: string | null;
+  attachments: Array<Record<string, unknown>>;
+};
 
 const expectedWidgetOrigin = process.env.EXPECTED_WIDGET_ORIGIN;
 const expectedWidgetSha256 = process.env.EXPECTED_WIDGET_SHA256;
@@ -23,22 +32,19 @@ if (bypassSecret) {
   });
 }
 
-async function loadFlowWidget(page: Page): Promise<void> {
-  const response = expectedWidgetOrigin
-    ? waitForPreviewWidgetResponse(page, expectedWidgetOrigin)
-    : undefined;
+async function loadExactFlowWidget(page: Page): Promise<void> {
+  if (!expectedWidgetOrigin || !expectedWidgetSha256) {
+    throw new Error('Composable preview journeys require exact candidate origin and SHA-256');
+  }
+  const response = waitForPreviewWidgetResponse(page, expectedWidgetOrigin);
   await page.goto(venuePath);
   await expect
     .poll(() => page.evaluate(() => typeof window.BugDrop?.registerFlow))
     .toBe('function');
-  if (response && expectedWidgetSha256) {
-    await assertExactPreviewWidgetResponse(await response, expectedWidgetSha256);
-  }
+  await assertExactPreviewWidgetResponse(await response, expectedWidgetSha256);
 }
 
-test('runs a conditional multi-screen FlowConfig through the exact preview widget', async ({
-  page,
-}) => {
+async function prepareJourney(page: Page, issueNumber: number): Promise<Payload[]> {
   await page.route('**/api/check/**', route =>
     route.fulfill({
       status: 200,
@@ -46,97 +52,135 @@ test('runs a conditional multi-screen FlowConfig through the exact preview widge
       body: JSON.stringify({ installed: true, appName: 'neonwatty-bugdrop' }),
     })
   );
-  const submissions: Array<Record<string, unknown>> = [];
+  const payloads: Payload[] = [];
   await page.route('**/api/feedback', route => {
-    submissions.push(route.request().postDataJSON() as Record<string, unknown>);
+    payloads.push(route.request().postDataJSON() as Payload);
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
         success: true,
-        issueNumber: 902,
-        issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/902',
+        issueNumber,
+        issueUrl: `https://github.com/mean-weasel/bugdrop-widget-test/issues/${issueNumber}`,
         isPublic: false,
       }),
     });
   });
+  await loadExactFlowWidget(page);
+  return payloads;
+}
 
-  await loadFlowWidget(page);
-  await page.evaluate(() => {
-    window
-      .BugDrop!.registerFlow({
-        configVersion: 1,
-        id: 'merge-queue-composable-flow',
-        presentation: { kind: 'modal' },
-        forms: [
-          {
-            id: 'triage',
-            title: 'Classify your feedback',
-            fields: [
-              {
-                id: 'kind',
-                type: 'singleChoice',
-                label: 'Type',
-                required: true,
-                options: [
-                  { value: 'bug', label: 'Bug' },
-                  { value: 'idea', label: 'Idea' },
-                ],
-              },
-              { id: 'summary', type: 'shortText', label: 'Summary', required: true },
-            ],
-          },
-          {
-            id: 'detail',
-            title: 'Describe the bug',
-            fields: [{ id: 'description', type: 'longText', label: 'Steps', required: true }],
-          },
-        ],
-        screens: [
-          { id: 'intro', type: 'message', title: 'Help us improve' },
-          { id: 'triage-screen', type: 'form', form: 'triage' },
-          {
-            id: 'detail-screen',
-            type: 'form',
-            form: 'detail',
-            when: { answer: 'triage.kind', equals: 'bug' },
-          },
-          {
-            id: 'screenshot',
-            type: 'screenshot',
-            mode: 'optional',
-            when: { answer: 'triage.kind', equals: 'bug' },
-          },
-        ],
-        issue: {
-          classification: 'bug',
-          title: '{{triage.summary}}',
-          sections: [{ heading: 'Steps', answer: 'detail.description' }],
-        },
-      })
-      .open();
+async function openRecipe(page: Page, id: FlowRecipeId) {
+  const recipe = flowRecipes[id];
+  await page.evaluate(
+    ({ config, openOptions }) => window.BugDrop!.registerFlow(config).open(openOptions),
+    { config: recipe.config, openOptions: recipe.openOptions }
+  );
+  return page.locator(`body > [data-bugdrop-flow="${recipe.config.id}"]`);
+}
+
+function expectValidPngDataUrl(value: unknown): void {
+  expect(value).toEqual(expect.stringMatching(/^data:image\/png;base64,[A-Za-z0-9+/]+=*$/));
+  const bytes = Buffer.from((value as string).split(',')[1]!, 'base64');
+  expect(bytes.subarray(0, 8)).toEqual(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
+}
+
+test('Bug Report completes its exact candidate preview journey', async ({ page }) => {
+  const payloads = await prepareJourney(page, 951);
+  await page.evaluate(() => console.info('preview-bug-report-log'));
+  const host = await openRecipe(page, 'bug-report');
+
+  await expect(host.getByRole('heading', { name: 'Report a problem' })).toBeVisible();
+  await host.getByRole('button', { name: 'Start report' }).click();
+  await host.getByLabel('Summary').fill('Preview save crashes');
+  await host.getByLabel('Steps to reproduce').fill('Open settings\nClick save');
+  await host.getByRole('button', { name: 'Add evidence' }).click();
+  await host.getByLabel('Attachments').setInputFiles({
+    name: 'preview-trace.png',
+    mimeType: 'image/png',
+    buffer: Buffer.from('preview trace'),
   });
+  await host.getByLabel('Your name').fill('Ada');
+  await host.getByLabel('Email').fill('ada@example.com');
+  await host.getByRole('button', { name: 'Continue' }).click();
+  await expect(host.getByRole('heading', { name: 'Show us the problem' })).toBeVisible();
+  await expect(host.getByLabel('Include a screenshot')).toHaveCount(0);
+  await host.getByRole('button', { name: 'Submit' }).click();
 
-  const host = page.locator('body > [data-bugdrop-flow="merge-queue-composable-flow"]');
-  await expect(host.getByRole('heading', { name: 'Help us improve' })).toBeVisible();
+  const capture = page.locator('#bugdrop-host');
+  await expect(capture.getByRole('heading', { name: 'Capture Screenshot' })).toBeVisible();
+  await expect(capture.getByRole('button', { name: /skip screenshot/i })).toHaveCount(0);
+  await capture.locator('[data-action="capture"]').focus();
+  await page.keyboard.press('Enter');
+  await expect(capture.locator('#annotation-canvas canvas')).toBeVisible();
+  await capture.locator('[data-action="done"]').focus();
+  await page.keyboard.press('Enter');
+  await expect(host.getByRole('heading', { name: 'Report received' })).toBeVisible();
+
+  expect(payloads).toHaveLength(1);
+  expect(payloads[0]).toMatchObject({
+    title: 'Bug: Preview save crashes',
+    category: 'bug',
+    submitter: { name: 'Ada', email: 'ada@example.com' },
+    attachments: [expect.objectContaining({ name: 'preview-trace.png', type: 'image/png' })],
+  });
+  expect(payloads[0]?.description).toContain('> Open settings\n> Click save');
+  expectValidPngDataUrl(payloads[0]?.screenshot);
+});
+
+test('Product Triage completes its exact candidate preview journey', async ({ page }) => {
+  const payloads = await prepareJourney(page, 952);
+  const host = await openRecipe(page, 'product-triage');
+
   await host.getByRole('button', { name: 'Continue' }).click();
   await host.getByLabel('Bug').click();
-  await host.getByLabel('Summary').fill('Preview flow failure');
+  await host.getByRole('radio', { name: '2 stars' }).click();
+  await host.getByLabel('Summary').fill('Preview checkout stalls');
   await host.getByRole('button', { name: 'Continue' }).click();
-  await host.getByLabel('Steps').fill('Open the preview and submit');
+  await host.getByLabel('What happened?').fill('Spinner never stops');
+  await host.getByLabel('Chromium').click();
   await host.getByRole('button', { name: 'Continue' }).click();
-  await host.getByLabel('Include a screenshot', { exact: true }).uncheck();
+  await host.getByRole('button', { name: 'Back' }).click();
+  await expect(host.getByLabel('What happened?')).toHaveValue('Spinner never stops');
+  await expect(host.getByLabel('Chromium')).toBeChecked();
+  await host.getByRole('button', { name: 'Back' }).click();
+  await host.getByRole('radio', { name: '4 stars' }).click();
+  await host.getByRole('button', { name: 'Continue' }).click();
+  await host.getByLabel('Include a screenshot').uncheck();
   await host.getByRole('button', { name: 'Submit' }).click();
   await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
 
-  expect(submissions).toHaveLength(1);
-  expect(submissions[0]).toMatchObject({
-    repo: 'mean-weasel/bugdrop-widget-test',
-    title: 'Preview flow failure',
-    description: '## Steps\n\nOpen the preview and submit',
-    category: 'bug',
+  expect(payloads).toHaveLength(1);
+  expect(payloads[0]).toMatchObject({
+    title: 'Triage: Preview checkout stalls',
+    category: 'feature',
     screenshot: null,
     attachments: [],
+    description: '## Type\n\nBug\n\n## Experience\n\n★★★★☆ (4/5)',
   });
-  expect(submissions[0]?.kind).toBeUndefined();
+  expect(payloads[0]?.description).not.toContain('Spinner never stops');
+});
+
+test('Customer Pulse completes its exact candidate preview journey', async ({ page }) => {
+  const payloads = await prepareJourney(page, 953);
+  const host = await openRecipe(page, 'customer-pulse');
+
+  await host.getByRole('radio', { name: '3 stars' }).click();
+  await host.getByRole('button', { name: 'Continue' }).click();
+  await host.getByLabel('What made this difficult?').fill('Invoice filters reset');
+  await host.getByLabel('Yes').click();
+  await host.getByLabel('I consent to a product follow-up').check();
+  await host.getByRole('button', { name: 'Send pulse' }).click();
+  await expect(host.getByRole('heading', { name: 'Pulse recorded' })).toBeVisible();
+  await expect(host.getByText('Thanks for sharing how billing feels today.')).toBeVisible();
+
+  expect(payloads).toHaveLength(1);
+  expect(payloads[0]).toMatchObject({
+    title: 'Billing pulse 3/10',
+    category: 'question',
+    screenshot: null,
+    attachments: [],
+    description:
+      '## Score\n\n3\n\n## Follow-up\n\nInvoice filters reset\n\n## Contact\n\nYes\n\n## Consent\n\ntrue',
+  });
 });

--- a/e2e/public-flow.spec.ts
+++ b/e2e/public-flow.spec.ts
@@ -1,6 +1,46 @@
 import { expect, test, type Page } from '@playwright/test';
+import type { FlowConfig, FlowOpenOptions } from '../src/widget/flows/public-types';
+import { flowRecipes, type FlowRecipeId } from '../test/fixtures/flow-recipes';
 
-async function ready(page: Page) {
+type Payload = Record<string, unknown> & {
+  title: string;
+  description: string;
+  category: string;
+  screenshot: string | null;
+  attachments: Array<Record<string, unknown>>;
+  consoleLogs?: Array<{ message?: string }>;
+  submitter?: { name?: string; email?: string };
+  metadata: Record<string, unknown>;
+};
+
+const stubPng =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+function expectValidPngDataUrl(value: unknown): void {
+  expect(value).toEqual(expect.stringMatching(/^data:image\/png;base64,[A-Za-z0-9+/]+=*$/));
+  const bytes = Buffer.from((value as string).split(',')[1]!, 'base64');
+  expect(bytes.subarray(0, 8)).toEqual(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
+}
+
+function materialPayload(payload: Payload): Payload {
+  const metadata = { ...payload.metadata };
+  delete metadata.timestamp;
+  return { ...payload, metadata };
+}
+
+async function ready(page: Page, capture = false) {
+  if (capture) {
+    await page.addInitScript(png => {
+      const target = window as Window & {
+        __bugdropMockToPng?: () => Promise<string>;
+        __captureCount?: number;
+      };
+      target.__bugdropMockToPng = () => {
+        target.__captureCount = (target.__captureCount ?? 0) + 1;
+        return Promise.resolve(png);
+      };
+    }, stubPng);
+  }
   await page.route('**/api/check/**', route =>
     route.fulfill({
       status: 200,
@@ -14,172 +54,514 @@ async function ready(page: Page) {
     .toBe('function');
 }
 
-async function register(page: Page) {
-  await page.evaluate(() => {
-    const opened = window
-      .BugDrop!.registerFlow({
-        configVersion: 1,
-        id: 'public-triage',
-        presentation: { kind: 'modal' },
-        forms: [
-          {
-            id: 'triage',
-            title: 'Classify your feedback',
-            fields: [
-              {
-                id: 'kind',
-                type: 'singleChoice',
-                label: 'Type',
-                required: true,
-                options: [
-                  { value: 'bug', label: 'Bug' },
-                  { value: 'idea', label: 'Idea' },
-                ],
-              },
-              { id: 'summary', type: 'shortText', label: 'Summary', required: true },
-            ],
-          },
-          {
-            id: 'detail',
-            title: 'Describe the bug',
-            fields: [{ id: 'description', type: 'longText', label: 'Steps' }],
-          },
-        ],
-        screens: [
-          {
-            id: 'intro',
-            type: 'message',
-            title: 'Help us improve',
-            when: { context: 'surface', equals: 'browser-test' },
-          },
-          { id: 'triage-screen', type: 'form', form: 'triage' },
-          {
-            id: 'detail-screen',
-            type: 'form',
-            form: 'detail',
-            when: { answer: 'triage.kind', equals: 'bug' },
-          },
-          {
-            id: 'screenshot',
-            type: 'screenshot',
-            mode: 'optional',
-            when: { answer: 'triage.kind', equals: 'bug' },
-          },
-        ],
-        issue: {
-          classification: 'bug',
-          title: '{{triage.summary}}',
-          sections: [{ heading: 'Steps', answer: 'detail.description', omitWhenEmpty: true }],
-        },
-      })
-      .open({ context: { surface: 'browser-test' } });
-    (window as Window & { __publicFlow?: typeof opened }).__publicFlow = opened;
-  });
+async function openConfig(page: Page, config: FlowConfig, openOptions?: FlowOpenOptions) {
+  await page.evaluate(
+    ({ recipe, options }) => {
+      const opened = window.BugDrop!.registerFlow(recipe).open(options);
+      (window as Window & { __publicFlow?: typeof opened }).__publicFlow = opened;
+    },
+    { recipe: config, options: openOptions }
+  );
+  return page.locator(`body > [data-bugdrop-flow="${config.id}"]`);
 }
 
-test.describe('public modal FlowConfig V1', () => {
-  test('navigates conditionally, retains Back values, submits the legacy recipe, retries, and restores focus', async ({
-    page,
-  }) => {
-    const submissions: Array<Record<string, unknown>> = [];
-    let attempt = 0;
-    await page.route('**/api/feedback', route => {
-      submissions.push(route.request().postDataJSON() as Record<string, unknown>);
-      attempt += 1;
-      return route.fulfill(
-        attempt === 1
-          ? {
-              status: 500,
-              contentType: 'application/json',
-              body: JSON.stringify({ error: 'Temporary failure' }),
-            }
-          : {
-              status: 200,
-              contentType: 'application/json',
-              body: JSON.stringify({
-                success: true,
-                issueNumber: 44,
-                issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/44',
-                isPublic: false,
-              }),
-            }
-      );
+async function openRecipe(page: Page, id: FlowRecipeId) {
+  const recipe = flowRecipes[id];
+  return openConfig(page, recipe.config, recipe.openOptions);
+}
+
+async function mockFeedback(page: Page, issueNumber: number, failFirst = false) {
+  const payloads: Payload[] = [];
+  let attempts = 0;
+  await page.route('**/api/feedback', route => {
+    payloads.push(route.request().postDataJSON() as Payload);
+    attempts += 1;
+    if (failFirst && attempts === 1) {
+      return route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Temporary failure' }),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        issueNumber,
+        issueUrl: `https://github.com/mean-weasel/bugdrop-widget-test/issues/${issueNumber}`,
+        isPublic: false,
+      }),
     });
-    await ready(page);
+  });
+  return payloads;
+}
+
+test.describe('public modal FlowConfig V1 representative recipes', () => {
+  test('bug-report completes its natural composable journey', async ({ page }) => {
+    const payloads = await mockFeedback(page, 51, true);
+    await ready(page, true);
+    const canonicalPageUrl = new URL(page.url());
+    canonicalPageUrl.search = '';
+    canonicalPageUrl.hash = '';
+    await page.evaluate(() => console.info('bug-report-log-marker'));
     const trigger = page.getByRole('button', { name: /feedback/i });
     await trigger.focus();
-    await register(page);
-    const host = page.locator('body > [data-bugdrop-flow="public-triage"]');
-    await expect(host.getByRole('heading', { name: 'Help us improve' })).toBeVisible();
-    await host.getByRole('button', { name: 'Continue' }).click();
-    await host.getByLabel('Bug').click();
+    const host = await openRecipe(page, 'bug-report');
+    const root = host.locator('.bdv-root');
+
+    await expect(root).toHaveAttribute('data-size', 'default');
+    await expect(root).toHaveAttribute('data-columns', '2');
+    await expect(root).toHaveAttribute('data-density', 'comfortable');
+    await expect(root).not.toHaveClass(/bdv-dark/);
+    expect(await root.evaluate(element => element.style.getPropertyValue('--bdv-accent'))).toBe(
+      '#2563eb'
+    );
+    await expect(host.getByRole('heading', { name: 'Report a problem' })).toBeVisible();
+    await expect(host.getByText('This takes about a minute.')).toBeVisible();
+    await expect(host.getByText('Step 1 of 4')).toBeVisible();
+    await host.getByRole('button', { name: 'Start report' }).click();
+    await host.getByRole('button', { name: 'Add evidence' }).click();
+    await expect(host.getByLabel('Summary')).toBeFocused();
+    await expect(host.getByLabel('Summary')).toHaveAttribute('aria-invalid', 'true');
+    await expect(host.locator('[data-bugdrop-field="summary"]')).toHaveAttribute('data-span', '2');
+    await expect(host.locator('[data-bugdrop-field="steps"]')).toHaveAttribute('data-span', '2');
     await host.getByLabel('Summary').fill('Save crashes');
-    await host.getByRole('button', { name: 'Continue' }).click();
-    await host.getByLabel('Steps').fill('Click save twice');
-    await host.getByRole('button', { name: 'Back' }).click();
-    await expect(host.getByLabel('Summary')).toHaveValue('Save crashes');
-    await host.getByRole('button', { name: 'Continue' }).click();
-    await expect(host.getByLabel('Steps')).toHaveValue('Click save twice');
-    await host.getByRole('button', { name: 'Continue' }).click();
-    await host.getByLabel('Include a screenshot', { exact: true }).click();
-    await host.getByRole('button', { name: 'Submit' }).click();
-    await expect(host.getByText('Temporary failure')).toBeVisible();
-    await host.getByRole('button', { name: 'Try again' }).click();
-    await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
-    expect(submissions).toHaveLength(2);
-    expect(submissions[0]).toMatchObject({
-      repo: 'mean-weasel/bugdrop-widget-test',
-      title: 'Save crashes',
-      description: '## Steps\n\nClick save twice',
-      screenshot: null,
-      attachments: [],
+    await host.getByLabel('Steps to reproduce').fill('Open settings\nClick save');
+    await host.getByRole('button', { name: 'Add evidence' }).click();
+    await expect(host.locator('[data-bugdrop-field="files"]')).toHaveAttribute('data-span', '2');
+    await host.getByLabel('Attachments').setInputFiles({
+      name: 'trace.png',
+      mimeType: 'image/png',
+      buffer: Buffer.from('local trace'),
     });
-    expect(submissions[0]?.kind).toBeUndefined();
+    await expect(host.getByText('trace.png')).toBeVisible();
+    await expect(host.getByLabel('Include console logs')).toBeChecked();
+    await host.getByLabel('Your name').fill(' Ada ');
+    await host.getByLabel('Email').fill(' ada@example.com ');
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await expect(host.getByRole('heading', { name: 'Show us the problem' })).toBeVisible();
+    await expect(host.getByLabel('Include a screenshot')).toHaveCount(0);
+    await host.getByRole('button', { name: 'Submit' }).click();
+
+    const capture = page.locator('#bugdrop-host');
+    await expect(capture.getByRole('heading', { name: 'Capture Screenshot' })).toBeVisible();
+    await expect(capture.getByRole('button', { name: /skip screenshot/i })).toHaveCount(0);
+    await capture.locator('[data-action="capture"]').focus();
+    await page.keyboard.press('Enter');
+    await expect(capture.locator('#annotation-canvas canvas')).toBeVisible();
+    await capture.locator('[data-action="done"]').focus();
+    await page.keyboard.press('Enter');
+    await expect(host.getByText('Temporary failure')).toBeVisible();
+    await expect(host.getByRole('button', { name: 'Discard report' })).toBeVisible();
+    await host.getByRole('button', { name: 'Try again' }).click();
+    await expect(host.getByRole('heading', { name: 'Report received' })).toBeVisible();
+    await expect(host.getByText('Thanks for helping us fix this.')).toBeVisible();
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]).toMatchObject({
+      title: 'Bug: Save crashes',
+      category: 'bug',
+      submitter: { name: 'Ada', email: 'ada@example.com' },
+      attachments: [
+        expect.objectContaining({
+          name: 'trace.png',
+          type: 'image/png',
+          dataUrl: expect.stringMatching(/^data:image\/png;base64,/),
+        }),
+      ],
+      metadata: {
+        url: canonicalPageUrl.toString(),
+        elementSelector: null,
+        fullElementSelector: null,
+      },
+    });
+    expectValidPngDataUrl(payloads[0].screenshot);
+    expect(materialPayload(payloads[1]!)).toEqual(materialPayload(payloads[0]!));
+    expect(payloads[0].description).toContain('> Open settings\n> Click save');
+    expect(payloads[0].consoleLogs?.some(entry => entry.message === 'bug-report-log-marker')).toBe(
+      true
+    );
+    expect(
+      await page.evaluate(
+        () =>
+          (window as Window & { __publicFlow?: { result: Promise<unknown> } }).__publicFlow?.result
+      )
+    ).toEqual({
+      status: 'submitted',
+      result: {
+        issueNumber: 51,
+        issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/51',
+        isPublic: false,
+      },
+    });
     await host.getByRole('button', { name: 'Done' }).click();
     await expect(trigger).toBeFocused();
   });
 
-  test('clears hidden answers after predicate changes and shares modal ownership', async ({
+  test('registerFlow two-column modal stays contained and collapses at narrow viewports', async ({
     page,
   }) => {
-    const submissions: Array<Record<string, unknown>> = [];
-    await page.route('**/api/feedback', route => {
-      submissions.push(route.request().postDataJSON() as Record<string, unknown>);
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          issueNumber: 45,
-          issueUrl: 'https://github.com/mean-weasel/bugdrop-widget-test/issues/45',
-          isPublic: false,
-        }),
-      });
-    });
+    await page.setViewportSize({ width: 800, height: 700 });
     await ready(page);
-    await register(page);
-    const host = page.locator('body > [data-bugdrop-flow="public-triage"]');
+    const config: FlowConfig = {
+      configVersion: 1,
+      id: 'responsive-two-column-proof',
+      presentation: { kind: 'modal', size: 'wide', columns: 2 },
+      forms: [
+        {
+          id: 'details',
+          title: 'Responsive details',
+          fields: [
+            { id: 'summary', type: 'shortText', label: 'Summary' },
+            { id: 'owner', type: 'shortText', label: 'Owner' },
+          ],
+        },
+      ],
+      screens: [{ id: 'details-screen', type: 'form', form: 'details' }],
+      issue: { title: 'Responsive proof' },
+    };
+    const host = await openConfig(page, config);
+    const root = host.locator('.bdv-root');
+    const surface = host.locator('.bdv-surface');
+    const fields = host.locator('.bdv-field');
+
+    await expect(root).toHaveAttribute('data-columns', '2');
+    await expect
+      .poll(() =>
+        host
+          .locator('.bdv-fields')
+          .evaluate(
+            element =>
+              getComputedStyle(element).gridTemplateColumns.split(' ').filter(Boolean).length
+          )
+      )
+      .toBe(2);
+    const wideFirst = await fields.nth(0).boundingBox();
+    const wideSecond = await fields.nth(1).boundingBox();
+    expect(wideFirst).not.toBeNull();
+    expect(wideSecond).not.toBeNull();
+    expect(wideSecond!.y).toBe(wideFirst!.y);
+    expect(wideSecond!.x).toBeGreaterThan(wideFirst!.x);
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect
+      .poll(() =>
+        host
+          .locator('.bdv-fields')
+          .evaluate(
+            element =>
+              getComputedStyle(element).gridTemplateColumns.split(' ').filter(Boolean).length
+          )
+      )
+      .toBe(1);
+    const narrowFirst = await fields.nth(0).boundingBox();
+    const narrowSecond = await fields.nth(1).boundingBox();
+    const surfaceBox = await surface.boundingBox();
+    expect(narrowFirst).not.toBeNull();
+    expect(narrowSecond).not.toBeNull();
+    expect(surfaceBox).not.toBeNull();
+    expect(narrowSecond!.y).toBeGreaterThan(narrowFirst!.y);
+    expect(surfaceBox!.x).toBeGreaterThanOrEqual(0);
+    expect(surfaceBox!.x + surfaceBox!.width).toBeLessThanOrEqual(390);
+    const surfaceWidths = await surface.evaluate(element => ({
+      client: element.clientWidth,
+      scroll: element.scrollWidth,
+    }));
+    expect(surfaceWidths.scroll).toBeLessThanOrEqual(surfaceWidths.client);
+  });
+
+  test('registerFlow reduced motion removes Flow surface and control motion', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await mockFeedback(page, 56);
+    await ready(page);
+    const config: FlowConfig = {
+      configVersion: 1,
+      id: 'reduced-motion-proof',
+      presentation: { kind: 'modal' },
+      forms: [
+        {
+          id: 'details',
+          title: 'Reduced motion details',
+          fields: [{ id: 'summary', type: 'shortText', label: 'Summary', required: true }],
+        },
+      ],
+      screens: [{ id: 'details-screen', type: 'form', form: 'details' }],
+      issue: { title: '{{details.summary}}' },
+    };
+    const host = await openConfig(page, config);
+    const surface = host.locator('.bdv-surface');
+    const input = host.getByLabel('Summary');
+    const submit = host.getByRole('button', { name: 'Submit' });
+
+    expect(await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches)).toBe(
+      true
+    );
+    await expect(surface).toBeVisible();
+    expect(
+      await Promise.all(
+        [surface, input, submit].map(locator =>
+          locator.evaluate(element => {
+            const style = getComputedStyle(element);
+            return {
+              animationName: style.animationName,
+              animationDuration: style.animationDuration,
+              transitionDuration: style.transitionDuration,
+            };
+          })
+        )
+      )
+    ).toEqual([
+      { animationName: 'none', animationDuration: '0s', transitionDuration: '0s' },
+      { animationName: 'none', animationDuration: '0s', transitionDuration: '0s' },
+      { animationName: 'none', animationDuration: '0s', transitionDuration: '0s' },
+    ]);
+    await input.fill('No animated transition');
+    await submit.click();
+    await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+    await expect(host.getByRole('button', { name: 'Done' })).toHaveCSS('transition-duration', '0s');
+  });
+
+  test('registerFlow remains interactive inside Radix-style host dismissal and focus traps', async ({
+    page,
+  }) => {
+    await ready(page);
+    await page.evaluate(() => {
+      const hostDialog = document.createElement('div');
+      hostDialog.id = 'flow-host-dialog';
+      hostDialog.tabIndex = -1;
+      document.body.appendChild(hostDialog);
+      hostDialog.focus();
+      const state = window as Window & {
+        __flowHostDismissed?: boolean;
+        __flowHostDismissEvents?: string[];
+      };
+      state.__flowHostDismissed = false;
+      state.__flowHostDismissEvents = [];
+      document.addEventListener(
+        'pointerdown',
+        event => {
+          const owned = document.querySelector('[data-bugdrop-flow="radix-flow-proof"]');
+          if (!owned || !event.composedPath().includes(owned)) return;
+          for (const eventType of [
+            'dismissableLayer.pointerDownOutside',
+            'dismissableLayer.interactOutside',
+          ]) {
+            const outside = new CustomEvent(eventType, {
+              bubbles: true,
+              cancelable: true,
+              composed: true,
+              detail: { originalEvent: event },
+            });
+            state.__flowHostDismissEvents?.push(eventType);
+            document.dispatchEvent(outside);
+            if (!outside.defaultPrevented) state.__flowHostDismissed = true;
+          }
+        },
+        true
+      );
+      document.addEventListener(
+        'focusin',
+        event => {
+          const owned = document.querySelector('[data-bugdrop-flow="radix-flow-proof"]');
+          if (owned && event.composedPath().includes(owned)) hostDialog.focus();
+        },
+        true
+      );
+    });
+    const config: FlowConfig = {
+      configVersion: 1,
+      id: 'radix-flow-proof',
+      presentation: { kind: 'modal' },
+      forms: [
+        {
+          id: 'answer',
+          title: 'Radix Flow proof',
+          fields: [{ id: 'detail', type: 'longText', label: 'Your answer', required: true }],
+        },
+      ],
+      screens: [{ id: 'answer-screen', type: 'form', form: 'answer' }],
+      issue: { title: 'Radix Flow proof' },
+    };
+    const host = await openConfig(page, config);
+    const answer = host.getByRole('textbox', { name: 'Your answer' });
+
+    await answer.click();
+    await answer.fill('OpenStack');
+    await expect(answer).toHaveValue('OpenStack');
+    await expect(answer).toBeFocused();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as Window & { __flowHostDismissEvents?: string[] }).__flowHostDismissEvents
+        )
+      )
+      .toEqual(['dismissableLayer.pointerDownOutside', 'dismissableLayer.interactOutside']);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as Window & { __flowHostDismissed?: boolean }).__flowHostDismissed
+        )
+      )
+      .toBe(false);
+    await expect
+      .poll(() => page.evaluate(() => document.activeElement?.id))
+      .not.toBe('flow-host-dialog');
+  });
+
+  test('product-triage completes its natural composable journey', async ({ page }) => {
+    const payloads = await mockFeedback(page, 52);
+    await ready(page);
+    const host = await openRecipe(page, 'product-triage');
+    const root = host.locator('.bdv-root');
+    await expect(root).toHaveAttribute('data-size', 'wide');
+    await expect(root).toHaveAttribute('data-columns', '2');
+    await expect(root).toHaveAttribute('data-density', 'compact');
+    await expect(root).toHaveClass(/bdv-dark/);
+    expect(await root.evaluate(element => element.style.getPropertyValue('--bdv-accent'))).toBe(
+      '#f97316'
+    );
+
     await host.getByRole('button', { name: 'Continue' }).click();
     await host.getByLabel('Bug').click();
-    await host.getByLabel('Summary').fill('First');
+    await host.getByRole('radio', { name: '2 stars' }).click();
+    await host.getByLabel('Summary').fill('Checkout stalls');
+    await expect(host.getByText('Step 2 of 4')).toBeVisible();
     await host.getByRole('button', { name: 'Continue' }).click();
-    await host.getByLabel('Steps').fill('Secret stale detail');
+    await host.getByLabel('What happened?').fill('Spinner never stops');
+    await host.getByLabel('Chromium').click();
+    await host.getByRole('button', { name: 'Continue' }).click();
     await host.getByRole('button', { name: 'Back' }).click();
-    await host.getByLabel('Idea').click();
-    await host.getByLabel('Summary').fill('Idea title');
+    await expect(host.getByLabel('What happened?')).toHaveValue('Spinner never stops');
+    await expect(host.getByLabel('Chromium')).toBeChecked();
+    await host.getByRole('button', { name: 'Back' }).click();
+    await expect(host.getByLabel('Summary')).toHaveValue('Checkout stalls');
+    await expect(host.getByRole('radio', { name: '2 stars' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    await host.getByRole('radio', { name: '4 stars' }).click();
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await expect(host.getByText('Step 3 of 3')).toBeVisible();
+    await host.getByLabel('Include a screenshot').uncheck();
     await host.getByRole('button', { name: 'Submit' }).click();
     await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
-    expect(submissions[0]).toMatchObject({ title: 'Idea title', description: '' });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({
+      title: 'Triage: Checkout stalls',
+      category: 'feature',
+      screenshot: null,
+      attachments: [],
+      description: '## Type\n\nBug\n\n## Experience\n\n★★★★☆ (4/5)',
+    });
+    expect(payloads[0].description).not.toContain('Spinner never stops');
+  });
+
+  test('customer-pulse completes its natural composable journey', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.emulateMedia({ colorScheme: 'dark' });
+    const payloads = await mockFeedback(page, 53, true);
+    await ready(page);
+    const host = await openRecipe(page, 'customer-pulse');
+    const root = host.locator('.bdv-root');
+    await expect(root).toHaveAttribute('data-size', 'compact');
+    await expect(root).toHaveAttribute('data-columns', '1');
+    await expect(root).toHaveAttribute('data-density', 'comfortable');
+    await expect(root).toHaveClass(/bdv-dark/);
+    expect((await host.boundingBox())?.width).toBeLessThanOrEqual(390);
+
+    const scoreGroup = host.getByRole('radiogroup', { name: 'Ease score' });
+    const scoreControls = scoreGroup.getByRole('radio');
+    await expect(scoreControls).toHaveCount(10);
+    expect(await scoreControls.allTextContents()).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '10',
+    ]);
+    await expect(host.getByText('Difficult', { exact: true })).toBeVisible();
+    await expect(host.getByText('Easy', { exact: true })).toBeVisible();
+
+    await host.getByRole('radio', { name: '3 stars' }).click();
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await expect(host.getByRole('button', { name: 'Change score' })).toBeVisible();
+    await host.getByRole('button', { name: 'Change score' }).click();
+    await expect(host.getByRole('radio', { name: '3 stars' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await host.getByLabel('What made this difficult?').fill('Invoice filters reset');
+    await host.getByLabel('Yes').click();
+    await host.getByLabel('I consent to a product follow-up').check();
+    await host.getByRole('button', { name: 'Send pulse' }).click();
+    await expect(host.getByText('Temporary failure')).toBeVisible();
+    await expect(host.getByRole('button', { name: 'Not now' })).toBeVisible();
+    await host.getByRole('button', { name: 'Try again' }).click();
+    await expect(host.getByRole('heading', { name: 'Pulse recorded' })).toBeVisible();
+    await expect(host.getByText('Thanks for sharing how billing feels today.')).toBeVisible();
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]).toEqual(
+      expect.objectContaining({
+        title: 'Billing pulse 3/10',
+        category: 'question',
+        screenshot: null,
+        attachments: [],
+        description:
+          '## Score\n\n3\n\n## Follow-up\n\nInvoice filters reset\n\n## Contact\n\nYes\n\n## Consent\n\ntrue',
+      })
+    );
+  });
+
+  test('auto screenshot captures once without showing chooser or annotation', async ({ page }) => {
+    const payloads = await mockFeedback(page, 54);
+    await ready(page, true);
+    const config: FlowConfig = {
+      configVersion: 1,
+      id: 'auto-capture-proof',
+      presentation: { kind: 'modal' },
+      forms: [
+        {
+          id: 'report',
+          title: 'Automatic evidence',
+          fields: [{ id: 'summary', type: 'shortText', label: 'Summary', required: true }],
+        },
+      ],
+      screens: [
+        { id: 'report-screen', type: 'form', form: 'report' },
+        { id: 'capture', type: 'screenshot', mode: 'auto' },
+      ],
+      issue: { title: '{{report.summary}}' },
+    };
+    const host = await openConfig(page, config);
+    await host.getByLabel('Summary').fill('Automatic proof');
+    await host.getByRole('button', { name: 'Continue' }).click();
+    await host.getByRole('button', { name: 'Submit' }).click();
+    await expect(host.getByRole('heading', { name: 'Thanks for your feedback!' })).toBeVisible();
+    await expect(page.locator('#bugdrop-host [data-action="capture"]')).toHaveCount(0);
+    await expect(page.locator('#bugdrop-host #annotation-canvas')).toHaveCount(0);
+    expect(
+      await page.evaluate(() => (window as Window & { __captureCount?: number }).__captureCount)
+    ).toBe(1);
+    expect(payloads[0]).toMatchObject({ title: 'Automatic proof', screenshot: stubPng });
   });
 
   test('close tears down an in-progress screenshot chooser', async ({ page }) => {
+    await mockFeedback(page, 55);
     await ready(page);
-    await register(page);
-    const host = page.locator('body > [data-bugdrop-flow="public-triage"]');
+    const host = await openRecipe(page, 'product-triage');
     await host.getByRole('button', { name: 'Continue' }).click();
     await host.getByLabel('Bug').click();
+    await host.getByRole('radio', { name: '4 stars' }).click();
     await host.getByLabel('Summary').fill('Close capture');
-    await host.getByRole('button', { name: 'Continue' }).click();
     await host.getByRole('button', { name: 'Continue' }).click();
     await host.getByRole('button', { name: 'Submit' }).click();
     const chooser = page.locator('#bugdrop-host .bd-overlay');

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -14,6 +14,11 @@ live_spec="$repo_root/e2e/widget.live.spec.ts"
 variant_live_spec="$repo_root/e2e/variant.live.spec.ts"
 variant_accessibility_spec="$repo_root/e2e/variant-accessibility.radix.spec.ts"
 variant_conformance_spec="$repo_root/test/variantFieldConformance.test.ts"
+flow_coverage_spec="$repo_root/test/flowCoverageMatrix.test.ts"
+flow_recipe_spec="$repo_root/test/flowRecipeConformance.test.ts"
+flow_recipe_fixture="$repo_root/test/fixtures/flow-recipes.ts"
+local_flow_spec="$repo_root/e2e/public-flow.spec.ts"
+live_flow_spec="$repo_root/e2e/public-flow.flow-live.spec.ts"
 variant_inline_spec="$repo_root/e2e/widget.spec.ts"
 live_radix_spec="$repo_root/e2e/widget.live-radix.spec.ts"
 cross_browser_live_spec="$repo_root/e2e/widget.cross-browser-live.spec.ts"
@@ -249,6 +254,18 @@ local_discovery=$(env -u LIVE_TARGET -u PLAYWRIGHT_BASE_URL \
   npx playwright test --list --reporter=line 2>&1) ||
   fail 'local Playwright discovery failed without live inputs'
 grep -Fq '[chromium]' <<< "$local_discovery" || fail 'local Chromium project was not discovered'
+for local_flow_test in \
+  'bug-report completes its natural composable journey' \
+  'product-triage completes its natural composable journey' \
+  'customer-pulse completes its natural composable journey' \
+  'registerFlow two-column modal stays contained and collapses at narrow viewports' \
+  'registerFlow reduced motion removes Flow surface and control motion' \
+  'registerFlow remains interactive inside Radix-style host dismissal and focus traps' \
+  'auto screenshot captures once without showing chooser or annotation'; do
+  grep -Fq "$local_flow_test" <<< "$local_discovery" ||
+    fail "ordinary local Playwright discovery omitted composable proof: $local_flow_test"
+  require_literal "$local_flow_spec" "$local_flow_test"
+done
 for excluded_project in \
   chromium-live \
   chromium-flow-live \
@@ -472,9 +489,26 @@ done
 require_paired_lane 'Run composable FlowConfig live E2E tests' \
   EXACT_WIDGET_FIXTURE_PATH EXPECTED_WIDGET_SHA256 \
   'npx playwright test --project=chromium-flow-live --workers=1 --retries=0'
-grep -Fq 'runs a conditional multi-screen FlowConfig through the exact preview widget' \
-  "$repo_root/e2e/public-flow.flow-live.spec.ts" ||
-  fail 'the candidate-only custom FlowConfig lane lost its conditional multi-screen assertion'
+flow_live_discovery=$(LIVE_TARGET=preview PLAYWRIGHT_BASE_URL=https://example.invalid \
+  npx playwright test "$live_flow_spec" --project=chromium-flow-live --list --reporter=line 2>&1) ||
+  fail 'candidate-only composable preview discovery failed'
+for preview_flow_test in \
+  'Bug Report completes its exact candidate preview journey' \
+  'Product Triage completes its exact candidate preview journey' \
+  'Customer Pulse completes its exact candidate preview journey'; do
+  require_literal "$live_flow_spec" "$preview_flow_test"
+  grep -Fq "$preview_flow_test" <<< "$flow_live_discovery" ||
+    fail "candidate-only composable preview discovery omitted: $preview_flow_test"
+done
+[[ $(grep -Fc '[chromium-flow-live]' <<< "$flow_live_discovery") -eq 3 ]] ||
+  fail 'candidate-only composable preview lane must discover exactly three journeys'
+require_literal "$live_flow_spec" "from '../test/fixtures/flow-recipes'"
+require_literal "$live_flow_spec" "page.route('**/api/check/**'"
+require_literal "$live_flow_spec" "page.route('**/api/feedback'"
+require_literal "$live_flow_spec" 'await loadExactFlowWidget(page)'
+require_literal "$live_flow_spec" 'await assertExactPreviewWidgetResponse(await response, expectedWidgetSha256)'
+require_absent "$live_flow_spec" 'merge-queue-composable-flow'
+require_absent "$live_flow_spec" 'runs a conditional multi-screen FlowConfig through the exact preview widget'
 
 require_paired_lane 'Run one structured real-Issue canary' \
   EXACT_WIDGET_FIXTURE_PATH EXPECTED_WIDGET_SHA256 \
@@ -653,6 +687,14 @@ require_literal "$variant_conformance_spec" 'short text'
 require_literal "$variant_conformance_spec" 'long text'
 require_literal "$variant_conformance_spec" 'rating'
 require_literal "$variant_conformance_spec" 'single choice'
+require_literal "$flow_coverage_spec" 'canonical composable flow coverage matrix'
+require_literal "$flow_coverage_spec" 'records true multi-select as deferred product work'
+require_literal "$flow_recipe_spec" 'representative FlowConfig recipe conformance'
+require_literal "$repo_root/test/flowFormScreen.test.ts" 'applies every inherited field control through the thin FlowForm adapter'
+require_literal "$repo_root/test/flowManager.test.ts" 'renders valid initial answers in the opened Flow UI and routed runtime'
+for recipe_id in bug-report product-triage customer-pulse; do
+  require_literal "$flow_recipe_fixture" "id: '$recipe_id'"
+done
 require_literal "$variant_inline_spec" 'simultaneous inline variants isolate answers, submission IDs, reset, disposal, and legacy state'
 require_literal "$cross_browser_live_spec" 'submits a compact suggestion from the exact preview widget without a real Issue'
 require_literal "$makefile" 'npx playwright test e2e/widget.radix.spec.ts e2e/variant-modal.radix.spec.ts e2e/variant-accessibility.radix.spec.ts --project=$(BROWSER)-radix --workers=1 --retries=0'

--- a/test/fixtures/flow-coverage.ts
+++ b/test/fixtures/flow-coverage.ts
@@ -1,0 +1,615 @@
+import type { FlowRecipeId } from './flow-recipes';
+
+export type ProofLevel = 'focused' | 'local-browser' | 'compatibility-control';
+export type ArtifactIdentity = 'source' | 'local-widget' | 'candidate-and-classic';
+
+export interface FlowCoverageRow {
+  readonly primitiveOrState: string;
+  readonly publicContract: string;
+  readonly proofOwner: string;
+  readonly proofLevel: ProofLevel;
+  readonly recipe: FlowRecipeId | null;
+  readonly artifactIdentity: ArtifactIdentity;
+  readonly expectedAssertion: string;
+  readonly gapStatus: 'covered' | 'deferred-product';
+}
+
+type Row = Omit<FlowCoverageRow, 'gapStatus'> & { gapStatus?: FlowCoverageRow['gapStatus'] };
+const row = (value: Row): FlowCoverageRow => ({ gapStatus: 'covered', ...value });
+const recipe = (
+  primitiveOrState: string,
+  publicContract: string,
+  recipeId: FlowRecipeId,
+  expectedAssertion: string
+) =>
+  row({
+    primitiveOrState,
+    publicContract,
+    proofOwner: `e2e/public-flow.spec.ts#${recipeId} completes its natural composable journey`,
+    proofLevel: 'local-browser',
+    recipe: recipeId,
+    artifactIdentity: 'local-widget',
+    expectedAssertion,
+  });
+const focused = (
+  primitiveOrState: string,
+  publicContract: string,
+  proofOwner: string,
+  expectedAssertion: string
+) =>
+  row({
+    primitiveOrState,
+    publicContract,
+    proofOwner,
+    proofLevel: 'focused',
+    recipe: null,
+    artifactIdentity: 'source',
+    expectedAssertion,
+  });
+const browser = (
+  primitiveOrState: string,
+  publicContract: string,
+  proofOwner: string,
+  expectedAssertion: string
+) =>
+  row({
+    primitiveOrState,
+    publicContract,
+    proofOwner,
+    proofLevel: 'local-browser',
+    recipe: null,
+    artifactIdentity: 'local-widget',
+    expectedAssertion,
+  });
+const control = (
+  primitiveOrState: string,
+  publicContract: string,
+  proofOwner: string,
+  expectedAssertion: string
+) =>
+  row({
+    primitiveOrState,
+    publicContract,
+    proofOwner,
+    proofLevel: 'compatibility-control',
+    recipe: null,
+    artifactIdentity: 'candidate-and-classic',
+    expectedAssertion,
+  });
+
+export const canonicalFlowCoverage: readonly FlowCoverageRow[] = Object.freeze([
+  recipe(
+    'field.shortText',
+    'FlowField shortText',
+    'bug-report',
+    'summary and submitter text survive submission'
+  ),
+  focused(
+    'field.helpText',
+    'FlowField helpText',
+    'test/flowFormScreen.test.ts#applies every inherited field control through the thin FlowForm adapter',
+    'configured help copy renders and is referenced by the Flow control'
+  ),
+  focused(
+    'field.shortText.placeholder',
+    'ShortTextField placeholder',
+    'test/flowFormScreen.test.ts#applies every inherited field control through the thin FlowForm adapter',
+    'configured placeholder reaches the Flow input'
+  ),
+  focused(
+    'field.shortText.minLength',
+    'ShortTextField minLength',
+    'test/flowFormScreen.test.ts#applies every inherited field control through the thin FlowForm adapter',
+    'configured minimum length reaches the Flow input'
+  ),
+  focused(
+    'field.shortText.maxLength',
+    'ShortTextField maxLength',
+    'test/flowFormScreen.test.ts#applies every inherited field control through the thin FlowForm adapter',
+    'configured maximum length reaches the Flow input'
+  ),
+  recipe(
+    'field.longText',
+    'FlowField longText',
+    'bug-report',
+    'multiline steps compile as a quote'
+  ),
+  focused(
+    'field.longText.placeholder',
+    'LongTextField placeholder',
+    'test/flowFormScreen.test.ts#applies every inherited field control through the thin FlowForm adapter',
+    'configured placeholder reaches the Flow textarea'
+  ),
+  focused(
+    'field.longText.rows',
+    'LongTextField rows',
+    'test/flowFormScreen.test.ts#applies every inherited field control through the thin FlowForm adapter',
+    'configured row count reaches the Flow textarea'
+  ),
+  focused(
+    'field.longText.minLength',
+    'LongTextField minLength',
+    'test/flowFormScreen.test.ts#applies every inherited field control through the thin FlowForm adapter',
+    'configured minimum length reaches the Flow textarea'
+  ),
+  focused(
+    'field.longText.maxLength',
+    'LongTextField maxLength',
+    'test/flowFormScreen.test.ts#applies every inherited field control through the thin FlowForm adapter',
+    'configured maximum length reaches the Flow textarea'
+  ),
+  recipe(
+    'field.rating.5.star',
+    'rating scale 5 icon star',
+    'product-triage',
+    'five-star answer renders and compiles'
+  ),
+  recipe(
+    'field.rating.10.number',
+    'rating scale 10 icon number',
+    'customer-pulse',
+    'exactly ten numeric radio controls render and the selected answer compiles'
+  ),
+  recipe(
+    'field.rating.lowLabel',
+    'RatingField lowLabel',
+    'customer-pulse',
+    'configured Difficult endpoint label renders beside the ten-point scale'
+  ),
+  recipe(
+    'field.rating.highLabel',
+    'RatingField highLabel',
+    'customer-pulse',
+    'configured Easy endpoint label renders beside the ten-point scale'
+  ),
+  recipe(
+    'field.singleChoice.radio',
+    'singleChoice display radio',
+    'product-triage',
+    'radio choice retains its stable value'
+  ),
+  recipe(
+    'field.singleChoice.cards',
+    'singleChoice display cards',
+    'product-triage',
+    'card choice drives conditional routing'
+  ),
+  recipe(
+    'field.singleChoice.buttons',
+    'singleChoice display buttons',
+    'customer-pulse',
+    'button choice compiles its label'
+  ),
+  focused(
+    'field.singleChoice.option.description',
+    'SingleChoiceField option description',
+    'test/flowFormScreen.test.ts#applies every inherited field control through the thin FlowForm adapter',
+    'configured choice description renders inside the Flow choice control'
+  ),
+  recipe(
+    'field.checkbox',
+    'FlowField checkbox',
+    'customer-pulse',
+    'consent boolean reaches the draft'
+  ),
+  focused(
+    'field.checkbox.initialValue',
+    'CheckboxField initialValue',
+    'test/flowFormScreen.test.ts#applies every inherited field control through the thin FlowForm adapter',
+    'configured initial true state reaches the Flow checkbox and snapshot'
+  ),
+  recipe(
+    'field.attachments',
+    'FlowField attachments',
+    'bug-report',
+    'selected attachment reaches mocked feedback'
+  ),
+  focused(
+    'field.shared-controller-adapter',
+    'VariantField controllers reused by FlowForm',
+    'test/flowRecipeConformance.test.ts#reuses shared field controllers through the thin flow adapter',
+    'FlowForm renders and normalizes all inherited field types'
+  ),
+  focused(
+    'field.adapter-instance-isolation',
+    'thin FlowForm adapter instance isolation and disposal',
+    'test/flowRecipeConformance.test.ts#namespaces simultaneous thin flow adapters and disposes them independently',
+    'simultaneous adapters have disjoint ids and radio names, and disposing one leaves the other interactive'
+  ),
+  focused(
+    'field.required-focus',
+    'required field validation and focus',
+    'test/flowFormScreen.test.ts#focuses the first invalid shared or extra field',
+    'aria-invalid and active control identify the first failure'
+  ),
+  focused(
+    'field.attachment-bounds',
+    'attachment count, type, size, and read races',
+    'test/flowFormScreen.test.ts#enforces selected attachment count, type, size, and latest-read race behavior',
+    'over-count, unsupported-type, and oversized selections fail locally while only the latest read wins'
+  ),
+  recipe(
+    'layout.field-span',
+    'field layout span 1 or 2',
+    'bug-report',
+    'full-span fields and two-column evidence render naturally'
+  ),
+  recipe(
+    'screen.message',
+    'MessageScreen',
+    'bug-report',
+    'custom welcome copy and progress render'
+  ),
+  recipe('screen.form', 'FormScreen', 'product-triage', 'forms navigate forward and backward'),
+  recipe(
+    'screen.screenshot.optional',
+    'ScreenshotScreen optional',
+    'product-triage',
+    'optional capture can be skipped'
+  ),
+  recipe(
+    'screen.screenshot.required',
+    'ScreenshotScreen required',
+    'bug-report',
+    'required capture has no skip and supplies PNG evidence'
+  ),
+  browser(
+    'screen.screenshot.auto',
+    'ScreenshotScreen auto',
+    'e2e/public-flow.spec.ts#auto screenshot captures once without showing chooser or annotation',
+    'automatic capture supplies PNG evidence without picker UI'
+  ),
+  focused(
+    'screen.single-screenshot-bound',
+    'at most one screenshot screen',
+    'test/flowConfig.test.ts#two screenshots',
+    'a second screenshot screen is rejected'
+  ),
+  recipe(
+    'presentation.modal.compact',
+    'modal size compact',
+    'customer-pulse',
+    'compact modal renders terminal pulse'
+  ),
+  recipe(
+    'presentation.modal.default',
+    'modal size default',
+    'bug-report',
+    'default modal renders report'
+  ),
+  recipe(
+    'presentation.modal.wide',
+    'modal size wide',
+    'product-triage',
+    'wide modal renders triage'
+  ),
+  recipe(
+    'presentation.columns.1',
+    'modal columns 1',
+    'customer-pulse',
+    'single-column pulse renders'
+  ),
+  browser(
+    'presentation.columns.2',
+    'modal columns 2',
+    'e2e/public-flow.spec.ts#registerFlow two-column modal stays contained and collapses at narrow viewports',
+    'configured columns render as two tracks at wide width and collapse to one track when narrow'
+  ),
+  recipe(
+    'appearance.theme.light',
+    'appearance theme light',
+    'bug-report',
+    'light theme tokens apply'
+  ),
+  recipe(
+    'appearance.theme.dark',
+    'appearance theme dark',
+    'product-triage',
+    'dark theme tokens apply'
+  ),
+  recipe(
+    'appearance.theme.auto',
+    'appearance theme auto',
+    'customer-pulse',
+    'automatic theme tokens apply'
+  ),
+  recipe(
+    'appearance.accent',
+    'appearance accentColor',
+    'bug-report',
+    'configured accent token applies'
+  ),
+  recipe(
+    'appearance.density.compact',
+    'appearance density compact',
+    'product-triage',
+    'compact density token applies'
+  ),
+  recipe(
+    'appearance.density.comfortable',
+    'appearance density comfortable',
+    'customer-pulse',
+    'comfortable density token applies'
+  ),
+  recipe(
+    'content.action-copy',
+    'screen continueLabel and backLabel',
+    'customer-pulse',
+    'Continue, Change score, and Send pulse labels drive their configured actions'
+  ),
+  recipe(
+    'content.success-copy',
+    'content successTitle and successMessage',
+    'bug-report',
+    'Report received and its configured thank-you message replace default success copy'
+  ),
+  recipe(
+    'content.cancel-copy',
+    'content cancelLabel',
+    'bug-report',
+    'retryable failure renders Discard report as the cancel action'
+  ),
+  browser(
+    'presentation.responsive',
+    'modal responsive behavior',
+    'e2e/public-flow.spec.ts#registerFlow two-column modal stays contained and collapses at narrow viewports',
+    'the narrow modal surface stays inside the viewport without horizontal overflow and uses one field column'
+  ),
+  browser(
+    'presentation.reduced-motion',
+    'prefers-reduced-motion Flow behavior',
+    'e2e/public-flow.spec.ts#registerFlow reduced motion removes Flow surface and control motion',
+    'under reduced-motion emulation the opened Flow surface, input, and action controls have no animation or transition duration and remain operable'
+  ),
+  browser(
+    'presentation.radix',
+    'shared modal ownership with Radix hosts',
+    'e2e/public-flow.spec.ts#registerFlow remains interactive inside Radix-style host dismissal and focus traps',
+    'registerFlow input keeps focus and host outside-interaction events are prevented from dismissing the host dialog'
+  ),
+  focused(
+    'condition.answer',
+    'answer equality predicate',
+    'test/flowConditions.test.ts#evaluates answer, context, all, and any predicates',
+    'only present exact scalar answers match'
+  ),
+  focused(
+    'condition.context',
+    'context equality predicate',
+    'test/flowConditions.test.ts#evaluates answer, context, all, and any predicates',
+    'immutable context drives visibility'
+  ),
+  focused(
+    'condition.all',
+    'all condition group',
+    'test/flowConditions.test.ts#evaluates answer, context, all, and any predicates',
+    'every child must match'
+  ),
+  focused(
+    'condition.any',
+    'any condition group',
+    'test/flowConditions.test.ts#evaluates answer, context, all, and any predicates',
+    'one matching child is sufficient'
+  ),
+  focused(
+    'condition.bounds',
+    'depth 4 and node count 32',
+    'test/flowConditions.test.ts#bounds condition depth and size',
+    'over-depth and over-size trees throw'
+  ),
+  focused(
+    'condition.backward-only',
+    'answer predicates reference earlier forms',
+    'test/flowConfig.test.ts#forward condition',
+    'forward answer reference throws'
+  ),
+  focused(
+    'navigation.hidden-clearing',
+    'newly hidden answer and capture clearing',
+    'test/flowRuntime.test.ts#navigates visible screens, retains Back answers, and clears newly hidden answers/evidence',
+    'pruned branches cannot leak stale state'
+  ),
+  focused(
+    'navigation.back-retention',
+    'Back snapshots visible answers',
+    'test/flowRuntime.test.ts#does not clear still-visible form state during Back snapshots',
+    'visible form answers remain intact'
+  ),
+  focused(
+    'navigation.nearest-visible',
+    'current route recovers when hidden',
+    'test/flowRuntime.test.ts#recovers to the nearest visible screen after cascading branch changes',
+    'current screen moves to nearest earlier visible route'
+  ),
+  focused(
+    'navigation.progress',
+    'position and total reflect visible routes',
+    'test/flowRuntime.test.ts#uses visible routes and removes initially hidden answers before Issue compilation',
+    'position and total omit hidden screens'
+  ),
+  focused(
+    'navigation.async-suppression',
+    'duplicate async navigation is ignored',
+    'test/flowManager.test.ts#ignores a second form advance while async collection is in progress',
+    'one action causes one transition'
+  ),
+  focused(
+    'lifecycle.registration',
+    'registration validation and duplicate rejection',
+    'test/flowManager.test.ts#validates synchronously before DOM/network effects and rejects duplicates',
+    'invalid configurations have no DOM effects and duplicate configured ids reject'
+  ),
+  focused(
+    'lifecycle.public-identity',
+    'FlowHandle.id and OpenedFlow.instanceId',
+    'test/flowManager.test.ts#returns configured FlowHandle.id and generated OpenedFlow.instanceId',
+    'the handle id equals the configured flow id and a normal open exposes its generated runtime instance id'
+  ),
+  focused(
+    'lifecycle.initial-answers',
+    'FlowOpenOptions.initialAnswers',
+    'test/flowManager.test.ts#renders valid initial answers in the opened Flow UI and routed runtime',
+    'valid namespaced choice, text, and checkbox answers seed the opened Flow and its conditional route'
+  ),
+  focused(
+    'lifecycle.preflight-retry',
+    'installation preflight retry',
+    'test/flowManager.test.ts#retries installation preflight without closing the opened flow',
+    'retry keeps the same opened flow'
+  ),
+  focused(
+    'lifecycle.preflight-race',
+    'stale preflight suppression',
+    'test/flowManager.test.ts#ignores a stale preflight failure after a newer retry succeeds',
+    'older completion cannot replace newer UI'
+  ),
+  focused(
+    'lifecycle.busy-open',
+    'public busy outcome while the legacy modal owns the surface',
+    'test/flowManager.test.ts#returns busy while the legacy modal owns the surface',
+    "the opened result is exactly {status:'busy'} and no Flow surface opens"
+  ),
+  focused(
+    'lifecycle.busy',
+    'one active submission or navigation action',
+    'test/flowModal.test.ts#suppresses duplicate submit while busy and keeps named dialog ownership through success',
+    'two submit clicks call the submission port once while the dialog is aria-busy'
+  ),
+  focused(
+    'lifecycle.focus-trap-restore',
+    'dialog focus containment and restoration',
+    'test/flowModal.test.ts#contains Tab and Shift+Tab focus and restores the invoking control',
+    'Tab wraps in both directions and closing restores the invoking control'
+  ),
+  focused(
+    'lifecycle.validation-aria',
+    'required errors use ARIA and live regions',
+    'test/flowFormScreen.test.ts#focuses the first invalid shared or extra field',
+    'invalid control exposes aria-invalid and live error copy'
+  ),
+  recipe(
+    'lifecycle.submit-retry-success',
+    'retryable submit then success result',
+    'bug-report',
+    'one retry resolves OpenedFlow.result to the exact submitted Issue result'
+  ),
+  browser(
+    'lifecycle.close-teardown',
+    'close aborts capture and disposes host',
+    'e2e/public-flow.spec.ts#close tears down an in-progress screenshot chooser',
+    'flow and chooser are both removed and result closes'
+  ),
+  focused(
+    'output.title-interpolation',
+    'Issue title namespaced interpolation',
+    'test/flowIssueDraft.test.ts#maps namespaced answers and context without HTML execution',
+    'trimmed answers interpolate literally'
+  ),
+  focused(
+    'output.title-bound',
+    'Issue title receiver bound',
+    'test/flowIssueDraft.test.ts#bounds compiled Issue titles to the receiver contract',
+    'compiled title is at most 256 characters'
+  ),
+  recipe(
+    'output.classification.bug',
+    'Issue classification bug',
+    'bug-report',
+    'mocked payload uses the configured bug classification'
+  ),
+  recipe(
+    'output.classification.feature',
+    'Issue classification feature',
+    'product-triage',
+    'mocked payload uses the configured feature classification'
+  ),
+  recipe(
+    'output.classification.question',
+    'Issue classification question',
+    'customer-pulse',
+    'mocked payload uses the configured question classification'
+  ),
+  focused(
+    'output.format.text',
+    'answer/context text format',
+    'test/flowIssueDraft.test.ts#compiles every supported output format and omits only empty sections',
+    'text values compile without decoration'
+  ),
+  focused(
+    'output.format.quote',
+    'answer quote format',
+    'test/flowIssueDraft.test.ts#compiles every supported output format and omits only empty sections',
+    'each line receives a quote marker'
+  ),
+  focused(
+    'output.format.code',
+    'answer/context inline code format',
+    'test/flowIssueDraft.test.ts#keeps embedded backticks inside configured code spans',
+    'delimiter grows around embedded backticks'
+  ),
+  focused(
+    'output.format.stars',
+    'rating stars format honors scale',
+    'test/flowIssueDraft.test.ts#uses configured rating scales and choice labels and rejects empty compiled titles',
+    'rating prints filled and empty glyphs plus fraction'
+  ),
+  focused(
+    'output.format.choice',
+    'singleChoice format uses label',
+    'test/flowIssueDraft.test.ts#uses configured rating scales and choice labels and rejects empty compiled titles',
+    'stable value maps to human label'
+  ),
+  focused(
+    'output.omit-empty',
+    'omitWhenEmpty',
+    'test/flowIssueDraft.test.ts#compiles every supported output format and omits only empty sections',
+    'undefined null and empty string sections disappear'
+  ),
+  recipe(
+    'evidence.attachments',
+    'mapped attachment payload',
+    'bug-report',
+    'attachment data URL reaches mocked feedback'
+  ),
+  recipe(
+    'evidence.console-logs',
+    'opt-in console log payload',
+    'bug-report',
+    'checked log consent supplies console logs'
+  ),
+  recipe(
+    'evidence.submitter',
+    'mapped submitter name and email',
+    'bug-report',
+    'trimmed submitter fields reach mocked feedback'
+  ),
+  focused(
+    'evidence.screenshot-selectors',
+    'screenshot and selector metadata',
+    'test/flowSubmission.test.ts#carries mapped screenshot, attachments, logs, and submitter through the legacy recipe',
+    'capture bytes and selectors reach mocked feedback'
+  ),
+  focused(
+    'evidence.result-validation',
+    'canonical Issue response validation',
+    'test/flowSubmission.test.ts#rejects non-canonical legacy Issue results',
+    'foreign or mismatched Issue URLs reject'
+  ),
+  control(
+    'compatibility.classic-default',
+    'classic/default lanes remain additive',
+    'test/ci-workflow-contract.test.sh#Require identical candidate and classic legacy outcomes',
+    'candidate and classic identifiers outcomes screenshots payload privacy and style controls remain present'
+  ),
+  row({
+    primitiveOrState: 'unsupported.multi-select',
+    publicContract: 'not present in FlowField union or scalar conditions',
+    proofOwner:
+      'test/flowCoverageMatrix.test.ts#records true multi-select as deferred product work',
+    proofLevel: 'focused',
+    recipe: null,
+    artifactIdentity: 'source',
+    expectedAssertion: 'no recipe or owner simulates choose-many behavior',
+    gapStatus: 'deferred-product',
+  }),
+]);

--- a/test/fixtures/flow-recipes.ts
+++ b/test/fixtures/flow-recipes.ts
@@ -1,0 +1,288 @@
+import type { FlowConfig, FlowOpenOptions } from '../../src/widget/flows/public-types';
+
+export type FlowRecipeId = 'bug-report' | 'product-triage' | 'customer-pulse';
+
+export interface FlowRecipe {
+  readonly id: FlowRecipeId;
+  readonly label: string;
+  readonly config: FlowConfig;
+  readonly openOptions?: FlowOpenOptions;
+}
+
+const bugReport: FlowRecipe = {
+  id: 'bug-report',
+  label: 'Bug Report',
+  openOptions: { context: { surface: 'settings', build: '2026.08.15' } },
+  config: {
+    configVersion: 1,
+    id: 'bug-report',
+    presentation: { kind: 'modal', size: 'default', columns: 2 },
+    appearance: { theme: 'light', accentColor: '#2563eb', density: 'comfortable' },
+    content: {
+      successTitle: 'Report received',
+      successMessage: 'Thanks for helping us fix this.',
+      cancelLabel: 'Discard report',
+    },
+    forms: [
+      {
+        id: 'report',
+        title: 'What went wrong?',
+        description: 'Give us a concise summary and reproducible details.',
+        fields: [
+          {
+            id: 'summary',
+            type: 'shortText',
+            label: 'Summary',
+            required: true,
+            maxLength: 120,
+            layout: { span: 2 },
+          },
+          {
+            id: 'steps',
+            type: 'longText',
+            label: 'Steps to reproduce',
+            required: true,
+            rows: 6,
+            layout: { span: 2 },
+          },
+        ],
+      },
+      {
+        id: 'evidence',
+        title: 'Evidence and contact',
+        fields: [
+          {
+            id: 'files',
+            type: 'attachments',
+            label: 'Attachments',
+            required: true,
+            maxFiles: 2,
+            accept: ['image/png', 'application/pdf'],
+            layout: { span: 2 },
+          },
+          { id: 'logs', type: 'checkbox', label: 'Include console logs', initialValue: true },
+          { id: 'name', type: 'shortText', label: 'Your name' },
+          { id: 'email', type: 'shortText', label: 'Email' },
+        ],
+      },
+    ],
+    screens: [
+      {
+        id: 'welcome',
+        type: 'message',
+        title: 'Report a problem',
+        description: 'This takes about a minute.',
+        continueLabel: 'Start report',
+      },
+      { id: 'report-screen', type: 'form', form: 'report', continueLabel: 'Add evidence' },
+      { id: 'evidence-screen', type: 'form', form: 'evidence' },
+      {
+        id: 'capture',
+        type: 'screenshot',
+        mode: 'required',
+        title: 'Show us the problem',
+        description: 'Capture the page before sending your report.',
+      },
+    ],
+    issue: {
+      classification: 'bug',
+      title: 'Bug: {{report.summary}}',
+      sections: [
+        { heading: 'Steps', answer: 'report.steps', format: 'quote' },
+        { heading: 'Surface', context: 'surface' },
+        { heading: 'Build', context: 'build', format: 'code' },
+      ],
+    },
+    evidence: {
+      attachments: 'evidence.files',
+      sendConsoleLogs: 'evidence.logs',
+      submitter: { name: 'evidence.name', email: 'evidence.email' },
+    },
+  },
+};
+
+const productTriage: FlowRecipe = {
+  id: 'product-triage',
+  label: 'Product Triage',
+  config: {
+    configVersion: 1,
+    id: 'product-triage',
+    presentation: { kind: 'modal', size: 'wide', columns: 2 },
+    appearance: { theme: 'dark', accentColor: '#f97316', density: 'compact' },
+    forms: [
+      {
+        id: 'triage',
+        title: 'Classify the signal',
+        fields: [
+          {
+            id: 'kind',
+            type: 'singleChoice',
+            label: 'Feedback type',
+            required: true,
+            display: 'cards',
+            options: [
+              { value: 'bug', label: 'Bug', description: 'Something is broken' },
+              { value: 'idea', label: 'Idea', description: 'A product opportunity' },
+            ],
+          },
+          {
+            id: 'rating',
+            type: 'rating',
+            label: 'Current experience',
+            required: true,
+            scale: 5,
+            icon: 'star',
+            lowLabel: 'Blocked',
+            highLabel: 'Excellent',
+          },
+          { id: 'summary', type: 'shortText', label: 'Summary', required: true },
+        ],
+      },
+      {
+        id: 'diagnostics',
+        title: 'Add diagnostics',
+        fields: [
+          { id: 'detail', type: 'longText', label: 'What happened?', rows: 5 },
+          {
+            id: 'browser',
+            type: 'singleChoice',
+            label: 'Browser',
+            display: 'radio',
+            options: [
+              { value: 'chromium', label: 'Chromium' },
+              { value: 'firefox', label: 'Firefox' },
+            ],
+          },
+        ],
+      },
+    ],
+    screens: [
+      { id: 'intro', type: 'message', title: 'Triage product feedback' },
+      { id: 'triage-screen', type: 'form', form: 'triage' },
+      {
+        id: 'diagnostics-screen',
+        type: 'form',
+        form: 'diagnostics',
+        when: {
+          all: [
+            { answer: 'triage.kind', equals: 'bug' },
+            {
+              any: [
+                { answer: 'triage.rating', equals: 1 },
+                { answer: 'triage.rating', equals: 2 },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        id: 'capture',
+        type: 'screenshot',
+        mode: 'optional',
+        when: { answer: 'triage.kind', equals: 'bug' },
+      },
+    ],
+    issue: {
+      classification: 'feature',
+      title: 'Triage: {{triage.summary}}',
+      sections: [
+        { heading: 'Type', answer: 'triage.kind', format: 'choice' },
+        { heading: 'Experience', answer: 'triage.rating', format: 'stars' },
+        { heading: 'Diagnostics', answer: 'diagnostics.detail', omitWhenEmpty: true },
+        {
+          heading: 'Browser',
+          answer: 'diagnostics.browser',
+          format: 'choice',
+          omitWhenEmpty: true,
+        },
+      ],
+    },
+  },
+};
+
+const customerPulse: FlowRecipe = {
+  id: 'customer-pulse',
+  label: 'Customer Pulse',
+  openOptions: { context: { surface: 'billing' } },
+  config: {
+    configVersion: 1,
+    id: 'customer-pulse',
+    presentation: { kind: 'modal', size: 'compact', columns: 1 },
+    appearance: { theme: 'auto', density: 'comfortable' },
+    content: {
+      successTitle: 'Pulse recorded',
+      successMessage: 'Thanks for sharing how billing feels today.',
+      cancelLabel: 'Not now',
+    },
+    forms: [
+      {
+        id: 'pulse',
+        title: 'How easy was this?',
+        fields: [
+          {
+            id: 'score',
+            type: 'rating',
+            label: 'Ease score',
+            required: true,
+            scale: 10,
+            icon: 'number',
+            lowLabel: 'Difficult',
+            highLabel: 'Easy',
+          },
+        ],
+      },
+      {
+        id: 'followup',
+        title: 'Help us improve billing',
+        fields: [
+          { id: 'detail', type: 'longText', label: 'What made this difficult?', rows: 4 },
+          {
+            id: 'contact',
+            type: 'singleChoice',
+            label: 'May we follow up?',
+            display: 'buttons',
+            options: [
+              { value: 'yes', label: 'Yes' },
+              { value: 'no', label: 'No' },
+            ],
+          },
+          { id: 'consent', type: 'checkbox', label: 'I consent to a product follow-up' },
+        ],
+      },
+    ],
+    screens: [
+      { id: 'pulse-screen', type: 'form', form: 'pulse', continueLabel: 'Continue' },
+      {
+        id: 'followup-screen',
+        type: 'form',
+        form: 'followup',
+        backLabel: 'Change score',
+        continueLabel: 'Send pulse',
+        when: {
+          all: [
+            { answer: 'pulse.score', equals: 3 },
+            { context: 'surface', equals: 'billing' },
+          ],
+        },
+      },
+    ],
+    issue: {
+      classification: 'question',
+      title: 'Billing pulse {{pulse.score}}/10',
+      sections: [
+        { heading: 'Score', answer: 'pulse.score', format: 'text' },
+        { heading: 'Follow-up', answer: 'followup.detail', omitWhenEmpty: true },
+        { heading: 'Contact', answer: 'followup.contact', format: 'choice', omitWhenEmpty: true },
+        { heading: 'Consent', answer: 'followup.consent', omitWhenEmpty: true },
+      ],
+    },
+  },
+};
+
+export const flowRecipes: Readonly<Record<FlowRecipeId, FlowRecipe>> = Object.freeze({
+  'bug-report': bugReport,
+  'product-triage': productTriage,
+  'customer-pulse': customerPulse,
+});
+
+export const flowRecipeList = Object.freeze(Object.values(flowRecipes));

--- a/test/flowConditions.test.ts
+++ b/test/flowConditions.test.ts
@@ -3,7 +3,7 @@ import { countConditionNodes, evaluateCondition } from '../src/widget/flows/cond
 import type { FlowCondition } from '../src/widget/flows/public-types';
 
 describe('flow conditions', () => {
-  it('matches only present exact scalar answers and immutable context', () => {
+  it('evaluates answer, context, all, and any predicates', () => {
     expect(evaluateCondition({ answer: 'a.b', equals: false }, { 'a.b': false }, {})).toBe(true);
     expect(evaluateCondition({ answer: 'missing.value', equals: null }, {}, {})).toBe(false);
     expect(
@@ -18,11 +18,41 @@ describe('flow conditions', () => {
         { surface: 'billing' }
       )
     ).toBe(true);
+    expect(
+      evaluateCondition(
+        {
+          any: [
+            { answer: 'a.b', equals: 1 },
+            { context: 'surface', equals: 'billing' },
+          ],
+        },
+        { 'a.b': 2 },
+        { surface: 'billing' }
+      )
+    ).toBe(true);
+    expect(
+      evaluateCondition(
+        {
+          all: [
+            { answer: 'a.b', equals: 2 },
+            { context: 'surface', equals: 'other' },
+          ],
+        },
+        { 'a.b': 2 },
+        { surface: 'billing' }
+      )
+    ).toBe(false);
   });
   it('bounds condition depth and size', () => {
     const deep: FlowCondition = {
       all: [{ all: [{ all: [{ all: [{ answer: 'a.b', equals: true }] }] }] }],
     };
     expect(() => countConditionNodes(deep)).toThrow('depth');
+    const wide: FlowCondition = {
+      all: Array.from({ length: 8 }, () => ({
+        any: Array.from({ length: 4 }, () => ({ answer: 'a.b', equals: true })),
+      })),
+    };
+    expect(() => countConditionNodes(wide)).toThrow('32 nodes');
   });
 });

--- a/test/flowConditions.test.ts
+++ b/test/flowConditions.test.ts
@@ -5,6 +5,7 @@ import type { FlowCondition } from '../src/widget/flows/public-types';
 describe('flow conditions', () => {
   it('evaluates answer, context, all, and any predicates', () => {
     expect(evaluateCondition({ answer: 'a.b', equals: false }, { 'a.b': false }, {})).toBe(true);
+    expect(evaluateCondition({ answer: 'a.b', equals: 1 }, { 'a.b': 2 }, {})).toBe(false);
     expect(evaluateCondition({ answer: 'missing.value', equals: null }, {}, {})).toBe(false);
     expect(
       evaluateCondition(

--- a/test/flowCoverageMatrix.test.ts
+++ b/test/flowCoverageMatrix.test.ts
@@ -1,0 +1,157 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { canonicalFlowCoverage } from './fixtures/flow-coverage';
+import { flowRecipes } from './fixtures/flow-recipes';
+
+const EXACT_COVERED_SURFACE = [
+  'field.shortText',
+  'field.helpText',
+  'field.shortText.placeholder',
+  'field.shortText.minLength',
+  'field.shortText.maxLength',
+  'field.longText',
+  'field.longText.placeholder',
+  'field.longText.rows',
+  'field.longText.minLength',
+  'field.longText.maxLength',
+  'field.rating.5.star',
+  'field.rating.10.number',
+  'field.rating.lowLabel',
+  'field.rating.highLabel',
+  'field.singleChoice.radio',
+  'field.singleChoice.cards',
+  'field.singleChoice.buttons',
+  'field.singleChoice.option.description',
+  'field.checkbox',
+  'field.checkbox.initialValue',
+  'field.attachments',
+  'field.shared-controller-adapter',
+  'field.adapter-instance-isolation',
+  'field.required-focus',
+  'field.attachment-bounds',
+  'layout.field-span',
+  'screen.message',
+  'screen.form',
+  'screen.screenshot.optional',
+  'screen.screenshot.required',
+  'screen.screenshot.auto',
+  'screen.single-screenshot-bound',
+  'presentation.modal.compact',
+  'presentation.modal.default',
+  'presentation.modal.wide',
+  'presentation.columns.1',
+  'presentation.columns.2',
+  'appearance.theme.light',
+  'appearance.theme.dark',
+  'appearance.theme.auto',
+  'appearance.accent',
+  'appearance.density.compact',
+  'appearance.density.comfortable',
+  'content.action-copy',
+  'content.success-copy',
+  'content.cancel-copy',
+  'presentation.responsive',
+  'presentation.reduced-motion',
+  'presentation.radix',
+  'condition.answer',
+  'condition.context',
+  'condition.all',
+  'condition.any',
+  'condition.bounds',
+  'condition.backward-only',
+  'navigation.hidden-clearing',
+  'navigation.back-retention',
+  'navigation.nearest-visible',
+  'navigation.progress',
+  'navigation.async-suppression',
+  'lifecycle.registration',
+  'lifecycle.public-identity',
+  'lifecycle.initial-answers',
+  'lifecycle.preflight-retry',
+  'lifecycle.preflight-race',
+  'lifecycle.busy-open',
+  'lifecycle.busy',
+  'lifecycle.focus-trap-restore',
+  'lifecycle.validation-aria',
+  'lifecycle.submit-retry-success',
+  'lifecycle.close-teardown',
+  'output.title-interpolation',
+  'output.title-bound',
+  'output.classification.bug',
+  'output.classification.feature',
+  'output.classification.question',
+  'output.format.text',
+  'output.format.quote',
+  'output.format.code',
+  'output.format.stars',
+  'output.format.choice',
+  'output.omit-empty',
+  'evidence.attachments',
+  'evidence.console-logs',
+  'evidence.submitter',
+  'evidence.screenshot-selectors',
+  'evidence.result-validation',
+  'compatibility.classic-default',
+] as const;
+
+const EXACT_DEFERRED_SURFACE = ['unsupported.multi-select'] as const;
+
+describe('canonical composable flow coverage matrix', () => {
+  it('gives every supported primitive and state exactly one primary proof owner', () => {
+    const identities = canonicalFlowCoverage.map(entry => entry.primitiveOrState);
+    expect(new Set(identities).size).toBe(identities.length);
+    expect(
+      canonicalFlowCoverage
+        .filter(entry => entry.gapStatus === 'covered')
+        .map(entry => entry.primitiveOrState)
+    ).toEqual(EXACT_COVERED_SURFACE);
+    expect(
+      canonicalFlowCoverage
+        .filter(entry => entry.gapStatus === 'deferred-product')
+        .map(entry => entry.primitiveOrState)
+    ).toEqual(EXACT_DEFERRED_SURFACE);
+
+    for (const entry of canonicalFlowCoverage) {
+      expect(entry.publicContract.trim()).not.toBe('');
+      expect(entry.expectedAssertion.trim()).not.toBe('');
+      const [ownerFile, ownerAnchor, ...extra] = entry.proofOwner.split('#');
+      expect(extra).toEqual([]);
+      expect(ownerFile).toBeTruthy();
+      expect(ownerAnchor).toBeTruthy();
+      expect(existsSync(ownerFile!)).toBe(true);
+      expect(readFileSync(ownerFile!, 'utf8')).toContain(ownerAnchor);
+      if (entry.recipe) expect(flowRecipes[entry.recipe].id).toBe(entry.recipe);
+      if (entry.proofLevel === 'focused') {
+        expect(entry.artifactIdentity).toBe('source');
+        expect(ownerFile).toMatch(/^test\//);
+      }
+      if (entry.proofLevel === 'local-browser') {
+        expect(entry.artifactIdentity).toBe('local-widget');
+        expect(ownerFile).toBe('e2e/public-flow.spec.ts');
+      }
+      if (entry.proofLevel === 'compatibility-control') {
+        expect(entry.artifactIdentity).toBe('candidate-and-classic');
+        expect(ownerFile).toMatch(/^(e2e\/|test\/ci-workflow-contract\.test\.sh$)/);
+      }
+      if (entry.recipe) expect(entry.proofLevel).toBe('local-browser');
+    }
+  });
+
+  it('records true multi-select as deferred product work', () => {
+    const deferred = canonicalFlowCoverage.filter(entry => entry.gapStatus === 'deferred-product');
+    expect(deferred).toEqual([
+      expect.objectContaining({
+        primitiveOrState: 'unsupported.multi-select',
+        recipe: null,
+        publicContract: expect.stringContaining('not present'),
+      }),
+    ]);
+    expect(
+      Object.values(flowRecipes).some(recipe =>
+        recipe.config.forms.some(form =>
+          form.fields.some(field => (field as { type: string }).type === 'multiSelect')
+        )
+      )
+    ).toBe(false);
+  });
+});

--- a/test/flowDefinition.test.ts
+++ b/test/flowDefinition.test.ts
@@ -5,11 +5,30 @@ import { flowConfig } from './flowConfig.test';
 
 describe('flow definition', () => {
   it('compiles stable identities and namespaced screen answer ownership', () => {
-    const definition = normalizeFlowDefinition(validateAndFreezeFlowConfig(flowConfig()));
+    const config = flowConfig();
+    config.screens[2]!.when = {
+      all: [
+        { answer: 'triage.kind', equals: 'bug' },
+        { context: 'surface', equals: 'billing' },
+      ],
+    };
+    config.issue.sections = [
+      ...(config.issue.sections ?? []),
+      { heading: 'Build', context: 'build', format: 'code' },
+    ];
+    const definition = normalizeFlowDefinition(validateAndFreezeFlowConfig(config));
     expect(definition.compiler).toBe('bugdrop-flow@1');
     expect(definition.screenAnswerPaths.get('triage-step')).toEqual([
       'triage.kind',
       'triage.summary',
+    ]);
+    expect([...definition.contextKeys]).toEqual(['surface', 'build']);
+    expect([...definition.fields.keys()]).toEqual([
+      'triage.kind',
+      'triage.summary',
+      'detail.description',
+      'detail.logs',
+      'detail.files',
     ]);
   });
 });

--- a/test/flowFormScreen.test.ts
+++ b/test/flowFormScreen.test.ts
@@ -21,6 +21,122 @@ const form: FlowForm = {
 };
 
 describe('flow form screen', () => {
+  it('applies every inherited field control through the thin FlowForm adapter', async () => {
+    const inherited: FlowForm = {
+      id: 'inherited',
+      title: 'Inherited controls',
+      fields: [
+        {
+          id: 'summary',
+          type: 'shortText',
+          label: 'Summary',
+          helpText: 'Keep it concise',
+          placeholder: 'A short summary',
+          minLength: 3,
+          maxLength: 40,
+        },
+        {
+          id: 'detail',
+          type: 'longText',
+          label: 'Detail',
+          placeholder: 'What happened?',
+          rows: 7,
+          minLength: 5,
+          maxLength: 500,
+        },
+        {
+          id: 'choice',
+          type: 'singleChoice',
+          label: 'Choice',
+          options: [
+            { value: 'first', label: 'First', description: 'The first described option' },
+            { value: 'second', label: 'Second' },
+          ],
+        },
+        {
+          id: 'enabled',
+          type: 'checkbox',
+          label: 'Enabled by default',
+          initialValue: true,
+        },
+      ],
+    };
+    const controller = createFlowFormScreen(inherited, 'adapter', {});
+    const summary = controller.element.querySelector<HTMLInputElement>('#adapter-summary')!;
+    const detail = controller.element.querySelector<HTMLTextAreaElement>('#adapter-detail')!;
+    const choice = controller.element.querySelector<HTMLElement>('[data-bugdrop-field="choice"]')!;
+    const enabled = controller.element.querySelector<HTMLInputElement>('#adapter-enabled')!;
+
+    expect(summary.placeholder).toBe('A short summary');
+    expect(summary.minLength).toBe(3);
+    expect(summary.maxLength).toBe(40);
+    expect(summary.getAttribute('aria-describedby')).toContain('adapter-summary-help');
+    expect(controller.element.querySelector('#adapter-summary-help')?.textContent).toBe(
+      'Keep it concise'
+    );
+    expect(detail.placeholder).toBe('What happened?');
+    expect(detail.rows).toBe(7);
+    expect(detail.minLength).toBe(5);
+    expect(detail.maxLength).toBe(500);
+    expect(choice.querySelector('.bdv-help')?.textContent).toBe('The first described option');
+    expect(enabled.checked).toBe(true);
+    await expect(controller.snapshot()).resolves.toMatchObject({ enabled: true });
+  });
+
+  it('focuses the first invalid shared or extra field', async () => {
+    const requiredForm: FlowForm = {
+      ...form,
+      fields: form.fields.map(field =>
+        field.id === 'first' ? { ...field, required: true } : field
+      ),
+    };
+    const controller = createFlowFormScreen(requiredForm, 'required', {});
+    document.body.appendChild(controller.element);
+
+    await expect(controller.collect()).resolves.toBeNull();
+    const first = controller.element.querySelector<HTMLInputElement>('#required-first')!;
+    expect(first.getAttribute('aria-invalid')).toBe('true');
+    expect(document.activeElement).toBe(first);
+    const firstError = controller.element.querySelector<HTMLElement>('#required-first-error')!;
+    expect(firstError.getAttribute('aria-live')).toBe('polite');
+    expect(firstError.hidden).toBe(false);
+    expect(firstError.textContent).toBe('is required');
+    expect(first.getAttribute('aria-describedby')).toContain(firstError.id);
+
+    first.value = 'Complete';
+    await expect(controller.collect()).resolves.toBeNull();
+    const agree = controller.element.querySelector<HTMLInputElement>('#required-agree')!;
+    expect(agree.getAttribute('aria-invalid')).toBe('true');
+    expect(document.activeElement).toBe(agree);
+    const agreeError = controller.element.querySelector<HTMLElement>('#required-agree-error')!;
+    expect(agreeError.getAttribute('aria-live')).toBe('polite');
+    expect(agreeError.hidden).toBe(false);
+    expect(agreeError.textContent).toBe('This checkbox is required.');
+    expect(agree.getAttribute('aria-describedby')).toContain(agreeError.id);
+  });
+
+  it('reads an accepted attachment and exposes its stable evidence envelope', async () => {
+    const controller = createFlowFormScreen(form, 'accepted', { 'details.agree': true });
+    const input = controller.element.querySelector<HTMLInputElement>('#accepted-files')!;
+    Object.defineProperty(input, 'files', {
+      value: [new File(['trace'], 'trace.png', { type: 'image/png' })],
+    });
+    input.dispatchEvent(new Event('change'));
+
+    await expect(controller.collect()).resolves.toMatchObject({
+      agree: true,
+      files: [
+        {
+          name: 'trace.png',
+          type: 'image/png',
+          size: 5,
+          dataUrl: expect.stringMatching(/^data:image\/png;base64,/),
+        },
+      ],
+    });
+    expect(controller.element.querySelector('.bdf-file-list')?.textContent).toBe('trace.png');
+  });
+
   it('preserves declared order, layout, help relationships, and snapshots without required validation', async () => {
     const controller = createFlowFormScreen(form, 'instance', {
       'details.first': 'One',
@@ -45,38 +161,45 @@ describe('flow form screen', () => {
     expect(checkbox.getAttribute('aria-invalid')).toBeNull();
   });
 
-  it('waits for file reads and exposes accessible read errors', async () => {
+  it('enforces selected attachment count, type, size, and latest-read race behavior', async () => {
     const fileForm: FlowForm = {
       ...form,
       fields: form.fields.map(field =>
-        field.id === 'files' ? { ...field, maxFileSize: 1 } : field
+        field.id === 'files'
+          ? { ...field, maxFiles: 1, maxFileSize: 1, accept: ['image/png'] }
+          : field
       ),
     };
-    const controller = createFlowFormScreen(fileForm, 'instance', { 'details.agree': true });
-    const input = controller.element.querySelector<HTMLInputElement>('#instance-files')!;
+    const constrained = createFlowFormScreen(fileForm, 'constrained', { 'details.agree': true });
+    const input = constrained.element.querySelector<HTMLInputElement>('#constrained-files')!;
     Object.defineProperty(input, 'files', {
-      value: [new File(['too large'], 'large.png', { type: 'image/png' })],
+      configurable: true,
+      value: [
+        new File(['a'], 'a.png', { type: 'image/png' }),
+        new File(['b'], 'b.png', { type: 'image/png' }),
+      ],
     });
     input.dispatchEvent(new Event('change'));
-    await expect(controller.collect()).resolves.toBeNull();
+    await expect(constrained.collect()).resolves.toBeNull();
     expect(input.getAttribute('aria-invalid')).toBe('true');
-    expect(controller.element.textContent).toContain('too large');
-    vi.restoreAllMocks();
-  });
-
-  it('rejects unsupported selected attachment types before reading them', async () => {
-    const controller = createFlowFormScreen(form, 'instance', { 'details.agree': true });
-    const input = controller.element.querySelector<HTMLInputElement>('#instance-files')!;
+    expect(constrained.element.textContent).toContain('Select at most 1 attachment');
     Object.defineProperty(input, 'files', {
+      configurable: true,
       value: [new File(['archive'], 'archive.zip', { type: 'application/zip' })],
     });
     input.dispatchEvent(new Event('change'));
-    await expect(controller.collect()).resolves.toBeNull();
+    await expect(constrained.collect()).resolves.toBeNull();
     expect(input.getAttribute('aria-invalid')).toBe('true');
-    expect(controller.element.textContent).toContain('unsupported file type');
-  });
+    expect(constrained.element.textContent).toContain('unsupported file type');
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      value: [new File(['ab'], 'large.png', { type: 'image/png' })],
+    });
+    input.dispatchEvent(new Event('change'));
+    await expect(constrained.collect()).resolves.toBeNull();
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    expect(constrained.element.textContent).toContain('large.png is too large');
 
-  it('does not let an older file read overwrite a newer selection', async () => {
     const readers: Array<{ file?: File; resolve(): void }> = [];
     class ControlledReader {
       result: string | ArrayBuffer | null = null;
@@ -96,23 +219,23 @@ describe('flow form screen', () => {
       }
     }
     vi.stubGlobal('FileReader', ControlledReader);
-    const controller = createFlowFormScreen(form, 'instance', { 'details.agree': true });
-    const input = controller.element.querySelector<HTMLInputElement>('#instance-files')!;
-    Object.defineProperty(input, 'files', {
+    const raced = createFlowFormScreen(form, 'raced', { 'details.agree': true });
+    const racedInput = raced.element.querySelector<HTMLInputElement>('#raced-files')!;
+    Object.defineProperty(racedInput, 'files', {
       configurable: true,
       value: [new File(['a'], 'old.png', { type: 'image/png' })],
     });
-    input.dispatchEvent(new Event('change'));
-    Object.defineProperty(input, 'files', {
+    racedInput.dispatchEvent(new Event('change'));
+    Object.defineProperty(racedInput, 'files', {
       configurable: true,
       value: [new File(['b'], 'new.png', { type: 'image/png' })],
     });
-    input.dispatchEvent(new Event('change'));
+    racedInput.dispatchEvent(new Event('change'));
     readers[1]!.resolve();
     await Promise.resolve();
     readers[0]!.resolve();
     await Promise.resolve();
-    await expect(controller.collect()).resolves.toMatchObject({ files: [{ name: 'new.png' }] });
+    await expect(raced.collect()).resolves.toMatchObject({ files: [{ name: 'new.png' }] });
     vi.unstubAllGlobals();
   });
 

--- a/test/flowIssueDraft.test.ts
+++ b/test/flowIssueDraft.test.ts
@@ -3,6 +3,42 @@ import { compileFlowIssueDraft } from '../src/widget/flows/issue-draft';
 import { flowConfig } from './flowConfig.test';
 
 describe('flow Issue mapping', () => {
+  it('compiles every supported output format and omits only empty sections', () => {
+    const config = flowConfig();
+    config.forms[0]!.fields.push({
+      id: 'score',
+      type: 'rating',
+      label: 'Score',
+      scale: 5,
+    });
+    config.issue.sections = [
+      { heading: 'Text', answer: 'triage.summary', format: 'text' },
+      { heading: 'Quote', answer: 'detail.description', format: 'quote' },
+      { heading: 'Code', context: 'build', format: 'code' },
+      { heading: 'Stars', answer: 'triage.score', format: 'stars' },
+      { heading: 'Choice', answer: 'triage.kind', format: 'choice' },
+      { heading: 'Undefined', context: 'missing', omitWhenEmpty: true },
+      { heading: 'Null', context: 'emptyNull', omitWhenEmpty: true },
+      { heading: 'Empty string', answer: 'detail.empty', omitWhenEmpty: true },
+    ];
+
+    expect(
+      compileFlowIssueDraft(
+        config,
+        {
+          'triage.summary': 'Crash',
+          'triage.kind': 'bug',
+          'triage.score': 3,
+          'detail.description': 'first\nsecond',
+          'detail.empty': '',
+        },
+        { build: 'sha`123', emptyNull: null }
+      ).description
+    ).toBe(
+      '## Text\n\nCrash\n\n## Quote\n\n> first\n> second\n\n## Code\n\n``sha`123``\n\n## Stars\n\n★★★☆☆ (3/5)\n\n## Choice\n\nBug'
+    );
+  });
+
   it('maps namespaced answers and context without HTML execution', () => {
     const config = flowConfig();
     config.issue.sections = [

--- a/test/flowManager.test.ts
+++ b/test/flowManager.test.ts
@@ -26,6 +26,19 @@ describe('flow manager and modal', () => {
     manager.register(flowConfig());
     expect(() => manager.register(flowConfig())).toThrow('already registered');
   });
+  it('returns configured FlowHandle.id and generated OpenedFlow.instanceId', async () => {
+    const handle = createFlowManager({ repo: 'owner/repo', apiUrl: '/api' }, ports).register(
+      flowConfig()
+    );
+    expect(handle.id).toBe('product-triage');
+
+    const opened = handle.open();
+    expect(opened.instanceId).toBe('product-triage-runtime-id');
+    opened.close();
+
+    await expect(opened.result).resolves.toEqual({ status: 'closed' });
+    expect(document.body.childElementCount).toBe(0);
+  });
   it('returns busy while the legacy modal owns the surface', async () => {
     const opened = createFlowManager({ repo: 'owner/repo', apiUrl: '/api' }, ports, {
       isLegacyModalOpen: () => true,
@@ -132,6 +145,41 @@ describe('flow manager and modal', () => {
     ).toThrow('dataUrl');
     expect(preflight).not.toHaveBeenCalled();
     expect(document.body.childElementCount).toBe(0);
+  });
+  it('renders valid initial answers in the opened Flow UI and routed runtime', async () => {
+    const config = flowConfig();
+    config.screens = config.screens.slice(1);
+    const opened = createFlowManager({ repo: 'owner/repo', apiUrl: '/api' }, ports)
+      .register(config)
+      .open({
+        initialAnswers: {
+          'triage.kind': 'bug',
+          'triage.summary': 'Seeded summary',
+          'detail.description': 'Seeded details',
+          'detail.logs': true,
+        },
+      });
+    await Promise.resolve();
+    await Promise.resolve();
+    const host = document.querySelector<HTMLElement>('[data-bugdrop-flow="product-triage"]')!;
+    const triage = host.shadowRoot!;
+    expect(triage.querySelector<HTMLInputElement>('input[value="bug"]')?.checked).toBe(true);
+    expect(
+      triage.querySelector<HTMLInputElement>('#product-triage-runtime-id-summary')?.value
+    ).toBe('Seeded summary');
+
+    triage.querySelector<HTMLButtonElement>('.bdv-submit')?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(
+      host.shadowRoot?.querySelector<HTMLTextAreaElement>('#product-triage-runtime-id-description')
+        ?.value
+    ).toBe('Seeded details');
+    expect(
+      host.shadowRoot?.querySelector<HTMLInputElement>('#product-triage-runtime-id-logs')?.checked
+    ).toBe(true);
+    expect(host.shadowRoot?.querySelector('.bdv-title')?.textContent).toBe('Add details');
+    opened.close();
   });
   it('retries installation preflight without closing the opened flow', async () => {
     const preflight = vi

--- a/test/flowModal.test.ts
+++ b/test/flowModal.test.ts
@@ -12,7 +12,7 @@ describe('flow modal runtime states', () => {
     document.body.replaceChildren();
     vi.stubGlobal('crypto', { randomUUID: () => 'runtime-id' });
   });
-  it('keeps named dialog ownership through preflight, submission, and success and restores overflow priority', async () => {
+  it('suppresses duplicate submit while busy and keeps named dialog ownership through success', async () => {
     document.body.style.setProperty('overflow', 'clip', 'important');
     const value = {
       issueNumber: 1,
@@ -20,9 +20,10 @@ describe('flow modal runtime states', () => {
       isPublic: false,
     };
     let resolveSubmit!: (result: typeof value) => void;
-    const submit = new Promise<typeof value>(resolve => {
+    const submitResult = new Promise<typeof value>(resolve => {
       resolveSubmit = resolve;
     });
+    const submit = vi.fn(() => submitResult);
     const opened = openFlowModal(
       normalizeFlowDefinition(validateAndFreezeFlowConfig(flowConfig())),
       { initialAnswers: { 'triage.kind': 'idea', 'triage.summary': 'Idea' } },
@@ -34,18 +35,22 @@ describe('flow modal runtime states', () => {
           fullElementSelector: null,
           returnToForm: false,
         }),
-        submit: () => submit,
+        submit,
       }
     );
     await Promise.resolve();
     const host = document.querySelector<HTMLElement>('[data-bugdrop-flow]')!;
     const dialog = () => host.shadowRoot?.querySelector<HTMLElement>('[role="dialog"]');
     expect(dialog()?.getAttribute('aria-labelledby')).toBeTruthy();
-    host.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-submit')?.click();
+    const advance = host.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-submit');
+    advance?.click();
     await Promise.resolve();
-    host.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-submit')?.click();
+    const submitButton = host.shadowRoot?.querySelector<HTMLButtonElement>('.bdv-submit');
+    submitButton?.click();
+    submitButton?.click();
     await Promise.resolve();
     await Promise.resolve();
+    expect(submit).toHaveBeenCalledOnce();
     expect(dialog()?.getAttribute('aria-busy')).toBe('true');
     resolveSubmit(value);
     await Promise.resolve();
@@ -54,6 +59,54 @@ describe('flow modal runtime states', () => {
     opened.close();
     expect(document.body.style.getPropertyValue('overflow')).toBe('clip');
     expect(document.body.style.getPropertyPriority('overflow')).toBe('important');
+  });
+
+  it('contains Tab and Shift+Tab focus and restores the invoking control', async () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+    const opened = openFlowModal(
+      normalizeFlowDefinition(validateAndFreezeFlowConfig(flowConfig())),
+      undefined,
+      {
+        preflight: async () => ({ status: 'installed' }),
+        capture: async () => ({
+          screenshot: null,
+          elementSelector: null,
+          fullElementSelector: null,
+          returnToForm: false,
+        }),
+        submit: async () => ({
+          issueNumber: 1,
+          issueUrl: 'https://github.com/owner/repo/issues/1',
+          isPublic: false,
+        }),
+      }
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const shadow = document.querySelector<HTMLElement>('[data-bugdrop-flow]')!.shadowRoot!;
+    const close = shadow.querySelector<HTMLButtonElement>('.bdv-close')!;
+    const continueButton = shadow.querySelector<HTMLButtonElement>('.bdv-submit')!;
+    continueButton.focus();
+    continueButton.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, composed: true, cancelable: true })
+    );
+    expect(shadow.activeElement).toBe(close);
+
+    close.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Tab',
+        shiftKey: true,
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      })
+    );
+    expect(shadow.activeElement).toBe(continueButton);
+    opened.close();
+    expect(document.activeElement).toBe(trigger);
   });
 
   it('allows a new modal owner to close a flow while it is submitting', async () => {

--- a/test/flowRecipeConformance.test.ts
+++ b/test/flowRecipeConformance.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { normalizeFlowDefinition } from '../src/widget/flows/definition';
+import { createFlowFormScreen } from '../src/widget/flows/form-screen';
+import { compileFlowIssueDraft } from '../src/widget/flows/issue-draft';
+import { FlowRuntime } from '../src/widget/flows/runtime';
+import { validateAndFreezeFlowConfig } from '../src/widget/flows/validate-config';
+import { flowRecipeList, flowRecipes } from './fixtures/flow-recipes';
+
+describe('representative FlowConfig recipe conformance', () => {
+  beforeEach(() => document.body.replaceChildren());
+
+  it('validates and freezes exactly three bounded natural recipes', () => {
+    expect(flowRecipeList.map(recipe => recipe.id)).toEqual([
+      'bug-report',
+      'product-triage',
+      'customer-pulse',
+    ]);
+    for (const recipe of flowRecipeList) {
+      const config = validateAndFreezeFlowConfig(recipe.config);
+      expect(config.id).toBe(recipe.id);
+      expect(Object.isFrozen(config)).toBe(true);
+      expect(config.forms.length).toBeLessThanOrEqual(2);
+      expect(config.screens.length).toBeLessThanOrEqual(4);
+    }
+  });
+
+  it('reuses shared field controllers through the thin flow adapter', async () => {
+    const triage = flowRecipes['product-triage'].config.forms[0]!;
+    const diagnostics = flowRecipes['product-triage'].config.forms[1]!;
+    const triageController = createFlowFormScreen(triage, 'triage-adapter', {});
+    const diagnosticsController = createFlowFormScreen(diagnostics, 'diagnostics-adapter', {});
+    document.body.append(triageController.element, diagnosticsController.element);
+
+    const kind = triageController.element.querySelector<HTMLInputElement>('input[value="bug"]')!;
+    const rating = triageController.element.querySelector<HTMLButtonElement>(
+      '[role="radio"][aria-label="2 stars"]'
+    )!;
+    const summary = triageController.element.querySelector<HTMLInputElement>('input[type="text"]')!;
+    const detail = diagnosticsController.element.querySelector<HTMLTextAreaElement>('textarea')!;
+    const browser =
+      diagnosticsController.element.querySelector<HTMLInputElement>('input[value="chromium"]')!;
+    expect(kind.closest('[role="radiogroup"]')?.classList).toContain('cards');
+    expect(rating.closest('[role="radiogroup"]')).not.toBeNull();
+    expect(browser.closest('[role="radiogroup"]')?.classList).toContain('radio');
+
+    kind.click();
+    rating.click();
+    summary.value = '  Checkout crashes  ';
+    detail.value = '  Spinner never stops  ';
+    browser.click();
+    expect(await triageController.collect()).toEqual({
+      kind: 'bug',
+      rating: 2,
+      summary: 'Checkout crashes',
+    });
+    expect(await diagnosticsController.collect()).toEqual({
+      detail: 'Spinner never stops',
+      browser: 'chromium',
+    });
+    triageController.dispose();
+    diagnosticsController.dispose();
+  });
+
+  it('namespaces simultaneous thin flow adapters and disposes them independently', async () => {
+    const triage = flowRecipes['product-triage'].config.forms[0]!;
+    const first = createFlowFormScreen(triage, 'first-instance', {});
+    const second = createFlowFormScreen(triage, 'second-instance', {});
+    document.body.append(first.element, second.element);
+
+    const firstIds = [...first.element.querySelectorAll<HTMLElement>('[id]')].map(node => node.id);
+    const secondIds = [...second.element.querySelectorAll<HTMLElement>('[id]')].map(
+      node => node.id
+    );
+    expect(firstIds.every(id => id.startsWith('first-instance-'))).toBe(true);
+    expect(secondIds.every(id => id.startsWith('second-instance-'))).toBe(true);
+    expect(firstIds.filter(id => secondIds.includes(id))).toEqual([]);
+    expect(first.element.querySelector<HTMLInputElement>('input[value="bug"]')?.name).toBe(
+      'first-instance-kind'
+    );
+    expect(second.element.querySelector<HTMLInputElement>('input[value="bug"]')?.name).toBe(
+      'second-instance-kind'
+    );
+
+    first.dispose();
+    first.dispose();
+    second.element.querySelector<HTMLInputElement>('input[value="idea"]')!.click();
+    second.element.querySelector<HTMLButtonElement>('[aria-label="5 stars"]')!.click();
+    const summary = second.element.querySelector<HTMLInputElement>('input[type="text"]')!;
+    summary.value = 'Independent adapter';
+    await expect(second.collect()).resolves.toEqual({
+      kind: 'idea',
+      rating: 5,
+      summary: 'Independent adapter',
+    });
+    second.dispose();
+  });
+
+  it('compiles the three recipes with their declared formatters and evidence mappings', () => {
+    const bug = compileFlowIssueDraft(
+      flowRecipes['bug-report'].config,
+      {
+        'report.summary': 'Save crashes',
+        'report.steps': 'Open settings\nClick save',
+      },
+      { surface: 'settings', build: '2026.08.15' }
+    );
+    expect(bug).toEqual({
+      title: 'Bug: Save crashes',
+      category: 'bug',
+      description:
+        '## Steps\n\n> Open settings\n> Click save\n\n## Surface\n\nsettings\n\n## Build\n\n`2026.08.15`',
+    });
+
+    const triage = compileFlowIssueDraft(
+      flowRecipes['product-triage'].config,
+      {
+        'triage.kind': 'bug',
+        'triage.rating': 2,
+        'triage.summary': 'Checkout',
+      },
+      {}
+    );
+    expect(triage.description).toBe('## Type\n\nBug\n\n## Experience\n\n★★☆☆☆ (2/5)');
+
+    const pulse = compileFlowIssueDraft(
+      flowRecipes['customer-pulse'].config,
+      {
+        'pulse.score': 3,
+        'followup.contact': 'yes',
+        'followup.consent': true,
+      },
+      { surface: 'billing' }
+    );
+    expect(pulse).toMatchObject({
+      title: 'Billing pulse 3/10',
+      category: 'question',
+      description: '## Score\n\n3\n\n## Contact\n\nYes\n\n## Consent\n\ntrue',
+    });
+  });
+
+  it('owns natural branch visibility without generating permutations', () => {
+    const triageDefinition = normalizeFlowDefinition(
+      validateAndFreezeFlowConfig(flowRecipes['product-triage'].config)
+    );
+    const blockedBug = new FlowRuntime(triageDefinition, {});
+    blockedBug.next();
+    blockedBug.setFormAnswers('triage', { kind: 'bug', rating: 2, summary: 'Crash' });
+    expect(blockedBug.route().total).toBe(4);
+    blockedBug.next();
+    blockedBug.setFormAnswers('diagnostics', { detail: 'stale', browser: 'chromium' });
+    blockedBug.back();
+    blockedBug.setFormAnswers('triage', { kind: 'idea', rating: 5, summary: 'Idea' });
+    expect(blockedBug.route()).toMatchObject({ total: 2, position: 2, hasNext: false });
+    expect(blockedBug.answers['diagnostics.detail']).toBeUndefined();
+
+    const pulse = new FlowRuntime(
+      normalizeFlowDefinition(validateAndFreezeFlowConfig(flowRecipes['customer-pulse'].config)),
+      { surface: 'billing' }
+    );
+    pulse.setFormAnswers('pulse', { score: 3 });
+    expect(pulse.route()).toMatchObject({ total: 2, hasNext: true });
+  });
+});

--- a/test/flowRuntime.test.ts
+++ b/test/flowRuntime.test.ts
@@ -64,4 +64,42 @@ describe('flow runtime', () => {
     expect(runtime.answers['detail.description']).toBe('Retained');
     expect(runtime.current()?.id).toBe('triage-step');
   });
+
+  it('recovers to the nearest visible screen after cascading branch changes', () => {
+    const config = flowConfig();
+    config.screens = [
+      { id: 'triage-step', type: 'form', form: 'triage' },
+      {
+        id: 'detail-step',
+        type: 'form',
+        form: 'detail',
+        when: { answer: 'triage.kind', equals: 'bug' },
+      },
+      {
+        id: 'evidence',
+        type: 'screenshot',
+        mode: 'optional',
+        when: { answer: 'detail.description', equals: 'show' },
+      },
+    ];
+    const runtime = new FlowRuntime(
+      normalizeFlowDefinition(validateAndFreezeFlowConfig(config)),
+      {}
+    );
+    runtime.setFormAnswers('triage', { kind: 'bug', summary: 'Broken' });
+    runtime.next();
+    runtime.setFormAnswers('detail', { description: 'show', logs: false, files: [] });
+    runtime.next();
+    runtime.capture = {
+      screenshot: 'data:image/png;base64,x',
+      elementSelector: null,
+      fullElementSelector: null,
+    };
+
+    runtime.setFormAnswers('triage', { kind: 'idea', summary: 'Better' });
+    expect(runtime.current()?.id).toBe('triage-step');
+    expect(runtime.answers['detail.description']).toBeUndefined();
+    expect(runtime.capture).toBeNull();
+    expect(runtime.route()).toMatchObject({ position: 1, total: 1, canGoBack: false });
+  });
 });

--- a/test/flowSubmission.test.ts
+++ b/test/flowSubmission.test.ts
@@ -54,7 +54,10 @@ describe('flow legacy submission', () => {
       screenshot: 'data:image/png;base64,x',
       attachments: [{ name: 'trace.txt' }],
       submitter: { name: 'Ada' },
-      metadata: { elementSelector: '#save' },
+      metadata: {
+        elementSelector: '#save',
+        fullElementSelector: 'html body #save',
+      },
     });
     expect(body.kind).toBeUndefined();
     await expect(


### PR DESCRIPTION
## Summary

- add an executable ownership matrix for the complete public FlowConfig surface and lifecycle
- add reusable Bug Report, Product Triage, and Customer Pulse recipes
- expand focused and local Chromium coverage across fields, screens, conditions, evidence, lifecycle, accessibility, responsive behavior, and reduced motion
- replace the one-off composable preview example with exactly three exact-candidate preview journeys
- preserve the existing classic/default, styling, Radix, cross-browser, privacy, release, and canary controls

## Why

Composable FlowConfig coverage was distributed across focused tests and a single preview example, so supported controls and lifecycle states did not have one truthful executable owner. This change makes the coverage contract explicit and adds representative end-to-end journeys without creating a combinatorial suite or replacing legacy/default compatibility testing.

## Impact

Maintainers can run the same comprehensive suites locally and in ordinary CI. At the merge-queue tip, the three composable journeys run additively against the exact candidate widget while the existing classic/default controls remain independent and unchanged.

## Validation

- `npm test -- --coverage` — 1,433 tests passed
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run build:widget`
- `bash test/ci-workflow-contract.test.sh`
- committed-tree Chromium FlowConfig suite — 8/8 passed, retries disabled
- exact preview project discovery — exactly 3 composable journeys
- PR Review Toolkit — no high-confidence issues after corrections
