### PR TITLE
docs: make widget the canonical flow docs source

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'docs/website/**'
+      - 'scripts/sync-website-docs.mjs'
+      - '.github/workflows/sync-docs.yml'
 
 permissions: {}
 
@@ -28,11 +30,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.BUGDROP_WEB_TOKEN }}
         run: |
-          cp docs/website/*.mdx bugdrop-web/src/content/docs/
+          node scripts/sync-website-docs.mjs bugdrop-web "$GITHUB_SHA"
           cd bugdrop-web
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/content/docs/
+          git add src/content/docs/ src/lib/flow-capabilities.ts
           if git diff --cached --quiet; then
             echo "No documentation changes to sync"
           else
@@ -42,6 +44,6 @@ jobs:
             git push -u origin "$BRANCH"
             gh pr create --repo mean-weasel/bugdrop-web \
               --title "docs: sync documentation from bugdrop repo" \
-              --body "Automated sync of docs/website/*.mdx from mean-weasel/bugdrop." \
+              --body "Automated sync of canonical website documentation and the released Flow capability manifest from mean-weasel/bugdrop at $GITHUB_SHA." \
               --base main --head "$BRANCH"
           fi

--- a/docs/website/ci-testing.mdx
+++ b/docs/website/ci-testing.mdx
@@ -1,297 +1,79 @@
 # CI Testing with Playwright
 
-BugDrop can be tested in your CI/CD pipeline using Playwright. This guide covers everything from a quick verification check to a comprehensive test suite that validates functionality, accessibility, and configuration.
+BugDrop can be checked in CI without submitting a real report. The stable browser contract is the `bugdrop:ready` window event, a `#bugdrop-host` element, and controls inside its open Shadow DOM. The current trigger, dialog, and close selectors are `.bd-trigger`, `.bd-modal`, and `.bd-close`.
 
-## Quick Check
+Source reviewed: [official BugDrop README and repository](https://github.com/mean-weasel/bugdrop) on 2026-08-14. The example below was exercised against the hosted widget and the checksum-pinned copy used by this site.
 
-The fastest way to verify BugDrop is loading correctly is to check for its console message. When the widget initializes successfully, it logs:
+## Copy this smoke test
 
-```
-[BugDrop] Widget initialized
-```
-
-You can check for this in a simple Playwright test:
-
-```typescript
-import { test, expect } from '@playwright/test';
-
-test('BugDrop loads', async ({ page }) => {
-  const messages: string[] = [];
-  page.on('console', (msg) => messages.push(msg.text()));
-
-  await page.goto('https://your-site.com');
-  await page.waitForTimeout(2000);
-
-  expect(messages.some((m) => m.includes('[BugDrop]'))).toBe(true);
-});
-```
-
-## Full Playwright Test Suite
-
-Here is a comprehensive test file that validates BugDrop's functionality, accessibility (WCAG AA compliance), and configuration. You can copy this directly into your project:
+Register the event observer before navigation so a fast synchronous load cannot race the test:
 
 ```typescript
 import { test, expect } from "@playwright/test";
 
-// ── EXPECTED configuration ──────────────────────────────────────
-// Update these values to match YOUR script tag's data-* attributes.
-const EXPECTED = {
-  theme: "light",
-  position: "bottom-right",
-  color: "#7c3aed",
-  showName: false,
-  requireName: false,
-  showEmail: false,
-  requireEmail: false,
-  buttonDismissible: false,
-  showRestore: true,
-  welcomeMessage: "Report a bug or request a feature",
-};
+test("BugDrop loads and opens", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.addEventListener(
+      "bugdrop:ready",
+      () => document.documentElement.setAttribute("data-bugdrop-ready", "true"),
+      { once: true },
+    );
+  });
 
-const URL = "https://your-site.com"; // Replace with your site URL
+  await page.goto(process.env.PREVIEW_URL ?? "http://127.0.0.1:3000");
 
-// ── Helper: reach into the Shadow DOM ───────────────────────────
-async function shadowEl(page, hostSel: string, innerSel: string) {
-  return page.evaluateHandle(
-    ([h, s]) => {
-      const host = document.querySelector(h);
-      if (!host?.shadowRoot) throw new Error(`No shadow root on ${h}`);
-      const el = host.shadowRoot.querySelector(s);
-      if (!el) throw new Error(`${s} not found in shadow DOM`);
-      return el;
-    },
-    [hostSel, innerSel]
+  await expect(page.locator("html")).toHaveAttribute("data-bugdrop-ready", "true");
+  await expect(page.locator("#bugdrop-host")).toBeAttached();
+
+  const trigger = page.locator("#bugdrop-host .bd-trigger");
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+  await expect(page.locator("#bugdrop-host .bd-modal")).toBeVisible();
+  await expect(page.locator("#bugdrop-host .bd-close")).toBeVisible();
+});
+```
+
+Playwright locators pierce an open Shadow DOM, so the descendant selectors above reach the widget without a custom helper. If your environment blocks third-party scripts, assert the request policy explicitly instead of adding a timeout.
+
+## Verify the loading element
+
+The widget must execute from a normal script tag with its repository configuration attached. This assertion catches an accidental `async`, `defer`, duplicate, or wrong repository value:
+
+```typescript
+test("uses one synchronous configured script", async ({ page }) => {
+  await page.goto(process.env.PREVIEW_URL!);
+  const scripts = page.locator(
+    'script[src="https://bugdrop.neonwatty.workers.dev/widget.js"]',
   );
-}
-
-// ── Tests ───────────────────────────────────────────────────────
-
-test.describe("BugDrop Widget", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto(URL);
-    await page.waitForSelector("bug-drop-widget");
-  });
-
-  test("renders the floating button", async ({ page }) => {
-    const btn = await shadowEl(page, "bug-drop-widget", ".floating-btn");
-    expect(btn).toBeTruthy();
-  });
-
-  test("opens and closes the form", async ({ page }) => {
-    const btn = await shadowEl(page, "bug-drop-widget", ".floating-btn");
-    await (btn as any).click();
-
-    const form = await shadowEl(page, "bug-drop-widget", ".feedback-form");
-    expect(form).toBeTruthy();
-
-    const closeBtn = await shadowEl(page, "bug-drop-widget", ".close-btn");
-    await (closeBtn as any).click();
-  });
-
-  test("has correct position", async ({ page }) => {
-    const pos = await page.evaluate(() => {
-      const host = document.querySelector("bug-drop-widget");
-      const btn = host?.shadowRoot?.querySelector(".floating-btn");
-      if (!btn) throw new Error("Button not found");
-      const style = window.getComputedStyle(btn);
-      return { right: style.right, left: style.left, bottom: style.bottom };
-    });
-
-    if (EXPECTED.position === "bottom-right") {
-      expect(parseInt(pos.right)).toBeLessThan(100);
-    } else {
-      expect(parseInt(pos.left)).toBeLessThan(100);
-    }
-  });
-
-  test("uses correct accent color", async ({ page }) => {
-    const bgColor = await page.evaluate(() => {
-      const host = document.querySelector("bug-drop-widget");
-      const btn = host?.shadowRoot?.querySelector(".floating-btn");
-      if (!btn) throw new Error("Button not found");
-      return window.getComputedStyle(btn).backgroundColor;
-    });
-    expect(bgColor).toBeTruthy();
-  });
-
-  test("displays correct welcome message", async ({ page }) => {
-    const btn = await shadowEl(page, "bug-drop-widget", ".floating-btn");
-    await (btn as any).click();
-
-    const welcomeText = await page.evaluate(() => {
-      const host = document.querySelector("bug-drop-widget");
-      const welcome = host?.shadowRoot?.querySelector(".welcome-message, h2");
-      return welcome?.textContent?.trim();
-    });
-
-    expect(welcomeText).toContain(EXPECTED.welcomeMessage);
-  });
-
-  test("shows/hides name field based on config", async ({ page }) => {
-    const btn = await shadowEl(page, "bug-drop-widget", ".floating-btn");
-    await (btn as any).click();
-
-    const nameFieldVisible = await page.evaluate(() => {
-      const host = document.querySelector("bug-drop-widget");
-      const nameField = host?.shadowRoot?.querySelector(
-        '[name="name"], #name, .name-field'
-      );
-      if (!nameField) return false;
-      return window.getComputedStyle(nameField).display !== "none";
-    });
-
-    expect(nameFieldVisible).toBe(EXPECTED.showName);
-  });
-
-  test("shows/hides email field based on config", async ({ page }) => {
-    const btn = await shadowEl(page, "bug-drop-widget", ".floating-btn");
-    await (btn as any).click();
-
-    const emailFieldVisible = await page.evaluate(() => {
-      const host = document.querySelector("bug-drop-widget");
-      const emailField = host?.shadowRoot?.querySelector(
-        '[name="email"], #email, .email-field'
-      );
-      if (!emailField) return false;
-      return window.getComputedStyle(emailField).display !== "none";
-    });
-
-    expect(emailFieldVisible).toBe(EXPECTED.showEmail);
-  });
-
-  // ── Accessibility (WCAG AA) ─────────────────────────────────
-  test("button meets WCAG AA contrast ratio", async ({ page }) => {
-    const contrast = await page.evaluate(() => {
-      function luminance(r: number, g: number, b: number) {
-        const [rs, gs, bs] = [r, g, b].map((c) => {
-          c /= 255;
-          return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
-        });
-        return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
-      }
-      function parseRgb(color: string) {
-        const match = color.match(/(\d+)/g);
-        return match ? match.map(Number) : [0, 0, 0];
-      }
-
-      const host = document.querySelector("bug-drop-widget");
-      const btn = host?.shadowRoot?.querySelector(".floating-btn");
-      if (!btn) return 0;
-      const style = window.getComputedStyle(btn);
-      const [r1, g1, b1] = parseRgb(style.backgroundColor);
-      const bgLum = luminance(r1, g1, b1);
-      const whiteLum = luminance(255, 255, 255);
-      const ratio =
-        (Math.max(bgLum, whiteLum) + 0.05) /
-        (Math.min(bgLum, whiteLum) + 0.05);
-      return ratio;
-    });
-
-    // WCAG AA requires 4.5:1 for normal text, 3:1 for large text
-    expect(contrast).toBeGreaterThanOrEqual(3);
-  });
-
-  test("form elements are keyboard accessible", async ({ page }) => {
-    // Open the form
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("Enter");
-
-    // Verify form opened and is focusable
-    const formExists = await page.evaluate(() => {
-      const host = document.querySelector("bug-drop-widget");
-      return !!host?.shadowRoot?.querySelector(".feedback-form, form");
-    });
-
-    expect(formExists).toBe(true);
-  });
+  await expect(scripts).toHaveCount(1);
+  await expect(scripts).toHaveAttribute("data-repo", "owner/repo");
+  await expect(scripts).not.toHaveAttribute("async", /.*/);
+  await expect(scripts).not.toHaveAttribute("defer", /.*/);
 });
 ```
 
-## Installation and Setup
+## Check preview-only loading
 
-To run the tests, you need Playwright installed in your project:
+For the [Vercel preview workflow](/use-cases/vercel-preview-feedback), run the smoke test against a Preview Deployment. Run this negative check against the production URL:
+
+```typescript
+test("production omits preview feedback", async ({ page }) => {
+  await page.goto(process.env.PRODUCTION_URL!);
+  await expect(
+    page.locator('script[data-label="Preview feedback"]'),
+  ).toHaveCount(0);
+  await expect(page.locator("#bugdrop-host")).toHaveCount(0);
+});
+```
+
+The negative assertion applies to the preview-only integration. If production intentionally has a different BugDrop installation, distinguish it with a different label and assert the preview script itself is absent.
+
+## Run it in CI
 
 ```bash
