### PR TITLE
docs: clarify flow preview and type distribution

### DIFF
--- a/docs/website/custom-flows.mdx
+++ b/docs/website/custom-flows.mdx
@@ -6,7 +6,7 @@ The default feedback flow is still the fastest way to collect a bug report with 
 
 - **Build your first flow below** when you want the smallest working example.
 - Use [Flow Design](/docs/flow-design) for screens, branching, context, issue output, and evidence.
-- Try the [Flow Examples](/docs/flow-examples) to combine released components, motion, and styling without leaving the page.
+- Explore [Flow Examples](/docs/flow-examples) to combine released fields, motion, and styling; local development also enables the interactive launcher.
 - Use the [Flow Reference](/docs/flow-reference) for the released v1.56.3 shapes, values, and validation boundaries.
 
 ## Register a first flow
@@ -54,6 +54,6 @@ Registration returns a `FlowHandle`. Each `open()` creates an `OpenedFlow` with 
 ## Next steps
 
 - Design a multi-screen journey in [Flow Design](/docs/flow-design)
-- See the released API working in [Flow Examples](/docs/flow-examples)
+- See the released API working locally in [Flow Examples](/docs/flow-examples)
 - Match the widget to your application with [Styling](/docs/styling)
 - Keep production behavior predictable with [Version Pinning](/docs/version-pinning)

--- a/docs/website/flow-examples.mdx
+++ b/docs/website/flow-examples.mdx
@@ -2,7 +2,7 @@
 
 import { FlowCapabilityExamples } from "@/components/docs/flow-capability-examples";
 
-Combine three curated journeys with every released transition and three supported styling presets. The gallery loads the checksum-pinned v1.56.3 runtime from this site and points submission at the local feedback route, so it cannot create a real GitHub Issue or send a payload to an external service.
+Combine three curated journeys with every released transition and three supported styling presets. The configuration gallery is available everywhere. Its interactive launcher is enabled only in local development, where it loads the checksum-pinned v1.56.3 runtime and uses the local feedback route. Deployed documentation never loads the preview runtime or enables submission.
 
 Use these examples to explore combinations, then return to [Flow Design](/docs/flow-design) for implementation guidance or the [Flow Reference](/docs/flow-reference) for exact configuration shapes.
 

--- a/docs/website/flow-presentation-and-motion.mdx
+++ b/docs/website/flow-presentation-and-motion.mdx
@@ -34,7 +34,7 @@ When a user prefers reduced motion, BugDrop replaces screens immediately even wh
 
 Use `kind: 'custom'` when the built-ins do not fit. Custom motion declares separate `forward` and `backward` frames, plus an optional duration and easing. Each direction specifies where the incoming screen starts (`enterFrom`) and where the outgoing screen ends (`exitTo`). The released frame controls are opacity, horizontal and vertical translation, and scale.
 
-Keep custom motion short and restrained, and verify both directions. The [Flow Examples](/docs/flow-examples) page lets you compare every built-in and a custom example before choosing one.
+Keep custom motion short and restrained, and verify both directions. The [Flow Examples](/docs/flow-examples) page compares every built-in and a custom configuration before you choose one; local development also enables interactive previews.
 
 ## Match your app
 
@@ -46,4 +46,4 @@ The tables below are the exact released presentation, appearance, content, and s
 
 <FlowCapabilityReference section="presentation-and-motion" />
 