-# Install Playwright
 npm install --save-dev @playwright/test
-
-# Install browsers
-npx playwright install
+npx playwright install --with-deps chromium
+npx playwright test e2e/bugdrop.spec.ts
 ```
 
-Create or update your `playwright.config.ts`:
-
-```typescript
-import { defineConfig } from '@playwright/test';
-
-export default defineConfig({
-  testDir: './e2e',
-  timeout: 30000,
-  use: {
-    baseURL: 'https://your-site.com',
-  },
-});
-```
-
-Then run the tests:
-
-```bash
-npx playwright test
-```
-
-## What the Tests Check
-
-The test suite covers three areas:
-
-### Functional Tests
-
-- **Renders the floating button** -- Verifies the widget loads and the button appears in the Shadow DOM
-- **Opens and closes the form** -- Clicks the button, verifies the form appears, then closes it
-- **Correct position** -- Validates the button is in the expected corner (bottom-right or bottom-left)
-- **Correct accent color** -- Checks the button's background color
-- **Welcome message** -- Opens the form and verifies the correct welcome text is displayed
-- **Name/email field visibility** -- Confirms fields show or hide based on your configuration
-
-### Accessibility Tests (WCAG AA)
-
-- **Contrast ratio** -- Calculates the luminance contrast ratio between the button's background color and white text, ensuring it meets WCAG AA standards (3:1 for large text)
-- **Keyboard accessibility** -- Verifies the form can be opened and navigated using only the keyboard
-
-### Configuration Verification
-
-The `EXPECTED` object at the top of the test file defines your expected configuration. Update it to match your actual `data-*` attributes:
-
-```typescript
-const EXPECTED = {
-  theme: "light",           // data-theme
-  position: "bottom-right", // data-position
-  color: "#7c3aed",         // data-color
-  showName: false,          // data-show-name
-  requireName: false,       // data-require-name
-  showEmail: false,         // data-show-email
-  requireEmail: false,      // data-require-email
-  buttonDismissible: false, // data-button-dismissible
-  showRestore: true,        // data-show-restore
-  welcomeMessage: "Report a bug or request a feature", // data-welcome
-};
-```
-
-If any of these values do not match what the widget actually renders, the corresponding test will fail -- catching configuration drift between your script tag and your expected behavior.
-
-## Running in CI
-
-Add the test to your CI workflow (GitHub Actions example):
-
-```yaml
-- name: Install Playwright
-  run: npx playwright install --with-deps chromium
-
-- name: Run BugDrop tests
-  run: npx playwright test e2e/bugdrop.spec.ts
-```
-
-## Next Steps
-
-- [Configure the widget](/docs/configuration) with data attributes
-- [Review security and rate limiting](/docs/security)
-- [Pin your widget version](/docs/version-pinning) for stable CI runs
+Pin the widget for deterministic CI if your release process requires it, and review [installation](/docs/installation), [configuration](/docs/configuration), and [security](/docs/security) before enabling screenshots on sensitive routes. A smoke test proves loading and interaction; only a deliberate end-to-end canary should create and then verify a real GitHub Issue.

--- a/docs/website/custom-flows.mdx
+++ b/docs/website/custom-flows.mdx
@@ -1,0 +1,59 @@
+# Custom Flows
+
+The default feedback flow is still the fastest way to collect a bug report with a screenshot, annotations, browser details, and privacy controls. Custom flows use the same BugDrop runtime and submission path, but let you collect different information in a journey that fits a particular part of your product.
+
+## Choose your path
+
+- **Build your first flow below** when you want the smallest working example.
+- Use [Flow Design](/docs/flow-design) for screens, branching, context, issue output, and evidence.
+- Try the [Flow Examples](/docs/flow-examples) to combine released components, motion, and styling without leaving the page.
+- Use the [Flow Reference](/docs/flow-reference) when you need the exact v1.56.3 contract.
+
+## Register a first flow
+
+Register once after `bugdrop:ready`, keep the returned handle, and open it from your product UI:
+
+```js
+window.addEventListener('bugdrop:ready', () => {
+  const productQuestion = window.BugDrop.registerFlow({
+    configVersion: 1,
+    id: 'product-question',
+    presentation: { kind: 'modal', size: 'compact' },
+    appearance: { theme: 'auto', accentColor: '#7c3aed' },
+    forms: [{
+      id: 'question',
+      title: 'Help us choose what to build',
+      fields: [{
+        id: 'answer',
+        type: 'longText',
+        label: 'What would improve your workflow?',
+        required: true,
+        maxLength: 1000,
+      }],
+    }],
+    screens: [{ id: 'question-screen', type: 'form', form: 'question' }],
+    issue: {
+      classification: 'question',
+      title: 'Product question response',
+      sections: [
+        { heading: 'Response', answer: 'question.answer' },
+        { heading: 'Surface', context: 'surface', format: 'code' },
+      ],
+    },
+  });
+
+  document.querySelector('#product-question').addEventListener('click', async () => {
+    const opened = productQuestion.open({ context: { surface: 'settings' } });
+    console.log((await opened.result).status);
+  });
+});
+```
+
+Registration returns a `FlowHandle`. Each `open()` creates an `OpenedFlow` with its own `instanceId`, `result` promise, and `close()` method. See [JavaScript API: custom-flow lifecycle](/docs/javascript-api#custom-flow-lifecycle) for result handling.
+
+## Next steps
+
+- Design a multi-screen journey in [Flow Design](/docs/flow-design)
+- See the released API working in [Flow Examples](/docs/flow-examples)
+- Match the widget to your application with [Styling](/docs/styling)
+- Keep production behavior predictable with [Version Pinning](/docs/version-pinning)

--- a/docs/website/custom-flows.mdx
+++ b/docs/website/custom-flows.mdx
@@ -7,7 +7,7 @@ The default feedback flow is still the fastest way to collect a bug report with 
 - **Build your first flow below** when you want the smallest working example.
 - Use [Flow Design](/docs/flow-design) for screens, branching, context, issue output, and evidence.
 - Try the [Flow Examples](/docs/flow-examples) to combine released components, motion, and styling without leaving the page.
-- Use the [Flow Reference](/docs/flow-reference) when you need the exact v1.56.3 contract.
+- Use the [Flow Reference](/docs/flow-reference) for the released v1.56.3 shapes, values, and validation boundaries.
 
 ## Register a first flow
 

--- a/docs/website/faq.mdx
+++ b/docs/website/faq.mdx
@@ -96,9 +96,9 @@ To completely remove BugDrop:
 
 Removing the script tag is all that is needed to stop BugDrop from appearing. Steps 2 and 3 are optional cleanup.
 
-### Why can't I use async or defer on the script tag?
+### Why must the script omit async and defer?
 
-BugDrop needs to initialize synchronously to ensure the widget is ready as early as possible and to properly read its configuration from the script tag's data attributes. Using `async` or `defer` can cause the widget to initialize after other scripts have run, which may lead to race conditions with the `bugdrop:ready` event or the `window.BugDrop` API.
+BugDrop reads configuration from the script element that is executing. Use the official synchronous snippet without `async` or `defer` so execution order and the element's `data-*` attributes remain one contract. If application code depends on the widget, register a `bugdrop:ready` listener on `window` before the script executes.
 
 ## Configuration
 

--- a/docs/website/flow-branching-and-output.mdx
+++ b/docs/website/flow-branching-and-output.mdx
@@ -1,0 +1,59 @@
+# Flow Branching & Output
+
+import { FlowCapabilityReference } from "@/components/docs/flow-capability-reference";
+
+Branching lets one flow adapt to what a user has already answered or to context supplied by your app. Output mappings then turn the answers that remain relevant into a useful GitHub Issue and supporting evidence.
+
+## Show the right screens
+
+Add `when` to a screen to show it only when a value matches. An `answer` condition refers to an earlier field by its `formId.fieldId` path. A `context` condition refers to a key supplied through `open({ context })`. Matching uses exact equality, including the value type: the number `5` is different from the string `'5'`.
+
+```js
+{
+  id: 'diagnostics-screen',
+  type: 'form',
+  form: 'diagnostics',
+  when: {
+    any: [
+      { answer: 'triage.kind', equals: 'bug' },
+      { context: 'supportPlan', equals: 'priority' },
+    ],
+  },
+}
+```
+
+Use `all` when every nested condition must match and `any` when one match is enough. Groups can contain other groups for more involved routes.
+
+When an answer change hides a screen, BugDrop removes the answers and screenshot evidence owned by that screen. This prevents information from a route the user abandoned from appearing in the final Issue. Going Back to a screen that remains visible keeps its answers.
+
+## Know the stored answer values
+
+Answer and initial-answer paths use these values:
+
+| Field | Stored value |
+|-------|--------------|
+| Short text or long text | A trimmed string |
+| Rating | An integer from `1` through the configured scale |
+| Single choice | The selected option's configured `value` string |
+| Checkbox | `true` or `false` |
+| Attachments | An array of attachment records |
+
+Attachments can be mapped as evidence, but they cannot be used as scalar condition values, Issue-title placeholders, or ordinary Issue sections.
+
+## Shape the GitHub Issue
+
+Issue titles can interpolate answer paths such as `{{report.summary}}`. Ordered sections can read either an answer or a context key and format it as text, a quote, stars, a choice label, or code where supported. Set `omitWhenEmpty: true` when an optional section should disappear instead of leaving an empty heading.
+
+Evidence mappings have narrower jobs: an attachments field supplies uploaded files, a checkbox records consent to send console logs, and text fields can supply the submitter's name or email. Mapping a field does not bypass the normal user consent or submission flow.
+
+## Handle the outcome
+
+Every opened flow settles as `submitted`, `closed`, or `busy`. A busy result means another BugDrop modal already owns the shared surface; wait for that experience to close before opening another one. See the [JavaScript API lifecycle guide](/docs/javascript-api#custom-flow-lifecycle) for a complete example.
+
+## Exact reference
+
+The tables below are the exact released condition, context, issue, evidence, lifecycle, outcome, and scope-boundary contracts for BugDrop v1.56.3.
+
+<FlowCapabilityReference section="branching-and-output" />
+
+Return to [Flow Design](/docs/flow-design) for practical composition guidance.

--- a/docs/website/flow-branching-and-output.mdx
+++ b/docs/website/flow-branching-and-output.mdx
@@ -50,9 +50,9 @@ Evidence mappings have narrower jobs: an attachments field supplies uploaded fil
 
 Every opened flow settles as `submitted`, `closed`, or `busy`. A busy result means another BugDrop modal already owns the shared surface; wait for that experience to close before opening another one. See the [JavaScript API lifecycle guide](/docs/javascript-api#custom-flow-lifecycle) for a complete example.
 
-## Exact reference
+## Property and value reference
 
-The tables below are the exact released condition, context, issue, evidence, lifecycle, outcome, and scope-boundary contracts for BugDrop v1.56.3.
+The tables below list the released condition, context, issue, evidence, lifecycle, outcome, and scope-boundary properties and values for BugDrop v1.56.3. See [Flow Design](/docs/flow-design#stay-within-the-validation-boundaries) for config-wide limits and relationships that `registerFlow()` also validates.
 
 <FlowCapabilityReference section="branching-and-output" />
 

--- a/docs/website/flow-capabilities.ts
+++ b/docs/website/flow-capabilities.ts
@@ -1,0 +1,300 @@
+type PropertyContract = {
+  readonly required: readonly string[];
+  readonly optional: readonly string[];
+};
+
+const FIELD_CONTRACTS = {
+  shortText: {
+    required: ['id', 'type', 'label'],
+    optional: ['helpText', 'required', 'layout', 'placeholder', 'minLength', 'maxLength'],
+  },
+  longText: {
+    required: ['id', 'type', 'label'],
+    optional: ['helpText', 'required', 'layout', 'placeholder', 'rows', 'minLength', 'maxLength'],
+  },
+  rating: {
+    required: ['id', 'type', 'label'],
+    optional: ['helpText', 'required', 'layout', 'scale', 'icon', 'lowLabel', 'highLabel'],
+  },
+  singleChoice: {
+    required: ['id', 'type', 'label', 'options'],
+    optional: ['helpText', 'required', 'layout', 'display'],
+  },
+  checkbox: {
+    required: ['id', 'type', 'label'],
+    optional: ['helpText', 'required', 'initialValue', 'layout'],
+  },
+  attachments: {
+    required: ['id', 'type', 'label'],
+    optional: ['helpText', 'required', 'maxFiles', 'maxFileSize', 'accept', 'layout'],
+  },
+} as const satisfies Record<string, PropertyContract>;
+
+const SCREEN_CONTRACTS = {
+  message: {
+    required: ['id', 'type', 'title'],
+    optional: ['when', 'description', 'continueLabel'],
+  },
+  form: {
+    required: ['id', 'type', 'form'],
+    optional: ['when', 'continueLabel', 'backLabel'],
+  },
+  screenshot: {
+    required: ['id', 'type', 'mode'],
+    optional: ['when', 'title', 'description', 'continueLabel', 'backLabel'],
+  },
+} as const satisfies Record<string, PropertyContract>;
+
+const TRANSITION_KINDS = [
+  'none',
+  'slide-horizontal',
+  'slide-vertical',
+  'fade',
+  'scale-fade',
+  'custom',
+] as const;
+
+/**
+ * The single documentation inventory for the released BugDrop Flow API.
+ * Exact declaration and runtime-source parity is enforced by the fixture test.
+ */
+export const FLOW_CAPABILITIES = {
+  versionKey: 'v1.56.3@47a392d1e7b1a8d8adeff1692f6bbbd84696280d',
+  release: 'v1.56.3',
+  targetCommit: '47a392d1e7b1a8d8adeff1692f6bbbd84696280d',
+  runtime: {
+    byteLength: 238_591,
+    sha256: '338cdb5b19c69dc3429fdcb8f800e3b98a3bdd442fee78563523cd731e2bdf0e',
+  },
+  publicContract: {
+    CheckboxField:
+      "interface CheckboxField{id:string;type:'checkbox';label:string;helpText?:string;required?:boolean;initialValue?:boolean;layout?:{span?:1|2};}",
+    AttachmentsField:
+      "interface AttachmentsField{id:string;type:'attachments';label:string;helpText?:string;required?:boolean;maxFiles?:number;maxFileSize?:number;accept?:string[];layout?:{span?:1|2};}",
+    FlowField: 'type FlowField = VariantField|CheckboxField|AttachmentsField;',
+    FlowScalar: 'type FlowScalar = string|number|boolean|null;',
+    FlowCondition:
+      'type FlowCondition =|{answer:string;equals:FlowScalar}|{context:string;equals:FlowScalar}|{all:FlowCondition[]}|{any:FlowCondition[]};',
+    FlowForm: 'interface FlowForm{id:string;title:string;description?:string;fields:FlowField[];}',
+    BaseScreen: 'interface BaseScreen{id:string;when?:FlowCondition;}',
+    MessageScreen:
+      "interface MessageScreen extends BaseScreen{type:'message';title:string;description?:string;continueLabel?:string;}",
+    FormScreen:
+      "interface FormScreen extends BaseScreen{type:'form';form:string;continueLabel?:string;backLabel?:string;}",
+    ScreenshotScreen:
+      "interface ScreenshotScreen extends BaseScreen{type:'screenshot';title?:string;description?:string;mode:'optional'|'auto'|'required';continueLabel?:string;backLabel?:string;}",
+    FlowScreen: 'type FlowScreen = MessageScreen|FormScreen|ScreenshotScreen;',
+    FlowScreenTransitionFrame:
+      'interface FlowScreenTransitionFrame{opacity?:number;translateX?:number;translateY?:number;scale?:number;}',
+    FlowScreenTransitionMotion:
+      'interface FlowScreenTransitionMotion{enterFrom:FlowScreenTransitionFrame;exitTo:FlowScreenTransitionFrame;}',
+    FlowScreenTransition:
+      "type FlowScreenTransition =|{kind:'none'}|{kind:'slide-horizontal'|'slide-vertical'|'fade'|'scale-fade';durationMs?:number;}|{kind:'custom';durationMs?:number;easing?:'standard'|'linear'|'ease-in'|'ease-out'|'ease-in-out';forward:FlowScreenTransitionMotion;backward:FlowScreenTransitionMotion;};",
+    FlowIssueSection:
+      "type FlowIssueSection =|{heading:string;answer:string;format?:'text'|'quote'|'stars'|'choice'|'code';omitWhenEmpty?:boolean;}|{heading:string;context:string;format?:'text'|'code';omitWhenEmpty?:boolean;};",
+    FlowConfig:
+      "interface FlowConfig{configVersion:1;id:string;presentation:{kind:'modal';size?:'compact'|'default'|'wide';columns?:1|2;screenTransition?:FlowScreenTransition;};appearance?:{theme?:VariantTheme;accentColor?:string;density?:'compact'|'comfortable';};content?:{successTitle?:string;successMessage?:string;cancelLabel?:string;};forms:FlowForm[];screens:FlowScreen[];issue:{classification?:'bug'|'feature'|'question';title:string;sections?:FlowIssueSection[];};evidence?:{attachments?:string;sendConsoleLogs?:string;submitter?:{name?:string;email?:string};};}",
+    FlowOpenOptions:
+      'interface FlowOpenOptions{context?:VariantContext;initialAnswers?:Record<string,unknown>;}',
+    FlowOutcome:
+      "type FlowOutcome ={status:'submitted';result:SubmissionResult}|{status:'closed'}|{status:'busy'};",
+    OpenedFlow:
+      'interface OpenedFlow{readonly instanceId:string;readonly result:Promise<FlowOutcome>;close():void;}',
+    FlowHandle:
+      'interface FlowHandle{readonly id:string;open(options?:FlowOpenOptions):OpenedFlow;}',
+    VariantTheme: "type VariantTheme = 'light'|'dark'|'auto';",
+    VariantContextValue: 'type VariantContextValue = string|number|boolean|null;',
+    VariantContext: 'type VariantContext = Record<string,VariantContextValue>;',
+    BaseField:
+      'interface BaseField{id:string;label:string;helpText?:string;required?:boolean;layout?:{span?:1|2};}',
+    ShortTextField:
+      "interface ShortTextField extends BaseField{type:'shortText';placeholder?:string;minLength?:number;maxLength?:number;}",
+    LongTextField:
+      "interface LongTextField extends BaseField{type:'longText';placeholder?:string;rows?:number;minLength?:number;maxLength?:number;}",
+    RatingField:
+      "interface RatingField extends BaseField{type:'rating';scale?:5|10;icon?:'star'|'number';lowLabel?:string;highLabel?:string;}",
+    SingleChoiceField:
+      "interface SingleChoiceField extends BaseField{type:'singleChoice';options:Array<{value:string;label:string;description?:string}>;display?:'radio'|'cards'|'buttons';}",
+    VariantField: 'type VariantField = ShortTextField|LongTextField|RatingField|SingleChoiceField;',
+    SubmissionResult:
+      'interface SubmissionResult{issueNumber:number;issueUrl:string;isPublic:boolean;labelMappingWarnings?:string[];}',
+    'BugDropPublicAPI.registerFlow':
+      "registerFlow(config:import('../flows/public-types').FlowConfig):import('../flows/public-types').FlowHandle;",
+  },
+  registration: {
+    method: 'registerFlow',
+    parameter: 'config',
+    parameterType: 'FlowConfig',
+    parameterRequired: true,
+    returnType: 'FlowHandle',
+  },
+  configVersion: [1],
+  configProperties: {
+    required: ['configVersion', 'id', 'presentation', 'forms', 'screens', 'issue'],
+    optional: ['appearance', 'content', 'evidence'],
+  },
+  fields: {
+    types: Object.keys(FIELD_CONTRACTS),
+    byType: FIELD_CONTRACTS,
+    optionShape: { required: ['value', 'label'], optional: ['description'] },
+    layoutProperties: { required: [], optional: ['span'] },
+    layoutSpans: [1, 2],
+    ratingScales: [5, 10],
+    ratingIcons: ['star', 'number'],
+    singleChoiceDisplays: ['radio', 'cards', 'buttons'],
+    constraints: {
+      text: {
+        minLength: { minimum: 0, maximum: 5_000, default: 0 },
+        maxLength: { minimum: 1, maximum: 5_000, defaults: { shortText: 500, longText: 5_000 } },
+        longTextRows: { minimum: 1, maximum: 50 },
+      },
+      singleChoiceOptions: { minimum: 2, maximum: 50 },
+      attachments: {
+        maxFiles: { minimum: 1, maximum: 5, default: 5 },
+        maxFileSizeBytes: { minimum: 1, maximum: 5_242_880, default: 5_242_880 },
+        acceptCount: { minimum: 1, maximum: 20 },
+        acceptedMimeTypes: [
+          'image/png', 'image/jpeg', 'image/gif', 'image/webp',
+          'application/pdf', 'video/mp4', 'video/webm', 'video/quicktime',
+        ],
+      },
+    },
+  },
+  forms: {
+    properties: { required: ['id', 'title', 'fields'], optional: ['description'] },
+  },
+  screens: {
+    types: Object.keys(SCREEN_CONTRACTS),
+    byType: SCREEN_CONTRACTS,
+    screenshotModes: ['optional', 'auto', 'required'],
+  },
+  conditions: {
+    branches: {
+      answer: { required: ['answer', 'equals'], optional: [] },
+      context: { required: ['context', 'equals'], optional: [] },
+      all: { required: ['all'], optional: [] },
+      any: { required: ['any'], optional: [] },
+    },
+    scalarTypes: ['string', 'number', 'boolean', 'null'],
+    contextValueTypes: ['string', 'number', 'boolean', 'null'],
+    recursiveBranches: ['all', 'any'],
+  },
+  presentation: {
+    properties: {
+      required: ['kind'],
+      optional: ['size', 'columns', 'screenTransition'],
+    },
+    kinds: ['modal'],
+    sizes: ['compact', 'default', 'wide'],
+    columns: [1, 2],
+  },
+  appearance: {
+    properties: { required: [], optional: ['theme', 'accentColor', 'density'] },
+    themes: ['light', 'dark', 'auto'],
+    densities: ['compact', 'comfortable'],
+  },
+  content: {
+    properties: { required: [], optional: ['successTitle', 'successMessage', 'cancelLabel'] },
+  },
+  transitions: {
+    kinds: TRANSITION_KINDS,
+    builtInKinds: TRANSITION_KINDS.filter(kind => kind !== 'none' && kind !== 'custom'),
+    branches: {
+      none: { required: ['kind'], optional: [] },
+      builtIn: { required: ['kind'], optional: ['durationMs'] },
+      custom: {
+        required: ['kind', 'forward', 'backward'],
+        optional: ['durationMs', 'easing'],
+      },
+    },
+    easings: ['standard', 'linear', 'ease-in', 'ease-out', 'ease-in-out'],
+    customEasingDefault: 'standard',
+    motionProperties: { required: ['enterFrom', 'exitTo'], optional: [] },
+    frameProperties: {
+      required: [],
+      optional: ['opacity', 'translateX', 'translateY', 'scale'],
+    },
+    durationMs: { minimum: 100, maximum: 1_000, integer: true },
+    defaultDurationMs: {
+      'slide-horizontal': 500,
+      'slide-vertical': 500,
+      fade: 350,
+      'scale-fade': 450,
+      custom: 500,
+    },
+    frameBounds: {
+      opacity: { minimum: 0, maximum: 1 },
+      translateX: { minimum: -200, maximum: 200 },
+      translateY: { minimum: -200, maximum: 200 },
+      scale: { minimum: 0.5, maximum: 1.5 },
+    },
+    frameDefaults: { opacity: 1, translateX: 0, translateY: 0, scale: 1 },
+    directions: ['forward', 'backward'],
+    directionBehavior:
+      'configured motion and built-in slide classes follow the navigation direction',
+    immediateWhen: ['transition omitted', 'kind none', 'initial screen', 'reduced motion'],
+  },
+  issue: {
+    properties: {
+      required: ['title'],
+      optional: ['classification', 'sections'],
+    },
+    classifications: ['bug', 'feature', 'question'],
+    sections: {
+      answer: {
+        properties: {
+          required: ['heading', 'answer'],
+          optional: ['format', 'omitWhenEmpty'],
+        },
+        formats: ['text', 'quote', 'stars', 'choice', 'code'],
+      },
+      context: {
+        properties: {
+          required: ['heading', 'context'],
+          optional: ['format', 'omitWhenEmpty'],
+        },
+        formats: ['text', 'code'],
+      },
+    },
+  },
+  evidence: {
+    properties: {
+      required: [],
+      optional: ['attachments', 'sendConsoleLogs', 'submitter'],
+    },
+    submitterProperties: { required: [], optional: ['name', 'email'] },
+  },
+  lifecycle: {
+    handleProperties: { required: ['id', 'open'], optional: [] },
+    openMethod: {
+      parameter: 'options',
+      parameterType: 'FlowOpenOptions',
+      parameterRequired: false,
+      returnType: 'OpenedFlow',
+    },
+    openOptionProperties: { required: [], optional: ['context', 'initialAnswers'] },
+    openedProperties: { required: ['instanceId', 'result', 'close'], optional: [] },
+    closeMethod: { parameterCount: 0, returnType: 'void' },
+    outcomeBranches: {
+      submitted: { required: ['status', 'result'], optional: [] },
+      closed: { required: ['status'], optional: [] },
+      busy: { required: ['status'], optional: [] },
+    },
+    submissionResultProperties: {
+      required: ['issueNumber', 'issueUrl', 'isPublic'],
+      optional: ['labelMappingWarnings'],
+    },
+  },
+  exclusions: {
+    variantOnly: [
+      'presentation.kind=inline',
+      'issue.classification=feedback',
+      'VariantHandle.mount',
+      'VariantHandle.submit',
+      'VariantContent requirement',
+    ],
+    unreleased: ['field.type=multiSelect'],
+  },
+} as const;
+
+export type FlowCapabilities = typeof FLOW_CAPABILITIES;

--- a/docs/website/flow-capabilities.ts
+++ b/docs/website/flow-capabilities.ts
@@ -55,8 +55,8 @@ const TRANSITION_KINDS = [
 ] as const;
 
 /**
- * The single documentation inventory for the released BugDrop Flow API.
- * Exact declaration and runtime-source parity is enforced by the fixture test.
+ * The canonical documentation inventory for the released BugDrop Flow API.
+ * Fixture tests bind the documented runtime bounds below to released source.
  */
 export const FLOW_CAPABILITIES = {
   versionKey: 'v1.56.3@47a392d1e7b1a8d8adeff1692f6bbbd84696280d',
@@ -132,6 +132,22 @@ export const FLOW_CAPABILITIES = {
   configProperties: {
     required: ['configVersion', 'id', 'presentation', 'forms', 'screens', 'issue'],
     optional: ['appearance', 'content', 'evidence'],
+  },
+  validation: {
+    forms: { minimum: 1, maximum: 12 },
+    screens: { minimum: 1, maximum: 20 },
+    fieldsPerForm: { minimum: 1, maximum: 20 },
+    screenshotScreens: { maximum: 1 },
+    conditionGroupEntries: { minimum: 1, maximum: 8 },
+    conditionDepth: { maximum: 4 },
+    conditionNodes: { maximum: 32 },
+    issueSections: { maximum: 20 },
+    structuralRules: [
+      'every form must be referenced by exactly one form screen',
+      'at least one screen must be unconditional',
+      'answer conditions may reference only fields from earlier form screens',
+      'a placeholder-only Issue title must reference an unconditional required answer',
+    ],
   },
   fields: {
     types: Object.keys(FIELD_CONTRACTS),

--- a/docs/website/flow-design.mdx
+++ b/docs/website/flow-design.mdx
@@ -63,6 +63,21 @@ const opened = productQuestion.open({
 
 Keep private or privileged values out of both inputs. Values mapped into an issue or captured as evidence can leave the browser when the user submits.
 
+## Stay within the validation boundaries
+
+`registerFlow()` validates the complete configuration before returning a handle. A flow may contain
+1–12 forms and 1–20 screens; each form may contain 1–20 fields. Every form must be referenced by
+exactly one form screen, at least one screen must be unconditional, and a flow may contain at most one
+screenshot screen.
+
+Conditions may contain 1–8 entries per `all` or `any` group, nest up to four levels deep, and contain
+at most 32 nodes in total. Answer conditions can reference only fields from earlier form screens. Issue
+output may contain at most 20 sections. If an Issue title contains only answer placeholders and no
+literal text, at least one placeholder must reference a required field on an unconditional form screen.
+
+These boundaries are part of the canonical [Flow Reference](/docs/flow-reference). Treat a synchronous
+registration error as a configuration error and correct it before calling `open()`.
+
 ## Add motion intentionally
 
 Set `presentation.screenTransition` to immediate replacement, a built-in transition, or custom declarative motion. Back navigation uses the reverse direction. BugDrop replaces motion immediately when the user prefers reduced motion.

--- a/docs/website/flow-design.mdx
+++ b/docs/website/flow-design.mdx
@@ -1,0 +1,77 @@
+# Flow Design
+
+Custom flows have four layers: forms and fields collect answers, screens arrange the journey, issue and evidence mappings create useful output, and a registered handle owns each open instance.
+
+## Arrange forms into screens
+
+Forms are reusable groups of fields. Screens determine what a user sees and in which order. A form screen refers to a form by ID; a screenshot screen hands capture to BugDrop; a message screen can introduce or explain a branch.
+
+Use `when` to include a screen only when an answer or opening context matches. Conditions can be combined recursively with `all` or `any`:
+
+```js
+{
+  id: 'diagnostics-screen',
+  type: 'form',
+  form: 'diagnostics',
+  when: {
+    any: [
+      { answer: 'triage.kind', equals: 'bug' },
+      { context: 'supportPlan', equals: 'priority' },
+    ],
+  },
+}
+```
+
+Answer paths use `formId.fieldId`. Context values come from `open({ context })` and may be strings, numbers, booleans, or `null`.
+Every context key passed to `open()` must also be referenced by that flow in a screen condition or a
+context-backed Issue section. An unreferenced key is rejected synchronously as an unknown context
+key.
+
+## Map issue output and evidence
+
+Issue templates can classify the report, interpolate answers in the title, and render ordered sections. Evidence mappings connect dedicated fields to attachments, console-log consent, and submitter details:
+
+```js
+issue: {
+  classification: 'bug',
+  title: '{{report.summary}}',
+  sections: [
+    { heading: 'Steps', answer: 'report.steps', omitWhenEmpty: true },
+    { heading: 'Surface', context: 'surface', format: 'code' },
+  ],
+},
+evidence: {
+  attachments: 'evidence.files',
+  sendConsoleLogs: 'evidence.sendLogs',
+  submitter: { name: 'evidence.name', email: 'evidence.email' },
+},
+```
+
+Mapping a field does not bypass consent or the normal BugDrop submission path. Submitting a flow can create a real GitHub Issue, so use a repository and environment appropriate for testing.
+
+## Seed answers and pass product context
+
+`open()` accepts `context` and `initialAnswers`. Use declared context keys for routing and issue
+metadata your application already knows, and initial answers to prefill known values:
+
+```js
+const opened = productQuestion.open({
+  context: { surface: 'export' },
+  initialAnswers: { 'question.answer': 'Export needs a CSV option.' },
+});
+```
+
+Keep private or privileged values out of both inputs. Values mapped into an issue or captured as evidence can leave the browser when the user submits.
+
+## Add motion intentionally
+
+Set `presentation.screenTransition` to immediate replacement, a built-in transition, or custom declarative motion. Back navigation uses the reverse direction. BugDrop replaces motion immediately when the user prefers reduced motion.
+
+```js
+presentation: {
+  kind: 'modal',
+  screenTransition: { kind: 'fade', durationMs: 350 },
+},
+```
+
+See [Presentation & Motion](/docs/flow-presentation-and-motion) for every released transition and [Styling](/docs/styling#custom-flow-appearance) for supported appearance controls.

--- a/docs/website/flow-examples.mdx
+++ b/docs/website/flow-examples.mdx
@@ -1,0 +1,9 @@
+# Flow Examples
+
+import { FlowCapabilityExamples } from "@/components/docs/flow-capability-examples";
+
+Combine three curated journeys with every released transition and three supported styling presets. The gallery loads the checksum-pinned v1.56.3 runtime from this site and points submission at the local feedback route, so it cannot create a real GitHub Issue or send a payload to an external service.
+
+Use these examples to explore combinations, then return to [Flow Design](/docs/flow-design) for implementation guidance or the [Flow Reference](/docs/flow-reference) for exact configuration shapes.
+
+<FlowCapabilityExamples />

--- a/docs/website/flow-field-guide.mdx
+++ b/docs/website/flow-field-guide.mdx
@@ -1,0 +1,91 @@
+# Flow Field Guide
+
+import { FlowBuildingBlockPreview } from "@/components/docs/flow-building-block-preview";
+
+Fields collect information inside a form. Every field has an `id`, `type`, and visible `label`; fields may also be required, include help text, and span one or two columns.
+
+## Short text
+
+Collects a brief response on one line.
+
+<FlowBuildingBlockPreview kind="short-text" />
+
+```js
+{ id: 'summary', type: 'shortText', label: 'What happened?', required: true, maxLength: 120 }
+```
+
+You can add help text and placeholder copy, set minimum and maximum lengths, and control its column span.
+
+## Long text
+
+Collects a response that may need multiple lines.
+
+<FlowBuildingBlockPreview kind="long-text" />
+
+```js
+{ id: 'details', type: 'longText', label: 'Tell us more', rows: 5, maxLength: 1000 }
+```
+
+You can add help text and placeholder copy, set the visible row count, set minimum and maximum lengths, require a response, and control its column span.
+
+## Rating
+
+Collects a score on a five- or ten-point scale using stars or numbers.
+
+<FlowBuildingBlockPreview kind="rating" />
+
+```js
+{ id: 'score', type: 'rating', label: 'How was this experience?', scale: 5, icon: 'star', lowLabel: 'Poor', highLabel: 'Great' }
+```
+
+You can choose the scale and icon, label both ends of the scale, add help text, require a rating, and control its column span.
+
+## Single choice
+
+Lets someone select exactly one option.
+
+<FlowBuildingBlockPreview kind="single-choice" />
+
+```js
+{
+  id: 'priority',
+  type: 'singleChoice',
+  label: 'How important is this?',
+  display: 'cards',
+  options: [
+    { value: 'low', label: 'Low' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'high', label: 'High', description: 'Blocking important work' },
+  ],
+}
+```
+
+Options require a stored value and visible label, and may include a description. The choices can appear as radio controls, cards, or buttons. You can also add help text, require a selection, and control the field's column span.
+
+## Checkbox
+
+Collects one checked-or-unchecked answer.
+
+<FlowBuildingBlockPreview kind="checkbox" />
+
+```js
+{ id: 'contact', type: 'checkbox', label: 'You may contact me about this feedback', initialValue: false }
+```
+
+You can set its initial state, add help text, require it to be checked, and control its column span.
+
+## Attachments
+
+Lets someone add supporting files to the feedback submission.
+
+<FlowBuildingBlockPreview kind="attachments" />
+
+```js
+{ id: 'files', type: 'attachments', label: 'Add supporting files', maxFiles: 3, accept: ['image/png', 'image/jpeg'] }
+```
+
+You can limit the number and size of files, restrict accepted file types, add help text, require an attachment, and control the field's column span.
+
+`maxFileSize` is measured in bytes. Each attachment value contains its file name, MIME type, byte size, and data URL; most flows should map the field through `evidence.attachments` instead of rendering it as ordinary Issue text.
+
+For every exact property and allowed value, see the [Fields & Screens Reference](/docs/flow-fields-and-screens-reference).

--- a/docs/website/flow-fields-and-screens-reference.mdx
+++ b/docs/website/flow-fields-and-screens-reference.mdx
@@ -1,0 +1,9 @@
+# Fields & Screens Reference
+
+import { FlowCapabilityReference } from "@/components/docs/flow-capability-reference";
+
+The exact field and screen property contract released with BugDrop v1.56.3. For plain-English descriptions and examples, start with [Fields & Screens](/docs/flow-fields-and-screens).
+
+<FlowCapabilityReference section="fields-and-screens" />
+
+Continue with [Flow Types](/docs/flow-types) for the public declarations these fields and screens use.

--- a/docs/website/flow-fields-and-screens.mdx
+++ b/docs/website/flow-fields-and-screens.mdx
@@ -1,0 +1,28 @@
+# Flow Fields & Screens
+
+BugDrop flow building blocks are organized into two groups: **fields** collect information, and **screens** arrange the steps someone moves through.
+
+## Available fields
+
+- **[Short text](/docs/flow-field-guide#short-text)** collects a brief, single-line response.
+- **[Long text](/docs/flow-field-guide#long-text)** collects a longer, multi-line response.
+- **[Rating](/docs/flow-field-guide#rating)** collects a score using five or ten stars or numbers.
+- **[Single choice](/docs/flow-field-guide#single-choice)** lets someone choose one option displayed as radio controls, cards, or buttons.
+- **[Checkbox](/docs/flow-field-guide#checkbox)** collects a single yes-or-no confirmation, acknowledgment, or consent choice.
+- **[Attachments](/docs/flow-field-guide#attachments)** lets someone add one or more supporting files.
+
+[Open the complete Field Guide →](/docs/flow-field-guide)
+
+## Available screens
+
+- **[Message screen](/docs/flow-screen-guide#message-screen)** presents a title and optional explanation before someone continues.
+- **[Form screen](/docs/flow-screen-guide#form-screen)** displays a reusable group of fields with forward and back navigation.
+- **[Screenshot screen](/docs/flow-screen-guide#screenshot-screen)** guides someone through optional, automatic, or required screenshot capture.
+
+[Open the complete Screen Guide →](/docs/flow-screen-guide)
+
+## Technical reference
+
+Use the [Fields & Screens Reference](/docs/flow-fields-and-screens-reference) for the exact required properties, optional controls, layouts, and values supported by BugDrop v1.56.3.
+
+Continue with [Flow Design](/docs/flow-design) to arrange fields and screens into a complete journey.

--- a/docs/website/flow-presentation-and-motion.mdx
+++ b/docs/website/flow-presentation-and-motion.mdx
@@ -1,0 +1,49 @@
+# Flow Presentation & Motion
+
+import { FlowCapabilityReference } from "@/components/docs/flow-capability-reference";
+
+Custom flows open as modals. Presentation controls their size and layout, appearance helps them fit your app, and an optional screen transition controls how one step gives way to the next.
+
+## Choose a transition
+
+Omit `screenTransition` or use `{ kind: 'none' }` for immediate screen replacement. The four built-in animations need only a `kind`:
+
+| Transition | Effect | Default duration |
+|------------|--------|------------------|
+| `slide-horizontal` | Slides between steps from side to side | 500 ms |
+| `slide-vertical` | Slides between steps vertically | 500 ms |
+| `fade` | Crossfades between steps | 350 ms |
+| `scale-fade` | Combines a subtle scale change with a fade | 450 ms |
+
+```js
+presentation: {
+  kind: 'modal',
+  size: 'default',
+  columns: 1,
+  screenTransition: { kind: 'slide-horizontal', durationMs: 500 },
+}
+```
+
+`durationMs` is optional and accepts an integer from 100 through 1,000 milliseconds. Forward and Back navigation use their corresponding directions. The first screen appears immediately because there is no outgoing screen to animate.
+
+## Respect reduced motion
+
+When a user prefers reduced motion, BugDrop replaces screens immediately even when a transition is configured. You do not need to add a separate media-query implementation.
+
+## Add custom motion
+
+Use `kind: 'custom'` when the built-ins do not fit. Custom motion declares separate `forward` and `backward` frames, plus an optional duration and easing. Each direction specifies where the incoming screen starts (`enterFrom`) and where the outgoing screen ends (`exitTo`). The released frame controls are opacity, horizontal and vertical translation, and scale.
+
+Keep custom motion short and restrained, and verify both directions. The [Flow Examples](/docs/flow-examples) page lets you compare every built-in and a custom example before choosing one.
+
+## Match your app
+
+Use `size`, `columns`, `theme`, `accentColor`, and `density` to align the flow with its host application. These declarative controls are the supported styling boundary; custom flows do not expose arbitrary class names, CSS injection, or inline mounting.
+
+## Exact reference
+
+The tables below are the exact released presentation, appearance, content, and screen-transition contracts for BugDrop v1.56.3, including custom motion and reduced-motion behavior.
+
+<FlowCapabilityReference section="presentation-and-motion" />
+
+Try these choices interactively in [Flow Examples](/docs/flow-examples), then match the rest of the widget in [Styling](/docs/styling#custom-flow-appearance).

--- a/docs/website/flow-reference.mdx
+++ b/docs/website/flow-reference.mdx
@@ -1,0 +1,21 @@
+# Flow Reference
+
+This reference is generated from the canonical BugDrop v1.56.3 capability manifest checked against the authenticated public declarations and pinned runtime source. It is divided into focused pages so you can get to the relevant contract without scanning one long table.
+
+## [Fields & Screens](/docs/flow-fields-and-screens)
+
+Every released field and screen, with plain-English explanations and links to the [Field Guide](/docs/flow-field-guide), [Screen Guide](/docs/flow-screen-guide), and [exact property reference](/docs/flow-fields-and-screens-reference). Start here when you want to see what you can put in a flow.
+
+## [Flow Types](/docs/flow-types)
+
+Top-level configuration, exported public types, and the structural declarations they depend on.
+
+## [Branching & Output](/docs/flow-branching-and-output)
+
+Conditions, opening context, issue formatting, evidence mappings, registration, outcomes, and explicit scope boundaries.
+
+## [Presentation & Motion](/docs/flow-presentation-and-motion)
+
+Modal presentation, appearance, content controls, built-in transitions, custom motion frames, duration defaults, and reduced-motion behavior.
+
+For a task-oriented introduction, start with [Custom Flows](/docs/custom-flows). The default feedback flow remains the primary starting point for standard bug capture.

--- a/docs/website/flow-reference.mdx
+++ b/docs/website/flow-reference.mdx
@@ -1,6 +1,6 @@
 # Flow Reference
 
-This reference is generated from the canonical BugDrop v1.56.3 capability manifest checked against the authenticated public declarations and pinned runtime source. It is divided into focused pages so you can get to the relevant contract without scanning one long table.
+This reference is generated from the canonical BugDrop v1.56.3 capability manifest. It combines the released public shapes and supported values with the flow-wide validation boundaries described in [Flow Design](/docs/flow-design#stay-within-the-validation-boundaries). Source-contract tests pin the documented bounds to the released validator, while `registerFlow()` remains the final validation boundary. The reference is divided into focused pages so you can get to the relevant contract without scanning one long table.
 
 ## [Fields & Screens](/docs/flow-fields-and-screens)
 

--- a/docs/website/flow-screen-guide.mdx
+++ b/docs/website/flow-screen-guide.mdx
@@ -1,0 +1,43 @@
+# Flow Screen Guide
+
+import { FlowBuildingBlockPreview } from "@/components/docs/flow-building-block-preview";
+
+Screens arrange the steps someone moves through. They appear in the order you define and can be shown conditionally based on an earlier answer or application context.
+
+## Message screen
+
+Presents a title and optional explanation without collecting a field response.
+
+<FlowBuildingBlockPreview kind="message-screen" />
+
+```js
+{ id: 'intro', type: 'message', title: 'Help us improve', description: 'This takes about a minute.', continueLabel: 'Start' }
+```
+
+Use the title and description to explain the flow. You can customize the continue label and add a condition that determines whether the screen appears.
+
+## Form screen
+
+Displays one of the reusable forms defined in the flow configuration.
+
+<FlowBuildingBlockPreview kind="form-screen" />
+
+```js
+{ id: 'feedback-screen', type: 'form', form: 'feedback', continueLabel: 'Continue', backLabel: 'Back' }
+```
+
+The `form` value points to a form ID. You can customize the forward and back labels and add a condition that determines whether the screen appears.
+
+## Screenshot screen
+
+Guides someone through screenshot capture as a dedicated step.
+
+<FlowBuildingBlockPreview kind="screenshot-screen" />
+
+```js
+{ id: 'screenshot', type: 'screenshot', mode: 'optional', title: 'Add a screenshot', description: 'Show us what you saw.' }
+```
+
+Screenshot capture can be optional, automatic, or required. You can customize the title, description, forward and back labels, and add a condition that determines whether the screen appears.
+
+For every exact property and allowed value, see the [Fields & Screens Reference](/docs/flow-fields-and-screens-reference).

--- a/docs/website/flow-types.mdx
+++ b/docs/website/flow-types.mdx
@@ -1,0 +1,9 @@
+# Flow Types
+
+import { FlowCapabilityReference } from "@/components/docs/flow-capability-reference";
+
+The exact top-level configuration and public type declarations released with BugDrop v1.56.3.
+
+<FlowCapabilityReference section="types" />
+
+See [Fields & Screens](/docs/flow-fields-and-screens) for the building-block inventory developers use most often.

--- a/docs/website/installation.mdx
+++ b/docs/website/installation.mdx
@@ -1,5 +1,7 @@
 # Installation
 
+import { WidgetInstallSnippet } from "@/components/widget-install-snippet";
+
 Getting BugDrop running on your site takes about 30 seconds. There are only two steps: install the GitHub App and add a script tag. No npm packages, no build configuration, no backend setup required.
 
 ## Step 1: Install the GitHub App
@@ -23,12 +25,7 @@ These are the minimum permissions required for BugDrop to function. The app does
 
 Add the BugDrop script tag to your HTML, just before the closing `</body>` tag:
 
-```html
-<script
-  src="https://bugdrop.neonwatty.workers.dev/widget.js"
-  data-repo="your-username/your-repo"
-></script>
-```
+<WidgetInstallSnippet repo="your-username/your-repo" />
 
 Replace `your-username/your-repo` with your actual GitHub repository path (e.g., `acme-corp/my-website`).
 
@@ -89,7 +86,7 @@ BugDrop to visually cover in supported screenshot modes, mark those elements wit
 
 BugDrop covers each marked element with an opaque rectangle on supported captured screenshots.
 Password inputs and credit-card autocomplete fields are masked automatically. See
-[Screenshot masking](/security#screenshot-masking) on the Security page for details.
+[Screenshot masking](/docs/security#screenshot-masking) on the Security page for details.
 
 ## Step 3: You Are Done
 
@@ -97,18 +94,11 @@ That is it. Load your page and you will see the BugDrop button in the corner of 
 
 ## Important Notes
 
-### Do Not Use async or defer
+### Preserve the widget's loading contract
 
-The BugDrop script tag should **not** include the `async` or `defer` attributes. The widget needs to load synchronously to properly initialize:
+Use a normal script element without `async` or `defer`. The widget reads configuration from the executing script element, so changing execution order can separate initialization from its `data-*` attributes. This is the contract in the [official BugDrop README](https://github.com/mean-weasel/bugdrop#quick-start) and the same contract used by BugDrop's own website.
 
-```html
-<!-- Correct -->
-<script src="https://bugdrop.neonwatty.workers.dev/widget.js" data-repo="owner/repo"></script>
-
-<!-- Incorrect - do NOT do this -->
-<script async src="https://bugdrop.neonwatty.workers.dev/widget.js" data-repo="owner/repo"></script>
-<script defer src="https://bugdrop.neonwatty.workers.dev/widget.js" data-repo="owner/repo"></script>
-```
+<WidgetInstallSnippet />
 
 ### Content Security Policy (CSP)
 
@@ -135,7 +125,7 @@ Without this, screenshot uploads will fail silently, though the issue itself wil
 
 ### Framework-Specific Notes
 
-**React / Next.js**: Add the script tag to your `index.html`, or use a `<Script>` component. For Next.js App Router, place it in your root layout:
+**Next.js App Router**: Render the normal script element near the end of the root layout body. Do not use `next/script`, because its loading strategies intentionally change when the script is injected or executed. Place the widget in one shared layout, not both a root and nested layout:
 
 ```tsx
 // app/layout.tsx
@@ -154,26 +144,18 @@ export default function RootLayout({ children }) {
 }
 ```
 
-**Vue / Nuxt**: Add the script tag to your `index.html` or use the Nuxt `useHead` composable.
-
-**Svelte / SvelteKit**: Add to your `app.html` template.
-
-**Static sites (Hugo, Jekyll, Astro)**: Add to your base layout template, before the closing `</body>` tag.
+For a preview-only Vercel workflow, render this element only when the server-side `VERCEL_ENV` value is `preview`; see the [tested Vercel preview guide](/use-cases/vercel-preview-feedback).
 
 ## Verifying the Installation
 
-After adding the script tag, open your browser's developer console. You should see:
-
-```
-[BugDrop] Widget initialized
-```
+After adding the script tag, verify the current public contract: `window` emits `bugdrop:ready`, the page contains `#bugdrop-host`, and its open Shadow DOM contains `.bd-trigger`. The [CI testing guide](/docs/ci-testing) has an executable Playwright check.
 
 If you see any errors, check that:
 
 1. The `data-repo` attribute matches your GitHub repository path exactly
 2. The GitHub App is installed on that repository
 3. Your CSP (if any) allows the required domains
-4. The script tag does not have `async` or `defer`
+4. The script request returns JavaScript rather than an HTML error page
 
 You can also test by clicking the bug button and submitting a test report. Check your GitHub repository's Issues tab to confirm it was created successfully.
 