-Try these choices interactively in [Flow Examples](/docs/flow-examples), then match the rest of the widget in [Styling](/docs/styling#custom-flow-appearance).
+Compare these choices in [Flow Examples](/docs/flow-examples), preview them interactively in local development, then match the rest of the widget in [Styling](/docs/styling#custom-flow-appearance).

--- a/docs/website/javascript-api.mdx
+++ b/docs/website/javascript-api.mdx
@@ -220,8 +220,10 @@ The `result` promise settles with one released status:
 Call `opened.close()` to close that custom-flow instance. This is separate from `BugDrop.close()`,
 which controls the default feedback form.
 
-TypeScript consumers can import the Flow configuration, handle, opening, and outcome declarations
-from the `bugdrop` package. The exact property contract is kept on the
+The Flow configuration, handle, opening, and outcome declarations are published with each tagged
+release in BugDrop's repository. Script-tag consumers can pin or copy the declarations from the
+[v1.56.3 public type source](https://github.com/mean-weasel/bugdrop/blob/v1.56.3/src/widget/flows/public-types.d.ts).
+BugDrop does not currently publish an npm package. The exact property contract is kept on the
 [Branching & Output reference](/docs/flow-branching-and-output#lifecycle) so this lifecycle guide does not duplicate it.
 
 ## Configurable Variants
@@ -322,8 +324,8 @@ const result = await review.submit(
 console.log(result.issueNumber, result.issueUrl);
 ```
 
-TypeScript consumers can import `VariantConfig`, `VariantHandle`, `MountedVariant`, and related
-declarations from the `bugdrop` package.
+The tagged repository source also includes `VariantConfig`, `VariantHandle`, `MountedVariant`, and
+the related declarations for script-tag integrations.
 
 ## Keyboard Shortcut Example
 

--- a/test/syncWebsiteDocs.test.ts
+++ b/test/syncWebsiteDocs.test.ts
@@ -114,11 +114,15 @@ describe('website documentation sync', () => {
   it('keeps distribution and gallery guidance aligned with supported release paths', async () => {
     const api = await readFile('docs/website/javascript-api.mdx', 'utf8');
     const examples = await readFile('docs/website/flow-examples.mdx', 'utf8');
+    const customFlows = await readFile('docs/website/custom-flows.mdx', 'utf8');
+    const motion = await readFile('docs/website/flow-presentation-and-motion.mdx', 'utf8');
 
     expect(api).toContain('BugDrop does not currently publish an npm package');
     expect(api).not.toContain('from the `bugdrop` package');
     expect(examples).toContain('interactive launcher is enabled only in local development');
     expect(examples).toContain('Deployed documentation never loads the preview runtime');
+    expect(customFlows).toContain('local development also enables the interactive launcher');
+    expect(motion).toContain('preview them interactively in local development');
   });
 
   it('uses the same safe filename grammar for discovery and retirement', () => {

--- a/test/syncWebsiteDocs.test.ts
+++ b/test/syncWebsiteDocs.test.ts
@@ -111,6 +111,16 @@ describe('website documentation sync', () => {
     );
   });
 
+  it('keeps distribution and gallery guidance aligned with supported release paths', async () => {
+    const api = await readFile('docs/website/javascript-api.mdx', 'utf8');
+    const examples = await readFile('docs/website/flow-examples.mdx', 'utf8');
+
+    expect(api).toContain('BugDrop does not currently publish an npm package');
+    expect(api).not.toContain('from the `bugdrop` package');
+    expect(examples).toContain('interactive launcher is enabled only in local development');
+    expect(examples).toContain('Deployed documentation never loads the preview runtime');
+  });
+
   it('uses the same safe filename grammar for discovery and retirement', () => {
     expect(isWebsiteDocName('flow-reference.mdx')).toBe(true);
     expect(isWebsiteDocName('api_v2.mdx')).toBe(true);


### PR DESCRIPTION
## Summary
- clarify that interactive Flow examples run only in local development while deployed docs remain a configuration gallery
- point script-tag TypeScript users to the exact tagged declaration source and remove unsupported npm-package guidance
- add a canonical documentation contract test so both claims stay synchronized downstream

## Verification
- `npm test` — 1,468 tests passed
- `npm run typecheck`
- `npm run lint`
- PR Review Toolkit: fresh correctness, tests, contracts/types, silent-failure, and comments/docs review found no candidates
- `git diff --check`

No runtime, release, deployment, or production behavior changes.