--- a/docs/website/javascript-api.mdx
+++ b/docs/website/javascript-api.mdx
@@ -14,6 +14,7 @@ The `window.BugDrop` object is available after the widget initializes. It provid
 | `BugDrop.show()` | Method | Shows the floating button |
 | `BugDrop.isOpen()` | Method | Returns `true` if the feedback form is currently open |
 | `BugDrop.isButtonVisible()` | Method | Returns `true` if the floating button is currently visible |
+| `BugDrop.registerFlow(config)` | Method | Registers a released `FlowConfig` and returns a `FlowHandle` |
 | `BugDrop.registerVariant(config)` | Method | Registers an immutable custom feedback definition and returns a durable handle |
 
 ### Basic Usage
@@ -142,7 +143,91 @@ If your code runs after the page is fully loaded and you want to check whether B
 
 This "check first, listen second" pattern is useful in single-page applications where your code might run at various points in the page lifecycle.
 
+## Custom-flow lifecycle
+
+`registerFlow(config)` adds a custom modal journey without replacing the default feedback flow. The
+configuration contains forms, ordered screens, issue output, and optional evidence, appearance, and
+content controls. See [Custom Flows](/docs/custom-flows) for a complete walkthrough and the
+[Flow Reference](/docs/flow-reference) for the manifest-driven released contract.
+
+```js
+const triage = window.BugDrop.registerFlow({
+  configVersion: 1,
+  id: 'support-triage',
+  presentation: { kind: 'modal', size: 'compact' },
+  forms: [
+    {
+      id: 'request',
+      title: 'How can we help?',
+      fields: [
+        {
+          id: 'summary',
+          type: 'shortText',
+          label: 'Summary',
+          required: true,
+        },
+      ],
+    },
+  ],
+  screens: [
+    { id: 'request-screen', type: 'form', form: 'request' },
+  ],
+  issue: {
+    classification: 'question',
+    title: '{{request.summary}}',
+    sections: [{ heading: 'Surface', context: 'surface', format: 'code' }],
+  },
+});
+```
+
+The returned `FlowHandle` has a stable `id` and an `open(options?)` method. Opening returns an
+`OpenedFlow` for that instance:
+
+```js
+const opened = triage.open({
+  context: { surface: 'help-menu' },
+  initialAnswers: { 'request.summary': 'Export is unavailable' },
+});
+
+console.log(opened.instanceId);
+
+const outcome = await opened.result;
+if (outcome.status === 'submitted') {
+  console.log(outcome.result.issueNumber, outcome.result.issueUrl);
+}
+```
+
+Every `context` key must be referenced by a condition or context-backed Issue section in the
+registered configuration; `open()` rejects unreferenced keys synchronously. `initialAnswers`
+prefills known answers by their `formId.fieldId` paths. Use a string for text fields, an integer for
+ratings, an option's configured `value` string for single choice, a boolean for checkboxes, and an
+attachment array for attachments. Both opening properties are optional.
+
+Registration validates the complete configuration immediately and throws when it is invalid. Flow
+IDs must be unique within one loaded BugDrop runtime, so register each configuration once and keep
+the returned handle for later opens. Conditions may only reference earlier answers, form screens
+must reference existing forms, and output mappings must reference compatible fields. These checks
+happen at registration rather than after a user begins the flow.
+
+The `result` promise settles with one released status:
+
+| Status | Meaning | Additional value |
+|--------|---------|------------------|
+| `submitted` | Submission completed | `result` contains `issueNumber`, `issueUrl`, `isPublic`, and optional `labelMappingWarnings` |
+| `closed` | This flow instance closed without a completed submission | None |
+| `busy` | The runtime could not open this instance because the modal surface was busy | None |
+
+Call `opened.close()` to close that custom-flow instance. This is separate from `BugDrop.close()`,
+which controls the default feedback form.
+
+TypeScript consumers can import the Flow configuration, handle, opening, and outcome declarations
+from the `bugdrop` package. The exact property contract is kept on the
+[Branching & Output reference](/docs/flow-branching-and-output#lifecycle) so this lifecycle guide does not duplicate it.
+
 ## Configurable Variants
+
+Variants are a separate public contract. Use them when you specifically need Variant-only inline
+mounting or headless submission; do not place those properties in a `FlowConfig`.
 
 Use a registered variant for a focused feedback experience while reusing BugDrop's validation,
 metadata, auth, Worker policy, and GitHub Issue creation. Registration validates synchronously and
@@ -177,83 +262,11 @@ mountedReview.reset();
 mountedReview.unmount();
 ```
 
-The inline renderer provides accessible short-text, long-text, rating, and single-choice controls.
-Choosing an option changes only local form state; it never submits. A GitHub Issue is created only
-after the explicit Submit button succeeds.
+The inline renderer provides accessible short-text, long-text, and rating controls. Choosing a star
+changes only local form state; it never submits. A GitHub Issue is created only after the explicit
+Submit button succeeds.
 
-For example, an inline poll keeps stable answer values separate from its visible labels and optional
-descriptions. `radio`, `cards`, and `buttons` displays all retain native radio keyboard semantics:
-
-```js
-const poll = window.BugDrop.registerVariant({
-  id: 'next-integration-poll',
-  presentation: { kind: 'inline' },
-  content: { title: 'What should we build next?', submitLabel: 'Vote' },
-  fields: [
-    {
-      id: 'choice',
-      type: 'singleChoice',
-      label: 'Choose one',
-      required: true,
-      display: 'cards',
-      options: [
-        { value: 'onedrive', label: 'OneDrive' },
-        { value: 'box', label: 'Box' },
-        { value: 'other', label: 'Something else' },
-      ],
-    },
-    { id: 'detail', type: 'longText', label: 'Optional detail', maxLength: 500 },
-  ],
-  issue: {
-    classification: 'feature',
-    title: 'Integration vote — {{choice}}',
-    sections: [
-      { heading: 'Choice', field: 'choice', format: 'choice' },
-      { heading: 'Detail', field: 'detail', omitWhenEmpty: true },
-    ],
-  },
-});
-
-const mountedPoll = poll.mount(document.querySelector('#poll-slot'));
-```
-
-The title template receives the stable configured value (for example, `onedrive`), while the
-`choice` section renders its display label (`OneDrive`). Configured labels and descriptions are
-inserted as text. Resetting a successful mounted poll restores its initial answers and creates a new
-submission identity; `unmount()` disposes only that instance.
-
-Compact suggestions do not need a special renderer or field. Compose the existing short- and
-long-text controllers in the modal presentation:
-
-```js
-const suggestion = window.BugDrop.registerVariant({
-  id: 'compact-suggestion',
-  presentation: { kind: 'modal', size: 'default' },
-  content: { title: 'Share an idea', submitLabel: 'Submit idea' },
-  fields: [
-    { id: 'summary', type: 'shortText', label: 'Idea', required: true, maxLength: 120 },
-    { id: 'detail', type: 'longText', label: 'How would this help?', maxLength: 2000 },
-  ],
-  issue: {
-    classification: 'feature',
-    title: '[Idea] {{summary}}',
-    sections: [
-      { heading: 'Idea', field: 'summary' },
-      { heading: 'Why it would help', field: 'detail', omitWhenEmpty: true },
-    ],
-  },
-});
-
-suggestion.open();
-```
-
-Every built-in controller follows the same internal controller contract for values, errors,
-disabled state, focus, reset, and disposal. Contributors extending the built-in field union add a
-controller and its shared conformance fixture; the browser still emits generic Issue sections, so
-the Worker formatter does not gain a field-specific branch. A public renderer registration API is
-not part of this contract.
-
-For a host-owned CTA, register a modal variant and call its handle instead of the legacy
+For a host-owned CTA, register a modal variant and call its handle instead of the default-flow
 `BugDrop.open()` method:
 
 ```js
@@ -290,21 +303,14 @@ document.querySelector('#provider-cta').addEventListener('click', () => {
 ```
 
 The modal traps focus, closes on Escape, restores focus and page scrolling, and settles its result
-as `submitted`, `closed`, or `busy`. A variant requested while the legacy wizard is active returns
-`busy`. Opening the legacy wizard while a variant modal is active closes the variant first. The
-legacy `BugDrop.close()` method remains legacy-scoped.
+as `submitted`, `closed`, or `busy`. A variant requested while the default feedback form is active
+returns `busy`. Opening the default feedback form while a variant modal is active closes the variant
+first. `BugDrop.close()` continues to control only the default feedback form.
 
-BugDrop's merge-queue preview checks render the star review, CTA question, poll, and compact
-suggestion from the exact deployed widget bytes. Each UX intercepts and asserts its normalized draft
-without creating an Issue. A separate zero-retry representative canary then creates, independently
-verifies, closes, and sweeps exactly one real GitHub Issue through the shared Worker and GitHub App
-path; browser and UX coverage never multiply that destructive canary.
-
-For component cleanup, keep the returned mounted or opened handle. Call `unmount()` for inline
-instances and `close()` for an open modal. Both are safe to call repeatedly and dispose only their
-own host, controller state, and listeners. `reset()` restores the supplied initial answers and, after
-a successful submission, starts a new submission identity without affecting another mounted
-instance or the legacy widget.
+BugDrop's merge-queue preview checks render both this CTA modal and the inline star review from the
+exact deployed widget bytes. They assert each normalized draft without creating Issues, followed by
+one zero-retry rendered CTA canary that creates, independently verifies, closes, and sweeps one real
+GitHub Issue through the existing GitHub App.
 
 If your application owns the UI, the same immutable handle also supports headless submission:
 
@@ -411,5 +417,7 @@ The `show()` and `hide()` methods let you control the floating button's visibili
 ## Next Steps
 
 - [Configure the widget](/docs/configuration) with data attributes
+- [Build a custom flow](/docs/custom-flows) with forms, screens, branching, and evidence
+- [Use the exhaustive Flow Reference](/docs/flow-reference) for released values and properties
 - [Style the widget](/docs/styling) to match your site design
 - [Test your integration](/docs/ci-testing) with Playwright

--- a/docs/website/styling.mdx
+++ b/docs/website/styling.mdx
@@ -1,10 +1,10 @@
 # Styling
 
-BugDrop is designed to blend seamlessly into any website. Beyond the core theme and color options, a full set of styling attributes gives you fine-grained control over fonts, border radius, backgrounds, text colors, borders, and shadows. The widget renders inside a Shadow DOM, so your site's styles never leak in and the widget's styles never leak out.
+BugDrop is designed to blend seamlessly into any website. The default feedback flow uses script attributes for fonts, border radius, backgrounds, text colors, borders, and shadows. Custom flows add supported `appearance` and `presentation` configuration for each registered journey. The widget renders inside a Shadow DOM, so your site's styles never leak in and the widget's styles never leak out.
 
 ## Styling Attributes
 
-All styling is done through data attributes on the script tag. No CSS files to import, no class names to override.
+The default feedback flow is styled through data attributes on the script tag. No CSS files to import, no class names to override.
 
 | Attribute | Default | Description |
 |-----------|---------|-------------|
@@ -17,6 +17,61 @@ All styling is done through data attributes on the script tag. No CSS files to i
 | `data-shadow` | `"0 8px 30px rgba(0,0,0,0.12)"` | Box shadow of the form container |
 
 These same visual settings are also used by Select Element screenshots. When a user selects an element, BugDrop draws a border-only rounded highlight around that element using `data-color`, `data-radius`, and `data-border-width`. The captured highlight includes a small 2px inner gap so the border does not sit directly on top of the selected element. The GitHub issue caption mentions the exact resolved highlight color.
+
+## Custom-flow appearance
+
+A registered custom flow can select a theme, accent color, and density through `appearance`. Its
+`presentation` controls the modal size, the number of form columns, and optional screen motion:
+
+```js
+const brandedFlow = window.BugDrop.registerFlow({
+  configVersion: 1,
+  id: 'branded-feedback',
+  presentation: {
+    kind: 'modal',
+    size: 'wide',
+    columns: 2,
+    screenTransition: { kind: 'fade' },
+  },
+  appearance: {
+    theme: 'auto',
+    accentColor: '#7c3aed',
+    density: 'comfortable',
+  },
+  forms: [
+    {
+      id: 'feedback',
+      title: 'Share feedback',
+      fields: [
+        {
+          id: 'summary',
+          type: 'shortText',
+          label: 'Summary',
+          layout: { span: 2 },
+        },
+      ],
+    },
+  ],
+  screens: [{ id: 'feedback-screen', type: 'form', form: 'feedback' }],
+  issue: { title: '{{feedback.summary}}' },
+});
+```
+
+`theme: 'auto'` follows the runtime's automatic theme behavior. `accentColor` accepts a color string.
+Density changes the spacing of the flow controls. Modal size and columns shape the available layout,
+while an individual field's `layout.span` chooses whether it occupies one or two columns.
+
+These configuration properties are the public styling boundary for custom flows. The released Flow
+contract is modal-only; inline mounting belongs to the separate Variant contract. BugDrop does not
+expose arbitrary class names, style hooks, or CSS injection through the Shadow DOM. Use the exact
+[appearance and presentation values](/docs/flow-presentation-and-motion#presentation-and-appearance) and
+[screen transition values](/docs/flow-presentation-and-motion#screen-transitions) from the manifest-driven Flow
+Reference.
+
+Try the [live released examples](/docs/flow-examples) to compare a product-dark,
+editorial-light, and compact-console host application. Each preset changes only released
+`appearance`, `presentation`, and field-span controls; the surrounding preview card demonstrates
+the host application, while its CSS remains outside BugDrop's Shadow DOM.
 
 ### Defaults by Theme
 
@@ -200,5 +255,7 @@ Combine a custom icon with a text label for maximum clarity:
 ## Next Steps
 
 - [Configure widget behavior](/docs/configuration) with all available attributes
+- [Build a custom flow](/docs/custom-flows) with per-flow appearance and presentation
+- [Check the Flow styling contract](/docs/flow-presentation-and-motion#presentation-and-appearance)
 - [Use the JavaScript API](/docs/javascript-api) for programmatic control
 - [Test your configuration](/docs/ci-testing) with automated Playwright tests

--- a/docs/website/styling.mdx
+++ b/docs/website/styling.mdx
@@ -47,6 +47,7 @@ const brandedFlow = window.BugDrop.registerFlow({
           id: 'summary',
           type: 'shortText',
           label: 'Summary',
+          required: true,
           layout: { span: 2 },
         },
       ],

--- a/scripts/sync-website-docs.mjs
+++ b/scripts/sync-website-docs.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const sourceDirectory = path.join(repositoryRoot, 'docs/website');
 const manifestTarget = 'src/content/docs/.widget-docs-source.json';
+const WEBSITE_DOC_NAME = /^[^/\\]+\.mdx$/;
 
 function targetPath(targetRoot, relativePath) {
   const resolvedRoot = path.resolve(targetRoot);
@@ -19,8 +20,13 @@ function targetPath(targetRoot, relativePath) {
 function isOwnedTarget(relativePath) {
   return (
     relativePath === 'src/lib/flow-capabilities.ts' ||
-    /^src\/content\/docs\/[a-z0-9-]+\.mdx$/.test(relativePath)
+    (relativePath.startsWith('src/content/docs/') &&
+      isWebsiteDocName(relativePath.slice('src/content/docs/'.length)))
   );
+}
+
+export function isWebsiteDocName(name) {
+  return WEBSITE_DOC_NAME.test(name);
 }
 
 function sha256(value) {
@@ -45,7 +51,7 @@ export async function syncWebsiteDocs(targetRoot, sourceRevision) {
     throw new TypeError('Website documentation can only sync into the bugdrop-web repository');
   }
 
-  const mdxNames = (await readdir(sourceDirectory)).filter(name => name.endsWith('.mdx')).sort();
+  const mdxNames = (await readdir(sourceDirectory)).filter(isWebsiteDocName).sort();
   const files = [
     ...mdxNames.map(name => ({
       source: `docs/website/${name}`,

--- a/scripts/sync-website-docs.mjs
+++ b/scripts/sync-website-docs.mjs
@@ -1,0 +1,96 @@
+import { createHash } from 'node:crypto';
+import { copyFile, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const sourceDirectory = path.join(repositoryRoot, 'docs/website');
+const manifestTarget = 'src/content/docs/.widget-docs-source.json';
+
+function targetPath(targetRoot, relativePath) {
+  const resolvedRoot = path.resolve(targetRoot);
+  const resolved = path.resolve(resolvedRoot, relativePath);
+  if (!resolved.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new TypeError(`Website documentation target escapes the repository: ${relativePath}`);
+  }
+  return resolved;
+}
+
+function isOwnedTarget(relativePath) {
+  return (
+    relativePath === 'src/lib/flow-capabilities.ts' ||
+    /^src\/content\/docs\/[a-z0-9-]+\.mdx$/.test(relativePath)
+  );
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+async function readPreviousManifest(targetRoot) {
+  try {
+    return JSON.parse(await readFile(targetPath(targetRoot, manifestTarget), 'utf8'));
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+export async function syncWebsiteDocs(targetRoot, sourceRevision) {
+  if (typeof sourceRevision !== 'string' || !sourceRevision.trim()) {
+    throw new TypeError('A non-empty widget source revision is required');
+  }
+  const packageJson = JSON.parse(await readFile(targetPath(targetRoot, 'package.json'), 'utf8'));
+  if (packageJson.name !== 'bugdrop-web') {
+    throw new TypeError('Website documentation can only sync into the bugdrop-web repository');
+  }
+
+  const mdxNames = (await readdir(sourceDirectory)).filter(name => name.endsWith('.mdx')).sort();
+  const files = [
+    ...mdxNames.map(name => ({
+      source: `docs/website/${name}`,
+      target: `src/content/docs/${name}`,
+    })),
+    {
+      source: 'docs/website/flow-capabilities.ts',
+      target: 'src/lib/flow-capabilities.ts',
+    },
+  ];
+  const currentTargets = new Set(files.map(({ target }) => target));
+  const previous = await readPreviousManifest(targetRoot);
+  for (const entry of previous?.files ?? []) {
+    if (
+      typeof entry?.target === 'string' &&
+      isOwnedTarget(entry.target) &&
+      !currentTargets.has(entry.target)
+    ) {
+      await rm(targetPath(targetRoot, entry.target), { force: true });
+    }
+  }
+
+  const manifestFiles = [];
+  for (const entry of files) {
+    const source = path.join(repositoryRoot, entry.source);
+    const target = targetPath(targetRoot, entry.target);
+    const contents = await readFile(source);
+    await mkdir(path.dirname(target), { recursive: true });
+    await copyFile(source, target);
+    manifestFiles.push({ ...entry, sha256: sha256(contents) });
+  }
+
+  const manifest = {
+    schemaVersion: 1,
+    sourceRepository: 'mean-weasel/bugdrop',
+    sourceRevision,
+    files: manifestFiles,
+  };
+  const manifestPath = targetPath(targetRoot, manifestTarget);
+  await mkdir(path.dirname(manifestPath), { recursive: true });
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  const [, , targetRoot, sourceRevision] = process.argv;
+  await syncWebsiteDocs(targetRoot, sourceRevision);
+}

--- a/test/syncWebsiteDocs.test.ts
+++ b/test/syncWebsiteDocs.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { FLOW_CAPABILITIES } from '../docs/website/flow-capabilities';
-import { syncWebsiteDocs } from '../scripts/sync-website-docs.mjs';
+import { isWebsiteDocName, syncWebsiteDocs } from '../scripts/sync-website-docs.mjs';
 
 const temporaryRoots: string[] = [];
 
@@ -71,6 +71,54 @@ describe('website documentation sync', () => {
     );
   });
 
+  it('binds documented flow-wide validation boundaries to the released validator source', async () => {
+    const validationSource = await readFile('src/widget/flows/validate-config.ts', 'utf8');
+    const conditionSource = await readFile('src/widget/flows/conditions.ts', 'utf8');
+    const constraints = FLOW_CAPABILITIES.validation;
+
+    expect(validationSource).toContain('input.forms.length === 0');
+    expect(validationSource).toContain(`input.forms.length > ${constraints.forms.maximum}`);
+    expect(validationSource).toContain('input.screens.length === 0');
+    expect(validationSource).toContain(`input.screens.length > ${constraints.screens.maximum}`);
+    expect(validationSource).toContain('form.fields.length === 0');
+    expect(validationSource).toContain(`form.fields.length > ${constraints.fieldsPerForm.maximum}`);
+    expect(validationSource).toContain(`++screenshots > ${constraints.screenshotScreens.maximum}`);
+    expect(validationSource).toContain(
+      `issue.sections.length > ${constraints.issueSections.maximum}`
+    );
+    expect(conditionSource).toContain(
+      `const MAX_CONDITION_DEPTH = ${constraints.conditionDepth.maximum}`
+    );
+    expect(conditionSource).toContain(
+      `const MAX_CONDITION_NODES = ${constraints.conditionNodes.maximum}`
+    );
+    expect(validationSource).toContain(
+      `children.length > ${constraints.conditionGroupEntries.maximum}`
+    );
+    expect(validationSource).toContain('children.length < 1');
+    expect(validationSource).toContain('may be referenced only once');
+    expect(validationSource).toContain('at least one screen must be unconditional');
+    expect(validationSource).toContain('condition answer must reference an earlier field');
+    expect(validationSource).toContain(
+      'issue title must contain text or reference a required answer'
+    );
+  });
+
+  it('keeps the copyable styling flow backed by a guaranteed title answer', async () => {
+    const styling = await readFile('docs/website/styling.mdx', 'utf8');
+    expect(styling).toMatch(
+      /id: 'summary',[\s\S]*?required: true,[\s\S]*?issue: \{ title: '\{\{feedback\.summary\}\}' \}/
+    );
+  });
+
+  it('uses the same safe filename grammar for discovery and retirement', () => {
+    expect(isWebsiteDocName('flow-reference.mdx')).toBe(true);
+    expect(isWebsiteDocName('api_v2.mdx')).toBe(true);
+    expect(isWebsiteDocName('Flow-Reference.mdx')).toBe(true);
+    expect(isWebsiteDocName('../flow-reference.mdx')).toBe(false);
+    expect(isWebsiteDocName('nested/flow-reference.mdx')).toBe(false);
+  });
+
   it('stages both documentation and the canonical capability manifest', async () => {
     const workflow = await readFile('.github/workflows/sync-docs.yml', 'utf8');
     expect(workflow).toContain('git add src/content/docs/ src/lib/flow-capabilities.ts');
@@ -98,14 +146,14 @@ describe('website documentation sync', () => {
   it('removes only retired files previously owned by the manifest', async () => {
     const target = await temporaryWebsite();
     await syncWebsiteDocs(target, 'first');
-    const retired = 'src/content/docs/retired-flow.mdx';
+    const retired = 'src/content/docs/api_v2.mdx';
     const unrelated = 'src/content/docs/website-only.mdx';
     await writeFile(path.join(target, retired), 'retired');
     await writeFile(path.join(target, unrelated), 'website only');
     const manifestPath = path.join(target, 'src/content/docs/.widget-docs-source.json');
     const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
     manifest.files.push({
-      source: 'docs/website/retired-flow.mdx',
+      source: 'docs/website/api_v2.mdx',
       target: retired,
       sha256: '0'.repeat(64),
     });

--- a/test/syncWebsiteDocs.test.ts
+++ b/test/syncWebsiteDocs.test.ts
@@ -1,0 +1,126 @@
+import { readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { FLOW_CAPABILITIES } from '../docs/website/flow-capabilities';
+import { syncWebsiteDocs } from '../scripts/sync-website-docs.mjs';
+
+const temporaryRoots: string[] = [];
+
+async function temporaryWebsite(name = 'bugdrop-web') {
+  const root = await import('node:fs/promises').then(({ mkdtemp }) =>
+    mkdtemp(path.join(os.tmpdir(), 'bugdrop-doc-sync-'))
+  );
+  temporaryRoots.push(root);
+  await writeFile(path.join(root, 'package.json'), JSON.stringify({ name }));
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map(root => rm(root, { recursive: true })));
+});
+
+describe('website documentation sync', () => {
+  it('binds documented field limits and MIME values to the released validator source', async () => {
+    const source = await readFile('src/widget/flows/field-validation.ts', 'utf8');
+    const numericSource = source.replaceAll('_', '');
+    const constraints = FLOW_CAPABILITIES.fields.constraints;
+
+    expect(numericSource).toContain(
+      `const minimum = field.minLength ?? ${constraints.text.minLength.default}`
+    );
+    expect(numericSource).toContain(
+      `const maximum = field.maxLength ?? (field.type === 'shortText' ? ${constraints.text.maxLength.defaults.shortText} : ${constraints.text.maxLength.defaults.longText})`
+    );
+    expect(numericSource).toContain(
+      `boundedInteger(minimum, ${constraints.text.minLength.minimum}, ${constraints.text.minLength.maximum})`
+    );
+    expect(numericSource).toContain(
+      `boundedInteger(maximum, ${constraints.text.maxLength.minimum}, ${constraints.text.maxLength.maximum})`
+    );
+    expect(numericSource).toContain(
+      `boundedInteger(field.rows, ${constraints.text.longTextRows.minimum}, ${constraints.text.longTextRows.maximum})`
+    );
+    expect(numericSource).toContain(
+      `field.options.length < ${constraints.singleChoiceOptions.minimum} || field.options.length > ${constraints.singleChoiceOptions.maximum}`
+    );
+    expect(numericSource).toContain(
+      `boundedInteger(field.maxFiles, ${constraints.attachments.maxFiles.minimum}, ${constraints.attachments.maxFiles.maximum})`
+    );
+    expect(numericSource).toContain(
+      `field.maxFiles ?? ${constraints.attachments.maxFiles.default}`
+    );
+    expect(constraints.attachments.maxFileSizeBytes.maximum).toBe(5 * 1024 * 1024);
+    expect(constraints.attachments.maxFileSizeBytes.default).toBe(5 * 1024 * 1024);
+    expect(numericSource).toContain(
+      `boundedInteger(field.maxFileSize, ${constraints.attachments.maxFileSizeBytes.minimum}, 5 * 1024 * 1024)`
+    );
+    expect(numericSource).toContain('field.maxFileSize ?? 5 * 1024 * 1024');
+    expect(constraints.attachments.acceptCount.minimum).toBe(1);
+    expect(numericSource).toContain('field.accept.length === 0');
+    expect(numericSource).toContain(
+      `field.accept.length > ${constraints.attachments.acceptCount.maximum}`
+    );
+
+    const allowedTypes = source.match(/const ALLOWED_ATTACHMENT_TYPES = new Set\(\[([\s\S]*?)\]\)/);
+    expect(allowedTypes).not.toBeNull();
+    expect([...allowedTypes![1].matchAll(/'([^']+)'/g)].map(match => match[1])).toEqual(
+      constraints.attachments.acceptedMimeTypes
+    );
+  });
+
+  it('stages both documentation and the canonical capability manifest', async () => {
+    const workflow = await readFile('.github/workflows/sync-docs.yml', 'utf8');
+    expect(workflow).toContain('git add src/content/docs/ src/lib/flow-capabilities.ts');
+  });
+
+  it('copies every canonical page and capability manifest with content hashes', async () => {
+    const target = await temporaryWebsite();
+    const manifest = await syncWebsiteDocs(target, 'source-revision');
+
+    expect(manifest.sourceRepository).toBe('mean-weasel/bugdrop');
+    expect(manifest.files).toContainEqual(
+      expect.objectContaining({
+        source: 'docs/website/flow-capabilities.ts',
+        target: 'src/lib/flow-capabilities.ts',
+      })
+    );
+    for (const entry of manifest.files) {
+      expect(await readFile(path.join(target, entry.target), 'utf8')).toBe(
+        await readFile(path.resolve(entry.source), 'utf8')
+      );
+      expect(entry.sha256).toMatch(/^[a-f0-9]{64}$/);
+    }
+  });
+
+  it('removes only retired files previously owned by the manifest', async () => {
+    const target = await temporaryWebsite();
+    await syncWebsiteDocs(target, 'first');
+    const retired = 'src/content/docs/retired-flow.mdx';
+    const unrelated = 'src/content/docs/website-only.mdx';
+    await writeFile(path.join(target, retired), 'retired');
+    await writeFile(path.join(target, unrelated), 'website only');
+    const manifestPath = path.join(target, 'src/content/docs/.widget-docs-source.json');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+    manifest.files.push({
+      source: 'docs/website/retired-flow.mdx',
+      target: retired,
+      sha256: '0'.repeat(64),
+    });
+    await writeFile(manifestPath, JSON.stringify(manifest));
+
+    await syncWebsiteDocs(target, 'second');
+
+    await expect(readFile(path.join(target, retired), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(readFile(path.join(target, unrelated), 'utf8')).resolves.toBe('website only');
+  });
+
+  it('rejects a target that is not the website repository', async () => {
+    const target = await temporaryWebsite('another-project');
+    await expect(syncWebsiteDocs(target, 'source-revision')).rejects.toThrow('bugdrop-web');
+  });
+});


### PR DESCRIPTION
## Summary

- make `docs/website` the canonical source for the website documentation set and released Flow capability manifest
- add the v1.56.3 custom-flow guides, reference pages, field limits, motion, styling, branching, and lifecycle documentation
- replace the blind MDX copy with a bounded sync that writes a source-SHA and per-file SHA-256 receipt, removes only previously owned retired pages, and stages both documentation and capability outputs
- add source-contract tests that bind documented field limits and accepted attachment types to the released validator

## Verification

- `npm test` (93 files, 1464 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run check:workflow-permissions`
- `git diff --check`
- PR Review Toolkit: native review plus correctness, tests, silent-failures, contracts/types, and comments/docs; all accepted findings corrected and corrected-head review clean
- downstream website docs/parity verification: 25 tests passed

## Follow-up

The website feature branch now carries a receipt pinned to widget commit `00302ac3e733e4c04562423d365eb3d59dbe887e`. Its eventual website PR should depend on this PR so future widget documentation changes continue through the automated sync.